### PR TITLE
fix(terminal): sanitize inbound control sequences

### DIFF
--- a/runner/src/main/scala/orca/runner/terminal/Ansi.scala
+++ b/runner/src/main/scala/orca/runner/terminal/Ansi.scala
@@ -2,13 +2,79 @@ package orca.runner.terminal
 
 /** Single source of truth for the "ANSI optional" decision in the renderer
   * layer. Each renderer carries a `useColor` boolean it chose at construction
-  * time (or auto-detected); this helper applies the fansi attrs only when
-  * colour is on, returning the raw text otherwise.
+  * time (or auto-detected); this helper strips inbound terminal controls and
+  * applies the fansi attrs only when colour is on.
   *
   * Package-private — callers outside `orca.runner.terminal` have no reason to
   * reach into our colour decision.
   */
 private[terminal] object Ansi:
 
+  private val Esc: Char = 0x1b.toChar
+  private val Bel: Char = 0x07.toChar
+  private val Csi: Char = 0x9b.toChar
+  private val Osc: Char = 0x9d.toChar
+  private val Dcs: Char = 0x90.toChar
+  private val Sos: Char = 0x98.toChar
+  private val Pm: Char = 0x9e.toChar
+  private val Apc: Char = 0x9f.toChar
+
   def paint(useColor: Boolean, attr: fansi.Attrs, text: String): String =
-    if useColor then attr(text).render else text
+    val stripped = stripControlSequences(text)
+    if useColor then attr(stripped).render else stripped
+
+  /** Remove terminal control sequences from user/backend supplied text before
+    * applying Orca's own styling. `fansi.Attrs.apply(String)` parses existing
+    * ANSI and throws on unsupported sequences (for example cursor/status
+    * controls such as `ESC[?25l` or OSC hyperlinks). These bytes can arrive
+    * from subprocess stderr or model/tool output, so strip them instead of
+    * letting renderer decoration abort the flow.
+    */
+  private[terminal] def stripControlSequences(text: String): String =
+    val out = new StringBuilder(text.length)
+    var i = 0
+    while i < text.length do
+      text.charAt(i) match
+        case Esc                     => i = skipEsc(text, i)
+        case Csi                     => i = skipCsi(text, i + 1)
+        case Osc                     => i = skipStringControl(text, i + 1)
+        case Dcs | Sos | Pm | Apc    => i = skipStringControl(text, i + 1)
+        case c if isUnsafeControl(c) => i += 1
+        case c =>
+          val _ = out.append(c)
+          i += 1
+    out.toString
+
+  private def skipEsc(text: String, escIndex: Int): Int =
+    val nextIndex = escIndex + 1
+    if nextIndex >= text.length then text.length
+    else
+      text.charAt(nextIndex) match
+        case '['                   => skipCsi(text, nextIndex + 1)
+        case ']'                   => skipStringControl(text, nextIndex + 1)
+        case 'P' | 'X' | '^' | '_' => skipStringControl(text, nextIndex + 1)
+        case _                     => math.min(nextIndex + 1, text.length)
+
+  private def skipCsi(text: String, start: Int): Int =
+    var i = start
+    while i < text.length && !isCsiFinal(text.charAt(i)) do i += 1
+    if i < text.length then i + 1 else text.length
+
+  private def skipStringControl(text: String, start: Int): Int =
+    var i = start
+    var done = false
+    while i < text.length && !done do
+      text.charAt(i) match
+        case Bel =>
+          i += 1
+          done = true
+        case Esc if i + 1 < text.length && text.charAt(i + 1) == '\\' =>
+          i += 2
+          done = true
+        case _ => i += 1
+    i
+
+  private def isCsiFinal(c: Char): Boolean = c >= '@' && c <= '~'
+
+  private def isUnsafeControl(c: Char): Boolean =
+    (c < ' ' && c != '\n' && c != '\t') || (c >= 0x7f.toChar && c <= Apc)

--- a/runner/src/test/scala/orca/runner/terminal/TerminalEventListenerTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/TerminalEventListenerTest.scala
@@ -16,13 +16,14 @@ class TerminalEventListenerTest extends munit.FunSuite:
 
   private def renderWith(
       animated: Boolean,
-      events: List[OrcaEvent]
+      events: List[OrcaEvent],
+      listenerUseColor: Boolean = false
   ): String =
     val buf = new ByteArrayOutputStream()
     val ps = new PrintStream(buf)
     val output =
       new TerminalOutputState(ps, useColor = false, animated = animated)
-    val listener = new TerminalEventListener(output, useColor = false)
+    val listener = new TerminalEventListener(output, useColor = listenerUseColor)
     events.foreach(listener.onEvent)
     buf.toString
 
@@ -89,6 +90,22 @@ class TerminalEventListenerTest extends munit.FunSuite:
     val output = renderEvents(List(OrcaEvent.Error("boom")))
     assert(output.contains(TerminalEventListener.ErrorGlyph))
     assert(output.contains("boom"))
+
+  test("errors with backend terminal controls do not crash colored output"):
+    val output = renderWith(
+      animated = false,
+      events = List(
+        OrcaEvent.Error(
+          "before\u001b[?25lhidden\u001b[2Kafter" +
+            "\u001b]8;;https://example.com\u0007link\u001b]8;;\u0007"
+        )
+      ),
+      listenerUseColor = true
+    )
+    assert(output.contains("beforehiddenafterlink"), output)
+    assert(!output.contains("?25l"), output)
+    assert(!output.contains("[2K"), output)
+    assert(!output.contains("https://example.com"), output)
 
   test("AssistantMessage renders as a `●` line with the body"):
     val output =


### PR DESCRIPTION
## Summary

Orca's terminal renderer currently applies `fansi` styling directly to text that can originate from backend stderr, assistant/tool output, or user-provided content. If that text already contains terminal control sequences that `fansi` does not support, rendering can throw and abort an otherwise successful flow.

This PR strips inbound terminal control sequences before applying Orca's own coloring. That keeps backend/user text from controlling the terminal and avoids `fansi.Str` parse failures such as:

```text
Unknown ansi-escape ... cannot be parsed into an fansi.Str
```

## Details

- Centralizes sanitization in `Ansi.paint` so all terminal render paths benefit.
- Handles CSI sequences such as cursor/status controls (`ESC[?25l`, `ESC[2K`).
- Handles OSC/string controls such as hyperlinks or notifications (`ESC]...BEL`, `ESC]...ESC\\`).
- Drops other unsafe C0/C1 controls while preserving newlines and tabs.
- Applies sanitization whether color is enabled or disabled.

## Why

This was observed when a backend emitted terminal notification/control bytes on stderr. Orca attempted to paint the resulting error line red, `fansi` rejected the unsupported escape sequence, and the flow aborted from the renderer instead of surfacing the backend message safely.

## Testing

Added a regression test covering colored rendering of an error message containing CSI controls and OSC hyperlinks.

Ran:

```bash
sbt "runner/testOnly orca.runner.terminal.TerminalEventListenerTest"
```