### PR TITLE
Extract bounded-stderr diagnostics into a shared mixin

### DIFF
--- a/codex/src/main/scala/orca/tools/codex/CodexConversation.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexConversation.scala
@@ -4,7 +4,7 @@ import orca.llm.{BackendTag, Model, SessionId}
 import orca.events.{Usage}
 import orca.{OrcaFlowException}
 import orca.backend.{ConversationEvent, LlmResult}
-import orca.backend.{StreamConversation, StreamSource}
+import orca.backend.{BufferedStderrDiagnostics, StreamConversation, StreamSource}
 import orca.backend.mcp.{AskUserMcpServer, AskUserSession}
 import orca.subprocess.PipedCliProcess
 import orca.tools.codex.jsonl.{FileChangeDetail, InboundEvent, Item}
@@ -40,7 +40,8 @@ private[codex] class CodexConversation(
       source = StreamSource.fromProcess(process),
       backendName = "codex",
       initialPrompt = initialPrompt
-    ):
+    )
+    with BufferedStderrDiagnostics[BackendTag.Codex.type]:
 
   import CodexConversation.*
   import StreamConversation.Outcome
@@ -52,15 +53,6 @@ private[codex] class CodexConversation(
     * scaladoc for why we synthesise rather than receive.
     */
   private val lastAgentMessage = new AtomicReference[String]("")
-
-  /** Bounded ring of trimmed stderr lines (post-filter), kept so a non-zero
-    * exit or clean-exit-without-result can carry the actual failure context
-    * back to the caller in the thrown exception — listener subscribers already
-    * saw each line as a `ConversationEvent.Error`, but a noop listener (tests,
-    * simple scripts) would otherwise lose the diagnostic entirely. Capped on
-    * both line count and byte total so a runaway agent can't OOM us.
-    */
-  private val stderrBuffer = new AtomicReference[Vector[String]](Vector.empty)
 
   /** MCP item ids whose `AssistantToolCall` echo we drop — the host-side bridge
     * has already surfaced the corresponding `UserQuestion` event, so rendering
@@ -106,25 +98,15 @@ private[codex] class CodexConversation(
     *     written correctly to `~/.codex/sessions/`; the message is harmless.
     *
     * Filter both, plus empty lines. Anything else passes through with the
-    * default backend-prefixed Error event AND appends to the bounded
-    * [[stderrBuffer]] so the failure exception can include them.
+    * default backend-prefixed Error event AND is recorded in the bounded
+    * stderr buffer (see [[BufferedStderrDiagnostics]]) so the failure exception
+    * can include them.
     */
   override protected def handleStderr(line: String): Unit =
     val trimmed = line.trim
     if trimmed.nonEmpty && !CodexConversation.isKnownStderrNoise(trimmed) then
       eventQueue.enqueue(ConversationEvent.Error(s"codex: $trimmed"))
-      val _ = stderrBuffer.updateAndGet(appendBounded(_, trimmed))
-
-  /** Bounded wait for the stderr drain so any trailing error lines (which the
-    * consumer can't see once we close the queue) reach the events queue. The
-    * base closes the ask_user bundle after this hook returns.
-    */
-  override protected def onFinalize(): Unit =
-    try stderrDrainThread.join(StderrDrainTimeoutMs)
-    catch
-      // Interrupt while joining means the parent is shutting down.
-      // Restore the flag so callers up-stack can react.
-      case _: InterruptedException => Thread.currentThread().interrupt()
+      recordStderr(trimmed)
 
   override protected def cleanExitWithoutResult(): Throwable =
     // Defer the framing to the base so the diagnosticContext below gets
@@ -134,15 +116,6 @@ private[codex] class CodexConversation(
         "codex exited cleanly but never sent a turn.completed event"
       )
     )
-
-  /** Recent stderr lines, formatted as a `stderr:` block. The base layer
-    * ([[StreamConversation.appendContext]]) owns the leading-newline + indent
-    * framing so this override returns just the payload.
-    */
-  override protected def diagnosticContext: Option[String] =
-    val lines = stderrBuffer.get()
-    if lines.isEmpty then None
-    else Some(lines.mkString("stderr:\n    ", "\n    ", ""))
 
   // --- Per-event dispatch ---
 
@@ -264,43 +237,6 @@ private[codex] object CodexConversation:
       line.contains(
         "codex_core::session: failed to record rollout items"
       )
-
-  /** Bounded wait for the stderr thread to finish draining before the event
-    * queue is closed. Long enough that real EOF-after-process- exit lands;
-    * short enough that a stalled child doesn't deadlock `awaitResult`.
-    */
-  private val StderrDrainTimeoutMs: Long = 500L
-
-  /** Cap on lines kept in [[stderrBuffer]]. Sized for a typical stack trace
-    * plus a brief explanation — enough to diagnose a failure inline, bounded so
-    * a chatty subprocess can't grow memory. `private[codex]` so cap-edge tests
-    * can size their inputs against it.
-    */
-  private[codex] val StderrMaxLines: Int = 20
-
-  /** Soft byte cap on [[stderrBuffer]], counted across kept lines. Trims from
-    * the front (oldest) when exceeded, same as the line cap, so the most recent
-    * (typically most diagnostic) lines stay. `private[codex]` for the same
-    * test-visibility reason as [[StderrMaxLines]].
-    */
-  private[codex] val StderrMaxBytes: Int = 4096
-
-  /** Append `line` to `buf` while respecting both caps. Drops from the head
-    * (oldest line first) until the result fits. A single line that exceeds
-    * `StderrMaxBytes` on its own is kept anyway — one oversized line is more
-    * useful than empty diagnostics. Lives on the companion so the
-    * `AtomicReference.updateAndGet` callback stays a pure function.
-    * `private[codex]` so the cap-edge tests can exercise it directly.
-    */
-  private[codex] def appendBounded(
-      buf: Vector[String],
-      line: String
-  ): Vector[String] =
-    var result = buf :+ line
-    while result.size > StderrMaxLines do result = result.tail
-    while result.size > 1 && result.map(_.length).sum > StderrMaxBytes do
-      result = result.tail
-    result
 
   /** Synthetic JSON the driver hands the renderer for `bash` tool calls —
     * codex's `command_execution` items don't natively carry a JSON-shaped

--- a/pi/src/main/scala/orca/tools/pi/PiConversation.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiConversation.scala
@@ -4,7 +4,7 @@ import orca.events.Usage
 import orca.llm.{BackendTag, Model, SessionId}
 import orca.{OrcaFlowException}
 import orca.backend.{ConversationEvent, LlmResult}
-import orca.backend.{StreamConversation, StreamSource}
+import orca.backend.{BufferedStderrDiagnostics, StreamConversation, StreamSource}
 import orca.subprocess.PipedCliProcess
 import orca.util.TerminalControl
 import orca.tools.pi.rpc.{
@@ -14,7 +14,6 @@ import orca.tools.pi.rpc.{
   OutboundMessage
 }
 
-import java.util.concurrent.atomic.AtomicReference
 import scala.util.control.NonFatal
 
 /** Drives one `pi --mode rpc` process for a single Orca LLM call. The backend
@@ -38,7 +37,8 @@ private[pi] class PiConversation(
       backendName = "pi",
       initialPrompt = initialPrompt,
       nativeAskUser = askUserEnabled
-    ):
+    )
+    with BufferedStderrDiagnostics[BackendTag.Pi.type]:
 
   import PiConversation.*
 
@@ -59,11 +59,6 @@ private[pi] class PiConversation(
       sawAssistantMessage: Boolean = false
   )
   private var turnState: TurnState = TurnState()
-
-  /** Atomic, unlike [[turnState]]: written by the *stderr* drain thread
-    * ([[handleStderr]]) and read by the reader thread at finalize.
-    */
-  private val stderrBuffer = new AtomicReference[Vector[String]](Vector.empty)
 
   // All stdin writes funnel through this lock: `sendPrompt` runs on the caller's
   // thread, the ask-user reply on the event consumer's, and the reader thread
@@ -96,22 +91,17 @@ private[pi] class PiConversation(
     val trimmed = TerminalControl.stripControlSequences(line).trim
     if trimmed.nonEmpty && !isKnownStderrNoise(trimmed) then
       eventQueue.enqueue(ConversationEvent.Error(s"pi: $trimmed"))
-      val _ = stderrBuffer.updateAndGet(appendBounded(_, trimmed))
+      recordStderr(trimmed)
 
+  // Drain stderr (base) then close the per-turn temp resources.
   override protected def onFinalize(): Unit =
-    try stderrDrainThread.join(StderrDrainTimeoutMs)
-    catch case _: InterruptedException => Thread.currentThread().interrupt()
+    super.onFinalize()
     resources.foreach(closeQuietly)
 
   override protected def cleanExitWithoutResult(): Throwable =
     new OrcaFlowException(
       appendContext("pi exited cleanly but never emitted agent_end")
     )
-
-  override protected def diagnosticContext: Option[String] =
-    val lines = stderrBuffer.get()
-    if lines.isEmpty then None
-    else Some(lines.mkString("stderr:\n    ", "\n    ", ""))
 
   private def handle(event: InboundEvent): Unit = event match
     case InboundEvent.Response(_, command, success, error) =>
@@ -216,8 +206,6 @@ private[pi] class PiConversation(
 
 private[pi] object PiConversation:
 
-  private val StderrDrainTimeoutMs: Long = 500L
-
   private val FireAndForgetUiMethods: Set[String] = Set(
     "notify",
     "setStatus",
@@ -226,22 +214,9 @@ private[pi] object PiConversation:
     "set_editor_text"
   )
 
-  private val StderrMaxLines: Int = 20
-  private val StderrMaxBytes: Int = 4096
-
   private def isKnownStderrNoise(line: String): Boolean =
     // Pi's terminal notifier can write iTerm2-style notifications to stderr as
     // OSC 777 (`ESC ] 777 ; ... BEL`). We strip well-formed controls before
     // trimming, but keep this guard for environments that have already removed
     // the leading ESC byte before the line reaches us.
     line.startsWith("]777;notify;")
-
-  private def appendBounded(
-      buf: Vector[String],
-      line: String
-  ): Vector[String] =
-    var result = buf :+ line
-    while result.size > StderrMaxLines do result = result.tail
-    while result.size > 1 && result.map(_.length).sum > StderrMaxBytes do
-      result = result.tail
-    result

--- a/tools/src/main/scala/orca/backend/BufferedStderrDiagnostics.scala
+++ b/tools/src/main/scala/orca/backend/BufferedStderrDiagnostics.scala
@@ -1,0 +1,63 @@
+package orca.backend
+
+import orca.llm.BackendTag
+
+import java.util.concurrent.atomic.AtomicReference
+
+/** Bounded-stderr diagnostics shared by the subprocess [[StreamConversation]]s
+  * (codex, pi). Keeps the last few trimmed stderr lines (capped on count and
+  * bytes) so a non-zero exit / clean-exit-without-result carries the real
+  * failure context in the thrown exception — listener subscribers saw each line
+  * as a `ConversationEvent.Error`, but a noop listener (tests, simple scripts)
+  * would otherwise lose it. Also joins the stderr drain at finalize so trailing
+  * lines reach the queue before it closes.
+  *
+  * The driver keeps its own [[StreamConversation.handleStderr]] (the noise
+  * filter and prefix genuinely differ per backend) and calls [[recordStderr]]
+  * for lines worth keeping. A driver needing extra teardown overrides
+  * `onFinalize` and calls `super.onFinalize()`.
+  */
+private[orca] trait BufferedStderrDiagnostics[B <: BackendTag]
+    extends StreamConversation[B]:
+
+  import BufferedStderrDiagnostics.*
+
+  private val stderrBuffer = new AtomicReference[Vector[String]](Vector.empty)
+
+  /** Append a trimmed, noise-filtered stderr line to the bounded buffer. */
+  protected def recordStderr(line: String): Unit =
+    val _ = stderrBuffer.updateAndGet(appendBounded(_, line))
+
+  /** Bounded wait for the stderr drain so trailing lines reach the queue. */
+  override protected def onFinalize(): Unit =
+    try stderrDrainThread.join(DrainTimeoutMs)
+    catch case _: InterruptedException => Thread.currentThread().interrupt()
+
+  /** Recent stderr lines as a `stderr:` block; the base owns the outer framing. */
+  override protected def diagnosticContext: Option[String] =
+    val lines = stderrBuffer.get()
+    if lines.isEmpty then None
+    else Some(lines.mkString("stderr:\n    ", "\n    ", ""))
+
+private[orca] object BufferedStderrDiagnostics:
+  /** Bounded wait for the stderr drain thread at finalize. */
+  val DrainTimeoutMs: Long = 500L
+
+  /** Cap on lines kept — sized for a typical stack trace plus a brief
+    * explanation, bounded so a chatty subprocess can't grow memory.
+    */
+  val MaxLines: Int = 20
+
+  /** Cap on total bytes kept, for the same reason as [[MaxLines]]. */
+  val MaxBytes: Int = 4096
+
+  /** Append `line` while respecting both caps, dropping oldest first. A single
+    * over-cap line is kept anyway (better than empty diagnostics). Pure, so it's
+    * a safe `AtomicReference.updateAndGet` callback.
+    */
+  def appendBounded(buf: Vector[String], line: String): Vector[String] =
+    var result = buf :+ line
+    while result.size > MaxLines do result = result.tail
+    while result.size > 1 && result.map(_.length).sum > MaxBytes do
+      result = result.tail
+    result

--- a/tools/src/test/scala/orca/backend/AppendBoundedTest.scala
+++ b/tools/src/test/scala/orca/backend/AppendBoundedTest.scala
@@ -1,25 +1,25 @@
-package orca.tools.codex
+package orca.backend
 
-import CodexConversation.{StderrMaxBytes, StderrMaxLines, appendBounded}
+import BufferedStderrDiagnostics.{MaxBytes, MaxLines, appendBounded}
 
-/** Cap-edge coverage for [[CodexConversation.appendBounded]]. The function is
-  * the only stateful piece of the stderr-buffering path that isn't trivially
-  * verified by integration tests, and getting either cap wrong silently
-  * truncates the failure diagnostics it's supposed to preserve.
+/** Cap-edge coverage for [[BufferedStderrDiagnostics.appendBounded]]. The
+  * function is the only stateful piece of the stderr-buffering path that isn't
+  * trivially verified by integration tests, and getting either cap wrong
+  * silently truncates the failure diagnostics it's supposed to preserve.
   */
 class AppendBoundedTest extends munit.FunSuite:
 
   test("evicts oldest lines when the line cap is exceeded"):
-    val pre = (1 to StderrMaxLines).map(i => s"line $i").toVector
+    val pre = (1 to MaxLines).map(i => s"line $i").toVector
     val after = appendBounded(pre, "newest")
-    assertEquals(after.size, StderrMaxLines)
+    assertEquals(after.size, MaxLines)
     assertEquals(after.head, "line 2")
     assertEquals(after.last, "newest")
 
   test("evicts oldest lines when the byte cap is exceeded"):
     // Each line is ~half the byte budget; two of them plus a newcomer
     // would blow the cap, forcing the oldest out.
-    val big = "x" * (StderrMaxBytes / 2 + 10)
+    val big = "x" * (MaxBytes / 2 + 10)
     val after = appendBounded(Vector(big, big), "newest")
     // Single structural assertion: fails informatively if the byte loop
     // trims too much (e.g. down to just "newest") or too little.
@@ -28,6 +28,6 @@ class AppendBoundedTest extends munit.FunSuite:
   test("keeps at least one line even if it alone exceeds the byte cap"):
     // Empty diagnostics are useless; an oversized line is at least
     // *some* signal. The guard `result.size > 1` enforces this.
-    val oversized = "y" * (StderrMaxBytes * 2)
+    val oversized = "y" * (MaxBytes * 2)
     val after = appendBounded(Vector.empty, oversized)
     assertEquals(after, Vector(oversized))


### PR DESCRIPTION
codex and pi duplicated the bounded stderr buffer near-verbatim (buffer, appendBounded line+byte caps, the onFinalize drain-join, diagnosticContext).
  Hoisted into `BufferedStderrDiagnostics` in tools; each backend keeps its own `handleStderr` (noise filters differ) and calls `recordStderr`. pi's
  `onFinalize` chains `super` then closes temp resources. `AppendBoundedTest` moved codex→tools. ~60 lines removed; codex/pi/tools suites green, zero warnings.