### PR TITLE
feat(pi): add Pi backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ metals.sbt
 # OS
 .DS_Store
 Thumbs.db
+
+# Local agent/workflow files
+.pi/
+openspec/
+.envrc
+.nvmrc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,8 +90,11 @@ outside of `os.temp.dir()`.
 
 ### Iterating quickly
 
-- `sbt --client <cmd>` talks to a persistent sbt server; round-trips drop
-  from ~20s to ~2s.
+- Prefer plain `sbt <cmd>` in agent/non-interactive shells. Avoid
+  `sbt --client` unless you know the persistent sbt server was started with
+  the repo's direnv/JDK 21 environment; otherwise the client can attach to a
+  stale server running a different Java and fail despite the current shell's
+  `JAVA_HOME`.
 - `sbt ~test` re-runs tests on save.
 - Metals MCP is configured (`.metals/mcp.json`), so AI-assisted tooling can
   query real type info across modules.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ for task <- tasks do
 The first call opens the session; subsequent calls resume it. The library
 tracks fresh-vs-resume internally per backend (`--session-id` then `--resume`
 on claude; a client→server mapping on codex and opencode; caller-supplied
-`--session-id` on pi).
+`--session` on pi).
 
 A minimal Pi-backed flow looks the same; Pi reads your normal Pi configuration
 and is driven through RPC mode under the hood:

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ for task <- tasks do
 
 The first call opens the session; subsequent calls resume it. The library
 tracks fresh-vs-resume internally per backend (`--session-id` then `--resume`
-on claude; a client→server mapping on codex and opencode; caller-supplied
-`--session` on pi).
+on claude; a client→server mapping on codex and opencode; a per-session
+`--session-dir` resumed with `--continue` on pi).
 
 A minimal Pi-backed flow looks the same; Pi reads your normal Pi configuration
 and is driven through RPC mode under the hood:

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ problems.
 
 You can use Orca to orchestrate development in any language and ecosystem.
 
-Orca assumes that it has configured, logged-in access to Claude, Codex
-(depending which provider you use), as well as `gh` and `git`.
+Orca assumes that it has configured, logged-in access to Claude, Codex, Pi
+(depending which backend you use), as well as `gh` and `git`.
 
 ## An example flow
 
@@ -99,6 +99,7 @@ The following are available inside a `flow(...) { ... }`:
 |---|---|---|
 | `claude` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `haiku`/`sonnet`/`opus`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withSelfManagedGit` | Claude Code coding/reviewing agent. Bare `claude` defaults to **Opus with the 1M-token context window** (the long-lived implementer session needs the big window, and reviewers run on it too); use `claude.sonnet` / `claude.haiku` for cheaper one-shot calls (the reviewer picker, lint, the PR summariser). Each `run` returns `(SessionId, output)`. Pre-allocate a session with `claude.newSession` and pass it on every call to keep one conversation alive; omit the arg for a one-shot fresh session. The `autonomous` vs `interactive` mode is always visible at the call site (interactive lives only on `resultAs[O]`). |
 | `codex` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `mini`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withSelfManagedGit` | OpenAI Codex coding/reviewing agent. |
+| `pi` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withSelfManagedGit` | [Pi](https://pi.dev/) coding agent backend, driven through `pi --mode rpc`. Pi handles provider/model selection through its own CLI configuration; pin a model with `pi.withConfig(LlmConfig(model = Some(Model("provider/model"))))`. Interactive calls can ask clarifying questions via Orca's `ask_user` bridge. |
 | `git` | `createBranch`, `checkout`, `checkoutOrCreate`, `ensureClean`, `commit`, `push`, `currentBranch`, `diff`, `log`, `addWorktree`, `removeWorktree`, `listWorktrees` | Git operations against the working tree. Recoverable failures (`BranchAlreadyExists`, `BranchNotFound`, `NothingToCommit`, `PushRejected`, `WorktreeAddFailed`, `WorktreeNotFound`) surface as `Either`; `.orThrow` converts a `Left` back to an exception when the case is unexpected. |
 | `gh` | `createPr`, `updatePr`, `readIssue`, `readIssueComments`, `readPrComments`, `writeComment(pr, body)` / `writeComment(issue, body)`, `buildStatus`, `waitForBuild` | GitHub PR + CI integration via the `gh` CLI. `createPr` returns `Either[PrCreateFailed, …]` (covers `PrAlreadyExists` / `NoCommitsToPr`); `updatePr` replaces a PR's title + body (refresh a tentative description once the fix lands); `waitForBuild` returns `Either[BuildWaitFailed, …]`. |
 | `fs` | `read`, `write`, `list` | Working-tree file I/O. `read` returns `Option[String]` so a missing file is a branch point, not an exception. |
@@ -128,7 +129,17 @@ for task <- tasks do
 
 The first call opens the session; subsequent calls resume it. The library
 tracks fresh-vs-resume internally per backend (`--session-id` then `--resume`
-on claude; a client→server mapping on codex).
+on claude; a client→server mapping on codex; caller-supplied `--session-id`
+on pi).
+
+A minimal Pi-backed flow looks the same; Pi reads your normal Pi configuration
+and is driven through RPC mode under the hood:
+
+```scala
+flow(OrcaArgs(args)):
+  val session = pi.newSession
+  val _ = pi.autonomous.run(userPrompt, session)
+```
 
 ## Flow methods
 

--- a/build.sbt
+++ b/build.sbt
@@ -85,6 +85,14 @@ lazy val codex = (project in file("codex"))
     libraryDependencies ++= Seq(osLib, jsoniter, jsoniterMacros)
   )
 
+lazy val pi = (project in file("pi"))
+  .dependsOn(tools, tools % "test->test")
+  .settings(commonSettings)
+  .settings(
+    name := "orca-pi",
+    libraryDependencies ++= Seq(osLib, jsoniter, jsoniterMacros)
+  )
+
 lazy val flow = (project in file("flow"))
   .dependsOn(tools)
   .settings(commonSettings)
@@ -94,7 +102,7 @@ lazy val flow = (project in file("flow"))
   )
 
 lazy val runner = (project in file("runner"))
-  .dependsOn(tools, flow, claude, codex)
+  .dependsOn(tools, flow, claude, codex, pi)
   .settings(commonSettings)
   .settings(
     // Published as just "orca" so flow-script coordinates stay short.
@@ -139,4 +147,4 @@ lazy val orcaRoot = (project in file("."))
     // invoke each of them (they'd noisily warn about missing `doc`/`docs`).
     updateDocs / aggregate := false
   )
-  .aggregate(tools, flow, claude, codex, runner)
+  .aggregate(tools, flow, claude, codex, pi, runner)

--- a/flow/src/main/scala/orca/FlowContext.scala
+++ b/flow/src/main/scala/orca/FlowContext.scala
@@ -4,7 +4,7 @@ import orca.events.OrcaEvent
 import orca.tools.FsTool
 import orca.tools.GitTool
 import orca.tools.GitHubTool
-import orca.llm.{ClaudeTool, CodexTool}
+import orca.llm.{ClaudeTool, CodexTool, PiTool}
 
 /** Ambient context a flow script operates in. Bundles every tool the top- level
   * accessors (`claude`, `codex`, `git`, `gh`, `fs`) resolve against, the user's
@@ -19,6 +19,7 @@ import orca.llm.{ClaudeTool, CodexTool}
 trait FlowContext:
   def claude: ClaudeTool
   def codex: CodexTool
+  def pi: PiTool
   def git: GitTool
   def gh: GitHubTool
   def fs: FsTool

--- a/flow/src/main/scala/orca/accessors.scala
+++ b/flow/src/main/scala/orca/accessors.scala
@@ -3,7 +3,7 @@ package orca
 import orca.tools.FsTool
 import orca.tools.GitTool
 import orca.tools.GitHubTool
-import orca.llm.{ClaudeTool, CodexTool}
+import orca.llm.{ClaudeTool, CodexTool, PiTool}
 
 // Top-level accessors that resolve against the ambient FlowContext.
 // Flow scripts can write `git.checkout("main")` or `claude.ask(...)`
@@ -11,6 +11,7 @@ import orca.llm.{ClaudeTool, CodexTool}
 
 def claude(using ctx: FlowContext): ClaudeTool = ctx.claude
 def codex(using ctx: FlowContext): CodexTool = ctx.codex
+def pi(using ctx: FlowContext): PiTool = ctx.pi
 def git(using ctx: FlowContext): GitTool = ctx.git
 def gh(using ctx: FlowContext): GitHubTool = ctx.gh
 def fs(using ctx: FlowContext): FsTool = ctx.fs

--- a/flow/src/main/scala/orca/plan/Plan.scala
+++ b/flow/src/main/scala/orca/plan/Plan.scala
@@ -148,8 +148,9 @@ object Plan:
     *
     * The `B: CanAskUser` constraint means these compile only with backends that
     * can host an `ask_user` tool — claude and codex (both via the shared
-    * `AskUserMcpServer`). A future stdin-only backend would fail this at
-    * compile time. Use [[autonomous]] when no mid-session questions are needed.
+    * `AskUserMcpServer`) and pi (via Orca's temporary ask-user extension). A
+    * future stdin-only backend would fail this at compile time. Use
+    * [[autonomous]] when no mid-session questions are needed.
     *
     * Each operation returns a [[Sessioned]] so the conversation can carry into
     * implementation (e.g. a triage agent's exploration informs the fix).

--- a/flow/src/test/scala/orca/TestFlowContext.scala
+++ b/flow/src/test/scala/orca/TestFlowContext.scala
@@ -1,7 +1,7 @@
 package orca
 
 import orca.events.{EventDispatcher, OrcaEvent}
-import orca.llm.{ClaudeTool, CodexTool}
+import orca.llm.{ClaudeTool, CodexTool, PiTool}
 import orca.tools.FsTool
 import orca.tools.GitTool
 import orca.tools.GitHubTool
@@ -20,6 +20,7 @@ class TestFlowContext(
 
   lazy val claude: ClaudeTool = stub("claude")
   lazy val codex: CodexTool = stub("codex")
+  lazy val pi: PiTool = stub("pi")
   lazy val git: GitTool = stub("git")
   lazy val gh: GitHubTool = stub("gh")
   lazy val fs: FsTool = stub("fs")

--- a/pi/src/main/scala/orca/tools/pi/DefaultPiTool.scala
+++ b/pi/src/main/scala/orca/tools/pi/DefaultPiTool.scala
@@ -1,0 +1,43 @@
+package orca.tools.pi
+
+import orca.backend.{Interaction, LlmBackend}
+import orca.events.OrcaListener
+import orca.llm.{BackendTag, LlmConfig, PiTool, Prompts}
+import orca.llm.BaseLlmTool
+
+/** Default [[PiTool]] implementation. Inherits the autonomous-text and
+  * structured-output plumbing from [[BaseLlmTool]]; Pi model selection is left
+  * to generic [[LlmConfig.model]] values because Pi supports many providers and
+  * fuzzy model patterns through its own CLI.
+  */
+private[orca] class DefaultPiTool(
+    backend: LlmBackend[BackendTag.Pi.type],
+    config: LlmConfig,
+    prompts: Prompts,
+    workDir: os.Path,
+    events: OrcaListener,
+    interaction: Interaction,
+    val name: String = "pi"
+) extends BaseLlmTool[BackendTag.Pi.type, PiTool](
+      backend,
+      config,
+      prompts,
+      workDir,
+      events,
+      interaction
+    )
+    with PiTool:
+
+  protected def copyTool(
+      config: LlmConfig = config,
+      name: String = name
+  ): PiTool =
+    new DefaultPiTool(
+      backend,
+      config,
+      prompts,
+      workDir,
+      events,
+      interaction,
+      name
+    )

--- a/pi/src/main/scala/orca/tools/pi/PiArgs.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiArgs.scala
@@ -1,29 +1,31 @@
 package orca.tools.pi
 
 import orca.backend.CliArgs
-import orca.llm.{BackendTag, LlmConfig, SessionId}
+import orca.llm.LlmConfig
 
 /** Maps Orca backend configuration to Pi CLI arguments. The backend drives Pi
   * through RPC mode and sends prompts over stdin, so the argv carries only
   * process/session/configuration flags.
+  *
+  * Session continuity uses Pi's on-disk sessions: `--session-dir` points at a
+  * directory Pi creates a fresh session in on the first turn; `resume` adds
+  * `--continue` so a later turn picks up the prior session in that dir. (Pi's
+  * `--session <id>` only *resumes* an existing id, so it can't seed a
+  * caller-chosen id for a new session.)
   */
 private[pi] object PiArgs:
 
   val ReadOnlyTools: Seq[String] = Seq("read", "grep", "find", "ls")
 
   def rpc(
-      session: SessionId[BackendTag.Pi.type],
+      sessionDir: os.Path,
+      resume: Boolean,
       config: LlmConfig,
       systemPromptFile: Option[os.Path],
       askUserExtension: Option[os.Path] = None
   ): Seq[String] =
-    Seq(
-      "pi",
-      "--mode",
-      "rpc",
-      "--session",
-      SessionId.value(session)
-    ) ++
+    Seq("pi", "--mode", "rpc", "--session-dir", sessionDir.toString) ++
+      Option.when(resume)("--continue").toSeq ++
       CliArgs.modelArgs(config) ++
       systemPromptArgs(systemPromptFile) ++
       toolsArgs(config, askUserExtension.isDefined) ++

--- a/pi/src/main/scala/orca/tools/pi/PiArgs.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiArgs.scala
@@ -21,7 +21,7 @@ private[pi] object PiArgs:
       "pi",
       "--mode",
       "rpc",
-      "--session-id",
+      "--session",
       SessionId.value(session)
     ) ++
       CliArgs.modelArgs(config) ++

--- a/pi/src/main/scala/orca/tools/pi/PiArgs.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiArgs.scala
@@ -1,0 +1,47 @@
+package orca.tools.pi
+
+import orca.backend.CliArgs
+import orca.llm.{BackendTag, LlmConfig, SessionId}
+
+/** Maps Orca backend configuration to Pi CLI arguments. The backend drives Pi
+  * through RPC mode and sends prompts over stdin, so the argv carries only
+  * process/session/configuration flags.
+  */
+private[pi] object PiArgs:
+
+  val ReadOnlyTools: Seq[String] = Seq("read", "grep", "find", "ls")
+
+  def rpc(
+      session: SessionId[BackendTag.Pi.type],
+      config: LlmConfig,
+      systemPromptFile: Option[os.Path],
+      askUserExtension: Option[os.Path] = None
+  ): Seq[String] =
+    Seq(
+      "pi",
+      "--mode",
+      "rpc",
+      "--session-id",
+      SessionId.value(session)
+    ) ++
+      CliArgs.modelArgs(config) ++
+      systemPromptArgs(systemPromptFile) ++
+      toolsArgs(config, askUserExtension.isDefined) ++
+      extensionArgs(askUserExtension)
+
+  private def systemPromptArgs(file: Option[os.Path]): Seq[String] =
+    file.toSeq.flatMap(f => Seq("--append-system-prompt", f.toString))
+
+  private def toolsArgs(
+      config: LlmConfig,
+      includeAskUser: Boolean
+  ): Seq[String] =
+    if !config.readOnly then Seq.empty
+    else
+      val tools =
+        if includeAskUser then ReadOnlyTools :+ PiAskUserExtension.ToolName
+        else ReadOnlyTools
+      Seq("--tools", tools.mkString(","))
+
+  private def extensionArgs(file: Option[os.Path]): Seq[String] =
+    file.toSeq.flatMap(f => Seq("--extension", f.toString))

--- a/pi/src/main/scala/orca/tools/pi/PiAskUserExtension.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiAskUserExtension.scala
@@ -1,0 +1,70 @@
+package orca.tools.pi
+
+import scala.util.control.NonFatal
+
+/** Temporary Pi extension that exposes Orca's backend-agnostic `ask_user`
+  * conversation event through Pi's native extension UI protocol.
+  *
+  * The extension intentionally has no imports so it can be written to a temp
+  * directory and loaded by Pi without relying on Node module resolution from
+  * that directory. The `parameters` value is plain JSON Schema / TypeBox shape,
+  * which Pi accepts for tool schemas.
+  */
+private[pi] final class PiAskUserExtension private (
+    val dir: os.Path,
+    val file: os.Path
+) extends AutoCloseable:
+  def close(): Unit =
+    try os.remove.all(dir)
+    catch case NonFatal(_) => ()
+
+private[pi] object PiAskUserExtension:
+
+  val ToolName: String = "ask_user"
+
+  val Hint: String =
+    "If you need a concise clarification from the human before continuing, " +
+      s"call the `$ToolName` tool with a clear question. Use it sparingly; " +
+      "do not ask if you can make a reasonable assumption."
+
+  def allocate(): PiAskUserExtension =
+    val dir = os.temp.dir(prefix = "orca-pi-ask-user-", deleteOnExit = false)
+    val file = dir / "ask-user.ts"
+    os.write(file, Source)
+    new PiAskUserExtension(dir, file)
+
+  private val Source: String =
+    s"""
+       |export default function(pi) {
+       |  pi.registerTool({
+       |    name: "$ToolName",
+       |    label: "Ask User",
+       |    description: "Ask the human user one concise clarifying question and wait for their answer.",
+       |    promptSnippet: "Ask the user a clarifying question when necessary",
+       |    promptGuidelines: [
+       |      "Use $ToolName only when a human answer is required to proceed.",
+       |      "Ask exactly one concise, actionable question.",
+       |      "Do not use $ToolName for information you can infer or inspect yourself."
+       |    ],
+       |    parameters: {
+       |      type: "object",
+       |      properties: {
+       |        question: {
+       |          type: "string",
+       |          description: "The concise question to ask the human user."
+       |        }
+       |      },
+       |      required: ["question"],
+       |      additionalProperties: false
+       |    },
+       |    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+       |      const answer = await ctx.ui.input(params.question);
+       |      const text = answer ?? "";
+       |      return {
+       |        content: [{ type: "text", text }],
+       |        details: { answer: text }
+       |      };
+       |    }
+       |  });
+       |}
+       |""".stripMargin

--- a/pi/src/main/scala/orca/tools/pi/PiAskUserExtension.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiAskUserExtension.scala
@@ -28,7 +28,7 @@ private[pi] object PiAskUserExtension:
       "do not ask if you can make a reasonable assumption."
 
   def allocate(): PiAskUserExtension =
-    val dir = os.temp.dir(prefix = "orca-pi-ask-user-", deleteOnExit = false)
+    val dir = os.temp.dir(prefix = "orca-pi-ask-user-", deleteOnExit = true)
     val file = dir / "ask-user.ts"
     os.write(file, Source)
     new PiAskUserExtension(dir, file)

--- a/pi/src/main/scala/orca/tools/pi/PiBackend.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiBackend.scala
@@ -6,9 +6,11 @@ import orca.{AgentTurnFailed, OrcaFlowException}
 import orca.backend.{
   Conversation,
   Conversations,
+  Dispatch,
   LlmBackend,
   LlmResult,
   SessionMode,
+  SessionRegistry,
   SystemPromptComposer
 }
 import orca.subprocess.CliRunner
@@ -34,12 +36,12 @@ private[orca] class PiBackend(cli: CliRunner)
     extends LlmBackend[BackendTag.Pi.type]:
 
   // Pi persists each session in a directory; one dir per Orca session id gives
-  // caller-stable continuity. `started` records which ids have had their first
-  // turn, so the next turn on the same id adds `--continue`.
+  // caller-stable continuity. The registry tracks fresh-vs-resume and is
+  // committed only *after* a successful turn, so a retried open-failure starts
+  // fresh rather than `--continue`-ing a dir Pi never created.
   private val sessionsBase: os.Path =
     os.temp.dir(prefix = "orca-pi-sessions-", deleteOnExit = true)
-  private val started: java.util.Set[String] =
-    java.util.concurrent.ConcurrentHashMap.newKeySet[String]()
+  private val sessions = new SessionRegistry.ClaimedOnce[BackendTag.Pi.type]
 
   def runAutonomous(
       prompt: String,
@@ -59,6 +61,7 @@ private[orca] class PiBackend(cli: CliRunner)
     )
     try
       val result = Conversations.drainAutonomous(conv, events)
+      sessions.commitSuccess(session, session) // now resumable
       result.copy(sessionId = session)
     catch
       case e: AgentTurnFailed => throw e
@@ -81,6 +84,14 @@ private[orca] class PiBackend(cli: CliRunner)
       workDir = workDir,
       outputSchema = outputSchema
     )
+
+  /** Marks an interactive session resumable once its turn has succeeded — the
+    * framework calls this after driving the returned conversation to completion.
+    */
+  override def registerSession(
+      client: SessionId[BackendTag.Pi.type],
+      serverSession: SessionId[BackendTag.Pi.type]
+  ): Unit = sessions.commitSuccess(client, serverSession)
 
   private def openConversation(
       prompt: String,
@@ -113,10 +124,11 @@ private[orca] class PiBackend(cli: CliRunner)
       val systemPromptFile = writeSystemPromptIfPresent(config, extraHint)
         .map(register)
 
-      val sessionId = SessionId.value(session)
-      val resume = !started.add(sessionId) // first turn creates, later resume
+      val resume = sessions.dispatchFor(session) match
+        case Dispatch.Resume(_) => true
+        case Dispatch.Fresh(_)  => false
       val args = PiArgs.rpc(
-        sessionDir = sessionsBase / sessionId,
+        sessionDir = sessionsBase / SessionId.value(session),
         resume = resume,
         config = config,
         systemPromptFile = systemPromptFile.map(_.file),

--- a/pi/src/main/scala/orca/tools/pi/PiBackend.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiBackend.scala
@@ -72,6 +72,11 @@ private[orca] class PiBackend(cli: CliRunner)
       workDir: os.Path,
       outputSchema: Option[String]
   ): PiConversation =
+    // Temp files (ask-user extension, system prompt) Pi reads for the whole
+    // turn. Ownership passes to the conversation once it's constructed — it
+    // closes them in `onFinalize` when the turn ends; `closeResources` here is
+    // the backstop for a failure before that point. All closes are idempotent
+    // (`closeQuietly` + `os.remove.all`), so the paths can't leak or double-fail.
     val resources = ListBuffer.empty[AutoCloseable]
     def register[A <: AutoCloseable](resource: A): A =
       resources += resource

--- a/pi/src/main/scala/orca/tools/pi/PiBackend.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiBackend.scala
@@ -16,9 +16,18 @@ import orca.subprocess.CliRunner
 import scala.collection.mutable.ListBuffer
 import scala.util.control.NonFatal
 
-/** Pi backend driven through `pi --mode rpc` JSONL over stdio. Each Orca call
-  * owns one Pi RPC subprocess; Pi's persisted `--session` threads context
-  * across calls using the caller-supplied Orca session id.
+/** Pi backend driven through `pi --mode rpc` JSONL over stdio.
+  *
+  * Pi exposes no HTTP server and its in-process SDK is Node-only, so a
+  * subprocess is the only way to embed it from the JVM; `--mode rpc` is the
+  * bidirectional channel (needed within a turn for `ask_user` extension-UI
+  * replies).
+  *
+  * Lifecycle is deliberately per-call: each Orca call spawns its own
+  * `pi --mode rpc` process, sends one `prompt`, reads to `agent_end`, then lets
+  * the process exit. Context carries across calls through Pi's persisted
+  * `--session <id>` (keyed on the caller-supplied Orca session id) rather than a
+  * long-lived process — simpler, and stateless between turns.
   */
 private[orca] class PiBackend(cli: CliRunner)
     extends LlmBackend[BackendTag.Pi.type]:

--- a/pi/src/main/scala/orca/tools/pi/PiBackend.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiBackend.scala
@@ -25,12 +25,21 @@ import scala.util.control.NonFatal
   *
   * Lifecycle is deliberately per-call: each Orca call spawns its own
   * `pi --mode rpc` process, sends one `prompt`, reads to `agent_end`, then lets
-  * the process exit. Context carries across calls through Pi's persisted
-  * `--session <id>` (keyed on the caller-supplied Orca session id) rather than a
-  * long-lived process — simpler, and stateless between turns.
+  * the process exit. Context carries across calls through a per-session
+  * `--session-dir` (one dir per Orca session id) that Pi creates on the first
+  * turn and `--continue` resumes on later turns — rather than a long-lived
+  * process.
   */
 private[orca] class PiBackend(cli: CliRunner)
     extends LlmBackend[BackendTag.Pi.type]:
+
+  // Pi persists each session in a directory; one dir per Orca session id gives
+  // caller-stable continuity. `started` records which ids have had their first
+  // turn, so the next turn on the same id adds `--continue`.
+  private val sessionsBase: os.Path =
+    os.temp.dir(prefix = "orca-pi-sessions-", deleteOnExit = true)
+  private val started: java.util.Set[String] =
+    java.util.concurrent.ConcurrentHashMap.newKeySet[String]()
 
   def runAutonomous(
       prompt: String,
@@ -104,8 +113,11 @@ private[orca] class PiBackend(cli: CliRunner)
       val systemPromptFile = writeSystemPromptIfPresent(config, extraHint)
         .map(register)
 
+      val sessionId = SessionId.value(session)
+      val resume = !started.add(sessionId) // first turn creates, later resume
       val args = PiArgs.rpc(
-        session = session,
+        sessionDir = sessionsBase / sessionId,
+        resume = resume,
         config = config,
         systemPromptFile = systemPromptFile.map(_.file),
         askUserExtension = askUserExtension.map(_.file)

--- a/pi/src/main/scala/orca/tools/pi/PiBackend.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiBackend.scala
@@ -104,8 +104,9 @@ private[orca] class PiBackend(cli: CliRunner)
     // Temp files (ask-user extension, system prompt) Pi reads for the whole
     // turn. Ownership passes to the conversation once it's constructed — it
     // closes them in `onFinalize` when the turn ends; `closeResources` here is
-    // the backstop for a failure before that point. All closes are idempotent
-    // (`closeQuietly` + `os.remove.all`), so the paths can't leak or double-fail.
+    // the backstop for a failure before that point. Closes are idempotent
+    // (`closeQuietly` + `os.remove.all`); the temp dirs are also `deleteOnExit`,
+    // so a hard JVM kill mid-turn still reclaims them.
     val resources = ListBuffer.empty[AutoCloseable]
     def register[A <: AutoCloseable](resource: A): A =
       resources += resource
@@ -166,7 +167,7 @@ private[orca] class PiBackend(cli: CliRunner)
       .combine(config, extraHint)
       .map: text =>
         val dir =
-          os.temp.dir(prefix = "orca-pi-system-prompt-", deleteOnExit = false)
+          os.temp.dir(prefix = "orca-pi-system-prompt-", deleteOnExit = true)
         val file = dir / "system-prompt.md"
         os.write(file, text)
         TempFileResource(dir, file)

--- a/pi/src/main/scala/orca/tools/pi/PiBackend.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiBackend.scala
@@ -17,7 +17,7 @@ import scala.collection.mutable.ListBuffer
 import scala.util.control.NonFatal
 
 /** Pi backend driven through `pi --mode rpc` JSONL over stdio. Each Orca call
-  * owns one Pi RPC subprocess; Pi's persisted `--session-id` threads context
+  * owns one Pi RPC subprocess; Pi's persisted `--session` threads context
   * across calls using the caller-supplied Orca session id.
   */
 private[orca] class PiBackend(cli: CliRunner)

--- a/pi/src/main/scala/orca/tools/pi/PiBackend.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiBackend.scala
@@ -175,7 +175,3 @@ private[orca] class PiBackend(cli: CliRunner)
   private case class TempFileResource(dir: os.Path, file: os.Path)
       extends AutoCloseable:
     def close(): Unit = os.remove.all(dir)
-
-  private def closeQuietly(resource: AutoCloseable): Unit =
-    try resource.close()
-    catch case NonFatal(_) => ()

--- a/pi/src/main/scala/orca/tools/pi/PiBackend.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiBackend.scala
@@ -1,0 +1,142 @@
+package orca.tools.pi
+
+import orca.events.OrcaListener
+import orca.llm.{BackendTag, LlmConfig, SessionId}
+import orca.{AgentTurnFailed, OrcaFlowException}
+import orca.backend.{
+  Conversation,
+  Conversations,
+  LlmBackend,
+  LlmResult,
+  SessionMode,
+  SystemPromptComposer
+}
+import orca.subprocess.CliRunner
+
+import scala.collection.mutable.ListBuffer
+import scala.util.control.NonFatal
+
+/** Pi backend driven through `pi --mode rpc` JSONL over stdio. Each Orca call
+  * owns one Pi RPC subprocess; Pi's persisted `--session-id` threads context
+  * across calls using the caller-supplied Orca session id.
+  */
+private[orca] class PiBackend(cli: CliRunner)
+    extends LlmBackend[BackendTag.Pi.type]:
+
+  def runAutonomous(
+      prompt: String,
+      session: SessionId[BackendTag.Pi.type],
+      config: LlmConfig,
+      workDir: os.Path,
+      events: OrcaListener = OrcaListener.noop,
+      outputSchema: Option[String] = None
+  ): LlmResult[BackendTag.Pi.type] =
+    val conv = openConversation(
+      prompt = prompt,
+      mode = SessionMode.Autonomous,
+      session = session,
+      config = config,
+      workDir = workDir,
+      outputSchema = outputSchema
+    )
+    try
+      val result = Conversations.drainAutonomous(conv, events)
+      result.copy(sessionId = session)
+    catch
+      case e: AgentTurnFailed => throw e
+      case e: OrcaFlowException =>
+        throw new OrcaFlowException(s"pi CLI failed: ${e.getMessage}")
+
+  def runInteractive(
+      prompt: String,
+      session: SessionId[BackendTag.Pi.type],
+      displayPrompt: String,
+      config: LlmConfig,
+      workDir: os.Path,
+      outputSchema: Option[String]
+  ): Conversation[BackendTag.Pi.type] =
+    openConversation(
+      prompt = prompt,
+      mode = SessionMode.Interactive(displayPrompt),
+      session = session,
+      config = config,
+      workDir = workDir,
+      outputSchema = outputSchema
+    )
+
+  private def openConversation(
+      prompt: String,
+      mode: SessionMode,
+      session: SessionId[BackendTag.Pi.type],
+      config: LlmConfig,
+      workDir: os.Path,
+      outputSchema: Option[String]
+  ): PiConversation =
+    val resources = ListBuffer.empty[AutoCloseable]
+    def register[A <: AutoCloseable](resource: A): A =
+      resources += resource
+      resource
+
+    def closeResources(): Unit = resources.reverseIterator.foreach(closeQuietly)
+
+    try
+      val (displayPrompt, askUserExtension, extraHint) = mode match
+        case SessionMode.Autonomous =>
+          ("", None, None)
+        case SessionMode.Interactive(p) =>
+          val extension = register(PiAskUserExtension.allocate())
+          (p, Some(extension), Some(PiAskUserExtension.Hint))
+
+      val systemPromptFile = writeSystemPromptIfPresent(config, extraHint)
+        .map(register)
+
+      val args = PiArgs.rpc(
+        session = session,
+        config = config,
+        systemPromptFile = systemPromptFile.map(_.file),
+        askUserExtension = askUserExtension.map(_.file)
+      )
+      val process = cli.spawnPiped(args, cwd = workDir, pipeStderr = true)
+      try
+        val conversation = new PiConversation(
+          process = process,
+          clientSession = session,
+          initialPrompt = displayPrompt,
+          outputSchema = outputSchema,
+          askUserEnabled = askUserExtension.isDefined,
+          resources = resources.toList
+        )
+        conversation.sendPrompt(prompt)
+        conversation
+      catch
+        case e: Exception =>
+          process.sendSigInt()
+          closeResources()
+          throw OrcaFlowException(
+            s"Failed to open pi RPC session: ${e.getMessage}"
+          )
+    catch
+      case NonFatal(e) =>
+        closeResources()
+        throw e
+
+  private def writeSystemPromptIfPresent(
+      config: LlmConfig,
+      extraHint: Option[String]
+  ): Option[TempFileResource] =
+    SystemPromptComposer
+      .combine(config, extraHint)
+      .map: text =>
+        val dir =
+          os.temp.dir(prefix = "orca-pi-system-prompt-", deleteOnExit = false)
+        val file = dir / "system-prompt.md"
+        os.write(file, text)
+        TempFileResource(dir, file)
+
+  private case class TempFileResource(dir: os.Path, file: os.Path)
+      extends AutoCloseable:
+    def close(): Unit = os.remove.all(dir)
+
+  private def closeQuietly(resource: AutoCloseable): Unit =
+    try resource.close()
+    catch case NonFatal(_) => ()

--- a/pi/src/main/scala/orca/tools/pi/PiConversation.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiConversation.scala
@@ -41,7 +41,6 @@ private[pi] class PiConversation(
     ):
 
   import PiConversation.*
-  import StreamConversation.Outcome
 
   /** Turn state, accrued by the single reader thread — `handleLine` and the
     * handlers it drives all run there, so a plain `var` over an immutable
@@ -142,11 +141,7 @@ private[pi] class PiConversation(
           )
         )
       eventQueue.enqueue(ConversationEvent.Error(message))
-      val _ = outcomeRef.compareAndSet(
-        None,
-        Some(Outcome.Failed(new OrcaFlowException(message)))
-      )
-      process.sendSigInt()
+      failWith(new OrcaFlowException(message))
 
   private def handleDelta(delta: MessageDelta): Unit = delta match
     case MessageDelta.Text(text) =>
@@ -184,9 +179,10 @@ private[pi] class PiConversation(
       usage = turnState.usage,
       model = turnState.model.map(Model.apply)
     )
-    val _ = outcomeRef.compareAndSet(None, Some(Outcome.Success(result)))
+    // Closing stdin tells Pi no more commands are coming; `succeedWith` sets the
+    // outcome then interrupts the source (SIGINTs the process).
     closeStdin()
-    process.sendSigInt()
+    succeedWith(result)
 
   private def handleExtensionUiRequest(
       id: String,

--- a/pi/src/main/scala/orca/tools/pi/PiConversation.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiConversation.scala
@@ -44,6 +44,13 @@ private[pi] class PiConversation(
   private val modelRef = new AtomicReference[Option[String]](None)
   private val stderrBuffer = new AtomicReference[Vector[String]](Vector.empty)
 
+  // All stdin writes funnel through this lock: `sendPrompt` runs on the caller's
+  // thread, the ask-user reply on the event consumer's, and the reader thread
+  // may write an extension cancel. `writeLine` is an unsynchronised write+flush,
+  // so concurrent callers would otherwise interleave JSONL frames. Declared
+  // before `start()` so the reader thread never observes a null lock.
+  private val stdinLock = new AnyRef
+
   /** Pi normally streams text deltas, but tests and future protocol variants
     * may only emit a completed message. Track whether this assistant message
     * already streamed text so message_end can act as a fallback without
@@ -54,7 +61,13 @@ private[pi] class PiConversation(
   start()
 
   def sendPrompt(prompt: String): Unit =
-    process.writeLine(OutboundMessage.prompt(prompt))
+    sendLine(OutboundMessage.prompt(prompt))
+
+  private def sendLine(line: String): Unit =
+    stdinLock.synchronized(process.writeLine(line))
+
+  private def closeStdin(): Unit =
+    stdinLock.synchronized(process.closeStdin())
 
   /** Pi RPC prompts are command messages rather than a writable chat stdin.
     * Orca's interactive Pi support currently routes human input through the
@@ -151,7 +164,7 @@ private[pi] class PiConversation(
       model = modelRef.get().map(Model.apply)
     )
     val _ = outcomeRef.compareAndSet(None, Some(Outcome.Success(result)))
-    process.closeStdin()
+    closeStdin()
     process.sendSigInt()
 
   private def handleExtensionUiRequest(
@@ -165,7 +178,7 @@ private[pi] class PiConversation(
           ConversationEvent.UserQuestion(
             question,
             answer =>
-              process.writeLine(OutboundMessage.extensionUiValue(id, answer))
+              sendLine(OutboundMessage.extensionUiValue(id, answer))
           )
         )
       case method if FireAndForgetUiMethods.contains(method) =>
@@ -178,7 +191,7 @@ private[pi] class PiConversation(
             s"Unsupported Pi extension UI request '$other': $question"
           )
         )
-        process.writeLine(OutboundMessage.extensionUiCancelled(id))
+        sendLine(OutboundMessage.extensionUiCancelled(id))
 
 private[pi] object PiConversation:
 

--- a/pi/src/main/scala/orca/tools/pi/PiConversation.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiConversation.scala
@@ -1,0 +1,274 @@
+package orca.tools.pi
+
+import orca.events.Usage
+import orca.llm.{BackendTag, Model, SessionId}
+import orca.{OrcaFlowException}
+import orca.backend.{ConversationEvent, LlmResult}
+import orca.backend.StreamConversation
+import orca.subprocess.PipedCliProcess
+import orca.tools.pi.rpc.{
+  AgentMessage,
+  InboundEvent,
+  MessageDelta,
+  OutboundMessage
+}
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.util.control.NonFatal
+
+/** Drives one `pi --mode rpc` process for a single Orca LLM call. The backend
+  * sends one `prompt` command, this conversation translates Pi RPC events into
+  * Orca conversation events, and `agent_end` becomes the terminal
+  * [[LlmResult]].
+  */
+private[pi] class PiConversation(
+    process: PipedCliProcess,
+    clientSession: SessionId[BackendTag.Pi.type],
+    initialPrompt: String = "",
+    val outputSchema: Option[String] = None,
+    askUserEnabled: Boolean = false,
+    resources: List[AutoCloseable] = Nil
+) extends StreamConversation[BackendTag.Pi.type](
+      process = process,
+      backendName = "pi",
+      initialPrompt = initialPrompt,
+      canAskUserFlag = askUserEnabled
+    ):
+
+  import PiConversation.*
+  import StreamConversation.Outcome
+
+  private val lastAssistantMessage = new AtomicReference[String]("")
+  private val usageRef = new AtomicReference[Usage](Usage.empty)
+  private val modelRef = new AtomicReference[Option[String]](None)
+  private val stderrBuffer = new AtomicReference[Vector[String]](Vector.empty)
+
+  /** Pi normally streams text deltas, but tests and future protocol variants
+    * may only emit a completed message. Track whether this assistant message
+    * already streamed text so message_end can act as a fallback without
+    * duplicating output.
+    */
+  private var textDeltasSinceMessageBoundary: Boolean = false
+
+  start()
+
+  def sendPrompt(prompt: String): Unit =
+    process.writeLine(OutboundMessage.prompt(prompt))
+
+  /** Pi RPC prompts are command messages rather than a writable chat stdin.
+    * Orca's interactive Pi support currently routes human input through the
+    * ask_user extension UI bridge, so unsolicited user turns are a no-op.
+    */
+  def sendUserMessage(text: String): Unit = ()
+
+  override protected def handleLine(line: String): Unit =
+    handle(InboundEvent.parse(line))
+
+  override protected def handleStderr(line: String): Unit =
+    val trimmed = stripTerminalControlSequences(line).trim
+    if trimmed.nonEmpty && !isKnownStderrNoise(trimmed) then
+      eventQueue.enqueue(ConversationEvent.Error(s"pi: $trimmed"))
+      val _ = stderrBuffer.updateAndGet(appendBounded(_, trimmed))
+
+  override protected def onFinalize(): Unit =
+    try stderrDrainThread.join(StderrDrainTimeoutMs)
+    catch case _: InterruptedException => Thread.currentThread().interrupt()
+    resources.foreach(closeQuietly)
+
+  override protected def cleanExitWithoutResult(): Throwable =
+    new OrcaFlowException(
+      appendContext("pi exited cleanly but never emitted agent_end")
+    )
+
+  override protected def diagnosticContext: Option[String] =
+    val lines = stderrBuffer.get()
+    if lines.isEmpty then None
+    else Some(lines.mkString("stderr:\n    ", "\n    ", ""))
+
+  private def handle(event: InboundEvent): Unit = event match
+    case InboundEvent.Response(_, command, success, error) =>
+      handleResponse(command, success, error)
+    case InboundEvent.MessageUpdate(delta) => handleDelta(delta)
+    case InboundEvent.MessageEnd(message)  => handleMessageEnd(message)
+    case InboundEvent.AgentEnd             => handleAgentEnd()
+    case InboundEvent.ToolExecutionStart(toolName, rawArgs) =>
+      eventQueue.enqueue(ConversationEvent.AssistantToolCall(toolName, rawArgs))
+    case InboundEvent.ToolExecutionEnd(toolName, ok, content) =>
+      eventQueue.enqueue(ConversationEvent.ToolResult(toolName, ok, content))
+    case InboundEvent.ExtensionUiRequest(id, method, question) =>
+      handleExtensionUiRequest(id, method, question)
+    case InboundEvent.Unknown(_) => ()
+
+  private def handleResponse(
+      command: Option[String],
+      success: Boolean,
+      error: Option[String]
+  ): Unit =
+    if !success then
+      val message = error
+        .filter(_.nonEmpty)
+        .getOrElse(
+          command.fold("pi RPC command failed")(c =>
+            s"pi RPC command '$c' failed"
+          )
+        )
+      eventQueue.enqueue(ConversationEvent.Error(message))
+      val _ = outcomeRef.compareAndSet(
+        None,
+        Some(Outcome.Failed(new OrcaFlowException(message)))
+      )
+      process.sendSigInt()
+
+  private def handleDelta(delta: MessageDelta): Unit = delta match
+    case MessageDelta.Text(text) =>
+      if text.nonEmpty then textDeltasSinceMessageBoundary = true
+      eventQueue.enqueue(ConversationEvent.AssistantTextDelta(text))
+    case MessageDelta.Thinking(text) =>
+      eventQueue.enqueue(ConversationEvent.AssistantThinkingDelta(text))
+    case MessageDelta.Other(_) => ()
+
+  private def handleMessageEnd(message: AgentMessage): Unit =
+    if message.role == "assistant" then
+      message.errorMessage.foreach: error =>
+        if error.nonEmpty then
+          eventQueue.enqueue(ConversationEvent.Error(error))
+      lastAssistantMessage.set(message.text)
+      message.usage.foreach: usage =>
+        val _ = usageRef.updateAndGet(_ + usage)
+      message.model.foreach: model =>
+        modelRef.set(Some(model))
+      if message.text.nonEmpty && !textDeltasSinceMessageBoundary then
+        eventQueue.enqueue(ConversationEvent.AssistantTextDelta(message.text))
+      eventQueue.enqueue(ConversationEvent.AssistantTurnEnd)
+      textDeltasSinceMessageBoundary = false
+
+  private def handleAgentEnd(): Unit =
+    val result = LlmResult(
+      sessionId = clientSession,
+      output = lastAssistantMessage.get(),
+      usage = usageRef.get(),
+      model = modelRef.get().map(Model.apply)
+    )
+    val _ = outcomeRef.compareAndSet(None, Some(Outcome.Success(result)))
+    process.closeStdin()
+    process.sendSigInt()
+
+  private def handleExtensionUiRequest(
+      id: String,
+      method: String,
+      question: String
+  ): Unit =
+    method match
+      case "input" | "editor" =>
+        eventQueue.enqueue(
+          ConversationEvent.UserQuestion(
+            question,
+            answer =>
+              process.writeLine(OutboundMessage.extensionUiValue(id, answer))
+          )
+        )
+      case method if FireAndForgetUiMethods.contains(method) =>
+        // Pi extensions use these for TUI decoration/status. In RPC mode they
+        // are explicitly fire-and-forget, so Orca can safely ignore them.
+        ()
+      case other =>
+        eventQueue.enqueue(
+          ConversationEvent.Error(
+            s"Unsupported Pi extension UI request '$other': $question"
+          )
+        )
+        process.writeLine(OutboundMessage.extensionUiCancelled(id))
+
+private[pi] object PiConversation:
+
+  private val Esc: Char = 0x1b.toChar
+  private val Bel: Char = 0x07.toChar
+  private val Csi: Char = 0x9b.toChar
+  private val Osc: Char = 0x9d.toChar
+  private val Dcs: Char = 0x90.toChar
+  private val Sos: Char = 0x98.toChar
+  private val Pm: Char = 0x9e.toChar
+  private val Apc: Char = 0x9f.toChar
+
+  private val StderrDrainTimeoutMs: Long = 500L
+
+  private val FireAndForgetUiMethods: Set[String] = Set(
+    "notify",
+    "setStatus",
+    "setWidget",
+    "setTitle",
+    "set_editor_text"
+  )
+
+  private val StderrMaxLines: Int = 20
+  private val StderrMaxBytes: Int = 4096
+
+  private def isKnownStderrNoise(line: String): Boolean =
+    // Pi's terminal notifier can write iTerm2-style notifications to stderr as
+    // OSC 777 (`ESC ] 777 ; ... BEL`). We strip well-formed controls before
+    // trimming, but keep this guard for environments that have already removed
+    // the leading ESC byte before the line reaches us.
+    line.startsWith("]777;notify;")
+
+  private def stripTerminalControlSequences(text: String): String =
+    val out = new StringBuilder(text.length)
+    var i = 0
+    while i < text.length do
+      text.charAt(i) match
+        case Esc                     => i = skipEsc(text, i)
+        case Csi                     => i = skipCsi(text, i + 1)
+        case Osc                     => i = skipStringControl(text, i + 1)
+        case Dcs | Sos | Pm | Apc    => i = skipStringControl(text, i + 1)
+        case c if isUnsafeControl(c) => i += 1
+        case c =>
+          val _ = out.append(c)
+          i += 1
+    out.toString
+
+  private def skipEsc(text: String, escIndex: Int): Int =
+    val nextIndex = escIndex + 1
+    if nextIndex >= text.length then text.length
+    else
+      text.charAt(nextIndex) match
+        case '['                   => skipCsi(text, nextIndex + 1)
+        case ']'                   => skipStringControl(text, nextIndex + 1)
+        case 'P' | 'X' | '^' | '_' => skipStringControl(text, nextIndex + 1)
+        case _                     => math.min(nextIndex + 1, text.length)
+
+  private def skipCsi(text: String, start: Int): Int =
+    var i = start
+    while i < text.length && !isCsiFinal(text.charAt(i)) do i += 1
+    if i < text.length then i + 1 else text.length
+
+  private def skipStringControl(text: String, start: Int): Int =
+    var i = start
+    var done = false
+    while i < text.length && !done do
+      text.charAt(i) match
+        case Bel =>
+          i += 1
+          done = true
+        case Esc if i + 1 < text.length && text.charAt(i + 1) == '\\' =>
+          i += 2
+          done = true
+        case _ => i += 1
+    i
+
+  private def isCsiFinal(c: Char): Boolean = c >= '@' && c <= '~'
+
+  private def isUnsafeControl(c: Char): Boolean =
+    (c < ' ' && c != '\n' && c != '\t') || (c >= 0x7f.toChar && c <= Apc)
+
+  private def appendBounded(
+      buf: Vector[String],
+      line: String
+  ): Vector[String] =
+    var result = buf :+ line
+    while result.size > StderrMaxLines do result = result.tail
+    while result.size > 1 && result.map(_.length).sum > StderrMaxBytes do
+      result = result.tail
+    result
+
+  private def closeQuietly(resource: AutoCloseable): Unit =
+    try resource.close()
+    catch case NonFatal(_) => ()

--- a/pi/src/main/scala/orca/tools/pi/PiConversation.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiConversation.scala
@@ -21,6 +21,10 @@ import scala.util.control.NonFatal
   * sends one `prompt` command, this conversation translates Pi RPC events into
   * Orca conversation events, and `agent_end` becomes the terminal
   * [[LlmResult]].
+  *
+  * Pi has no native structured-output / JSON-schema flag, so `outputSchema` is
+  * carried only for the framework's parsing: the schema is enforced through the
+  * prompt (`DefaultLlmCall` injects the rules), not the Pi CLI.
   */
 private[pi] class PiConversation(
     process: PipedCliProcess,
@@ -39,9 +43,27 @@ private[pi] class PiConversation(
   import PiConversation.*
   import StreamConversation.Outcome
 
-  private val lastAssistantMessage = new AtomicReference[String]("")
-  private val usageRef = new AtomicReference[Usage](Usage.empty)
-  private val modelRef = new AtomicReference[Option[String]](None)
+  /** Turn state, accrued by the single reader thread — `handleLine` and the
+    * handlers it drives all run there, so a plain `var` over an immutable
+    * snapshot is safe and avoids cross-thread machinery; `awaitResult` reads the
+    * outcome only after joining the reader, which publishes these writes.
+    *
+    * `textStreamedThisMessage` lets `message_end` emit the completed text as a
+    * fallback only when no `text_delta` already streamed it; `sawAssistantMessage`
+    * gates the single `AssistantTurnEnd` at `agent_end`.
+    */
+  private case class TurnState(
+      lastAssistantMessage: String = "",
+      usage: Usage = Usage.empty,
+      model: Option[String] = None,
+      textStreamedThisMessage: Boolean = false,
+      sawAssistantMessage: Boolean = false
+  )
+  private var turnState: TurnState = TurnState()
+
+  /** Atomic, unlike [[turnState]]: written by the *stderr* drain thread
+    * ([[handleStderr]]) and read by the reader thread at finalize.
+    */
   private val stderrBuffer = new AtomicReference[Vector[String]](Vector.empty)
 
   // All stdin writes funnel through this lock: `sendPrompt` runs on the caller's
@@ -50,18 +72,6 @@ private[pi] class PiConversation(
   // so concurrent callers would otherwise interleave JSONL frames. Declared
   // before `start()` so the reader thread never observes a null lock.
   private val stdinLock = new AnyRef
-
-  /** Pi normally streams text deltas, but tests and future protocol variants
-    * may only emit a completed message. Track whether this assistant message
-    * already streamed text so message_end can act as a fallback without
-    * duplicating output.
-    */
-  private var textDeltasSinceMessageBoundary: Boolean = false
-
-  /** Whether any assistant `message_end` arrived this turn — gates the single
-    * `AssistantTurnEnd` at `agent_end` (a tool-only/empty turn emits none).
-    */
-  private var sawAssistantMessage: Boolean = false
 
   start()
 
@@ -140,7 +150,8 @@ private[pi] class PiConversation(
 
   private def handleDelta(delta: MessageDelta): Unit = delta match
     case MessageDelta.Text(text) =>
-      if text.nonEmpty then textDeltasSinceMessageBoundary = true
+      if text.nonEmpty then
+        turnState = turnState.copy(textStreamedThisMessage = true)
       eventQueue.enqueue(ConversationEvent.AssistantTextDelta(text))
     case MessageDelta.Thinking(text) =>
       eventQueue.enqueue(ConversationEvent.AssistantThinkingDelta(text))
@@ -148,29 +159,30 @@ private[pi] class PiConversation(
 
   private def handleMessageEnd(message: AgentMessage): Unit =
     if message.role == "assistant" then
-      sawAssistantMessage = true
       message.errorMessage.foreach: error =>
         if error.nonEmpty then
           eventQueue.enqueue(ConversationEvent.Error(error))
-      lastAssistantMessage.set(message.text)
-      message.usage.foreach: usage =>
-        val _ = usageRef.updateAndGet(_ + usage)
-      message.model.foreach: model =>
-        modelRef.set(Some(model))
-      if message.text.nonEmpty && !textDeltasSinceMessageBoundary then
+      val streamed = turnState.textStreamedThisMessage
+      turnState = turnState.copy(
+        lastAssistantMessage = message.text,
+        usage = message.usage.fold(turnState.usage)(turnState.usage + _),
+        model = message.model.orElse(turnState.model),
+        sawAssistantMessage = true,
+        textStreamedThisMessage = false // reset for the next message
+      )
+      if message.text.nonEmpty && !streamed then
         eventQueue.enqueue(ConversationEvent.AssistantTextDelta(message.text))
-      textDeltasSinceMessageBoundary = false
 
   // A turn can span several assistant messages (each ends with `message_end`),
   // so the single turn boundary is `agent_end`, not per-message.
   private def handleAgentEnd(): Unit =
-    if sawAssistantMessage then
+    if turnState.sawAssistantMessage then
       eventQueue.enqueue(ConversationEvent.AssistantTurnEnd)
     val result = LlmResult(
       sessionId = clientSession,
-      output = lastAssistantMessage.get(),
-      usage = usageRef.get(),
-      model = modelRef.get().map(Model.apply)
+      output = turnState.lastAssistantMessage,
+      usage = turnState.usage,
+      model = turnState.model.map(Model.apply)
     )
     val _ = outcomeRef.compareAndSet(None, Some(Outcome.Success(result)))
     closeStdin()

--- a/pi/src/main/scala/orca/tools/pi/PiConversation.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiConversation.scala
@@ -6,6 +6,7 @@ import orca.{OrcaFlowException}
 import orca.backend.{ConversationEvent, LlmResult}
 import orca.backend.{StreamConversation, StreamSource}
 import orca.subprocess.PipedCliProcess
+import orca.util.TerminalControl
 import orca.tools.pi.rpc.{
   AgentMessage,
   InboundEvent,
@@ -65,7 +66,7 @@ private[pi] class PiConversation(
     handle(InboundEvent.parse(line))
 
   override protected def handleStderr(line: String): Unit =
-    val trimmed = stripTerminalControlSequences(line).trim
+    val trimmed = TerminalControl.stripControlSequences(line).trim
     if trimmed.nonEmpty && !isKnownStderrNoise(trimmed) then
       eventQueue.enqueue(ConversationEvent.Error(s"pi: $trimmed"))
       val _ = stderrBuffer.updateAndGet(appendBounded(_, trimmed))
@@ -181,15 +182,6 @@ private[pi] class PiConversation(
 
 private[pi] object PiConversation:
 
-  private val Esc: Char = 0x1b.toChar
-  private val Bel: Char = 0x07.toChar
-  private val Csi: Char = 0x9b.toChar
-  private val Osc: Char = 0x9d.toChar
-  private val Dcs: Char = 0x90.toChar
-  private val Sos: Char = 0x98.toChar
-  private val Pm: Char = 0x9e.toChar
-  private val Apc: Char = 0x9f.toChar
-
   private val StderrDrainTimeoutMs: Long = 500L
 
   private val FireAndForgetUiMethods: Set[String] = Set(
@@ -209,55 +201,6 @@ private[pi] object PiConversation:
     // trimming, but keep this guard for environments that have already removed
     // the leading ESC byte before the line reaches us.
     line.startsWith("]777;notify;")
-
-  private def stripTerminalControlSequences(text: String): String =
-    val out = new StringBuilder(text.length)
-    var i = 0
-    while i < text.length do
-      text.charAt(i) match
-        case Esc                     => i = skipEsc(text, i)
-        case Csi                     => i = skipCsi(text, i + 1)
-        case Osc                     => i = skipStringControl(text, i + 1)
-        case Dcs | Sos | Pm | Apc    => i = skipStringControl(text, i + 1)
-        case c if isUnsafeControl(c) => i += 1
-        case c =>
-          val _ = out.append(c)
-          i += 1
-    out.toString
-
-  private def skipEsc(text: String, escIndex: Int): Int =
-    val nextIndex = escIndex + 1
-    if nextIndex >= text.length then text.length
-    else
-      text.charAt(nextIndex) match
-        case '['                   => skipCsi(text, nextIndex + 1)
-        case ']'                   => skipStringControl(text, nextIndex + 1)
-        case 'P' | 'X' | '^' | '_' => skipStringControl(text, nextIndex + 1)
-        case _                     => math.min(nextIndex + 1, text.length)
-
-  private def skipCsi(text: String, start: Int): Int =
-    var i = start
-    while i < text.length && !isCsiFinal(text.charAt(i)) do i += 1
-    if i < text.length then i + 1 else text.length
-
-  private def skipStringControl(text: String, start: Int): Int =
-    var i = start
-    var done = false
-    while i < text.length && !done do
-      text.charAt(i) match
-        case Bel =>
-          i += 1
-          done = true
-        case Esc if i + 1 < text.length && text.charAt(i + 1) == '\\' =>
-          i += 2
-          done = true
-        case _ => i += 1
-    i
-
-  private def isCsiFinal(c: Char): Boolean = c >= '@' && c <= '~'
-
-  private def isUnsafeControl(c: Char): Boolean =
-    (c < ' ' && c != '\n' && c != '\t') || (c >= 0x7f.toChar && c <= Apc)
 
   private def appendBounded(
       buf: Vector[String],

--- a/pi/src/main/scala/orca/tools/pi/PiConversation.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiConversation.scala
@@ -58,6 +58,11 @@ private[pi] class PiConversation(
     */
   private var textDeltasSinceMessageBoundary: Boolean = false
 
+  /** Whether any assistant `message_end` arrived this turn — gates the single
+    * `AssistantTurnEnd` at `agent_end` (a tool-only/empty turn emits none).
+    */
+  private var sawAssistantMessage: Boolean = false
+
   start()
 
   def sendPrompt(prompt: String): Unit =
@@ -143,6 +148,7 @@ private[pi] class PiConversation(
 
   private def handleMessageEnd(message: AgentMessage): Unit =
     if message.role == "assistant" then
+      sawAssistantMessage = true
       message.errorMessage.foreach: error =>
         if error.nonEmpty then
           eventQueue.enqueue(ConversationEvent.Error(error))
@@ -153,10 +159,13 @@ private[pi] class PiConversation(
         modelRef.set(Some(model))
       if message.text.nonEmpty && !textDeltasSinceMessageBoundary then
         eventQueue.enqueue(ConversationEvent.AssistantTextDelta(message.text))
-      eventQueue.enqueue(ConversationEvent.AssistantTurnEnd)
       textDeltasSinceMessageBoundary = false
 
+  // A turn can span several assistant messages (each ends with `message_end`),
+  // so the single turn boundary is `agent_end`, not per-message.
   private def handleAgentEnd(): Unit =
+    if sawAssistantMessage then
+      eventQueue.enqueue(ConversationEvent.AssistantTurnEnd)
     val result = LlmResult(
       sessionId = clientSession,
       output = lastAssistantMessage.get(),

--- a/pi/src/main/scala/orca/tools/pi/PiConversation.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiConversation.scala
@@ -195,7 +195,11 @@ private[pi] class PiConversation(
           ConversationEvent.UserQuestion(
             question,
             answer =>
-              sendLine(OutboundMessage.extensionUiValue(id, answer))
+              // The turn may have already reached agent_end (stdin closed) by
+              // the time a human answers; a late reply is moot, so don't let the
+              // write blow up the consumer thread.
+              try sendLine(OutboundMessage.extensionUiValue(id, answer))
+              catch case NonFatal(_) => ()
           )
         )
       case method if FireAndForgetUiMethods.contains(method) =>
@@ -241,7 +245,3 @@ private[pi] object PiConversation:
     while result.size > 1 && result.map(_.length).sum > StderrMaxBytes do
       result = result.tail
     result
-
-  private def closeQuietly(resource: AutoCloseable): Unit =
-    try resource.close()
-    catch case NonFatal(_) => ()

--- a/pi/src/main/scala/orca/tools/pi/rpc/InboundEvent.scala
+++ b/pi/src/main/scala/orca/tools/pi/rpc/InboundEvent.scala
@@ -84,8 +84,8 @@ private[pi] object InboundEvent:
   private def parseAgentMessage(raw: RawJson): AgentMessage =
     val wire = readFromString[AgentMessageWire](raw.value)
     AgentMessage(
-      role = wire.role,
-      text = renderContent(wire.content),
+      role = wire.role.getOrElse(""),
+      text = wire.content.map(renderContent).getOrElse(""),
       usage = wire.usage.map(_.toUsage),
       model = wire.model,
       errorMessage = wire.errorMessage
@@ -108,12 +108,15 @@ private[pi] object InboundEvent:
 
   private def parseExtensionUiRequest(line: String): InboundEvent =
     val wire = readFromString[ExtensionUiRequestWire](line)
+    // A missing/unknown method falls through to the driver's `other` branch,
+    // which replies with a cancel so Pi never blocks waiting on us.
+    val method = wire.method.getOrElse("")
     val question = wire.title
       .orElse(wire.message.flatMap(renderJsonString))
       .orElse(wire.placeholder)
       .orElse(wire.prefill)
-      .getOrElse(wire.method)
-    ExtensionUiRequest(wire.id, wire.method, question)
+      .getOrElse(method)
+    ExtensionUiRequest(wire.id, method, question)
 
   private def renderContent(raw: RawJson): String =
     val trimmed = raw.value.trim
@@ -169,8 +172,8 @@ private[pi] object InboundEvent:
       derives ConfiguredJsonValueCodec
 
   private case class AgentMessageWire(
-      role: String,
-      content: RawJson,
+      role: Option[String] = None,
+      content: Option[RawJson] = None,
       usage: Option[UsageWire] = None,
       model: Option[String] = None,
       errorMessage: Option[String] = None
@@ -220,7 +223,7 @@ private[pi] object InboundEvent:
 
   private case class ExtensionUiRequestWire(
       id: String,
-      method: String,
+      method: Option[String] = None,
       title: Option[String] = None,
       message: Option[RawJson] = None,
       placeholder: Option[String] = None,

--- a/pi/src/main/scala/orca/tools/pi/rpc/InboundEvent.scala
+++ b/pi/src/main/scala/orca/tools/pi/rpc/InboundEvent.scala
@@ -1,0 +1,228 @@
+package orca.tools.pi.rpc
+
+import orca.events.Usage
+import orca.util.RawJson
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{
+  JsonValueCodec,
+  readFromString
+}
+import com.github.plokhotnyuk.jsoniter_scala.macros.{
+  ConfiguredJsonValueCodec,
+  JsonCodecMaker
+}
+
+import scala.util.control.NonFatal
+
+/** One JSONL message read from `pi --mode rpc` stdout. The driver models only
+  * fields needed by Orca and collapses protocol additions to [[Unknown]].
+  */
+private[pi] enum InboundEvent:
+  case Response(
+      id: Option[String],
+      command: Option[String],
+      success: Boolean,
+      error: Option[String]
+  )
+  case MessageUpdate(delta: MessageDelta)
+  case MessageEnd(message: AgentMessage)
+  case AgentEnd
+  case ToolExecutionStart(toolName: String, rawArgs: String)
+  case ToolExecutionEnd(toolName: String, ok: Boolean, content: String)
+  case ExtensionUiRequest(id: String, method: String, question: String)
+  case Unknown(rawType: String)
+
+private[pi] enum MessageDelta:
+  case Text(text: String)
+  case Thinking(text: String)
+  case Other(deltaType: String)
+
+private[pi] case class AgentMessage(
+    role: String,
+    text: String,
+    usage: Option[Usage],
+    model: Option[String],
+    errorMessage: Option[String]
+)
+
+private[pi] object InboundEvent:
+
+  def parse(line: String): InboundEvent =
+    val envelope = readFromString[TopEnvelope](line)
+    envelope.`type` match
+      case "response"             => parseResponse(line)
+      case "message_update"       => parseMessageUpdate(line)
+      case "message_end"          => parseMessageEnd(line)
+      case "agent_end"            => AgentEnd
+      case "tool_execution_start" => parseToolExecutionStart(line)
+      case "tool_execution_end"   => parseToolExecutionEnd(line)
+      case "extension_ui_request" => parseExtensionUiRequest(line)
+      case other                  => Unknown(other)
+
+  private def parseResponse(line: String): InboundEvent =
+    val wire = readFromString[ResponseWire](line)
+    Response(wire.id, wire.command, wire.success.getOrElse(false), wire.error)
+
+  private def parseMessageUpdate(line: String): InboundEvent =
+    val wire = readFromString[MessageUpdateWire](line)
+    wire.assistantMessageEvent match
+      case Some(raw) => MessageUpdate(parseDelta(raw))
+      case None      => Unknown("message_update")
+
+  private def parseDelta(raw: RawJson): MessageDelta =
+    val wire = readFromString[DeltaWire](raw.value)
+    wire.`type` match
+      case "text_delta" => MessageDelta.Text(wire.delta.getOrElse(""))
+      case "thinking_delta" =>
+        MessageDelta.Thinking(wire.delta.getOrElse(""))
+      case other => MessageDelta.Other(other)
+
+  private def parseMessageEnd(line: String): InboundEvent =
+    val wire = readFromString[MessageEndWire](line)
+    MessageEnd(parseAgentMessage(wire.message))
+
+  private def parseAgentMessage(raw: RawJson): AgentMessage =
+    val wire = readFromString[AgentMessageWire](raw.value)
+    AgentMessage(
+      role = wire.role,
+      text = renderContent(wire.content),
+      usage = wire.usage.map(_.toUsage),
+      model = wire.model,
+      errorMessage = wire.errorMessage
+    )
+
+  private def parseToolExecutionStart(line: String): InboundEvent =
+    val wire = readFromString[ToolExecutionStartWire](line)
+    ToolExecutionStart(
+      wire.toolName.getOrElse(""),
+      wire.args.map(_.value).getOrElse("{}")
+    )
+
+  private def parseToolExecutionEnd(line: String): InboundEvent =
+    val wire = readFromString[ToolExecutionEndWire](line)
+    ToolExecutionEnd(
+      toolName = wire.toolName.getOrElse(""),
+      ok = !wire.isError.getOrElse(false),
+      content = wire.result.map(renderToolResult).getOrElse("")
+    )
+
+  private def parseExtensionUiRequest(line: String): InboundEvent =
+    val wire = readFromString[ExtensionUiRequestWire](line)
+    val question = wire.title
+      .orElse(wire.message.flatMap(renderJsonString))
+      .orElse(wire.placeholder)
+      .orElse(wire.prefill)
+      .getOrElse(wire.method)
+    ExtensionUiRequest(wire.id, wire.method, question)
+
+  private def renderContent(raw: RawJson): String =
+    val trimmed = raw.value.trim
+    if trimmed.isEmpty || trimmed == "null" then ""
+    else if trimmed.startsWith("\"") then
+      try readFromString[String](trimmed)
+      catch case NonFatal(_) => trimmed
+    else if trimmed.startsWith("[") then
+      try
+        readFromString[List[ContentBlockWire]](trimmed)
+          .flatMap(c => c.text.filter(_ => c.`type` == "text"))
+          .mkString
+      catch case NonFatal(_) => trimmed
+    else trimmed
+
+  private def renderToolResult(raw: RawJson): String =
+    val trimmed = raw.value.trim
+    if trimmed.isEmpty || trimmed == "null" then ""
+    else
+      try
+        readFromString[ToolResultWire](trimmed).content
+          .flatMap(c => c.text.filter(_ => c.`type` == "text"))
+          .mkString
+      catch case NonFatal(_) => trimmed
+
+  private def renderJsonString(raw: RawJson): Option[String] =
+    val trimmed = raw.value.trim
+    if trimmed.isEmpty || trimmed == "null" then None
+    else
+      try Some(readFromString[String](trimmed))
+      catch case NonFatal(_) => Some(trimmed)
+
+  private case class TopEnvelope(`type`: String)
+      derives ConfiguredJsonValueCodec
+
+  private case class ResponseWire(
+      id: Option[String] = None,
+      command: Option[String] = None,
+      success: Option[Boolean] = None,
+      error: Option[String] = None
+  ) derives ConfiguredJsonValueCodec
+
+  private case class MessageUpdateWire(
+      assistantMessageEvent: Option[RawJson] = None
+  ) derives ConfiguredJsonValueCodec
+
+  private case class DeltaWire(
+      `type`: String,
+      delta: Option[String] = None
+  ) derives ConfiguredJsonValueCodec
+
+  private case class MessageEndWire(message: RawJson)
+      derives ConfiguredJsonValueCodec
+
+  private case class AgentMessageWire(
+      role: String,
+      content: RawJson,
+      usage: Option[UsageWire] = None,
+      model: Option[String] = None,
+      errorMessage: Option[String] = None
+  ) derives ConfiguredJsonValueCodec
+
+  private case class UsageWire(
+      input: Option[Long] = None,
+      output: Option[Long] = None,
+      cacheRead: Option[Long] = None,
+      cacheWrite: Option[Long] = None,
+      cost: Option[CostWire] = None
+  ) derives ConfiguredJsonValueCodec:
+    def toUsage: Usage =
+      Usage(
+        inputTokens = input.getOrElse(0L),
+        outputTokens = output.getOrElse(0L),
+        cost = cost.flatMap(_.total),
+        cachedInputTokens = cacheRead.getOrElse(0L) + cacheWrite.getOrElse(0L)
+      )
+
+  private case class CostWire(total: Option[BigDecimal] = None)
+      derives ConfiguredJsonValueCodec
+
+  private case class ToolExecutionStartWire(
+      toolName: Option[String] = None,
+      args: Option[RawJson] = None
+  ) derives ConfiguredJsonValueCodec
+
+  private case class ToolExecutionEndWire(
+      toolName: Option[String] = None,
+      result: Option[RawJson] = None,
+      isError: Option[Boolean] = None
+  ) derives ConfiguredJsonValueCodec
+
+  private case class ToolResultWire(
+      content: List[ContentBlockWire] = Nil
+  ) derives ConfiguredJsonValueCodec
+
+  private case class ContentBlockWire(
+      `type`: String,
+      text: Option[String] = None
+  ) derives ConfiguredJsonValueCodec
+
+  private given JsonValueCodec[String] = JsonCodecMaker.make[String]
+  private given JsonValueCodec[List[ContentBlockWire]] =
+    JsonCodecMaker.make[List[ContentBlockWire]]
+
+  private case class ExtensionUiRequestWire(
+      id: String,
+      method: String,
+      title: Option[String] = None,
+      message: Option[RawJson] = None,
+      placeholder: Option[String] = None,
+      prefill: Option[String] = None
+  ) derives ConfiguredJsonValueCodec

--- a/pi/src/main/scala/orca/tools/pi/rpc/InboundEvent.scala
+++ b/pi/src/main/scala/orca/tools/pi/rpc/InboundEvent.scala
@@ -118,6 +118,10 @@ private[pi] object InboundEvent:
       .getOrElse(method)
     ExtensionUiRequest(wire.id, method, question)
 
+  /** Pi's `message.content` is polymorphic: either a JSON string, or an array of
+    * content blocks (of which we keep the `text` ones). Decode by shape; fall
+    * back to the raw trimmed value if it's neither, or fails to parse.
+    */
   private def renderContent(raw: RawJson): String =
     val trimmed = raw.value.trim
     if trimmed.isEmpty || trimmed == "null" then ""
@@ -125,10 +129,7 @@ private[pi] object InboundEvent:
       try readFromString[String](trimmed)
       catch case NonFatal(_) => trimmed
     else if trimmed.startsWith("[") then
-      try
-        readFromString[List[ContentBlockWire]](trimmed)
-          .flatMap(c => c.text.filter(_ => c.`type` == "text"))
-          .mkString
+      try renderTextBlocks(readFromString[List[ContentBlockWire]](trimmed))
       catch case NonFatal(_) => trimmed
     else trimmed
 
@@ -136,11 +137,14 @@ private[pi] object InboundEvent:
     val trimmed = raw.value.trim
     if trimmed.isEmpty || trimmed == "null" then ""
     else
-      try
-        readFromString[ToolResultWire](trimmed).content
-          .flatMap(c => c.text.filter(_ => c.`type` == "text"))
-          .mkString
+      try renderTextBlocks(readFromString[ToolResultWire](trimmed).content)
       catch case NonFatal(_) => trimmed
+
+  /** Concatenate the `"type":"text"` blocks; other kinds (tool, image, …) are
+    * dropped.
+    */
+  private def renderTextBlocks(blocks: List[ContentBlockWire]): String =
+    blocks.flatMap(b => Option.when(b.`type` == "text")(b.text).flatten).mkString
 
   private def renderJsonString(raw: RawJson): Option[String] =
     val trimmed = raw.value.trim

--- a/pi/src/main/scala/orca/tools/pi/rpc/OutboundMessage.scala
+++ b/pi/src/main/scala/orca/tools/pi/rpc/OutboundMessage.scala
@@ -1,0 +1,35 @@
+package orca.tools.pi.rpc
+
+import com.github.plokhotnyuk.jsoniter_scala.core.writeToString
+import com.github.plokhotnyuk.jsoniter_scala.macros.ConfiguredJsonValueCodec
+
+/** JSONL commands written to Pi RPC stdin. */
+private[pi] object OutboundMessage:
+
+  val PromptId: String = "orca-prompt"
+
+  def prompt(text: String): String =
+    writeToString(PromptCommand(PromptId, "prompt", text))
+
+  def extensionUiValue(id: String, value: String): String =
+    writeToString(ExtensionUiValueResponse("extension_ui_response", id, value))
+
+  def extensionUiCancelled(id: String): String =
+    writeToString(
+      ExtensionUiCancelledResponse("extension_ui_response", id, true)
+    )
+
+  private case class PromptCommand(id: String, `type`: String, message: String)
+      derives ConfiguredJsonValueCodec
+
+  private case class ExtensionUiValueResponse(
+      `type`: String,
+      id: String,
+      value: String
+  ) derives ConfiguredJsonValueCodec
+
+  private case class ExtensionUiCancelledResponse(
+      `type`: String,
+      id: String,
+      cancelled: Boolean
+  ) derives ConfiguredJsonValueCodec

--- a/pi/src/main/scala/orca/tools/pi/util.scala
+++ b/pi/src/main/scala/orca/tools/pi/util.scala
@@ -1,0 +1,11 @@
+package orca.tools.pi
+
+import scala.util.control.NonFatal
+
+/** Best-effort close: swallow a teardown failure so it can't mask the turn's
+  * real outcome. Shared by the backend (temp files) and the conversation
+  * (process resources).
+  */
+private[pi] def closeQuietly(resource: AutoCloseable): Unit =
+  try resource.close()
+  catch case NonFatal(_) => ()

--- a/pi/src/test/scala/orca/tools/pi/PiArgsTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiArgsTest.scala
@@ -11,7 +11,7 @@ class PiArgsTest extends munit.FunSuite:
     val args = PiArgs.rpc(sid, LlmConfig.default, None)
     assertEquals(
       args.take(5),
-      Seq("pi", "--mode", "rpc", "--session-id", "sid")
+      Seq("pi", "--mode", "rpc", "--session", "sid")
     )
 
   test("model and system prompt file are rendered"):

--- a/pi/src/test/scala/orca/tools/pi/PiArgsTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiArgsTest.scala
@@ -1,22 +1,28 @@
 package orca.tools.pi
 
-import orca.llm.{BackendTag, LlmConfig, Model, SessionId}
+import orca.llm.{LlmConfig, Model}
 
 class PiArgsTest extends munit.FunSuite:
 
-  private val sid: SessionId[BackendTag.Pi.type] =
-    SessionId[BackendTag.Pi.type]("sid")
+  private val dir: os.Path = os.Path("/tmp/orca-pi-session")
 
-  test("rpc args include mode and session id"):
-    val args = PiArgs.rpc(sid, LlmConfig.default, None)
+  test("a fresh turn opens the session dir without --continue"):
+    val args = PiArgs.rpc(dir, resume = false, LlmConfig.default, None)
     assertEquals(
       args.take(5),
-      Seq("pi", "--mode", "rpc", "--session", "sid")
+      Seq("pi", "--mode", "rpc", "--session-dir", dir.toString)
     )
+    assert(!args.contains("--continue"), args)
+
+  test("a resumed turn adds --continue for the same session dir"):
+    val args = PiArgs.rpc(dir, resume = true, LlmConfig.default, None)
+    assert(args.containsSlice(Seq("--session-dir", dir.toString)), args)
+    assert(args.contains("--continue"), args)
 
   test("model and system prompt file are rendered"):
     val args = PiArgs.rpc(
-      sid,
+      dir,
+      resume = false,
       LlmConfig.default.copy(model = Some(Model("openai/gpt-5"))),
       Some(os.Path("/tmp/system.md"))
     )
@@ -27,12 +33,14 @@ class PiArgsTest extends munit.FunSuite:
     )
 
   test("read-only tools exclude writes"):
-    val args = PiArgs.rpc(sid, LlmConfig.default.copy(readOnly = true), None)
+    val args =
+      PiArgs.rpc(dir, resume = false, LlmConfig.default.copy(readOnly = true), None)
     assert(args.containsSlice(Seq("--tools", "read,grep,find,ls")), args)
 
   test("interactive ask-user extension adds extension and ask_user tool"):
     val args = PiArgs.rpc(
-      sid,
+      dir,
+      resume = false,
       LlmConfig.default.copy(readOnly = true),
       None,
       askUserExtension = Some(os.Path("/tmp/ask-user.ts"))

--- a/pi/src/test/scala/orca/tools/pi/PiArgsTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiArgsTest.scala
@@ -1,0 +1,44 @@
+package orca.tools.pi
+
+import orca.llm.{BackendTag, LlmConfig, Model, SessionId}
+
+class PiArgsTest extends munit.FunSuite:
+
+  private val sid: SessionId[BackendTag.Pi.type] =
+    SessionId[BackendTag.Pi.type]("sid")
+
+  test("rpc args include mode and session id"):
+    val args = PiArgs.rpc(sid, LlmConfig.default, None)
+    assertEquals(
+      args.take(5),
+      Seq("pi", "--mode", "rpc", "--session-id", "sid")
+    )
+
+  test("model and system prompt file are rendered"):
+    val args = PiArgs.rpc(
+      sid,
+      LlmConfig.default.copy(model = Some(Model("openai/gpt-5"))),
+      Some(os.Path("/tmp/system.md"))
+    )
+    assert(args.containsSlice(Seq("--model", "openai/gpt-5")), args)
+    assert(
+      args.containsSlice(Seq("--append-system-prompt", "/tmp/system.md")),
+      args
+    )
+
+  test("read-only tools exclude writes"):
+    val args = PiArgs.rpc(sid, LlmConfig.default.copy(readOnly = true), None)
+    assert(args.containsSlice(Seq("--tools", "read,grep,find,ls")), args)
+
+  test("interactive ask-user extension adds extension and ask_user tool"):
+    val args = PiArgs.rpc(
+      sid,
+      LlmConfig.default.copy(readOnly = true),
+      None,
+      askUserExtension = Some(os.Path("/tmp/ask-user.ts"))
+    )
+    assert(
+      args.containsSlice(Seq("--tools", "read,grep,find,ls,ask_user")),
+      args
+    )
+    assert(args.containsSlice(Seq("--extension", "/tmp/ask-user.ts")), args)

--- a/pi/src/test/scala/orca/tools/pi/PiBackendTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiBackendTest.scala
@@ -1,0 +1,145 @@
+package orca.tools.pi
+
+import orca.backend.SystemPromptComposer
+import orca.events.Usage
+import orca.llm.{BackendTag, LlmConfig, Model, SessionId}
+import orca.subprocess.{FakePipedCliProcess, SpawnStubCliRunner}
+
+class PiBackendTest extends munit.FunSuite:
+
+  private def sid: SessionId[BackendTag.Pi.type] =
+    SessionId[BackendTag.Pi.type]("00000000-0000-0000-0000-000000000000")
+
+  private def successfulProcess(
+      message: String = "hello",
+      inputTokens: Long = 1L,
+      outputTokens: Long = 2L
+  ): FakePipedCliProcess =
+    val p = new FakePipedCliProcess()
+    p.enqueueStdout(
+      """{"type":"response","id":"orca-prompt","command":"prompt","success":true}"""
+    )
+    p.enqueueStdout(
+      s"""{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"$message"}],"usage":{"input":$inputTokens,"output":$outputTokens},"model":"pi-model"}}"""
+    )
+    p.enqueueStdout("""{"type":"agent_end","messages":[]}""")
+    p
+
+  test(
+    "runAutonomous starts pi RPC, writes prompt command, and returns stable session"
+  ):
+    val process = successfulProcess("answer", 10L, 5L)
+    val runner = new SpawnStubCliRunner(List(process))
+    val backend = new PiBackend(runner)
+    val workDir = os.temp.dir()
+
+    val result = backend.runAutonomous("do it", sid, LlmConfig.default, workDir)
+
+    assertEquals(result.sessionId, sid)
+    assertEquals(result.output, "answer")
+    assertEquals(result.usage, Usage(10L, 5L, None))
+    assertEquals(result.model.map(_.name), Some("pi-model"))
+
+    val call = runner.spawnCalls.head
+    assertEquals(call.cwd, workDir)
+    assertEquals(call.pipeStderr, true)
+    assert(call.args.containsSlice(Seq("pi", "--mode", "rpc")), call.args)
+    assert(call.args.containsSlice(Seq("--session-id", SessionId.value(sid))))
+    assert(process.writes.exists(_.contains("\"type\":\"prompt\"")))
+    assert(process.writes.exists(_.contains("do it")))
+
+  test("model and autonomous read-only config map to Pi flags"):
+    val process = successfulProcess()
+    val runner = new SpawnStubCliRunner(List(process))
+    val backend = new PiBackend(runner)
+
+    val _ = backend.runAutonomous(
+      "q",
+      sid,
+      LlmConfig.default.copy(
+        model = Some(Model("anthropic/claude-sonnet")),
+        readOnly = true
+      ),
+      os.temp.dir()
+    )
+
+    val args = runner.calls.head
+    assert(args.containsSlice(Seq("--model", "anthropic/claude-sonnet")), args)
+    assert(args.containsSlice(Seq("--tools", "read,grep,find,ls")), args)
+    assert(!args.contains("--extension"), args)
+
+  test("interactive read-only config includes ask_user extension and tool"):
+    val process = successfulProcess()
+    val runner = new SpawnStubCliRunner(List(process))
+    val backend = new PiBackend(runner)
+
+    val conv = backend.runInteractive(
+      "q",
+      sid,
+      displayPrompt = "q",
+      LlmConfig.default.copy(readOnly = true),
+      os.temp.dir(),
+      outputSchema = Some("{}")
+    )
+    assert(conv.canAskUser)
+    assertEquals(conv.outputSchema, Some("{}"))
+
+    val args = runner.calls.head
+    assert(
+      args.containsSlice(Seq("--tools", "read,grep,find,ls,ask_user")),
+      args
+    )
+    assert(args.contains("--extension"), args)
+
+    val _ = conv.events.toList
+    val _ = conv.awaitResult()
+
+  test(
+    "interactive system prompt file contains configured prompt, hint, and git rule"
+  ):
+    val process = new FakePipedCliProcess()
+    val runner = new SpawnStubCliRunner(List(process))
+    val backend = new PiBackend(runner)
+
+    val conv = backend.runInteractive(
+      "q",
+      sid,
+      displayPrompt = "q",
+      LlmConfig.default.copy(systemPrompt = Some("be terse")),
+      os.temp.dir(),
+      outputSchema = None
+    )
+
+    val args = runner.calls.head
+    val promptFile = args(args.indexOf("--append-system-prompt") + 1)
+    val promptText = os.read(os.Path(promptFile))
+    assert(promptText.contains("be terse"), promptText)
+    assert(promptText.contains(PiAskUserExtension.Hint), promptText)
+    assert(promptText.contains(SystemPromptComposer.RuntimeOwnsGit), promptText)
+
+    val extensionFile = os.Path(args(args.indexOf("--extension") + 1))
+    assert(os.exists(extensionFile))
+
+    process.enqueueStdout(
+      """{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}"""
+    )
+    process.enqueueStdout("""{"type":"agent_end","messages":[]}""")
+    val _ = conv.events.toList
+    val _ = conv.awaitResult()
+    assert(!os.exists(os.Path(promptFile)))
+    assert(!os.exists(extensionFile))
+
+  test("self-managed git suppresses the runtime git rule"):
+    val process = successfulProcess()
+    val runner = new SpawnStubCliRunner(List(process))
+    val backend = new PiBackend(runner)
+
+    val _ = backend.runAutonomous(
+      "q",
+      sid,
+      LlmConfig.default.copy(selfManagedGit = true),
+      os.temp.dir()
+    )
+
+    val args = runner.calls.head
+    assert(!args.contains("--append-system-prompt"), args)

--- a/pi/src/test/scala/orca/tools/pi/PiBackendTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiBackendTest.scala
@@ -44,7 +44,7 @@ class PiBackendTest extends munit.FunSuite:
     assertEquals(call.cwd, workDir)
     assertEquals(call.pipeStderr, true)
     assert(call.args.containsSlice(Seq("pi", "--mode", "rpc")), call.args)
-    assert(call.args.containsSlice(Seq("--session-id", SessionId.value(sid))))
+    assert(call.args.containsSlice(Seq("--session", SessionId.value(sid))))
     assert(process.writes.exists(_.contains("\"type\":\"prompt\"")))
     assert(process.writes.exists(_.contains("do it")))
 

--- a/pi/src/test/scala/orca/tools/pi/PiBackendTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiBackendTest.scala
@@ -44,9 +44,28 @@ class PiBackendTest extends munit.FunSuite:
     assertEquals(call.cwd, workDir)
     assertEquals(call.pipeStderr, true)
     assert(call.args.containsSlice(Seq("pi", "--mode", "rpc")), call.args)
-    assert(call.args.containsSlice(Seq("--session", SessionId.value(sid))))
+    // A fresh session opens a dir named for the session id, without --continue.
+    val dir = call.args(call.args.indexOf("--session-dir") + 1)
+    assert(dir.endsWith(SessionId.value(sid)), dir)
+    assert(!call.args.contains("--continue"), call.args)
     assert(process.writes.exists(_.contains("\"type\":\"prompt\"")))
     assert(process.writes.exists(_.contains("do it")))
+
+  test("a second turn on the same session resumes with --continue"):
+    val runner =
+      new SpawnStubCliRunner(List(successfulProcess(), successfulProcess()))
+    val backend = new PiBackend(runner)
+    val workDir = os.temp.dir()
+
+    val _ = backend.runAutonomous("one", sid, LlmConfig.default, workDir)
+    val _ = backend.runAutonomous("two", sid, LlmConfig.default, workDir)
+
+    val Seq(first, second) = runner.spawnCalls.take(2): @unchecked
+    assert(!first.args.contains("--continue"), first.args)
+    assert(second.args.contains("--continue"), second.args)
+    // Same session dir both times.
+    def dirOf(a: List[String]) = a(a.indexOf("--session-dir") + 1)
+    assertEquals(dirOf(first.args), dirOf(second.args))
 
   test("model and autonomous read-only config map to Pi flags"):
     val process = successfulProcess()

--- a/pi/src/test/scala/orca/tools/pi/PiBackendTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiBackendTest.scala
@@ -67,6 +67,24 @@ class PiBackendTest extends munit.FunSuite:
     def dirOf(a: List[String]) = a(a.indexOf("--session-dir") + 1)
     assertEquals(dirOf(first.args), dirOf(second.args))
 
+  test("a failed first turn leaves the session fresh, not --continue"):
+    val failing = new FakePipedCliProcess(initiallyAlive = false)
+    failing.closeStdout() // EOF before agent_end → the turn fails
+    failing.closeStderr()
+    val runner = new SpawnStubCliRunner(List(failing, successfulProcess()))
+    val backend = new PiBackend(runner)
+    val workDir = os.temp.dir()
+
+    val _ = intercept[Exception](
+      backend.runAutonomous("one", sid, LlmConfig.default, workDir)
+    )
+    val _ = backend.runAutonomous("two", sid, LlmConfig.default, workDir)
+
+    val Seq(first, second) = runner.spawnCalls.take(2): @unchecked
+    assert(!first.args.contains("--continue"), first.args)
+    // The failed first turn wasn't committed, so the retry starts fresh.
+    assert(!second.args.contains("--continue"), second.args)
+
   test("model and autonomous read-only config map to Pi flags"):
     val process = successfulProcess()
     val runner = new SpawnStubCliRunner(List(process))

--- a/pi/src/test/scala/orca/tools/pi/PiConversationTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiConversationTest.scala
@@ -1,0 +1,246 @@
+package orca.tools.pi
+
+import orca.backend.ConversationEvent
+import orca.events.Usage
+import orca.llm.{BackendTag, SessionId}
+import orca.{OrcaFlowException, OrcaInteractiveCancelled}
+import orca.subprocess.FakePipedCliProcess
+
+class PiConversationTest extends munit.FunSuite:
+
+  private val sid: SessionId[BackendTag.Pi.type] =
+    SessionId[BackendTag.Pi.type]("pi-session")
+
+  test("text deltas complete with AssistantTurnEnd and produce LlmResult"):
+    val process = new FakePipedCliProcess()
+    val conv = new PiConversation(process, sid)
+
+    process.enqueueStdout(
+      """{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"hello"}}"""
+    )
+    process.enqueueStdout(
+      """{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"hello"}],"model":"anthropic/claude-sonnet","usage":{"input":10,"output":3,"cacheRead":1,"cacheWrite":2,"cost":{"total":0.01}}}}"""
+    )
+    process.enqueueStdout("""{"type":"agent_end","messages":[]}""")
+
+    assertEquals(
+      conv.events.toList,
+      List(
+        ConversationEvent.AssistantTextDelta("hello"),
+        ConversationEvent.AssistantTurnEnd
+      )
+    )
+    val Right(result) = conv.awaitResult(): @unchecked
+    assertEquals(result.sessionId, sid)
+    assertEquals(result.output, "hello")
+    assertEquals(result.model.map(_.name), Some("anthropic/claude-sonnet"))
+    assertEquals(result.usage, Usage(10L, 3L, Some(BigDecimal("0.01")), 3L))
+    assertEquals(process.sigIntCount, 1)
+    assert(process.isStdinClosed)
+
+  test("message_end emits assistant text when no text delta streamed"):
+    val process = new FakePipedCliProcess()
+    val conv = new PiConversation(process, sid)
+
+    process.enqueueStdout(
+      """{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"fallback"}]}}"""
+    )
+    process.enqueueStdout("""{"type":"agent_end","messages":[]}""")
+
+    assertEquals(
+      conv.events.toList,
+      List(
+        ConversationEvent.AssistantTextDelta("fallback"),
+        ConversationEvent.AssistantTurnEnd
+      )
+    )
+    val Right(result) = conv.awaitResult(): @unchecked
+    assertEquals(result.output, "fallback")
+
+  test("thinking delta becomes AssistantThinkingDelta"):
+    val process = new FakePipedCliProcess()
+    val conv = new PiConversation(process, sid)
+
+    process.enqueueStdout(
+      """{"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","delta":"checking"}}"""
+    )
+    process.enqueueStdout(
+      """{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}"""
+    )
+    process.enqueueStdout("""{"type":"agent_end","messages":[]}""")
+
+    val events = conv.events.toList
+    assertEquals(
+      events.head,
+      ConversationEvent.AssistantThinkingDelta("checking")
+    )
+    val _ = conv.awaitResult()
+
+  test("tool execution events become tool call and tool result"):
+    val process = new FakePipedCliProcess()
+    val conv = new PiConversation(process, sid)
+
+    process.enqueueStdout(
+      """{"type":"tool_execution_start","toolCallId":"call-1","toolName":"bash","args":{"command":"ls"}}"""
+    )
+    process.enqueueStdout(
+      """{"type":"tool_execution_end","toolCallId":"call-1","toolName":"bash","result":{"content":[{"type":"text","text":"ok\n"}],"details":{}},"isError":false}"""
+    )
+    process.enqueueStdout("""{"type":"agent_end","messages":[]}""")
+
+    val events = conv.events.toList
+    events(0) match
+      case ConversationEvent.AssistantToolCall(name, rawInput) =>
+        assertEquals(name, "bash")
+        assert(rawInput.contains("ls"))
+      case other => fail(s"expected AssistantToolCall, got $other")
+    events(1) match
+      case ConversationEvent.ToolResult(name, ok, content) =>
+        assertEquals(name, "bash")
+        assertEquals(ok, true)
+        assertEquals(content, "ok\n")
+      case other => fail(s"expected ToolResult, got $other")
+    val _ = conv.awaitResult()
+
+  test("unknown events are ignored"):
+    val process = new FakePipedCliProcess()
+    val conv = new PiConversation(process, sid)
+
+    process.enqueueStdout("""{"type":"session","id":"s"}""")
+    process.enqueueStdout(
+      """{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}"""
+    )
+    process.enqueueStdout("""{"type":"agent_end","messages":[]}""")
+
+    val events = conv.events.toList
+    assert(!events.exists(_.isInstanceOf[ConversationEvent.Error]))
+    val Right(result) = conv.awaitResult(): @unchecked
+    assertEquals(result.output, "ok")
+
+  test("usage accumulates across assistant messages"):
+    val process = new FakePipedCliProcess()
+    val conv = new PiConversation(process, sid)
+
+    process.enqueueStdout(
+      """{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"first"}],"usage":{"input":1,"output":2,"cacheRead":3}}}"""
+    )
+    process.enqueueStdout(
+      """{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"second"}],"usage":{"input":4,"output":5,"cacheWrite":6}}}"""
+    )
+    process.enqueueStdout("""{"type":"agent_end","messages":[]}""")
+
+    val _ = conv.events.toList
+    val Right(result) = conv.awaitResult(): @unchecked
+    assertEquals(result.output, "second")
+    assertEquals(result.usage, Usage(5L, 7L, None, 9L))
+
+  test("failed prompt response fails the conversation"):
+    val process = new FakePipedCliProcess()
+    val conv = new PiConversation(process, sid)
+
+    process.enqueueStdout(
+      """{"type":"response","id":"orca-prompt","command":"prompt","success":false,"error":"model unavailable"}"""
+    )
+
+    val events = conv.events.toList
+    assert(events.exists {
+      case ConversationEvent.Error(message) =>
+        message.contains("model unavailable")
+      case _ => false
+    })
+    val ex = intercept[OrcaFlowException](conv.awaitResult())
+    assert(ex.getMessage.contains("model unavailable"))
+
+  test("extension UI input request becomes UserQuestion and writes response"):
+    val process = new FakePipedCliProcess()
+    val conv = new PiConversation(process, sid, askUserEnabled = true)
+    assert(conv.canAskUser)
+
+    process.enqueueStdout(
+      """{"type":"extension_ui_request","id":"ui-1","method":"input","title":"What branch?"}"""
+    )
+
+    conv.events.next() match
+      case ConversationEvent.UserQuestion(question, respond) =>
+        assertEquals(question, "What branch?")
+        respond("main")
+      case other => fail(s"expected UserQuestion, got $other")
+
+    assert(process.writes.exists(_.contains("extension_ui_response")))
+    assert(process.writes.exists(_.contains("main")))
+    conv.cancel()
+    conv.awaitResult() match
+      case Left(_: OrcaInteractiveCancelled) => ()
+      case other =>
+        fail(s"expected cancellation after test cleanup, got $other")
+
+  test("fire-and-forget extension UI requests are ignored"):
+    val process = new FakePipedCliProcess()
+    val conv = new PiConversation(process, sid)
+
+    process.enqueueStdout(
+      """{"type":"extension_ui_request","id":"ui-status","method":"setStatus","statusKey":"x","statusText":"running"}"""
+    )
+    process.enqueueStdout(
+      """{"type":"extension_ui_request","id":"ui-widget","method":"setWidget","widgetKey":"x","widgetLines":["running"]}"""
+    )
+    process.enqueueStdout("""{"type":"agent_end","messages":[]}""")
+
+    val events = conv.events.toList
+    assertEquals(events, Nil)
+    assert(!process.writes.exists(_.contains("extension_ui_response")))
+    val _ = conv.awaitResult()
+
+  test("clean exit before agent_end fails"):
+    val process = new FakePipedCliProcess(initiallyAlive = false)
+    val conv = new PiConversation(process, sid)
+    process.closeStdout()
+    process.closeStderr()
+
+    val _ = conv.events.toList
+    val ex = intercept[OrcaFlowException](conv.awaitResult())
+    assert(ex.getMessage.contains("agent_end"))
+
+  test("stderr diagnostics are attached to failures"):
+    val process = new FakePipedCliProcess(initiallyAlive = false):
+      override def tryExitCode: Option[Int] = Some(7)
+    val conv = new PiConversation(process, sid)
+    process.enqueueStderr("Pi auth failed")
+    process.closeStdout()
+    process.closeStderr()
+
+    val _ = conv.events.toList
+    val ex = intercept[OrcaFlowException](conv.awaitResult())
+    assert(ex.getMessage.contains("Pi auth failed"), ex.getMessage)
+
+  test("terminal notification stderr noise is ignored"):
+    val process = new FakePipedCliProcess()
+    val conv = new PiConversation(process, sid)
+
+    process.enqueueStderr(
+      "]777;notify;π;Implemented. Changed: extensions/relay/core/file.ts"
+    )
+    process.closeStderr()
+    process.enqueueStdout("""{"type":"agent_end","messages":[]}""")
+
+    val events = conv.events.toList
+    assertEquals(events, Nil)
+    val _ = conv.awaitResult()
+
+  test("stderr strips terminal controls before surfacing diagnostics"):
+    val process = new FakePipedCliProcess(initiallyAlive = false):
+      override def tryExitCode: Option[Int] = Some(7)
+    val conv = new PiConversation(process, sid)
+
+    process.enqueueStderr("auth\u001b[?25l failed\u001b[2K now")
+    process.closeStdout()
+    process.closeStderr()
+
+    val events = conv.events.toList
+    assert(events.exists {
+      case ConversationEvent.Error(message) =>
+        message.contains("auth failed now") && !message.contains("?25l")
+      case _ => false
+    })
+    val ex = intercept[OrcaFlowException](conv.awaitResult())
+    assert(ex.getMessage.contains("auth failed now"), ex.getMessage)

--- a/pi/src/test/scala/orca/tools/pi/PiConversationTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiConversationTest.scala
@@ -193,6 +193,46 @@ class PiConversationTest extends munit.FunSuite:
     assert(!process.writes.exists(_.contains("extension_ui_response")))
     val _ = conv.awaitResult()
 
+  test("an extension_ui_request without a method is cancelled, not dropped"):
+    val process = new FakePipedCliProcess()
+    val conv = new PiConversation(process, sid)
+
+    process.enqueueStdout(
+      """{"type":"extension_ui_request","id":"ui-x","title":"hm"}"""
+    )
+    process.enqueueStdout("""{"type":"agent_end","messages":[]}""")
+
+    val _ = conv.events.toList
+    // A cancel is written so Pi doesn't block waiting on a reply.
+    assert(process.writes.exists(_.contains("extension_ui_response")), process.writes)
+    val _ = conv.awaitResult()
+
+  test("message_end without content surfaces the error, not a parse failure"):
+    val process = new FakePipedCliProcess()
+    val conv = new PiConversation(process, sid)
+
+    process.enqueueStdout(
+      """{"type":"message_end","message":{"role":"assistant","errorMessage":"model exploded"}}"""
+    )
+    process.enqueueStdout("""{"type":"agent_end","messages":[]}""")
+
+    val events = conv.events.toList
+    assert(
+      events.exists {
+        case ConversationEvent.Error(m) => m.contains("model exploded")
+        case _                          => false
+      },
+      events
+    )
+    assert(
+      !events.exists {
+        case ConversationEvent.Error(m) => m.contains("parse")
+        case _                          => false
+      },
+      events
+    )
+    val _ = conv.awaitResult()
+
   test("clean exit before agent_end fails"):
     val process = new FakePipedCliProcess(initiallyAlive = false)
     val conv = new PiConversation(process, sid)

--- a/pi/src/test/scala/orca/tools/pi/PiConversationTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiConversationTest.scala
@@ -129,7 +129,9 @@ class PiConversationTest extends munit.FunSuite:
     )
     process.enqueueStdout("""{"type":"agent_end","messages":[]}""")
 
-    val _ = conv.events.toList
+    val events = conv.events.toList
+    // Two assistant message_ends, but one turn → exactly one AssistantTurnEnd.
+    assertEquals(events.count(_ == ConversationEvent.AssistantTurnEnd), 1)
     val Right(result) = conv.awaitResult(): @unchecked
     assertEquals(result.output, "second")
     assertEquals(result.usage, Usage(5L, 7L, None, 9L))

--- a/pi/src/test/scala/orca/tools/pi/PiIntegrationTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiIntegrationTest.scala
@@ -1,0 +1,33 @@
+package orca.tools.pi
+
+import orca.llm.{BackendTag, LlmConfig, SessionId}
+import orca.subprocess.OsProcCliRunner
+
+/** End-to-end smoke test against the real `pi` CLI. Gated on `ORCA_INTEGRATION`
+  * so normal unit test runs do not require Pi to be installed or authenticated.
+  */
+class PiIntegrationTest extends munit.FunSuite:
+
+  override def munitTests(): Seq[Test] =
+    if sys.env.contains("ORCA_INTEGRATION") then super.munitTests()
+    else Nil
+
+  override def munitTimeout: scala.concurrent.duration.Duration =
+    import scala.concurrent.duration.DurationInt
+    2.minutes
+
+  private def fresh: SessionId[BackendTag.Pi.type] =
+    SessionId.fresh[BackendTag.Pi.type]
+
+  test("RPC autonomous prompt returns requested literal output"):
+    val backend = new PiBackend(OsProcCliRunner)
+    val result = backend.runAutonomous(
+      prompt = "Reply with the single word: READY",
+      session = fresh,
+      config = LlmConfig.default.copy(readOnly = true),
+      workDir = os.temp.dir()
+    )
+    assert(
+      result.output.contains("READY"),
+      s"expected output to contain READY, got: ${result.output}"
+    )

--- a/plans/pi-smoke.sc
+++ b/plans/pi-smoke.sc
@@ -1,0 +1,34 @@
+#!/usr/bin/env -S scala-cli shebang -S 3
+//> using dep "org.virtuslab::orca:0.0.8+4-d118161b+20260606-1239-SNAPSHOT"
+//> using jvm 21
+
+/** Minimal Pi-backed flow.
+  *
+  * Requires `pi` on PATH and authenticated/configured for the model/provider
+  * you want to use. Orca drives Pi through `pi --mode rpc` and reuses the
+  * stable session across calls when you pass the same `session` value.
+  *
+  * ```bash
+  * scala-cli run pi-smoke.sc -- "Inspect this repository and summarize it"
+  * ```
+  */
+
+import orca.{*, given}
+
+case class RepoSummary(summary: String, nextSteps: List[String]) derives JsonData
+
+flow(OrcaArgs(args)):
+  val session = pi.newSession
+
+  stage("Free-form Pi turn"):
+    val _ = pi.autonomous.run(userPrompt, session)
+
+  stage("Structured Pi turn"):
+    val (_, summary) = pi.resultAs[RepoSummary].autonomous.run(
+      s"Summarize the outcome of the previous work for: $userPrompt",
+      session
+    )
+    fs.write(
+      ".orca/pi-summary.md",
+      s"${summary.summary}\n\n" + summary.nextSteps.map(s => s"- $s").mkString("\n")
+    )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.9
+sbt.version=1.12.11

--- a/runner/src/main/scala/orca/exports.scala
+++ b/runner/src/main/scala/orca/exports.scala
@@ -16,6 +16,7 @@ export orca.llm.{
   LlmTool,
   ClaudeTool,
   CodexTool,
+  PiTool,
   LlmCall,
   AutonomousTextCall,
   AutonomousLlmCall,

--- a/runner/src/main/scala/orca/flow.scala
+++ b/runner/src/main/scala/orca/flow.scala
@@ -8,7 +8,7 @@ import orca.events.{
   PriceList,
   Pricing
 }
-import orca.llm.{ClaudeTool, DefaultPrompts, Prompts}
+import orca.llm.{ClaudeTool, DefaultPrompts, PiTool, Prompts}
 import orca.runner.{DefaultFlowContext, LoggingListener, OrcaBanner, OrcaLog}
 import orca.runner.terminal.TerminalInteraction
 import org.slf4j.LoggerFactory
@@ -51,6 +51,7 @@ def flow(
     interaction: Option[Interaction] = None,
     extraListeners: List[OrcaListener] = Nil,
     claude: Option[ClaudeTool] = None,
+    pi: Option[PiTool] = None,
     git: Option[GitTool] = None,
     gh: Option[GitHubTool] = None,
     fs: Option[FsTool] = None,
@@ -100,6 +101,7 @@ def flow(
             workDir = workDir,
             interaction = effectiveInteraction,
             claude = claude,
+            pi = pi,
             git = git,
             gh = gh,
             fs = fs,

--- a/runner/src/main/scala/orca/runner/DefaultFlowContext.scala
+++ b/runner/src/main/scala/orca/runner/DefaultFlowContext.scala
@@ -4,12 +4,13 @@ import orca.{FlowContext}
 import orca.tools.{GitTool}
 import orca.tools.{GitHubTool}
 import orca.tools.{FsTool}
-import orca.llm.{ClaudeTool, CodexTool, LlmConfig, Prompts}
+import orca.llm.{ClaudeTool, CodexTool, LlmConfig, PiTool, Prompts}
 import orca.events.{EventDispatcher, OrcaEvent}
 
 import orca.backend.Interaction
 import orca.tools.claude.{ClaudeBackend, DefaultClaudeTool}
 import orca.tools.codex.{CodexBackend, DefaultCodexTool}
+import orca.tools.pi.{DefaultPiTool, PiBackend}
 import orca.llm.DefaultPrompts
 import orca.subprocess.OsProcCliRunner
 import orca.tools.OsFsTool
@@ -25,6 +26,7 @@ private[orca] class DefaultFlowContext(
     dispatcher: EventDispatcher,
     val claude: ClaudeTool,
     val codex: CodexTool,
+    val pi: PiTool,
     val git: GitTool,
     val gh: GitHubTool,
     val fs: FsTool
@@ -44,6 +46,7 @@ private[orca] object DefaultFlowContext:
       interaction: Interaction,
       claude: Option[ClaudeTool] = None,
       codex: Option[CodexTool] = None,
+      pi: Option[PiTool] = None,
       git: Option[GitTool] = None,
       gh: Option[GitHubTool] = None,
       fs: Option[FsTool] = None,
@@ -69,6 +72,16 @@ private[orca] object DefaultFlowContext:
       codex = codex.getOrElse(
         new DefaultCodexTool(
           backend = new CodexBackend(OsProcCliRunner),
+          config = LlmConfig.default,
+          prompts = prompts,
+          workDir = workDir,
+          events = dispatcher,
+          interaction = interaction
+        )
+      ),
+      pi = pi.getOrElse(
+        new DefaultPiTool(
+          backend = new PiBackend(OsProcCliRunner),
           config = LlmConfig.default,
           prompts = prompts,
           workDir = workDir,

--- a/runner/src/main/scala/orca/runner/terminal/Ansi.scala
+++ b/runner/src/main/scala/orca/runner/terminal/Ansi.scala
@@ -1,80 +1,18 @@
 package orca.runner.terminal
 
+import orca.util.TerminalControl
+
 /** Single source of truth for the "ANSI optional" decision in the renderer
   * layer. Each renderer carries a `useColor` boolean it chose at construction
-  * time (or auto-detected); this helper strips inbound terminal controls and
-  * applies the fansi attrs only when colour is on.
+  * time (or auto-detected); this helper strips inbound terminal controls (via
+  * the shared [[orca.util.TerminalControl]]) and applies the fansi attrs only
+  * when colour is on.
   *
   * Package-private — callers outside `orca.runner.terminal` have no reason to
   * reach into our colour decision.
   */
 private[terminal] object Ansi:
 
-  private val Esc: Char = 0x1b.toChar
-  private val Bel: Char = 0x07.toChar
-  private val Csi: Char = 0x9b.toChar
-  private val Osc: Char = 0x9d.toChar
-  private val Dcs: Char = 0x90.toChar
-  private val Sos: Char = 0x98.toChar
-  private val Pm: Char = 0x9e.toChar
-  private val Apc: Char = 0x9f.toChar
-
   def paint(useColor: Boolean, attr: fansi.Attrs, text: String): String =
-    val stripped = stripControlSequences(text)
+    val stripped = TerminalControl.stripControlSequences(text)
     if useColor then attr(stripped).render else stripped
-
-  /** Remove terminal control sequences from user/backend supplied text before
-    * applying Orca's own styling. `fansi.Attrs.apply(String)` parses existing
-    * ANSI and throws on unsupported sequences (for example cursor/status
-    * controls such as `ESC[?25l` or OSC hyperlinks). These bytes can arrive
-    * from subprocess stderr or model/tool output, so strip them instead of
-    * letting renderer decoration abort the flow.
-    */
-  private[terminal] def stripControlSequences(text: String): String =
-    val out = new StringBuilder(text.length)
-    var i = 0
-    while i < text.length do
-      text.charAt(i) match
-        case Esc                     => i = skipEsc(text, i)
-        case Csi                     => i = skipCsi(text, i + 1)
-        case Osc                     => i = skipStringControl(text, i + 1)
-        case Dcs | Sos | Pm | Apc    => i = skipStringControl(text, i + 1)
-        case c if isUnsafeControl(c) => i += 1
-        case c =>
-          val _ = out.append(c)
-          i += 1
-    out.toString
-
-  private def skipEsc(text: String, escIndex: Int): Int =
-    val nextIndex = escIndex + 1
-    if nextIndex >= text.length then text.length
-    else
-      text.charAt(nextIndex) match
-        case '['                   => skipCsi(text, nextIndex + 1)
-        case ']'                   => skipStringControl(text, nextIndex + 1)
-        case 'P' | 'X' | '^' | '_' => skipStringControl(text, nextIndex + 1)
-        case _                     => math.min(nextIndex + 1, text.length)
-
-  private def skipCsi(text: String, start: Int): Int =
-    var i = start
-    while i < text.length && !isCsiFinal(text.charAt(i)) do i += 1
-    if i < text.length then i + 1 else text.length
-
-  private def skipStringControl(text: String, start: Int): Int =
-    var i = start
-    var done = false
-    while i < text.length && !done do
-      text.charAt(i) match
-        case Bel =>
-          i += 1
-          done = true
-        case Esc if i + 1 < text.length && text.charAt(i + 1) == '\\' =>
-          i += 2
-          done = true
-        case _ => i += 1
-    i
-
-  private def isCsiFinal(c: Char): Boolean = c >= '@' && c <= '~'
-
-  private def isUnsafeControl(c: Char): Boolean =
-    (c < ' ' && c != '\n' && c != '\t') || (c >= 0x7f.toChar && c <= Apc)

--- a/runner/src/test/scala/flowtests/FlowCompilesTest.scala
+++ b/runner/src/test/scala/flowtests/FlowCompilesTest.scala
@@ -59,6 +59,9 @@ object FlowCanary:
         // Per-tool config knobs resolve and chain on both backends.
         val _ = claude.withReadOnly.withSelfManagedGit
         val _ = codex.withSelfManagedGit
+        val _ = pi.withConfig(
+          LlmConfig.default.copy(model = Some(Model("gpt-5.5")))
+        )
 
   /** Review-and-fix loop; pulls in `allReviewers` and the internal `stage`/fork
     * machinery.
@@ -144,11 +147,18 @@ object FlowCanary:
           Plan.autonomous.from(userPrompt, claude.opus)
         val intFrom: Sessioned[?, Plan] =
           Plan.interactive.from(userPrompt, claude)
-        // Codex also satisfies `CanAskUser`, so the interactive cells compile
-        // against it too (shared AskUserMcpServer via codex's MCP support).
+        // Codex and Pi also satisfy `CanAskUser`, so the interactive cells
+        // compile against them too.
         val intFromCodex: Sessioned[?, Plan] =
           Plan.interactive.from(userPrompt, codex)
-        val _ = (autoFrom.value, intFrom.value, intFromCodex.value)
+        val intFromPi: Sessioned[?, Plan] =
+          Plan.interactive.from(userPrompt, pi)
+        val _ = (
+          autoFrom.value,
+          intFrom.value,
+          intFromCodex.value,
+          intFromPi.value
+        )
 
         // --- assessThenPlan → Sessioned[B, Verdict[Plan]], both modes ---
         val autoAssess: Sessioned[?, Verdict[Plan]] =

--- a/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
+++ b/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
@@ -1,6 +1,6 @@
 package orca.runner
 
-import orca.{FlowContext, OrcaArgs, flow, fs}
+import orca.{FlowContext, OrcaArgs, flow, fs, pi}
 import orca.tools.{FsTool}
 import orca.llm.{
   Announce,
@@ -8,6 +8,7 @@ import orca.llm.{
   BackendTag,
   ClaudeTool,
   JsonData,
+  PiTool,
   LlmCall,
   LlmConfig,
   Model,
@@ -73,6 +74,39 @@ class OrcaOverridesTest extends munit.FunSuite:
       ):
         observed = summon[FlowContext].claude.autonomous.run("hi")._2
     assertEquals(observed, "echo: hi")
+
+  test("flow uses a custom PiTool when supplied"):
+    val fakePi = new PiTool:
+      val name = "fake-pi"
+      def withConfig(c: LlmConfig) = this
+      def withSystemPrompt(p: String) = this
+      def withName(n: String) = this
+      def withReadOnly = this
+      val autonomous: AutonomousTextCall[BackendTag.Pi.type] =
+        new AutonomousTextCall[BackendTag.Pi.type]:
+          def run(
+              p: String,
+              session: SessionId[BackendTag.Pi.type],
+              c: LlmConfig,
+              emitPrompt: Boolean
+          ): (SessionId[BackendTag.Pi.type], String) =
+            (SessionId[BackendTag.Pi.type]("fake-pi-sid"), s"pi: $p")
+      def resultAs[O: JsonData: Announce]: LlmCall[BackendTag.Pi.type, O] =
+        ???
+    var observed: String = ""
+    supervised:
+      val interaction = TerminalInteraction.start(
+        out = new PrintStream(new ByteArrayOutputStream()),
+        useColor = false,
+        animated = false
+      )
+      flow(
+        args = OrcaArgs(),
+        pi = Some(fakePi),
+        interaction = Some(interaction)
+      ):
+        observed = pi.autonomous.run("hi")._2
+    assertEquals(observed, "pi: hi")
 
   test("flow collects extra listeners alongside the interaction's"):
     val buf = new ByteArrayOutputStream()

--- a/tools/src/main/scala/orca/backend/StreamConversation.scala
+++ b/tools/src/main/scala/orca/backend/StreamConversation.scala
@@ -40,7 +40,13 @@ private[orca] abstract class StreamConversation[B <: BackendTag](
       * the user-facing backend name.
       */
     backendName: String,
-    initialPrompt: String = ""
+    initialPrompt: String = "",
+    /** Some backends expose user-question support through their own protocol
+      * rather than the shared MCP [[AskUserSession]] bridge. Setting this flag
+      * lets those drivers report [[Conversation.canAskUser]] without starting
+      * the MCP drainer machinery below.
+      */
+    canAskUserFlag: Boolean = false
 ) extends Conversation[B]:
 
   import StreamConversation.*
@@ -59,7 +65,7 @@ private[orca] abstract class StreamConversation[B <: BackendTag](
     */
   protected def askUser: Option[AskUserSession] = None
 
-  final def canAskUser: Boolean = askUser.isDefined
+  final def canAskUser: Boolean = canAskUserFlag || askUser.isDefined
 
   // Surface the opening prompt to the channel before any agent
   // output. Without this, the channel sits silent while the agent

--- a/tools/src/main/scala/orca/llm/BackendTag.scala
+++ b/tools/src/main/scala/orca/llm/BackendTag.scala
@@ -10,6 +10,7 @@ package orca.llm
 enum BackendTag:
   case ClaudeCode
   case Codex
+  case Pi
 
 opaque type SessionId[B <: BackendTag] = String
 

--- a/tools/src/main/scala/orca/llm/CanAskUser.scala
+++ b/tools/src/main/scala/orca/llm/CanAskUser.scala
@@ -16,7 +16,7 @@ package orca.llm
   * Mirrors `Conversation.canAskUser` at the type level. The runtime flag stays
   * useful for programmatic queries on a concrete `Conversation[?]`; the
   * typeclass catches mistakes one step earlier — at the
-  * `Plan.interactive.from(claude/codex, …)` call site — without requiring
+  * `Plan.interactive.from(claude/codex/pi, …)` call site — without requiring
   * pattern-matching on `B`.
   */
 trait CanAskUser[B <: BackendTag]
@@ -36,3 +36,10 @@ object CanAskUser:
     */
   given CanAskUser[BackendTag.Codex.type] =
     new CanAskUser[BackendTag.Codex.type] {}
+
+  /** Pi's interactive sessions load Orca's temporary ask-user extension, which
+    * forwards extension UI prompts into the same Orca `UserQuestion` event used
+    * by the other interactive backends.
+    */
+  given CanAskUser[BackendTag.Pi.type] =
+    new CanAskUser[BackendTag.Pi.type] {}

--- a/tools/src/main/scala/orca/llm/LlmTool.scala
+++ b/tools/src/main/scala/orca/llm/LlmTool.scala
@@ -86,6 +86,8 @@ trait ClaudeTool extends LlmTool[BackendTag.ClaudeCode.type]:
 trait CodexTool extends LlmTool[BackendTag.Codex.type]:
   def mini: CodexTool
 
+trait PiTool extends LlmTool[BackendTag.Pi.type]
+
 /** Free-form text autonomous calls — the `LlmTool.autonomous` shape. Single
   * method: pass a [[SessionId]] (typically from [[LlmTool.newSession]] or the
   * default fresh one) and the library starts the session on the first call,

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -5,6 +5,8 @@ import orca.events.{OrcaEvent, OrcaListener}
 import orca.subprocess.QuietProc
 import ox.either.orThrow
 
+import scala.util.control.NonFatal
+
 case class CommitInfo(hash: String, message: String, author: String)
 
 /** Which diff semantics [[GitTool.diffVsBase]] should produce.
@@ -379,7 +381,7 @@ private[orca] class OsGitTool(
         )
 
   def removeWorktree(path: os.Path): Either[WorktreeNotFound, Unit] =
-    if !listWorktrees().exists(_.path == path) then
+    if !listWorktrees().exists(w => samePath(w.path, path)) then
       Left(new WorktreeNotFound(path))
     else
       val _ = git("worktree", "remove", path.toString)
@@ -388,6 +390,12 @@ private[orca] class OsGitTool(
 
   def listWorktrees(): List[Worktree] =
     OsGitTool.parseWorktreeList(git("worktree", "list", "--porcelain"))
+
+  private def samePath(left: os.Path, right: os.Path): Boolean =
+    def normalised(path: os.Path): java.nio.file.Path =
+      try path.toNIO.toRealPath()
+      catch case NonFatal(_) => path.toNIO.toAbsolutePath.normalize()
+    normalised(left) == normalised(right)
 
   private def git(args: String*): String =
     // Route through QuietProc so git's stderr ("Switched to a new

--- a/tools/src/main/scala/orca/util/TerminalControl.scala
+++ b/tools/src/main/scala/orca/util/TerminalControl.scala
@@ -1,0 +1,68 @@
+package orca.util
+
+/** Strips terminal control sequences (CSI / OSC / DCS / SOS / PM / APC, plus
+  * unsafe C0/C1 control bytes) from text that originates outside Orca —
+  * subprocess stderr, model or tool output — before it is rendered or surfaced
+  * as a diagnostic. Left in, these bytes make `fansi` abort on unsupported
+  * sequences (cursor/status controls like `ESC[?25l`, OSC hyperlinks) and can
+  * corrupt the terminal. Newlines and tabs are kept; other controls are dropped.
+  */
+private[orca] object TerminalControl:
+
+  private val Esc: Char = 0x1b.toChar
+  private val Bel: Char = 0x07.toChar
+  private val Csi: Char = 0x9b.toChar
+  private val Osc: Char = 0x9d.toChar
+  private val Dcs: Char = 0x90.toChar
+  private val Sos: Char = 0x98.toChar
+  private val Pm: Char = 0x9e.toChar
+  private val Apc: Char = 0x9f.toChar
+
+  def stripControlSequences(text: String): String =
+    val out = new StringBuilder(text.length)
+    var i = 0
+    while i < text.length do
+      text.charAt(i) match
+        case Esc                     => i = skipEsc(text, i)
+        case Csi                     => i = skipCsi(text, i + 1)
+        case Osc                     => i = skipStringControl(text, i + 1)
+        case Dcs | Sos | Pm | Apc    => i = skipStringControl(text, i + 1)
+        case c if isUnsafeControl(c) => i += 1
+        case c =>
+          val _ = out.append(c)
+          i += 1
+    out.toString
+
+  private def skipEsc(text: String, escIndex: Int): Int =
+    val nextIndex = escIndex + 1
+    if nextIndex >= text.length then text.length
+    else
+      text.charAt(nextIndex) match
+        case '['                   => skipCsi(text, nextIndex + 1)
+        case ']'                   => skipStringControl(text, nextIndex + 1)
+        case 'P' | 'X' | '^' | '_' => skipStringControl(text, nextIndex + 1)
+        case _                     => math.min(nextIndex + 1, text.length)
+
+  private def skipCsi(text: String, start: Int): Int =
+    var i = start
+    while i < text.length && !isCsiFinal(text.charAt(i)) do i += 1
+    if i < text.length then i + 1 else text.length
+
+  private def skipStringControl(text: String, start: Int): Int =
+    var i = start
+    var done = false
+    while i < text.length && !done do
+      text.charAt(i) match
+        case Bel =>
+          i += 1
+          done = true
+        case Esc if i + 1 < text.length && text.charAt(i + 1) == '\\' =>
+          i += 2
+          done = true
+        case _ => i += 1
+    i
+
+  private def isCsiFinal(c: Char): Boolean = c >= '@' && c <= '~'
+
+  private def isUnsafeControl(c: Char): Boolean =
+    (c < ' ' && c != '\n' && c != '\t') || (c >= 0x7f.toChar && c <= Apc)

--- a/tools/src/test/scala/orca/subprocess/SpawnStubCliRunner.scala
+++ b/tools/src/test/scala/orca/subprocess/SpawnStubCliRunner.scala
@@ -13,9 +13,11 @@ import java.util.concurrent.atomic.AtomicReference
 class SpawnStubCliRunner(prepared: List[FakePipedCliProcess]) extends CliRunner:
   private val queue = new AtomicReference[List[FakePipedCliProcess]](prepared)
   private val recorded =
-    new AtomicReference[List[List[String]]](Nil)
+    new AtomicReference[List[SpawnStubCliRunner.SpawnCall]](Nil)
 
-  def calls: List[List[String]] = recorded.get().reverse
+  def calls: List[List[String]] = spawnCalls.map(_.args)
+
+  def spawnCalls: List[SpawnStubCliRunner.SpawnCall] = recorded.get().reverse
 
   def run(
       args: Seq[String],
@@ -33,7 +35,9 @@ class SpawnStubCliRunner(prepared: List[FakePipedCliProcess]) extends CliRunner:
       cwd: os.Path,
       pipeStderr: Boolean
   ): PipedCliProcess =
-    val _ = recorded.updateAndGet(args.toList :: _)
+    val _ = recorded.updateAndGet(
+      SpawnStubCliRunner.SpawnCall(args.toList, env, cwd, pipeStderr) :: _
+    )
     val next = queue
       .getAndUpdate(_.drop(1))
       .headOption
@@ -41,3 +45,11 @@ class SpawnStubCliRunner(prepared: List[FakePipedCliProcess]) extends CliRunner:
         throw new IllegalStateException("ran out of prepared processes")
       )
     next
+
+object SpawnStubCliRunner:
+  case class SpawnCall(
+      args: List[String],
+      env: Map[String, String],
+      cwd: os.Path,
+      pipeStderr: Boolean
+  )


### PR DESCRIPTION
## Summary

Adds a Pi backend to Orca, exposed as the top-level `pi` tool alongside `claude` and `codex`.

The backend drives the Pi coding agent through `pi --mode rpc`, maps Pi RPC events into Orca conversation events, and wires the tool into the default `flow(...)` context so flow scripts can use Pi for autonomous and structured calls.

## What is included

- New `orca-pi` module.
- New backend tag and tool surface:
  - `BackendTag.Pi`
  - `PiTool`
  - top-level `pi` accessor
  - `flow(..., pi = Some(customPi))` override support
- `DefaultPiTool` / `PiBackend` implementation.
- Pi RPC argument builder and JSON event parsing.
- Conversation event mapping for:
  - assistant text / thinking deltas
  - tool call start/end
  - usage/model metadata
  - terminal `agent_end` result
  - extension UI requests for interactive ask-user flows
- `CanAskUser[BackendTag.Pi.type]` support via a temporary Orca ask-user extension.
- Tests for argument construction, backend wiring, conversation parsing, custom flow override, and flow-script compile canaries.
- README docs for the new backend.

## Notes

This is intentionally opened as a draft/proposal PR because Pi support adds a new module and a new backend dependency surface. The implementation has been useful locally, but I would like maintainer feedback on:

- Whether `orca-pi` should be a first-class module like `orca-claude` and `orca-codex`.
- Whether the `ask_user` bridge should live as a temporary generated Pi extension or be abstracted differently.
- Whether `PiTool` should be included in the default runner artifact or published separately for opt-in use.
- Naming/config conventions for Pi model selection, since Pi delegates provider auth/model configuration to its own CLI.

## Testing

Ran targeted tests locally with JDK 21:

```bash
sbt "pi/testOnly orca.tools.pi.PiConversationTest"
sbt "runner/testOnly orca.runner.OrcaOverridesTest"
```

Also exercised the module through a local flow script and `publishLocal`.