### PR TITLE
Add Gemini CLI as an LLM backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The following are available inside a `flow(...) { ... }`:
 | `codex` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `mini`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withSelfManagedGit` | OpenAI Codex coding/reviewing agent. |
 | `opencode` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `anthropicOpus`/`anthropicSonnet`/`anthropicHaiku`, `openaiGpt5`/`openaiGpt5Codex`/`openaiGpt5Mini`, `withModel(providerModel)` / `withModel(provider, modelId)`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withSelfManagedGit` | [OpenCode](https://opencode.ai) coding/reviewing agent, driven over HTTP+SSE against a headless `opencode serve` (started lazily, shared for the run). Spans providers, so models are provider-qualified: use an accessor (`opencode.openaiGpt5Mini`) or `opencode.withModel("openai/gpt-4o-mini")` / `opencode.withModel("ollama", "llama3.1")`. Inherits the user's configured `opencode` providers/auth. |
 | `pi` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withSelfManagedGit` | [Pi](https://pi.dev/) coding agent backend, driven through `pi --mode rpc`. Pi handles provider/model selection through its own CLI configuration; pin a model with `pi.withConfig(LlmConfig(model = Some(Model("provider/model"))))`. Interactive calls can ask clarifying questions via Orca's `ask_user` bridge. |
+| `gemini` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `flash`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withSelfManagedGit` | Google Gemini CLI coding/reviewing agent, driven via `gemini --output-format stream-json`. Bare `gemini` pins **Gemini 2.5 Pro**; use `gemini.flash` for cheaper one-shot calls. Structured output is prompt-enforced (Gemini has no schema flag); `withReadOnly` maps to `--approval-mode plan`. See [ADR 0015](adr/0015-gemini-stream-json-driver.md). |
 | `git` | `createBranch`, `checkout`, `checkoutOrCreate`, `ensureClean`, `commit`, `push`, `currentBranch`, `diff`, `log`, `addWorktree`, `removeWorktree`, `listWorktrees` | Git operations against the working tree. Recoverable failures (`BranchAlreadyExists`, `BranchNotFound`, `NothingToCommit`, `PushRejected`, `WorktreeAddFailed`, `WorktreeNotFound`) surface as `Either`; `.orThrow` converts a `Left` back to an exception when the case is unexpected. |
 | `gh` | `createPr`, `updatePr`, `readIssue`, `readIssueComments`, `readPrComments`, `writeComment(pr, body)` / `writeComment(issue, body)`, `buildStatus`, `waitForBuild` | GitHub PR + CI integration via the `gh` CLI. `createPr` returns `Either[PrCreateFailed, …]` (covers `PrAlreadyExists` / `NoCommitsToPr`); `updatePr` replaces a PR's title + body (refresh a tentative description once the fix lands); `waitForBuild` returns `Either[BuildWaitFailed, …]`. |
 | `fs` | `read`, `write`, `list` | Working-tree file I/O. `read` returns `Option[String]` so a missing file is a branch point, not an exception. |
@@ -130,8 +131,9 @@ for task <- tasks do
 
 The first call opens the session; subsequent calls resume it. The library
 tracks fresh-vs-resume internally per backend (`--session-id` then `--resume`
-on claude; a client→server mapping on codex and opencode; a per-session
-`--session-dir` resumed with `--continue` on pi).
+on claude; a client→server mapping on codex, opencode, and gemini — codex and
+gemini mint their own id and resume via `codex exec resume` / `gemini --resume`;
+a per-session `--session-dir` resumed with `--continue` on pi).
 
 A minimal Pi-backed flow looks the same; Pi reads your normal Pi configuration
 and is driven through RPC mode under the hood:

--- a/adr/0015-gemini-stream-json-driver.md
+++ b/adr/0015-gemini-stream-json-driver.md
@@ -1,0 +1,188 @@
+# 0015. Drive Gemini CLI via `gemini --output-format stream-json` stdio JSONL
+
+Status: Accepted · Date: 2026-06-01
+Amends: [ADR 0003](0003-pluggable-llm-backends.md) (backend surface)
+Related: [ADR 0006](0006-stream-json-conversation-driver.md) (Claude stream-json driver), [ADR 0007](0007-codex-exec-jsonl-driver.md) (Codex exec JSONL driver), [ADR 0012](0012-mcp-host-bridge.md) (ask_user MCP bridge), [ADR 0014](0014-opencode-server-driver.md) (OpenCode server driver)
+
+## Context
+
+Orca already ships two LLM backends — Claude (bidirectional stream-json,
+ADR 0006) and Codex (one-shot `exec --json`, ADR 0007). Adding Google's
+`gemini` CLI as a third backend follows the established `LlmBackend[B]`
+SPI. The open question was which of gemini's headless output shapes to
+drive and how closely it maps to the existing infrastructure.
+
+Gemini's headless mode (triggered by `-p/--prompt` or a non-TTY) offers
+three output formats via `--output-format`: `text`, `json` (a single
+`{response, stats, error}` blob), and `stream-json` (newline-delimited
+JSONL events). It maps remarkably closely to the Codex shape: one-shot
+per invocation, multi-turn via a resume flag, no `--append-system-prompt`
+equivalent (it reads `GEMINI.md` for static instructions).
+
+## Findings
+
+`gemini -p <prompt> --output-format stream-json` emits one JSON object
+per line on stdout, with these event types:
+
+| `type`        | Payload (fields the driver reads)                       | Notes |
+| ------------- | ------------------------------------------------------- | ----- |
+| `init`        | `session_id`, `model`                                   | First event; `session_id` drives `--resume`. |
+| `message`     | `role`, `content`                                       | User (prompt echo) or assistant message chunk. |
+| `tool_use`    | `tool_name`, `tool_id`, `parameters`                    | Tool call request. |
+| `tool_result` | `tool_id`, `status`, `output`                           | Result of an executed tool. |
+| `error`       | `message`                                               | Non-fatal warning / system error. |
+| `result`      | `status`, `stats: { input_tokens, output_tokens, … }`  | Terminal event; carries aggregated usage. |
+
+Key differences from the existing backends:
+
+1. **No single terminal payload.** Unlike Claude's terminal `result`
+   message (which carries `output`/`structured_output`), gemini's
+   `result` event carries only status + stats. Like Codex, the driver
+   **synthesises** `LlmResult.output` — but where Codex snapshots the
+   *last* `agent_message`, gemini streams assistant prose as `message`
+   chunks, so the driver *accumulates* the content of every non-`user`
+   message and reads the buffer at the `result` event.
+2. **Assistant role is version-dependent.** Gemini's API uses the
+   `model` role; the CLI may spell it `model` or `assistant`. The driver
+   treats any role *other than* `user` as agent output, rather than
+   matching a fixed string.
+3. **No mid-turn approval subchannel.** Tool approvals are baked into the
+   spawn via `--approval-mode`. In headless mode `default` and
+   `auto_edit` would block on an approval prompt no one can answer, so
+   the only workable non-read-only mapping is `yolo`.
+4. **No `--output-schema` flag.** Gemini has no native structured-output
+   gate. `resultAs[O]` enforcement is prompt-template + the post-hoc
+   `DefaultLlmCall` corrective-retry loop only; `outputSchema` is still
+   threaded to `GeminiConversation` so the autonomous drain suppresses
+   the raw JSON payload from the user log.
+5. **Session resume** works via `gemini --resume <session-id> -p …`,
+   where the id is the one surfaced on the prior run's `init` event.
+6. **MCP servers are file-configured, not flag-configured.** Gemini reads
+   MCP servers only from `settings.json` (no inline `-c` override like
+   Codex).
+
+Example stream (tool-using scenario):
+
+```json
+{"type":"init","session_id":"019dc0e7-…","model":"gemini-2.5-pro"}
+{"type":"message","role":"assistant","content":"I'll list the files."}
+{"type":"tool_use","tool_name":"Bash","tool_id":"b1","parameters":{"command":"ls"}}
+{"type":"tool_result","tool_id":"b1","status":"success","output":"hello.txt\n"}
+{"type":"message","role":"assistant","content":"There is one file: hello.txt."}
+{"type":"result","status":"success","stats":{"input_tokens":120,"output_tokens":18}}
+```
+
+## Decision
+
+Drive Gemini via `gemini --output-format stream-json` over stdio. Reuse
+the `StreamConversation`/`Conversation[B]` infrastructure (the same base
+Claude and Codex sit on). Do **not** use the single-`json` blob (loses the
+live event stream) or any experimental app-server.
+
+Concretely:
+
+- `GeminiArgs.headless` spawns `gemini --skip-trust -p <prompt>
+  --output-format stream-json [-m <model>] [--approval-mode …]`;
+  `GeminiArgs.resume` adds `--resume <session-id>`. cwd is set on the OS
+  process spawn (gemini headless has no `-C` flag), so it isn't rendered
+  into argv.
+- **`--skip-trust` is unconditional.** Gemini refuses to run headless in a
+  folder it doesn't consider "trusted" (exit 55) and silently overrides
+  `--approval-mode` back to `default` before failing. orca always drives a
+  working directory the agent is meant to operate in, so trust is
+  unconditional — the direct analog of codex's `--skip-git-repo-check`
+  (equivalent to `GEMINI_CLI_TRUST_WORKSPACE=true`). Found via the gated
+  integration run.
+- `GeminiBackend` keeps a `SessionRegistry.ClientToServer` mapping the
+  caller's client id to gemini's `init`-reported session id (gemini mints
+  its own), committing the mapping post-drain so a follow-up call resumes
+  via `--resume`. Identical scheme to Codex.
+- `GeminiConversation` translates JSONL events:
+  - `init` → stash `session_id` + `model` (no event).
+  - `message` with `role != "user"` → one `AssistantTextDelta(content)`,
+    appended to the answer buffer. `role == "user"` (prompt echo) is
+    dropped — the base already surfaced the opening prompt.
+  - `tool_use` → `AssistantToolCall(tool_name, parameters)`; the
+    `tool_id → tool_name` map lets the later `tool_result` (which carries
+    only the id) be keyed by name.
+  - `tool_result` → `ToolResult(name, ok = status == "success", output)`.
+  - `error` → `ConversationEvent.Error`.
+  - `result` → emit `AssistantTurnEnd`, then finalise `LlmResult` with the
+    accumulated answer + usage.
+  - Unknown top-level types → dropped (forward-compat).
+- **System prompt fold.** Gemini has no `--append-system-prompt`, so the
+  composed system prompt (+ optional `ask_user` hint) is folded into the
+  user prompt as a `"System guidance:"` preamble — identical to Codex.
+- **Approval mapping** (`GeminiArgs`):
+  - `readOnly = true` → `--approval-mode plan`
+  - `AutoApprove.All` → `--approval-mode yolo`
+  - `AutoApprove.Only(_)` → `--approval-mode yolo` (widened — see below)
+- **Models.** `GeminiTool.flash` pins `gemini-2.5-flash`; bare `gemini`
+  pins `gemini-2.5-pro` in the runtime wiring (mirroring claude's Opus
+  default for the long-lived implementer). Model literals may rename in
+  future CLI versions; override via `withConfig`.
+
+### The `AutoApprove.Only` widening
+
+Gemini has no per-tool allowlist on the CLI, and in headless mode
+`auto_edit` blocks on shell-tool approvals that no one can answer. So
+`AutoApprove.Only(tools)` is mapped to `yolo` — "auto-approve a known set"
+widens to "auto-approve all". This is less restrictive than the caller
+asked for; it is the pragmatic analog of Codex's `--full-auto`
+approximation, and it keeps autonomous turns from deadlocking.
+
+### The `ask_user` MCP bridge via `.gemini/settings.json`
+
+Interactive calls stand up the shared `AskUserMcpServer` on an ephemeral
+port (ADR 0012). Because gemini reads MCP servers only from
+`settings.json`, `GeminiSettings.register` merges an
+`mcpServers.orca.httpUrl` entry into a project-local
+`<workDir>/.gemini/settings.json` before the spawn and restores the prior
+state afterward. The restore rides as an `extras` `AutoCloseable` on the
+`AskUserSession`, so the base layer runs it when the conversation
+finalises. The merge preserves unknown top-level keys and other configured
+servers (held as `RawJson`), and only touches `allowedMcpServerNames` when
+it already exists — introducing an allowlist where there was none would
+restrict gemini to *only* orca and hide the user's other servers.
+
+Two sharp edges, accepted:
+
+- **Concurrency.** Two interactive runs in the same `workDir` race on the
+  settings file. Flows already mint a fresh session per concurrent
+  reviewer, but two *interactive* runs in one directory is unsupported.
+- **Crash safety.** A hard crash skips the restore, leaving a stale `orca`
+  entry. Restore is best-effort, not transactional.
+
+## Why not the single `json` blob or an app-server
+
+- `--output-format json` returns one object at exit — no live
+  `ToolUse`/`AssistantMessage` events while the agent works, and a worse
+  fit for the `Conversation` contract every other backend implements.
+- The JSONL stream already covers every event the contract needs (tool
+  calls, results, assistant prose, usage, session id, errors), and future
+  gemini event types arrive additively in the same stream.
+
+## Alternatives considered
+
+- **`gemini mcp add` / `gemini mcp remove`** to register the ask_user
+  server. Rejected: mutates the user's *global* config with stateful side
+  effects; the project-local merge+restore is narrower and reversible.
+- **A throwaway config-dir override.** Cleaner isolation, but depends on a
+  config-home flag/env we couldn't confirm across versions. Deferred; the
+  project-local merge is the documented path today.
+
+## Testing
+
+- `GeminiArgsTest` — flag mapping (model, approval modes, resume).
+- `jsonl.InboundEventTest` — each event type parses defensively; unknown
+  types collapse to `Unknown`; missing fields default.
+- `GeminiConversationTest` — scripted JSONL against a
+  `FakePipedCliProcess`: answer accumulation, user-echo drop, tool
+  round-trip, ask_user suppression, cancel, clean-exit-without-result.
+- `GeminiSettingsTest` — merge preserves keys, allowlist rule, exact-byte
+  restore, file removal when none existed.
+- `GeminiBackendTest` — session id / usage extraction, resume dispatch,
+  systemPrompt fold, MCP registration on interactive (autonomous skips it).
+- `DefaultGeminiToolTest` — `flash`/pro model pins reach `--model`.
+- `GeminiIntegrationTest` (gated on `ORCA_INTEGRATION`) — real `gemini`:
+  headless round-trip and a resumed turn that recalls prior context.

--- a/build.sbt
+++ b/build.sbt
@@ -104,6 +104,14 @@ lazy val opencode = (project in file("opencode"))
     libraryDependencies ++= Seq(osLib, jsoniter, jsoniterMacros)
   )
 
+lazy val gemini = (project in file("gemini"))
+  .dependsOn(tools, tools % "test->test")
+  .settings(commonSettings)
+  .settings(
+    name := "orca-gemini",
+    libraryDependencies ++= Seq(osLib, jsoniter, jsoniterMacros)
+  )
+
 lazy val flow = (project in file("flow"))
   .dependsOn(tools)
   .settings(commonSettings)
@@ -113,7 +121,7 @@ lazy val flow = (project in file("flow"))
   )
 
 lazy val runner = (project in file("runner"))
-  .dependsOn(tools, flow, claude, codex, opencode, pi)
+  .dependsOn(tools, flow, claude, codex, opencode, pi, gemini)
   .settings(commonSettings)
   .settings(
     // Published as just "orca" so flow-script coordinates stay short.
@@ -157,4 +165,4 @@ lazy val orcaRoot = (project in file("."))
     // invoke each of them (they'd noisily warn about missing `doc`/`docs`).
     updateDocs / aggregate := false
   )
-  .aggregate(tools, flow, claude, codex, opencode, pi, runner)
+  .aggregate(tools, flow, claude, codex, opencode, pi, gemini, runner)

--- a/codex/src/main/scala/orca/tools/codex/CodexBackend.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexBackend.scala
@@ -134,7 +134,10 @@ private[orca] class CodexBackend(cli: CliRunner)(using Ox, BufferCapacity)
         case SessionMode.Interactive(p) => (Some(AskUserSession.allocate()), p)
         case SessionMode.Autonomous     => (None, "")
     try
-      val finalPrompt = mergeSystemPrompt(
+      // codex `exec` has no `--system-prompt` flag (it picks up `AGENTS.md`
+      // files for static instructions), so fold the composed system prompt into
+      // the user prompt.
+      val finalPrompt = SystemPromptComposer.foldIntoPrompt(
         config,
         prompt,
         extraHint = Option.when(askUser.isDefined)(AskUserMcpServer.Hint)
@@ -195,25 +198,6 @@ private[orca] class CodexBackend(cli: CliRunner)(using Ox, BufferCapacity)
       client: SessionId[BackendTag.Codex.type],
       server: SessionId[BackendTag.Codex.type]
   ): Unit = sessions.commitSuccess(client, server)
-
-  /** codex `exec` has no `--system-prompt` flag (codex picks up `AGENTS.md`
-    * files in the working directory for static instructions). Fold the composed
-    * system prompt (config + optional extra hint) into the user prompt as a
-    * preamble — a low-tech but predictable substitute.
-    */
-  private def mergeSystemPrompt(
-      config: LlmConfig,
-      userPrompt: String,
-      extraHint: Option[String]
-  ): String =
-    SystemPromptComposer.combine(config, extraHint) match
-      case None => userPrompt
-      case Some(text) =>
-        s"""System guidance:
-           |$text
-           |
-           |User request:
-           |$userPrompt""".stripMargin
 
   private def writeSchemaIfPresent(
       schema: Option[String],

--- a/flow/src/main/scala/orca/FlowContext.scala
+++ b/flow/src/main/scala/orca/FlowContext.scala
@@ -4,12 +4,13 @@ import orca.events.OrcaEvent
 import orca.tools.FsTool
 import orca.tools.GitTool
 import orca.tools.GitHubTool
-import orca.llm.{ClaudeTool, CodexTool, OpencodeTool, PiTool}
+import orca.llm.{ClaudeTool, CodexTool, GeminiTool, OpencodeTool, PiTool}
 
 /** Ambient context a flow script operates in. Bundles every tool the top- level
-  * accessors (`claude`, `codex`, `git`, `gh`, `fs`) resolve against, the user's
-  * positional prompt (`userPrompt`), and the event sink (`emit`) that
-  * stage/fail/fixLoop and the library's internals publish to.
+  * accessors (`claude`, `codex`, `opencode`, `pi`, `gemini`, `git`, `gh`, `fs`)
+  * resolve against, the user's positional prompt (`userPrompt`), and the event
+  * sink (`emit`) that stage/fail/fixLoop and the library's internals publish
+  * to.
   *
   * One is built per `flow(...)` invocation — flow scripts don't normally
   * instantiate `FlowContext` directly, just call the accessors inside a
@@ -21,6 +22,7 @@ trait FlowContext:
   def codex: CodexTool
   def opencode: OpencodeTool
   def pi: PiTool
+  def gemini: GeminiTool
   def git: GitTool
   def gh: GitHubTool
   def fs: FsTool

--- a/flow/src/main/scala/orca/accessors.scala
+++ b/flow/src/main/scala/orca/accessors.scala
@@ -3,7 +3,7 @@ package orca
 import orca.tools.FsTool
 import orca.tools.GitTool
 import orca.tools.GitHubTool
-import orca.llm.{ClaudeTool, CodexTool, OpencodeTool, PiTool}
+import orca.llm.{ClaudeTool, CodexTool, GeminiTool, OpencodeTool, PiTool}
 
 // Top-level accessors that resolve against the ambient FlowContext.
 // Flow scripts can write `git.checkout("main")` or `claude.ask(...)`
@@ -13,6 +13,7 @@ def claude(using ctx: FlowContext): ClaudeTool = ctx.claude
 def codex(using ctx: FlowContext): CodexTool = ctx.codex
 def opencode(using ctx: FlowContext): OpencodeTool = ctx.opencode
 def pi(using ctx: FlowContext): PiTool = ctx.pi
+def gemini(using ctx: FlowContext): GeminiTool = ctx.gemini
 def git(using ctx: FlowContext): GitTool = ctx.git
 def gh(using ctx: FlowContext): GitHubTool = ctx.gh
 def fs(using ctx: FlowContext): FsTool = ctx.fs

--- a/flow/src/main/scala/orca/events/Pricing.scala
+++ b/flow/src/main/scala/orca/events/Pricing.scala
@@ -113,7 +113,13 @@ object Pricing:
       Model("gpt-5-mini") -> ModelPricing(0.25, 0.025, 2),
       Model("gpt-5-nano") -> ModelPricing(0.05, 0.005, 0.40),
       // codex CLI 0.125.x default
-      Model("gpt-5.4-mini") -> ModelPricing(0.25, 0.025, 2)
+      Model("gpt-5.4-mini") -> ModelPricing(0.25, 0.025, 2),
+      // Gemini (paid tier). 2.5 Pro is tiered on prompt size; these are the
+      // ≤200k-token rates (the common case) — prompts above 200k bill more
+      // ($2.50 in / $15 out). gemini emits no cost on the wire, so these
+      // table rates × token counts are the only cost signal.
+      Model("gemini-2.5-pro") -> ModelPricing(1.25, 0.31, 10),
+      Model("gemini-2.5-flash") -> ModelPricing(0.30, 0.075, 2.50)
     ),
-    lastUpdated = LocalDate.of(2026, 5, 23)
+    lastUpdated = LocalDate.of(2026, 6, 7)
   )

--- a/flow/src/test/scala/orca/TestFlowContext.scala
+++ b/flow/src/test/scala/orca/TestFlowContext.scala
@@ -1,7 +1,7 @@
 package orca
 
 import orca.events.{EventDispatcher, OrcaEvent}
-import orca.llm.{ClaudeTool, CodexTool, OpencodeTool, PiTool}
+import orca.llm.{ClaudeTool, CodexTool, GeminiTool, OpencodeTool, PiTool}
 import orca.tools.FsTool
 import orca.tools.GitTool
 import orca.tools.GitHubTool
@@ -22,6 +22,7 @@ class TestFlowContext(
   lazy val codex: CodexTool = stub("codex")
   lazy val opencode: OpencodeTool = stub("opencode")
   lazy val pi: PiTool = stub("pi")
+  lazy val gemini: GeminiTool = stub("gemini")
   lazy val git: GitTool = stub("git")
   lazy val gh: GitHubTool = stub("gh")
   lazy val fs: FsTool = stub("fs")

--- a/gemini/src/main/scala/orca/tools/gemini/DefaultGeminiTool.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/DefaultGeminiTool.scala
@@ -1,0 +1,58 @@
+package orca.tools.gemini
+
+import orca.llm.{BackendTag, GeminiTool, LlmConfig, Model, Prompts}
+import orca.events.OrcaListener
+import orca.backend.{Interaction, LlmBackend}
+import orca.llm.BaseLlmTool
+
+/** Default [[GeminiTool]] implementation. Inherits the autonomous-text +
+  * `resultAs[O]` plumbing from [[BaseLlmTool]] and only adds the
+  * Gemini-specific `flash` model accessor.
+  */
+private[orca] class DefaultGeminiTool(
+    backend: LlmBackend[BackendTag.Gemini.type],
+    config: LlmConfig,
+    prompts: Prompts,
+    workDir: os.Path,
+    events: OrcaListener,
+    interaction: Interaction,
+    val name: String = "main"
+) extends BaseLlmTool[BackendTag.Gemini.type, GeminiTool](
+      backend,
+      config,
+      prompts,
+      workDir,
+      events,
+      interaction
+    )
+    with GeminiTool:
+
+  /** Pin the cheap-and-fast model variant. The literal id matches what's
+    * available in the installed `gemini` CLI; newer versions may rename, in
+    * which case callers override via `withConfig(LlmConfig(model =
+    * Some(Model("..."))))`.
+    */
+  def flash: GeminiTool = withModel(Model("gemini-2.5-flash"))
+
+  protected def copyTool(
+      config: LlmConfig = config,
+      name: String = name
+  ): GeminiTool =
+    new DefaultGeminiTool(
+      backend,
+      config,
+      prompts,
+      workDir,
+      events,
+      interaction,
+      name
+    )
+
+private[orca] object DefaultGeminiTool:
+
+  /** The strong default model. Bare `gemini` pins this (in the runtime wiring,
+    * mirroring claude's Opus default for the long-lived implementer); `flash`
+    * opts down. Newer `gemini` CLI versions may rename the id — override via
+    * `withConfig` if so.
+    */
+  val Pro: Model = Model("gemini-2.5-pro")

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
@@ -70,5 +70,5 @@ private[gemini] object GeminiArgs:
     if config.readOnly then Seq("--approval-mode", "plan")
     else
       config.autoApprove match
-        case AutoApprove.All     => Seq("--approval-mode", "yolo")
-        case AutoApprove.Only(_) => Seq("--approval-mode", "yolo")
+        case AutoApprove.All | AutoApprove.Only(_) =>
+          Seq("--approval-mode", "yolo")

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
@@ -1,0 +1,74 @@
+package orca.tools.gemini
+
+import orca.backend.CliArgs
+import orca.llm.{AutoApprove, BackendTag, LlmConfig, SessionId}
+
+/** Maps `LlmConfig` fields to `gemini` headless CLI flags. `systemPrompt` is
+  * not handled here — gemini has no `--append-system-prompt` equivalent (it
+  * picks up `GEMINI.md` files for static instructions), so the backend folds it
+  * into the user prompt before this method runs. The `ask_user` MCP server is
+  * registered via a project-local `.gemini/settings.json` merge in the backend
+  * rather than an argv flag (gemini has no inline MCP override like codex's
+  * `-c`).
+  *
+  * gemini headless is one-shot: each `-p` invocation processes one prompt and
+  * exits. Multi-turn happens via `--resume <session-id>`, where the id is the
+  * one surfaced on the `init` event of a prior `stream-json` run. We expose
+  * both shapes via [[headless]] / [[resume]].
+  */
+private[gemini] object GeminiArgs:
+
+  /** Single-turn `gemini -p <prompt> --output-format stream-json` invocation.
+    * cwd is set on the OS process spawn (gemini headless has no `-C` flag), so
+    * it isn't rendered here.
+    */
+  def headless(prompt: String, config: LlmConfig): Seq[String] =
+    Seq("gemini") ++
+      trustArgs ++
+      CliArgs.modelArgs(config) ++
+      approvalArgs(config) ++
+      Seq("--output-format", "stream-json", "-p", prompt)
+
+  /** Multi-turn continuation: `gemini --resume <id> -p <prompt>`. The id is the
+    * session id learned from the prior run's `init` event.
+    */
+  def resume(
+      sessionId: SessionId[BackendTag.Gemini.type],
+      prompt: String,
+      config: LlmConfig
+  ): Seq[String] =
+    Seq("gemini") ++
+      trustArgs ++
+      CliArgs.modelArgs(config) ++
+      approvalArgs(config) ++
+      Seq("--resume", SessionId.value(sessionId)) ++
+      Seq("--output-format", "stream-json", "-p", prompt)
+
+  /** gemini refuses to run headless in a folder it doesn't consider "trusted"
+    * (exit 55) and, worse, silently overrides `--approval-mode` back to
+    * `default` before failing. orca always drives a working directory the agent
+    * is meant to operate in, so trust is unconditional — the direct analog of
+    * codex's `--skip-git-repo-check`. (Equivalent to setting
+    * `GEMINI_CLI_TRUST_WORKSPACE=true`; the flag keeps it visible at the call
+    * site.)
+    */
+  private val trustArgs: Seq[String] = Seq("--skip-trust")
+
+  /** Approval-policy mapping. `readOnly` overrides any `autoApprove` setting —
+    * `--approval-mode plan` makes file writes and shelling-out unavailable to
+    * the agent, matching claude's `--permission-mode plan` and codex's
+    * `--sandbox read-only`. Otherwise gemini has no per-tool allowlist on the
+    * CLI, and in headless mode `auto_edit` blocks on shell approvals no one can
+    * answer, so both [[AutoApprove.All]] and [[AutoApprove.Only]] map to `yolo`
+    * (auto-approve all). The `Only` widening is documented in ADR 0015.
+    *
+    *   - `readOnly = true` → `--approval-mode plan`
+    *   - `AutoApprove.All` → `--approval-mode yolo`
+    *   - `AutoApprove.Only(_)` → `--approval-mode yolo`
+    */
+  private def approvalArgs(config: LlmConfig): Seq[String] =
+    if config.readOnly then Seq("--approval-mode", "plan")
+    else
+      config.autoApprove match
+        case AutoApprove.All     => Seq("--approval-mode", "yolo")
+        case AutoApprove.Only(_) => Seq("--approval-mode", "yolo")

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
@@ -130,7 +130,10 @@ private[orca] class GeminiBackend(cli: CliRunner)(using Ox, BufferCapacity)
           (Some(session), p)
         case SessionMode.Autonomous => (None, "")
     try
-      val finalPrompt = mergeSystemPrompt(
+      // gemini has no `--append-system-prompt` flag (it picks up `GEMINI.md`
+      // files for static instructions), so fold the composed system prompt into
+      // the user prompt — same approach as codex.
+      val finalPrompt = SystemPromptComposer.foldIntoPrompt(
         config,
         prompt,
         extraHint = Option.when(askUser.isDefined)(AskUserMcpServer.Hint)
@@ -175,23 +178,3 @@ private[orca] class GeminiBackend(cli: CliRunner)(using Ox, BufferCapacity)
       client: SessionId[BackendTag.Gemini.type],
       server: SessionId[BackendTag.Gemini.type]
   ): Unit = sessions.commitSuccess(client, server)
-
-  /** gemini has no `--append-system-prompt` flag (it picks up `GEMINI.md` files
-    * in the working directory for static instructions). Fold the composed
-    * system prompt (config + optional extra hint) into the user prompt as a
-    * preamble — a low-tech but predictable substitute, identical to codex's
-    * approach.
-    */
-  private def mergeSystemPrompt(
-      config: LlmConfig,
-      userPrompt: String,
-      extraHint: Option[String]
-  ): String =
-    SystemPromptComposer.combine(config, extraHint) match
-      case None => userPrompt
-      case Some(text) =>
-        s"""System guidance:
-           |$text
-           |
-           |User request:
-           |$userPrompt""".stripMargin

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
@@ -123,9 +123,6 @@ private[orca] class GeminiBackend(cli: CliRunner)(using Ox, BufferCapacity)
     val (askUser, displayPrompt): (Option[AskUserSession], String) =
       mode match
         case SessionMode.Interactive(p) =>
-          // The settings.json merge is registered as an `extras` AutoCloseable
-          // so it's restored when the conversation finalises (the base closes
-          // the AskUserSession post-drain).
           val askUserSession = AskUserSession.allocate: server =>
             List(GeminiSettings.register(workDir, server.url))
           (Some(askUserSession), p)
@@ -146,8 +143,8 @@ private[orca] class GeminiBackend(cli: CliRunner)(using Ox, BufferCapacity)
           GeminiArgs.headless(finalPrompt, config)
       val process = cli.spawnPiped(args, cwd = workDir, pipeStderr = true)
       try
-        // gemini consumes the prompt argv-side and ignores stdin; close it so
-        // the child stops waiting on stdin EOF.
+        // Close stdin so the child stops waiting on EOF (gemini reads the
+        // prompt argv-side).
         process.closeStdin()
         new GeminiConversation(
           process,

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
@@ -1,0 +1,197 @@
+package orca.tools.gemini
+
+import orca.events.OrcaListener
+import orca.llm.{BackendTag, LlmConfig, SessionId}
+import orca.{AgentTurnFailed, OrcaFlowException}
+import orca.backend.{
+  Conversation,
+  Conversations,
+  Dispatch,
+  LlmBackend,
+  LlmResult,
+  SessionMode,
+  SessionRegistry,
+  SystemPromptComposer
+}
+import orca.backend.mcp.{AskUserMcpServer, AskUserSession}
+import orca.subprocess.CliRunner
+import ox.Ox
+import ox.channels.BufferCapacity
+
+/** Gemini backend. Both autonomous and interactive paths drive `gemini -p
+  * <prompt> --output-format stream-json` over stdio: stdout JSONL is parsed
+  * into [[orca.tools.gemini.jsonl.InboundEvent]]s, and the accumulated
+  * assistant message content becomes the result at the terminal `result` event.
+  * See [[../../../adr/0015-gemini-stream-json-driver.md ADR 0015]] for the
+  * protocol shape and the rationale.
+  *
+  * Both modes wrap the subprocess in a [[GeminiConversation]]; the autonomous
+  * path drains it internally via [[orca.backend.Conversations.drainAutonomous]]
+  * while the interactive path returns the conversation for an `Interaction` to
+  * drive. Multi-turn: subsequent calls with the same session id route through
+  * `gemini --resume <session-id>` via the [[sessions]] registry (a
+  * [[SessionRegistry.ClientToServer]]), where the id was learned from the
+  * `init` event of the prior run.
+  *
+  * Interactive calls additionally stand up an `ask_user` MCP host bridge
+  * ([[AskUserMcpServer]]) on an ephemeral port and register it with gemini by
+  * merging an `mcpServers.orca` entry into a project-local
+  * `.gemini/settings.json` ([[GeminiSettings]]) — gemini has no inline `-c` MCP
+  * override like codex. The merge is restored when the conversation finalises
+  * (the restore rides as an `extras` `AutoCloseable` on the
+  * [[AskUserSession]]). Autonomous calls skip the bridge entirely.
+  */
+private[orca] class GeminiBackend(cli: CliRunner)(using Ox, BufferCapacity)
+    extends LlmBackend[BackendTag.Gemini.type]:
+
+  /** Maps the client-allocated session id to gemini's `init`-reported session
+    * id. `gemini -p` mints its own id, so we keep this mapping to dispatch
+    * subsequent calls through `gemini --resume <server-id>`.
+    */
+  private val sessions =
+    new SessionRegistry.ClientToServer[BackendTag.Gemini.type]
+
+  def runAutonomous(
+      prompt: String,
+      session: SessionId[BackendTag.Gemini.type],
+      config: LlmConfig,
+      workDir: os.Path,
+      events: OrcaListener = OrcaListener.noop,
+      outputSchema: Option[String] = None
+  ): LlmResult[BackendTag.Gemini.type] =
+    val conv = openConversation(
+      prompt = prompt,
+      mode = SessionMode.Autonomous,
+      session = session,
+      config = config,
+      workDir = workDir,
+      // Forwarded so `conv.outputSchema` signals structured mode to the drain
+      // (suppressing the raw JSON payload from the user log). gemini has no
+      // `--output-schema` flag, so enforcement is prompt-only.
+      outputSchema = outputSchema
+    )
+    try
+      val result = Conversations.drainAutonomous(conv, events)
+      sessions.commitSuccess(session, result.sessionId)
+      // Hide the server-allocated id from the caller — they keep using the
+      // client id they passed in. Future calls resolve via the registry.
+      result.copy(sessionId = session)
+    catch
+      // Preserve the non-retryable type: a turn that ran and failed must not
+      // be retried (it would reopen the now-registered session id).
+      case e: AgentTurnFailed => throw e
+      case e: OrcaFlowException =>
+        throw new OrcaFlowException(s"gemini CLI failed: ${e.getMessage}")
+
+  def runInteractive(
+      prompt: String,
+      session: SessionId[BackendTag.Gemini.type],
+      displayPrompt: String,
+      config: LlmConfig,
+      workDir: os.Path,
+      outputSchema: Option[String]
+  ): Conversation[BackendTag.Gemini.type] =
+    openConversation(
+      prompt,
+      mode = SessionMode.Interactive(displayPrompt),
+      session = session,
+      config = config,
+      workDir = workDir,
+      outputSchema = outputSchema
+    )
+
+  /** Spawn `gemini -p` (fresh) or `gemini --resume <server-id> -p`
+    * (continuation), and wrap the process in a live [[GeminiConversation]].
+    * Stdin is closed immediately — gemini consumes the prompt argv-side.
+    *
+    * `Interactive` mode wires the MCP `ask_user` tool: stand up the bridge +
+    * Netty server, merge the server URL into `.gemini/settings.json` (the
+    * restore rides as an `extras` `AutoCloseable`), fold the system-prompt hint
+    * into the user prompt (gemini has no `--append-system-prompt`), and hand
+    * the bundle to `GeminiConversation` so it can surface `UserQuestion` events
+    * and restore the settings file on finalize. `Autonomous` skips all of it.
+    */
+  private def openConversation(
+      prompt: String,
+      mode: SessionMode,
+      session: SessionId[BackendTag.Gemini.type],
+      config: LlmConfig,
+      workDir: os.Path,
+      outputSchema: Option[String]
+  ): Conversation[BackendTag.Gemini.type] =
+    val (askUser, displayPrompt): (Option[AskUserSession], String) =
+      mode match
+        case SessionMode.Interactive(p) =>
+          // The settings.json merge is registered as an `extras` AutoCloseable
+          // so it's restored when the conversation finalises (the base closes
+          // the AskUserSession post-drain).
+          val session = AskUserSession.allocate: server =>
+            List(GeminiSettings.register(workDir, server.url))
+          (Some(session), p)
+        case SessionMode.Autonomous => (None, "")
+    try
+      val finalPrompt = mergeSystemPrompt(
+        config,
+        prompt,
+        extraHint = Option.when(askUser.isDefined)(AskUserMcpServer.Hint)
+      )
+      val args = sessions.dispatchFor(session) match
+        case Dispatch.Resume(serverId) =>
+          GeminiArgs.resume(serverId, finalPrompt, config)
+        case Dispatch.Fresh(_) =>
+          GeminiArgs.headless(finalPrompt, config)
+      val process = cli.spawnPiped(args, cwd = workDir, pipeStderr = true)
+      try
+        // gemini consumes the prompt argv-side and ignores stdin; close it so
+        // the child stops waiting on stdin EOF.
+        process.closeStdin()
+        new GeminiConversation(
+          process,
+          initialPrompt = displayPrompt,
+          outputSchema = outputSchema,
+          askUser = askUser
+        )
+      catch
+        case e: Exception =>
+          process.sendSigInt()
+          throw OrcaFlowException(
+            s"Failed to open gemini session: ${e.getMessage}"
+          )
+    catch
+      case e: Throwable =>
+        // Any failure between resource allocation and a fully-constructed
+        // GeminiConversation: tear down the MCP server (which also restores
+        // the settings.json via its extras) so nothing leaks. Once the
+        // conversation owns the resources they ride through `onFinalize`.
+        askUser.foreach(_.close())
+        throw e
+
+  /** Record the server session id so subsequent calls with the same client id
+    * resume that session. Called by [[runAutonomous]] post-drain and by
+    * [[orca.llm.DefaultLlmCall]] post-`interaction.drive` on the interactive
+    * path; delegates to the registry's `commitSuccess`.
+    */
+  override def registerSession(
+      client: SessionId[BackendTag.Gemini.type],
+      server: SessionId[BackendTag.Gemini.type]
+  ): Unit = sessions.commitSuccess(client, server)
+
+  /** gemini has no `--append-system-prompt` flag (it picks up `GEMINI.md` files
+    * in the working directory for static instructions). Fold the composed
+    * system prompt (config + optional extra hint) into the user prompt as a
+    * preamble — a low-tech but predictable substitute, identical to codex's
+    * approach.
+    */
+  private def mergeSystemPrompt(
+      config: LlmConfig,
+      userPrompt: String,
+      extraHint: Option[String]
+  ): String =
+    SystemPromptComposer.combine(config, extraHint) match
+      case None => userPrompt
+      case Some(text) =>
+        s"""System guidance:
+           |$text
+           |
+           |User request:
+           |$userPrompt""".stripMargin

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
@@ -125,9 +125,9 @@ private[orca] class GeminiBackend(cli: CliRunner)(using Ox, BufferCapacity)
           // The settings.json merge is registered as an `extras` AutoCloseable
           // so it's restored when the conversation finalises (the base closes
           // the AskUserSession post-drain).
-          val session = AskUserSession.allocate: server =>
+          val askUserSession = AskUserSession.allocate: server =>
             List(GeminiSettings.register(workDir, server.url))
-          (Some(session), p)
+          (Some(askUserSession), p)
         case SessionMode.Autonomous => (None, "")
     try
       // gemini has no `--append-system-prompt` flag (it picks up `GEMINI.md`

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
@@ -77,8 +77,9 @@ private[orca] class GeminiBackend(cli: CliRunner)(using Ox, BufferCapacity)
       // client id they passed in. Future calls resolve via the registry.
       result.copy(sessionId = session)
     catch
-      // Preserve the non-retryable type: a turn that ran and failed must not
-      // be retried (it would reopen the now-registered session id).
+      // Preserve the non-retryable type: a turn that genuinely ran and failed
+      // must keep its `AgentTurnFailed` so the corrective-retry loop (which only
+      // retries parse failures) doesn't re-run it.
       case e: AgentTurnFailed => throw e
       case e: OrcaFlowException =>
         throw new OrcaFlowException(s"gemini CLI failed: ${e.getMessage}")

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiConversation.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiConversation.scala
@@ -117,7 +117,6 @@ private[gemini] class GeminiConversation(
     case InboundEvent.Error(message) =>
       eventQueue.enqueue(ConversationEvent.Error(s"gemini: $message"))
     case InboundEvent.Result(usage, status) =>
-      // Close the assistant turn for the drain, then settle the outcome.
       eventQueue.enqueue(ConversationEvent.AssistantTurnEnd)
       handleResult(usage, status)
     case InboundEvent.Unknown(_) =>

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiConversation.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiConversation.scala
@@ -163,7 +163,7 @@ private[gemini] class GeminiConversation(
       eventQueue.enqueue(ConversationEvent.AssistantTextDelta(content))
 
   private def handleToolUse(name: String, id: String, params: String): Unit =
-    if name.contains(AskUserMcpServer.ToolSlug) then
+    if GeminiConversation.isAskUserTool(name) then
       suppressedToolIds = suppressedToolIds + id
     else
       toolNames = toolNames + (id -> name)
@@ -188,6 +188,16 @@ private[gemini] class GeminiConversation(
       )
 
 private[gemini] object GeminiConversation:
+
+  /** The `ask_user` MCP tool as gemini names it in `tool_use` events: gemini
+    * qualifies an MCP tool as `<server>__<tool>` (e.g. `orca__ask_user`). Match
+    * that exact name (or the bare slug) rather than any name *containing*
+    * `ask_user`, so an unrelated tool whose name merely includes the slug isn't
+    * suppressed.
+    */
+  private def isAskUserTool(name: String): Boolean =
+    name == AskUserMcpServer.ToolSlug ||
+      name == s"${AskUserMcpServer.ServerName}__${AskUserMcpServer.ToolSlug}"
 
   /** Stderr lines gemini prints on every (successful) headless run that carry
     * no diagnostic value — filtered before they reach the event queue so they

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiConversation.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiConversation.scala
@@ -205,9 +205,12 @@ private[gemini] object GeminiConversation:
     *   - a 256-color terminal-capability warning,
     *   - `YOLO mode is enabled. …` notices (we always pass `--approval-mode
     *     yolo` for non-read-only turns),
-    *   - `Shell cwd was reset to …` after a tool run.
+    *   - `Shell cwd was reset to …` after a tool run,
+    *   - `[IDEClient]` companion-extension chatter (gemini probes for a VS Code
+    *     companion that an orca-driven subprocess never has).
     */
   private[gemini] def isKnownStderrNoise(line: String): Boolean =
     line.contains("256-color support not detected") ||
       line.startsWith("YOLO mode is enabled") ||
-      line.startsWith("Shell cwd was reset to")
+      line.startsWith("Shell cwd was reset to") ||
+      line.contains("[IDEClient]")

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiConversation.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiConversation.scala
@@ -1,0 +1,204 @@
+package orca.tools.gemini
+
+import orca.llm.{BackendTag, Model, SessionId}
+import orca.events.Usage
+import orca.{AgentTurnFailed, OrcaFlowException}
+import orca.backend.{
+  BufferedStderrDiagnostics,
+  ConversationEvent,
+  LlmResult,
+  StreamConversation,
+  StreamSource
+}
+import orca.backend.mcp.{AskUserMcpServer, AskUserSession}
+import orca.subprocess.PipedCliProcess
+import orca.tools.gemini.jsonl.InboundEvent
+
+import java.util.concurrent.atomic.AtomicReference
+
+/** Drives a `gemini -p <prompt> --output-format stream-json` session to
+  * completion. Boilerplate lives in [[StreamConversation]]; this class supplies
+  * the gemini-specific protocol translation: JSONL → [[InboundEvent]] →
+  * `ConversationEvent`s.
+  *
+  * Notable parity gaps vs. claude (deliberate — see ADR 0015):
+  *   - gemini emits whole `message` chunks, not negotiated tool approvals;
+  *     `approval-mode` is pre-baked into spawn args, so `ApproveTool` is never
+  *     emitted here.
+  *   - gemini headless is one-shot; multi-turn happens via `--resume` on a
+  *     fresh spawn, so `sendUserMessage` is a no-op.
+  *   - **`LlmResult.output` is synthesised**: gemini has no single terminal
+  *     message carrying the answer, so assistant-role `message` content is
+  *     accumulated as it streams and the result builder reads it at the
+  *     `result` event. The prompt template makes the closing content JSON in
+  *     structured mode.
+  */
+private[gemini] class GeminiConversation(
+    process: PipedCliProcess,
+    initialPrompt: String = "",
+    val outputSchema: Option[String] = None,
+    override val askUser: Option[AskUserSession] = None
+) extends StreamConversation[BackendTag.Gemini.type](
+      source = StreamSource.fromProcess(process),
+      backendName = "gemini",
+      initialPrompt = initialPrompt
+    )
+    with BufferedStderrDiagnostics[BackendTag.Gemini.type]:
+
+  import StreamConversation.Outcome
+
+  private val sessionIdRef = new AtomicReference[String]("")
+  private val modelRef = new AtomicReference[Option[String]](None)
+
+  /** Accumulated assistant-role `message` content — the synthesised answer. See
+    * the class scaladoc for why we build rather than receive.
+    */
+  private val answer = new StringBuilder
+
+  /** Maps a tool_use `tool_id` to the `tool_name` it announced, so the matching
+    * `tool_result` (which only carries the id) can be keyed by name in the
+    * emitted [[ConversationEvent.ToolResult]]. Single-threaded reader (the
+    * JSONL reader thread is the sole writer), so a plain `var` is enough.
+    */
+  private var toolNames: Map[String, String] = Map.empty
+
+  /** tool_use ids for `ask_user` MCP calls whose echo we drop — the host-side
+    * bridge already surfaced the matching `UserQuestion`, so rendering the tool
+    * call + the answer-as-result on top would be noise.
+    */
+  private var suppressedToolIds: Set[String] = Set.empty
+
+  // Subclass fields above are assigned; safe to spin up the reader.
+  start()
+
+  // --- Conversation surface ---
+
+  /** gemini headless consumes its prompt argv-side and exits; injecting more
+    * user turns mid-session isn't supported (multi-turn is a fresh `--resume`
+    * spawn). The contract still requires a callable method — this is a no-op.
+    */
+  def sendUserMessage(text: String): Unit = ()
+
+  // --- Reader hooks ---
+
+  override protected def handleLine(line: String): Unit =
+    handle(InboundEvent.parse(line))
+
+  /** Surface a real stderr line as an `Error` event AND record it in the
+    * bounded buffer ([[BufferedStderrDiagnostics]]) so the failure exception
+    * can include it. Known-benign chatter gemini prints on every successful run
+    * (see [[GeminiConversation.isKnownStderrNoise]]) is dropped so it doesn't
+    * render as a spurious `✖` on each call.
+    */
+  override protected def handleStderr(line: String): Unit =
+    val trimmed = line.trim
+    if trimmed.nonEmpty && !GeminiConversation.isKnownStderrNoise(trimmed) then
+      eventQueue.enqueue(ConversationEvent.Error(s"gemini: $trimmed"))
+      recordStderr(trimmed)
+
+  override protected def cleanExitWithoutResult(): Throwable =
+    new OrcaFlowException(
+      appendContext(
+        "gemini exited cleanly but never sent a result event"
+      )
+    )
+
+  // --- Per-event dispatch ---
+
+  private def handle(event: InboundEvent): Unit = event match
+    case InboundEvent.Init(sessionId, model) =>
+      sessionIdRef.set(sessionId)
+      modelRef.set(model)
+    case InboundEvent.Message(role, content) => handleMessage(role, content)
+    case InboundEvent.ToolUse(name, id, params) =>
+      handleToolUse(name, id, params)
+    case InboundEvent.ToolResult(id, status, output) =>
+      handleToolResult(id, status, output)
+    case InboundEvent.Error(message) =>
+      eventQueue.enqueue(ConversationEvent.Error(s"gemini: $message"))
+    case InboundEvent.Result(usage, status) =>
+      // Close the assistant turn for the drain, then settle the outcome.
+      eventQueue.enqueue(ConversationEvent.AssistantTurnEnd)
+      handleResult(usage, status)
+    case InboundEvent.Unknown(_) =>
+      // Forward-compat: gemini may add new top-level event types; drop them
+      // silently rather than rendering an error.
+      ()
+
+  /** Settle the conversation outcome at the terminal `result` event.
+    * `"success"` is the documented good status (headless stream-json); an
+    * empty/absent status is also treated as success for robustness. Any other
+    * non-empty status is a failed turn that must NOT be reported as success
+    * even though gemini exited 0 — tagged `AgentTurnFailed` so the autonomous
+    * retry loop doesn't reopen the now-registered session id.
+    */
+  private def handleResult(usage: Usage, status: String): Unit =
+    if status.nonEmpty && status != "success" then
+      val _ = outcomeRef.compareAndSet(
+        None,
+        Some(
+          Outcome.failed[BackendTag.Gemini.type](
+            new AgentTurnFailed(s"gemini turn ended with status '$status'")
+          )
+        )
+      )
+    else
+      val result = LlmResult(
+        sessionId = SessionId[BackendTag.Gemini.type](sessionIdRef.get()),
+        output = answer.toString,
+        usage = usage,
+        model = modelRef.get().map(Model.apply)
+      )
+      val _ = outcomeRef.compareAndSet(None, Some(Outcome.Success(result)))
+
+  /** A `user`-role message is the prompt echo (the base already surfaced the
+    * opening prompt as a `UserMessage`), so it's dropped from both the event
+    * stream and the answer. Any other role is treated as agent output — gemini
+    * spells the assistant side `model`/`assistant` across versions, so we match
+    * on "not user" rather than a fixed string.
+    */
+  private def handleMessage(role: String, content: String): Unit =
+    if role != "user" && content.nonEmpty then
+      val _ = answer.append(content)
+      eventQueue.enqueue(ConversationEvent.AssistantTextDelta(content))
+
+  private def handleToolUse(name: String, id: String, params: String): Unit =
+    if name.contains(AskUserMcpServer.ToolSlug) then
+      suppressedToolIds = suppressedToolIds + id
+    else
+      toolNames = toolNames + (id -> name)
+      eventQueue.enqueue(
+        ConversationEvent.AssistantToolCall(toolName = name, rawInput = params)
+      )
+
+  private def handleToolResult(
+      id: String,
+      status: String,
+      output: String
+  ): Unit =
+    if suppressedToolIds.contains(id) then
+      suppressedToolIds = suppressedToolIds - id
+    else
+      eventQueue.enqueue(
+        ConversationEvent.ToolResult(
+          toolName = toolNames.getOrElse(id, id),
+          ok = status == "success",
+          content = output
+        )
+      )
+
+private[gemini] object GeminiConversation:
+
+  /** Stderr lines gemini prints on every (successful) headless run that carry
+    * no diagnostic value — filtered before they reach the event queue so they
+    * don't render as spurious `✖` errors. Observed on gemini 0.45.2:
+    *
+    *   - a 256-color terminal-capability warning,
+    *   - `YOLO mode is enabled. …` notices (we always pass `--approval-mode
+    *     yolo` for non-read-only turns),
+    *   - `Shell cwd was reset to …` after a tool run.
+    */
+  private[gemini] def isKnownStderrNoise(line: String): Boolean =
+    line.contains("256-color support not detected") ||
+      line.startsWith("YOLO mode is enabled") ||
+      line.startsWith("Shell cwd was reset to")

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiConversation.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiConversation.scala
@@ -137,7 +137,12 @@ private[gemini] class GeminiConversation(
         None,
         Some(
           Outcome.failed[BackendTag.Gemini.type](
-            new AgentTurnFailed(s"gemini turn ended with status '$status'")
+            // Fold in the buffered stderr (the real reason — quota, auth, …)
+            // so the exception carries it even for a noop listener, matching
+            // the non-zero-exit and missing-result failure paths.
+            new AgentTurnFailed(
+              appendContext(s"gemini turn ended with status '$status'")
+            )
           )
         )
       )

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiSettings.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiSettings.scala
@@ -60,7 +60,11 @@ private[gemini] object GeminiSettings:
       .get("mcpServers")
       .map(raw => readFromString[Map[String, RawJson]](raw.value))
       .getOrElse(Map.empty)
-    val orcaEntry = RawJson(s"""{"httpUrl":"$mcpUrl"}""")
+    // Serialize the URL through the codec rather than interpolating it into a
+    // raw JSON string, so a value containing `"` or `\` stays valid JSON.
+    val orcaEntry = RawJson(
+      writeToString(Map("httpUrl" -> mcpUrl))(using strMapCodec)
+    )
     val mergedServers =
       servers + (AskUserMcpServer.ServerName -> orcaEntry)
     val withServers =
@@ -85,3 +89,6 @@ private[gemini] object GeminiSettings:
           ))
 
   private given listCodec: JsonValueCodec[List[String]] = JsonCodecMaker.make
+
+  private given strMapCodec: JsonValueCodec[Map[String, String]] =
+    JsonCodecMaker.make

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiSettings.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiSettings.scala
@@ -1,0 +1,87 @@
+package orca.tools.gemini
+
+import orca.backend.mcp.AskUserMcpServer
+import orca.util.RawJson
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{
+  JsonValueCodec,
+  readFromString,
+  writeToString
+}
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+
+/** Registers the ephemeral `ask_user` MCP server with gemini for the lifetime
+  * of one interactive conversation. Unlike codex (which takes an inline `-c
+  * mcp_servers.orca.url=…` override), gemini only reads MCP server config from
+  * `settings.json`, so we merge an entry into the project-local
+  * `<workDir>/.gemini/settings.json` and restore the prior state when the
+  * conversation finalises.
+  *
+  * Merge strategy preserves the user's file: unknown top-level keys and other
+  * configured `mcpServers` ride through verbatim (held as [[RawJson]]). The
+  * `allowedMcpServerNames` allowlist is only touched when it already exists —
+  * introducing one where there was none would restrict gemini to ONLY orca and
+  * hide the user's other servers.
+  *
+  * Two sharp edges (documented in ADR 0015): two interactive runs in the same
+  * `workDir` race on this file, and a hard crash skips the restore, leaving a
+  * stale `orca` entry behind. Restore is therefore best-effort, not
+  * transactional.
+  */
+private[gemini] object GeminiSettings:
+
+  private given objCodec: JsonValueCodec[Map[String, RawJson]] =
+    JsonCodecMaker.make
+
+  /** Merge the orca MCP server into `<workDir>/.gemini/settings.json` and
+    * return an [[AutoCloseable]] that restores the prior state (original bytes,
+    * or file removal if it didn't exist) on `close()`.
+    */
+  def register(workDir: os.Path, mcpUrl: String): AutoCloseable =
+    val file = workDir / ".gemini" / "settings.json"
+    val existed = os.exists(file)
+    val original = if existed then os.read(file) else ""
+    os.write.over(
+      file,
+      merge(if existed then original else "{}", mcpUrl),
+      createFolders = true
+    )
+    () =>
+      if existed then os.write.over(file, original)
+      else if os.exists(file) then
+        val _ = os.remove(file)
+
+  /** Pure merge: inject `mcpServers.<ServerName>.httpUrl = mcpUrl` into the
+    * top-level settings object, preserving every other key.
+    */
+  private[gemini] def merge(content: String, mcpUrl: String): String =
+    val top = readFromString[Map[String, RawJson]](content)
+    val servers = top
+      .get("mcpServers")
+      .map(raw => readFromString[Map[String, RawJson]](raw.value))
+      .getOrElse(Map.empty)
+    val orcaEntry = RawJson(s"""{"httpUrl":"$mcpUrl"}""")
+    val mergedServers =
+      servers + (AskUserMcpServer.ServerName -> orcaEntry)
+    val withServers =
+      top + ("mcpServers" -> RawJson(writeToString(mergedServers)))
+    writeToString(withAllowlist(withServers))
+
+  /** Append the orca server name to `allowedMcpServerNames`, but only when the
+    * allowlist already exists (see the object scaladoc for why).
+    */
+  private def withAllowlist(
+      top: Map[String, RawJson]
+  ): Map[String, RawJson] =
+    top.get("allowedMcpServerNames") match
+      case None => top
+      case Some(raw) =>
+        val names = readFromString[List[String]](raw.value)(using listCodec)
+        if names.contains(AskUserMcpServer.ServerName) then top
+        else
+          val updated = names :+ AskUserMcpServer.ServerName
+          top + ("allowedMcpServerNames" -> RawJson(
+            writeToString(updated)(using listCodec)
+          ))
+
+  private given listCodec: JsonValueCodec[List[String]] = JsonCodecMaker.make

--- a/gemini/src/main/scala/orca/tools/gemini/jsonl/InboundEvent.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/jsonl/InboundEvent.scala
@@ -88,9 +88,9 @@ private[gemini] object InboundEvent:
       Usage(
         inputTokens = s.input_tokens.getOrElse(0L),
         outputTokens = s.output_tokens.getOrElse(0L),
-        // gemini doesn't emit cost on the wire; cache sub-count is `cached`
-        // (older/forward shapes may use `cached_input_tokens`).
-        cost = None,
+        cost = None, // gemini doesn't emit cost on the wire
+        // cache sub-count is `cached` (older/forward shapes use
+        // `cached_input_tokens`).
         cachedInputTokens = s.cached.orElse(s.cached_input_tokens).getOrElse(0L)
       ),
       status = w.status.getOrElse("")
@@ -130,8 +130,7 @@ private[gemini] object InboundEvent:
       input_tokens: Option[Long] = None,
       output_tokens: Option[Long] = None,
       cached: Option[Long] = None,
-      cached_input_tokens: Option[Long] = None,
-      total_tokens: Option[Long] = None
+      cached_input_tokens: Option[Long] = None
   ) derives ConfiguredJsonValueCodec
 
   private case class ResultWire(

--- a/gemini/src/main/scala/orca/tools/gemini/jsonl/InboundEvent.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/jsonl/InboundEvent.scala
@@ -1,0 +1,140 @@
+package orca.tools.gemini.jsonl
+
+import orca.events.Usage
+import orca.util.RawJson
+
+import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
+import com.github.plokhotnyuk.jsoniter_scala.macros.ConfiguredJsonValueCodec
+
+/** One event parsed off gemini's stdout when it runs with `-p <prompt>
+  * --output-format stream-json`.
+  *
+  * The shape is documented in
+  * [[../../../adr/0015-gemini-stream-json-driver.md ADR 0015]]; each variant
+  * carries only the fields the driver actually inspects. Unknown top-level
+  * types collapse to [[Unknown]] so protocol drift doesn't crash the pipeline,
+  * and every wire field is optional with a default so a renamed/missing key
+  * degrades gracefully rather than throwing.
+  */
+private[gemini] enum InboundEvent:
+  /** First event in a session — carries the session id (used to drive
+    * `--resume`) and, when present, the resolved model id.
+    */
+  case Init(sessionId: String, model: Option[String])
+
+  /** A user or assistant message chunk. `role` is surfaced verbatim (gemini
+    * spells the assistant side `model`/`assistant` depending on version); the
+    * conversation decides which roles count as agent output.
+    */
+  case Message(role: String, content: String)
+  case ToolUse(toolName: String, toolId: String, parameters: String)
+  case ToolResult(toolId: String, status: String, output: String)
+  case Error(message: String)
+
+  /** Final event — aggregated token stats (mapped to [[Usage]]) and the
+    * terminal status string.
+    */
+  case Result(usage: Usage, status: String)
+  case Unknown(rawType: String)
+
+private[gemini] object InboundEvent:
+
+  /** Parse one JSONL line. Malformed JSON propagates `JsonReaderException` —
+    * callers decide whether to skip or fail.
+    */
+  def parse(line: String): InboundEvent =
+    val envelope = readFromString[TopEnvelope](line)
+    envelope.`type` match
+      case "init"        => parseInit(line)
+      case "message"     => parseMessage(line)
+      case "tool_use"    => parseToolUse(line)
+      case "tool_result" => parseToolResult(line)
+      case "error"       => parseError(line)
+      case "result"      => parseResult(line)
+      case other         => Unknown(other)
+
+  private def parseInit(line: String): InboundEvent =
+    val w = readFromString[InitWire](line)
+    Init(w.session_id.getOrElse(""), w.model)
+
+  private def parseMessage(line: String): InboundEvent =
+    val w = readFromString[MessageWire](line)
+    Message(w.role.getOrElse(""), w.content.getOrElse(""))
+
+  private def parseToolUse(line: String): InboundEvent =
+    val w = readFromString[ToolUseWire](line)
+    ToolUse(
+      toolName = w.tool_name.getOrElse(""),
+      toolId = w.tool_id.getOrElse(""),
+      parameters = w.parameters.map(_.value).getOrElse("{}")
+    )
+
+  private def parseToolResult(line: String): InboundEvent =
+    val w = readFromString[ToolResultWire](line)
+    ToolResult(
+      toolId = w.tool_id.getOrElse(""),
+      status = w.status.getOrElse(""),
+      output = w.output.getOrElse("")
+    )
+
+  private def parseError(line: String): InboundEvent =
+    val w = readFromString[ErrorWire](line)
+    Error(w.message.getOrElse(""))
+
+  private def parseResult(line: String): InboundEvent =
+    val w = readFromString[ResultWire](line)
+    val s = w.stats.getOrElse(StatsWire())
+    Result(
+      Usage(
+        inputTokens = s.input_tokens.getOrElse(0L),
+        outputTokens = s.output_tokens.getOrElse(0L),
+        // gemini doesn't emit cost on the wire; cache sub-count is `cached`
+        // (older/forward shapes may use `cached_input_tokens`).
+        cost = None,
+        cachedInputTokens = s.cached.orElse(s.cached_input_tokens).getOrElse(0L)
+      ),
+      status = w.status.getOrElse("")
+    )
+
+  // --- Wire shapes ---
+
+  private case class TopEnvelope(`type`: String)
+      derives ConfiguredJsonValueCodec
+
+  private case class InitWire(
+      session_id: Option[String] = None,
+      model: Option[String] = None
+  ) derives ConfiguredJsonValueCodec
+
+  private case class MessageWire(
+      role: Option[String] = None,
+      content: Option[String] = None
+  ) derives ConfiguredJsonValueCodec
+
+  private case class ToolUseWire(
+      tool_name: Option[String] = None,
+      tool_id: Option[String] = None,
+      parameters: Option[RawJson] = None
+  ) derives ConfiguredJsonValueCodec
+
+  private case class ToolResultWire(
+      tool_id: Option[String] = None,
+      status: Option[String] = None,
+      output: Option[String] = None
+  ) derives ConfiguredJsonValueCodec
+
+  private case class ErrorWire(message: Option[String] = None)
+      derives ConfiguredJsonValueCodec
+
+  private case class StatsWire(
+      input_tokens: Option[Long] = None,
+      output_tokens: Option[Long] = None,
+      cached: Option[Long] = None,
+      cached_input_tokens: Option[Long] = None,
+      total_tokens: Option[Long] = None
+  ) derives ConfiguredJsonValueCodec
+
+  private case class ResultWire(
+      status: Option[String] = None,
+      stats: Option[StatsWire] = None
+  ) derives ConfiguredJsonValueCodec

--- a/gemini/src/test/scala/orca/tools/gemini/DefaultGeminiToolTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/DefaultGeminiToolTest.scala
@@ -1,0 +1,75 @@
+package orca.tools.gemini
+
+import orca.backend.{Conversation, Interaction, LlmResult, SupervisedBackend}
+import orca.events.OrcaListener
+import orca.llm.{BackendTag, DefaultPrompts, LlmConfig, Model}
+import orca.subprocess.{FakePipedCliProcess, SpawnStubCliRunner}
+
+class DefaultGeminiToolTest extends munit.FunSuite:
+
+  private val stubInteraction: Interaction = new Interaction:
+    val listeners: List[OrcaListener] = Nil
+    def drive[B <: BackendTag](
+        conversation: Conversation[B]
+    ): LlmResult[B] = throw new UnsupportedOperationException("test stub")
+
+  private def successfulProcess(): FakePipedCliProcess =
+    val p = new FakePipedCliProcess()
+    p.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    p.enqueueStdout("""{"type":"message","role":"assistant","content":"ok"}""")
+    p.enqueueStdout(
+      """{"type":"result","status":"success","stats":{"input_tokens":1,"output_tokens":1}}"""
+    )
+    p.closeStdout()
+    p.closeStderr()
+    p.sendSigInt()
+    p
+
+  private def toolWith(
+      runner: SpawnStubCliRunner,
+      config: LlmConfig
+  )(body: DefaultGeminiTool => Unit): Unit =
+    SupervisedBackend.using(new GeminiBackend(runner)): backend =>
+      body(
+        new DefaultGeminiTool(
+          backend = backend,
+          config = config,
+          prompts = DefaultPrompts,
+          workDir = os.temp.dir(),
+          events = OrcaListener.noop,
+          interaction = stubInteraction
+        )
+      )
+
+  test("the base tool's pinned model reaches the CLI --model flag"):
+    val runner = new SpawnStubCliRunner(List(successfulProcess()))
+    toolWith(
+      runner,
+      LlmConfig.default.copy(model = Some(DefaultGeminiTool.Pro))
+    ): tool =>
+      val _ = tool.autonomous.run("q")
+      assert(
+        runner.calls.head.containsSlice(Seq("--model", "gemini-2.5-pro")),
+        s"expected the pro pin; got: ${runner.calls.head}"
+      )
+
+  test("flash opts the model down to gemini-2.5-flash"):
+    val runner = new SpawnStubCliRunner(List(successfulProcess()))
+    toolWith(
+      runner,
+      LlmConfig.default.copy(model = Some(DefaultGeminiTool.Pro))
+    ): tool =>
+      val _ = tool.flash.autonomous.run("q")
+      assert(
+        runner.calls.head.containsSlice(Seq("--model", "gemini-2.5-flash")),
+        s"expected the flash pin; got: ${runner.calls.head}"
+      )
+
+  test("withName preserves the GeminiTool type and renames"):
+    val runner = new SpawnStubCliRunner(List(successfulProcess()))
+    toolWith(runner, LlmConfig.default): tool =>
+      val renamed = tool.withName("planner")
+      assertEquals(renamed.name, "planner")
+
+  test("Pro is the gemini-2.5-pro model id"):
+    assertEquals(Model.name(DefaultGeminiTool.Pro), "gemini-2.5-pro")

--- a/gemini/src/test/scala/orca/tools/gemini/DefaultGeminiToolTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/DefaultGeminiToolTest.scala
@@ -2,7 +2,7 @@ package orca.tools.gemini
 
 import orca.backend.{Conversation, Interaction, LlmResult, SupervisedBackend}
 import orca.events.OrcaListener
-import orca.llm.{BackendTag, DefaultPrompts, LlmConfig, Model}
+import orca.llm.{BackendTag, DefaultPrompts, LlmConfig}
 import orca.subprocess.{FakePipedCliProcess, SpawnStubCliRunner}
 
 class DefaultGeminiToolTest extends munit.FunSuite:
@@ -70,6 +70,3 @@ class DefaultGeminiToolTest extends munit.FunSuite:
     toolWith(runner, LlmConfig.default): tool =>
       val renamed = tool.withName("planner")
       assertEquals(renamed.name, "planner")
-
-  test("Pro is the gemini-2.5-pro model id"):
-    assertEquals(Model.name(DefaultGeminiTool.Pro), "gemini-2.5-pro")

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiArgsTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiArgsTest.scala
@@ -21,11 +21,6 @@ class GeminiArgsTest extends munit.FunSuite:
     val args = GeminiArgs.headless("x", LlmConfig.default)
     assert(args.contains("--skip-trust"), args.toString)
 
-  test("resume also passes --skip-trust"):
-    val sid = SessionId[BackendTag.Gemini.type]("sid")
-    val args = GeminiArgs.resume(sid, "x", LlmConfig.default)
-    assert(args.contains("--skip-trust"), args.toString)
-
   test("headless passes --model when LlmConfig.model is set"):
     val args = GeminiArgs.headless(
       "x",

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiArgsTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiArgsTest.scala
@@ -1,0 +1,76 @@
+package orca.tools.gemini
+
+import orca.llm.{AutoApprove, BackendTag, LlmConfig, Model, SessionId}
+
+class GeminiArgsTest extends munit.FunSuite:
+
+  test("headless emits gemini -p <prompt> --output-format stream-json"):
+    val args = GeminiArgs.headless("summarize", LlmConfig.default)
+    assertEquals(args.head, "gemini")
+    assert(
+      args.containsSlice(Seq("--output-format", "stream-json")),
+      args.toString
+    )
+    assert(args.containsSlice(Seq("-p", "summarize")), args.toString)
+
+  test("headless passes --skip-trust so headless runs in an untrusted dir"):
+    // Without it gemini refuses to run in a non-trusted folder (exit 55) and
+    // silently overrides --approval-mode back to "default". orca always drives
+    // a working dir the agent is meant to operate in, so trust is unconditional
+    // — the analog of codex's --skip-git-repo-check.
+    val args = GeminiArgs.headless("x", LlmConfig.default)
+    assert(args.contains("--skip-trust"), args.toString)
+
+  test("resume also passes --skip-trust"):
+    val sid = SessionId[BackendTag.Gemini.type]("sid")
+    val args = GeminiArgs.resume(sid, "x", LlmConfig.default)
+    assert(args.contains("--skip-trust"), args.toString)
+
+  test("headless passes --model when LlmConfig.model is set"):
+    val args = GeminiArgs.headless(
+      "x",
+      LlmConfig.default.copy(model = Some(Model("gemini-2.5-flash")))
+    )
+    assert(args.containsSlice(Seq("--model", "gemini-2.5-flash")))
+
+  test("AutoApprove.All maps to --approval-mode yolo"):
+    val args = GeminiArgs.headless(
+      "x",
+      LlmConfig.default.copy(autoApprove = AutoApprove.All)
+    )
+    assert(args.containsSlice(Seq("--approval-mode", "yolo")), args.toString)
+
+  test("AutoApprove.Only widens to --approval-mode yolo"):
+    // Gemini has no per-tool CLI allowlist; Only(_) widens to yolo so
+    // autonomous (headless) turns actually progress instead of blocking on
+    // an approval prompt no one can answer. See ADR 0015.
+    val args = GeminiArgs.headless(
+      "x",
+      LlmConfig.default.copy(autoApprove = AutoApprove.Only(Set("Bash")))
+    )
+    assert(args.containsSlice(Seq("--approval-mode", "yolo")), args.toString)
+    assert(!args.contains("plan"))
+
+  test("readOnly maps to --approval-mode plan and overrides autoApprove"):
+    val args = GeminiArgs.headless(
+      "x",
+      LlmConfig.default.copy(readOnly = true, autoApprove = AutoApprove.All)
+    )
+    assert(args.containsSlice(Seq("--approval-mode", "plan")), args.toString)
+    assert(!args.containsSlice(Seq("--approval-mode", "yolo")))
+
+  test("resume builds gemini ... --resume <id> with the prompt"):
+    val sid = SessionId[BackendTag.Gemini.type]("uuid-123")
+    val args = GeminiArgs.resume(sid, "next step", LlmConfig.default)
+    assertEquals(args.head, "gemini")
+    assert(args.containsSlice(Seq("--resume", "uuid-123")), args.toString)
+    assert(args.containsSlice(Seq("-p", "next step")), args.toString)
+
+  test("resume propagates --model when LlmConfig.model is set"):
+    val sid = SessionId[BackendTag.Gemini.type]("sid")
+    val args = GeminiArgs.resume(
+      sid,
+      "x",
+      LlmConfig.default.copy(model = Some(Model("gemini-2.5-pro")))
+    )
+    assert(args.containsSlice(Seq("--model", "gemini-2.5-pro")))

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiBackendTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiBackendTest.scala
@@ -1,0 +1,229 @@
+package orca.tools.gemini
+
+import orca.backend.SupervisedBackend
+import orca.llm.{BackendTag, LlmConfig, Model, SessionId}
+import orca.OrcaFlowException
+import orca.subprocess.{FakePipedCliProcess, SpawnStubCliRunner}
+
+class GeminiBackendTest extends munit.FunSuite:
+
+  private def clientSid: SessionId[BackendTag.Gemini.type] =
+    SessionId[BackendTag.Gemini.type]("00000000-0000-0000-0000-000000000000")
+
+  private def withBackend[T](runner: SpawnStubCliRunner)(
+      body: GeminiBackend => T
+  ): T = SupervisedBackend.using(new GeminiBackend(runner))(body)
+
+  private def successfulProcess(
+      sessionId: String = "sess-test",
+      message: String = "hello world",
+      inputTokens: Long = 10L,
+      outputTokens: Long = 5L,
+      model: Option[String] = None
+  ): FakePipedCliProcess =
+    val p = new FakePipedCliProcess()
+    val modelField = model.map(m => s""","model":"$m"""").getOrElse("")
+    p.enqueueStdout(
+      s"""{"type":"init","session_id":"$sessionId"$modelField}"""
+    )
+    p.enqueueStdout(
+      s"""{"type":"message","role":"assistant","content":"$message"}"""
+    )
+    p.enqueueStdout(
+      s"""{"type":"result","status":"success","stats":{"input_tokens":$inputTokens,"output_tokens":$outputTokens}}"""
+    )
+    p.closeStdout()
+    p.closeStderr()
+    p.sendSigInt() // mark exited so waitForExit returns
+    p
+
+  /** A process that streams `init` but never closes stdout — the reader blocks,
+    * so the conversation's finalize (which restores settings.json) doesn't fire
+    * mid-test. Used by interactive tests that inspect the registered file.
+    */
+  private def pendingProcess(): FakePipedCliProcess =
+    val p = new FakePipedCliProcess()
+    p.enqueueStdout("""{"type":"init","session_id":"sess-pending"}""")
+    p
+
+  test("runAutonomous parses session id, assistant content, and usage"):
+    val runner = new SpawnStubCliRunner(
+      List(successfulProcess("sess-42", "the answer", 100L, 25L))
+    )
+    withBackend(runner): backend =>
+      val result =
+        backend.runAutonomous("q", clientSid, LlmConfig.default, os.temp.dir())
+      // The returned session id is the client id — the server's sess-42 is
+      // mapped internally so subsequent calls resume it.
+      assertEquals(result.sessionId, clientSid)
+      assertEquals(result.output, "the answer")
+      assertEquals(result.usage.inputTokens, 100L)
+      assertEquals(result.usage.outputTokens, 25L)
+
+  test("runAutonomous surfaces the model id reported on init"):
+    val runner =
+      new SpawnStubCliRunner(
+        List(successfulProcess(model = Some("gemini-2.5-pro")))
+      )
+    withBackend(runner): backend =>
+      val result =
+        backend.runAutonomous("q", clientSid, LlmConfig.default, os.temp.dir())
+      assertEquals(result.model, Some(Model("gemini-2.5-pro")))
+
+  test("runAutonomous throws when gemini exits without a result event"):
+    val p = new FakePipedCliProcess()
+    p.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    p.closeStdout()
+    p.closeStderr()
+    p.sendSigInt()
+    withBackend(new SpawnStubCliRunner(List(p))): backend =>
+      intercept[OrcaFlowException]:
+        backend.runAutonomous("q", clientSid, LlmConfig.default, os.temp.dir())
+
+  test("runAutonomous throws with the exit code when gemini exits non-zero"):
+    val p = new FakePipedCliProcess(initiallyAlive = false):
+      override def tryExitCode: Option[Int] = Some(7)
+    p.closeStdout()
+    p.closeStderr()
+    withBackend(new SpawnStubCliRunner(List(p))): backend =>
+      val ex = intercept[OrcaFlowException]:
+        backend.runAutonomous("q", clientSid, LlmConfig.default, os.temp.dir())
+      assert(
+        ex.getMessage.contains("exited with code 7"),
+        s"expected the exit code in the message; got: ${ex.getMessage}"
+      )
+
+  test("non-zero exit attaches buffered stderr to the exception message"):
+    val p = new FakePipedCliProcess(initiallyAlive = false):
+      override def tryExitCode: Option[Int] = Some(7)
+    p.enqueueStderr("Error: resume failed: session not found")
+    p.closeStdout()
+    p.closeStderr()
+    withBackend(new SpawnStubCliRunner(List(p))): backend =>
+      val ex = intercept[OrcaFlowException]:
+        backend.runAutonomous("q", clientSid, LlmConfig.default, os.temp.dir())
+      assert(
+        ex.getMessage.contains("resume failed: session not found"),
+        s"expected stderr in the exception; got: ${ex.getMessage}"
+      )
+
+  test("systemPrompt is folded into the user prompt as a preamble"):
+    val runner = new SpawnStubCliRunner(List(successfulProcess()))
+    withBackend(runner): backend =>
+      val _ = backend.runAutonomous(
+        "list files",
+        clientSid,
+        LlmConfig.default.copy(systemPrompt = Some("be terse")),
+        os.temp.dir()
+      )
+      val finalPrompt = runner.calls.head.last
+      assert(finalPrompt.contains("be terse"))
+      assert(finalPrompt.contains("list files"))
+
+  test("a second call with the same client id resumes the mapped session"):
+    val runner = new SpawnStubCliRunner(
+      List(
+        successfulProcess("sess-server-1"),
+        successfulProcess("sess-server-1")
+      )
+    )
+    withBackend(runner): backend =>
+      val workDir = os.temp.dir()
+      val _ =
+        backend.runAutonomous("first", clientSid, LlmConfig.default, workDir)
+      val _ =
+        backend.runAutonomous("again", clientSid, LlmConfig.default, workDir)
+      val firstArgs = runner.calls(0)
+      val secondArgs = runner.calls(1)
+      assert(!firstArgs.contains("--resume"), firstArgs.toString)
+      assert(secondArgs.contains("--resume"), secondArgs.toString)
+      assert(secondArgs.contains("sess-server-1"), secondArgs.toString)
+
+  test("registerSession lets a follow-up autonomous call resume"):
+    val runner = new SpawnStubCliRunner(List(successfulProcess("sess-via-int")))
+    withBackend(runner): backend =>
+      backend.registerSession(
+        clientSid,
+        SessionId[BackendTag.Gemini.type]("sess-via-int")
+      )
+      val _ =
+        backend.runAutonomous(
+          "after",
+          clientSid,
+          LlmConfig.default,
+          os.temp.dir()
+        )
+      val args = runner.calls.head
+      assert(args.contains("--resume"), args.toString)
+      assert(args.contains("sess-via-int"), args.toString)
+
+  test("distinct client ids both start fresh — no cross-client mapping"):
+    val runner = new SpawnStubCliRunner(
+      List(successfulProcess("sess-A"), successfulProcess("sess-B"))
+    )
+    withBackend(runner): backend =>
+      val workDir = os.temp.dir()
+      val sidA = SessionId[BackendTag.Gemini.type]("aaaaaaaa")
+      val sidB = SessionId[BackendTag.Gemini.type]("bbbbbbbb")
+      val _ = backend.runAutonomous("for A", sidA, LlmConfig.default, workDir)
+      val _ = backend.runAutonomous("for B", sidB, LlmConfig.default, workDir)
+      assert(
+        !runner.calls(1).contains("--resume"),
+        s"second call with a new client id must NOT resume; got: ${runner.calls(1)}"
+      )
+
+  test(
+    "runAutonomous does NOT register an MCP server (autonomous skips bridge)"
+  ):
+    val runner = new SpawnStubCliRunner(List(successfulProcess()))
+    withBackend(runner): backend =>
+      val workDir = os.temp.dir()
+      val _ = backend.runAutonomous("q", clientSid, LlmConfig.default, workDir)
+      assert(
+        !os.exists(workDir / ".gemini" / "settings.json"),
+        "autonomous must not write a .gemini/settings.json"
+      )
+
+  test(
+    "runInteractive registers the orca MCP server and folds the ask_user hint"
+  ):
+    val runner = new SpawnStubCliRunner(List(pendingProcess()))
+    withBackend(runner): backend =>
+      val workDir = os.temp.dir()
+      val _ = backend.runInteractive(
+        "q",
+        clientSid,
+        displayPrompt = "q",
+        LlmConfig.default,
+        workDir,
+        outputSchema = None
+      )
+      val settings = workDir / ".gemini" / "settings.json"
+      assert(os.exists(settings), "interactive must register an MCP server")
+      assert(
+        os.read(settings).contains("orca"),
+        s"expected the orca server in settings.json; got: ${os.read(settings)}"
+      )
+      val finalPrompt = runner.calls.head.last
+      assert(
+        finalPrompt.contains("ask_user"),
+        s"final prompt should fold in the ask_user hint; got: $finalPrompt"
+      )
+
+  test(
+    "runInteractive with a systemPrompt folds BOTH it and the ask_user hint"
+  ):
+    val runner = new SpawnStubCliRunner(List(pendingProcess()))
+    withBackend(runner): backend =>
+      val _ = backend.runInteractive(
+        "list files",
+        clientSid,
+        displayPrompt = "list files",
+        LlmConfig.default.copy(systemPrompt = Some("be terse")),
+        os.temp.dir(),
+        outputSchema = None
+      )
+      val finalPrompt = runner.calls.head.last
+      assert(finalPrompt.contains("be terse"))
+      assert(finalPrompt.contains("ask_user"))
+      assert(finalPrompt.contains("list files"))

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiCanAskUserTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiCanAskUserTest.scala
@@ -1,0 +1,13 @@
+package orca.tools.gemini
+
+import orca.llm.{BackendTag, CanAskUser}
+
+class GeminiCanAskUserTest extends munit.FunSuite:
+
+  test("Gemini exposes the CanAskUser capability"):
+    // Regression: gemini's interactive path wires the ask_user MCP bridge, so a
+    // `CanAskUser[BackendTag.Gemini.type]` given must exist — otherwise
+    // CanAskUser-constrained helpers (e.g. `Plan.interactive.from(gemini, …)`)
+    // fail to COMPILE for gemini. This summon only type-checks when the given
+    // is present.
+    val _ = summon[CanAskUser[BackendTag.Gemini.type]]

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiConversationTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiConversationTest.scala
@@ -133,6 +133,30 @@ class GeminiConversationTest extends munit.FunSuite:
     )
     val _ = conv.awaitResult()
 
+  test("a tool whose name merely contains 'ask_user' is NOT suppressed"):
+    // Suppression matches gemini's exact MCP qualification (orca__ask_user),
+    // not any name containing the slug — an unrelated tool must still surface.
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+
+    process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    process.enqueueStdout(
+      """{"type":"tool_use","tool_name":"ask_user_for_help","tool_id":"x1","parameters":{}}"""
+    )
+    process.enqueueStdout(result())
+    process.closeStdout()
+    process.closeStderr()
+
+    val events = conv.events.toList
+    assert(
+      events.exists {
+        case ConversationEvent.AssistantToolCall("ask_user_for_help", _) => true
+        case _ => false
+      },
+      s"a non-MCP tool must not be suppressed; got: $events"
+    )
+    val _ = conv.awaitResult()
+
   test("tool_result with a non-success status yields ok=false"):
     val process = new FakePipedCliProcess()
     val conv = new GeminiConversation(process)

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiConversationTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiConversationTest.scala
@@ -313,6 +313,64 @@ class GeminiConversationTest extends munit.FunSuite:
       s"expected the failing status in the message; got: ${ex.getMessage}"
     )
 
+  test("a result event with no status is treated as success"):
+    // The status field is optional; an absent/empty status is success, not a
+    // failed turn.
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+
+    process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    process.enqueueStdout(
+      """{"type":"message","role":"assistant","content":"done"}"""
+    )
+    process.enqueueStdout(
+      """{"type":"result","stats":{"input_tokens":1,"output_tokens":1}}"""
+    )
+    process.closeStdout()
+    process.closeStderr()
+
+    val _ = conv.events.toList
+    val Right(r) = conv.awaitResult(): @unchecked
+    assertEquals(r.output, "done")
+
+  test("interleaved tool calls are each keyed back to their own name"):
+    // Two tool calls complete out of order (B before A); each tool_result,
+    // which carries only the id, must resolve to the right tool_name.
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+
+    process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    process.enqueueStdout(
+      """{"type":"tool_use","tool_name":"Read","tool_id":"a","parameters":{}}"""
+    )
+    process.enqueueStdout(
+      """{"type":"tool_use","tool_name":"Bash","tool_id":"b","parameters":{}}"""
+    )
+    process.enqueueStdout(
+      """{"type":"tool_result","tool_id":"b","status":"success","output":"ls-out"}"""
+    )
+    process.enqueueStdout(
+      """{"type":"tool_result","tool_id":"a","status":"success","output":"file-out"}"""
+    )
+    process.enqueueStdout(result())
+    process.closeStdout()
+    process.closeStderr()
+
+    val events = conv.events.toList
+    assert(
+      events.contains(
+        ConversationEvent.ToolResult("Bash", ok = true, "ls-out")
+      ),
+      s"tool_result b must key to Bash; got: $events"
+    )
+    assert(
+      events.contains(
+        ConversationEvent.ToolResult("Read", ok = true, "file-out")
+      ),
+      s"tool_result a must key to Read; got: $events"
+    )
+    val _ = conv.awaitResult()
+
   test("cancel surfaces as Left(OrcaInteractiveCancelled) from awaitResult"):
     val process = new FakePipedCliProcess()
     val conv = new GeminiConversation(process)

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiConversationTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiConversationTest.scala
@@ -1,0 +1,405 @@
+package orca.tools.gemini
+
+import orca.llm.SessionId
+import orca.events.Usage
+import orca.{OrcaFlowException, OrcaInteractiveCancelled}
+import orca.backend.ConversationEvent
+import orca.subprocess.FakePipedCliProcess
+
+class GeminiConversationTest extends munit.FunSuite:
+
+  /** Minimal terminating tail: a `result` event ends the turn and lets
+    * `awaitResult` succeed.
+    */
+  private def result(input: Long = 0L, output: Long = 0L): String =
+    s"""{"type":"result","status":"success","stats":{"input_tokens":$input,"output_tokens":$output}}"""
+
+  test("assistant message accumulates into output; init sets session + model"):
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+
+    process.enqueueStdout(
+      """{"type":"init","session_id":"sess-1","model":"gemini-2.5-pro"}"""
+    )
+    process.enqueueStdout(
+      """{"type":"message","role":"assistant","content":"hello"}"""
+    )
+    process.enqueueStdout(result(input = 10L, output = 3L))
+    process.closeStdout()
+    process.closeStderr()
+
+    val events = conv.events.toList
+    assertEquals(
+      events,
+      List(
+        ConversationEvent.AssistantTextDelta("hello"),
+        ConversationEvent.AssistantTurnEnd
+      )
+    )
+    val Right(r) = conv.awaitResult(): @unchecked
+    assertEquals(SessionId.value(r.sessionId), "sess-1")
+    assertEquals(r.output, "hello")
+    assertEquals(r.usage, Usage(10L, 3L, None))
+    assertEquals(r.model.map(_.name), Some("gemini-2.5-pro"))
+
+  test("a user-role message is ignored (prompt echo, not agent output)"):
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+
+    process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    process.enqueueStdout(
+      """{"type":"message","role":"user","content":"List files"}"""
+    )
+    process.enqueueStdout(
+      """{"type":"message","role":"model","content":"done"}"""
+    )
+    process.enqueueStdout(result())
+    process.closeStdout()
+    process.closeStderr()
+
+    val events = conv.events.toList
+    assert(
+      !events.contains(ConversationEvent.AssistantTextDelta("List files")),
+      s"user message must not become agent output; got: $events"
+    )
+    val Right(r) = conv.awaitResult(): @unchecked
+    assertEquals(r.output, "done")
+
+  test("multiple assistant chunks concatenate into the output"):
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+
+    process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    process.enqueueStdout(
+      """{"type":"message","role":"assistant","content":"foo"}"""
+    )
+    process.enqueueStdout(
+      """{"type":"message","role":"assistant","content":"bar"}"""
+    )
+    process.enqueueStdout(result())
+    process.closeStdout()
+    process.closeStderr()
+
+    val _ = conv.events.toList
+    val Right(r) = conv.awaitResult(): @unchecked
+    assertEquals(r.output, "foobar")
+
+  test("initialPrompt becomes a UserMessage event before agent output"):
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process, initialPrompt = "do the thing")
+
+    process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    process.enqueueStdout(
+      """{"type":"message","role":"assistant","content":"ok"}"""
+    )
+    process.enqueueStdout(result())
+    process.closeStdout()
+    process.closeStderr()
+
+    val events = conv.events.toList
+    assertEquals(events.head, ConversationEvent.UserMessage("do the thing"))
+    val _ = conv.awaitResult()
+
+  test("tool_use + tool_result become AssistantToolCall + ToolResult"):
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+
+    process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    process.enqueueStdout(
+      """{"type":"tool_use","tool_name":"Bash","tool_id":"b1","parameters":{"command":"ls"}}"""
+    )
+    process.enqueueStdout(
+      """{"type":"tool_result","tool_id":"b1","status":"success","output":"hello.txt"}"""
+    )
+    process.enqueueStdout(
+      """{"type":"message","role":"assistant","content":"done"}"""
+    )
+    process.enqueueStdout(result())
+    process.closeStdout()
+    process.closeStderr()
+
+    val events = conv.events.toList
+    assert(
+      events.contains(
+        ConversationEvent.AssistantToolCall("Bash", """{"command":"ls"}""")
+      ),
+      s"expected AssistantToolCall for Bash; got: $events"
+    )
+    assert(
+      events.contains(
+        ConversationEvent.ToolResult("Bash", ok = true, "hello.txt")
+      ),
+      s"expected matching ToolResult keyed by name; got: $events"
+    )
+    val _ = conv.awaitResult()
+
+  test("tool_result with a non-success status yields ok=false"):
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+
+    process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    process.enqueueStdout(
+      """{"type":"tool_use","tool_name":"Bash","tool_id":"b1","parameters":{}}"""
+    )
+    process.enqueueStdout(
+      """{"type":"tool_result","tool_id":"b1","status":"error","output":"boom"}"""
+    )
+    process.enqueueStdout(result())
+    process.closeStdout()
+    process.closeStderr()
+
+    val events = conv.events.toList
+    val tr = events
+      .collectFirst { case r: ConversationEvent.ToolResult => r }
+      .getOrElse(fail("expected a ToolResult"))
+    assertEquals(tr.ok, false)
+    val _ = conv.awaitResult()
+
+  test("benign gemini stderr chatter is filtered (no Error events)"):
+    // Observed on every successful headless run (gemini 0.45.2): a 256-color
+    // warning, YOLO-mode notices, and a cwd-reset line — all informational.
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+
+    process.enqueueStderr(
+      "Warning: 256-color support not detected. Using a terminal with at least 256-color support is recommended for a better visual experience."
+    )
+    process.enqueueStderr(
+      "YOLO mode is enabled. All tool calls will be automatically approved."
+    )
+    process.enqueueStderr("Shell cwd was reset to /some/dir")
+    process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    process.enqueueStdout(
+      """{"type":"message","role":"assistant","content":"ok"}"""
+    )
+    process.enqueueStdout(result())
+    process.closeStdout()
+    process.closeStderr()
+
+    val events = conv.events.toList
+    assert(
+      !events.exists {
+        case ConversationEvent.Error(_) => true
+        case _                          => false
+      },
+      s"benign stderr must not surface as Error events; got: $events"
+    )
+    val _ = conv.awaitResult()
+
+  test("a real stderr line still surfaces as ConversationEvent.Error"):
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+
+    process.enqueueStderr("Error: quota exceeded for project")
+    process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    process.enqueueStdout(result())
+    process.closeStdout()
+    process.closeStderr()
+
+    val events = conv.events.toList
+    assert(
+      events.exists {
+        case ConversationEvent.Error(m) => m.contains("quota exceeded")
+        case _                          => false
+      },
+      s"a real error must surface; got: $events"
+    )
+    val _ = conv.awaitResult()
+
+  test("error event surfaces as ConversationEvent.Error"):
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+
+    process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    process.enqueueStdout("""{"type":"error","message":"rate limited"}""")
+    process.enqueueStdout(result())
+    process.closeStdout()
+    process.closeStderr()
+
+    val events = conv.events.toList
+    assert(
+      events.exists {
+        case ConversationEvent.Error(m) => m.contains("rate limited")
+        case _                          => false
+      },
+      s"expected an Error event; got: $events"
+    )
+    val _ = conv.awaitResult()
+
+  test("malformed JSONL surfaces as Error and the loop continues"):
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+
+    process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    process.enqueueStdout("not json at all")
+    process.enqueueStdout(
+      """{"type":"message","role":"assistant","content":"ok"}"""
+    )
+    process.enqueueStdout(result())
+    process.closeStdout()
+    process.closeStderr()
+
+    val events = conv.events.toList
+    assert(
+      events.exists {
+        case ConversationEvent.Error(m) => m.contains("Failed to parse")
+        case _                          => false
+      },
+      s"expected a parse-error event; got: $events"
+    )
+    val Right(r) = conv.awaitResult(): @unchecked
+    assertEquals(r.output, "ok")
+
+  test("clean exit without a result event surfaces as OrcaFlowException"):
+    val process = new FakePipedCliProcess(initiallyAlive = false)
+    val conv = new GeminiConversation(process)
+
+    process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    process.closeStdout()
+    process.closeStderr()
+
+    val _ = conv.events.toList
+    val ex = intercept[OrcaFlowException](conv.awaitResult())
+    assert(
+      ex.getMessage.contains("result"),
+      s"expected the missing-result message; got: ${ex.getMessage}"
+    )
+
+  test("a result event with a non-success status fails the turn"):
+    // gemini's `result` carries a status; a failed turn that still exits 0
+    // must not be reported as success. "success" is the documented good
+    // token (headless stream-json) — anything else non-empty is a failure.
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+
+    process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    process.enqueueStdout(
+      """{"type":"message","role":"assistant","content":"partial"}"""
+    )
+    process.enqueueStdout(
+      """{"type":"result","status":"error","stats":{"input_tokens":1,"output_tokens":1}}"""
+    )
+    process.closeStdout()
+    process.closeStderr()
+
+    val _ = conv.events.toList
+    val ex = intercept[orca.AgentTurnFailed](conv.awaitResult())
+    assert(
+      ex.getMessage.contains("error"),
+      s"expected the failing status in the message; got: ${ex.getMessage}"
+    )
+
+  test("cancel surfaces as Left(OrcaInteractiveCancelled) from awaitResult"):
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+    conv.cancel()
+    conv.awaitResult() match
+      case Left(_: OrcaInteractiveCancelled) => ()
+      case other =>
+        fail(s"expected Left(OrcaInteractiveCancelled), got: $other")
+    assertEquals(process.sigIntCount, 1)
+
+  test("sendUserMessage is a documented no-op (no stdin write)"):
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+    conv.sendUserMessage("ignored")
+    process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    process.enqueueStdout(
+      """{"type":"message","role":"assistant","content":"ok"}"""
+    )
+    process.enqueueStdout(result())
+    process.closeStdout()
+    process.closeStderr()
+    val _ = conv.events.toList
+    val _ = conv.awaitResult()
+    assertEquals(process.writes, Nil)
+
+  test("unknown top-level events are ignored without surfacing"):
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+
+    process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+    process.enqueueStdout("""{"type":"some.future.event","data":42}""")
+    process.enqueueStdout(
+      """{"type":"message","role":"assistant","content":"ok"}"""
+    )
+    process.enqueueStdout(result())
+    process.closeStdout()
+    process.closeStderr()
+
+    val events = conv.events.toList
+    assert(
+      !events.exists {
+        case ConversationEvent.Error(_) => true
+        case _                          => false
+      },
+      s"unknown events must drop silently; got: $events"
+    )
+    val _ = conv.awaitResult()
+
+  test("canAskUser is false when no bridge is provided"):
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+    assertEquals(conv.canAskUser, false)
+    process.closeStdout()
+    val _ = conv.events.toList
+
+  test("ask_user tool_use/tool_result are suppressed (no echo)"):
+    import ox.supervised
+    import ox.channels.BufferCapacity
+    import orca.backend.mcp.AskUserSession
+    supervised:
+      given BufferCapacity = BufferCapacity(8)
+      val process = new FakePipedCliProcess()
+      val conv = new GeminiConversation(
+        process,
+        askUser = Some(AskUserSession.allocate())
+      )
+
+      process.enqueueStdout("""{"type":"init","session_id":"s"}""")
+      process.enqueueStdout(
+        """{"type":"tool_use","tool_name":"orca__ask_user","tool_id":"au1","parameters":{"question":"q?"}}"""
+      )
+      process.enqueueStdout(
+        """{"type":"tool_result","tool_id":"au1","status":"success","output":"a"}"""
+      )
+      process.enqueueStdout(
+        """{"type":"message","role":"assistant","content":"hi"}"""
+      )
+      process.enqueueStdout(result())
+      process.closeStdout()
+      process.closeStderr()
+
+      val events = conv.events.toList
+      assert(
+        !events.exists {
+          case ConversationEvent.AssistantToolCall(n, _) =>
+            n.contains("ask_user")
+          case ConversationEvent.ToolResult(n, _, _) => n.contains("ask_user")
+          case _                                     => false
+        },
+        s"ask_user exchange must be suppressed; got: $events"
+      )
+      val _ = conv.awaitResult()
+
+  test("askUserBridge questions surface as UserQuestion; respond unblocks"):
+    import ox.{forkUser, supervised}
+    import ox.channels.BufferCapacity
+    import orca.backend.mcp.AskUserSession
+    supervised:
+      given BufferCapacity = BufferCapacity(8)
+      val process = new FakePipedCliProcess()
+      val askUser = AskUserSession.allocate()
+      val conv = new GeminiConversation(process, askUser = Some(askUser))
+      val bridge = askUser.bridge
+      assert(conv.canAskUser, "canAskUser must be true when a bridge is wired")
+
+      val askResult = forkUser:
+        bridge.ask("What's your favourite colour?")
+
+      val (question, respond) = conv.events.next() match
+        case ConversationEvent.UserQuestion(q, r) => (q, r)
+        case other => fail(s"expected UserQuestion; got: $other")
+      assertEquals(question, "What's your favourite colour?")
+      respond("magenta")
+      assertEquals(askResult.join(), "magenta")

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiConversationTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiConversationTest.scala
@@ -181,7 +181,8 @@ class GeminiConversationTest extends munit.FunSuite:
 
   test("benign gemini stderr chatter is filtered (no Error events)"):
     // Observed on every successful headless run (gemini 0.45.2): a 256-color
-    // warning, YOLO-mode notices, and a cwd-reset line — all informational.
+    // warning, YOLO-mode notices, a cwd-reset line, and IDE-companion probe
+    // chatter — all informational.
     val process = new FakePipedCliProcess()
     val conv = new GeminiConversation(process)
 
@@ -192,6 +193,9 @@ class GeminiConversationTest extends munit.FunSuite:
       "YOLO mode is enabled. All tool calls will be automatically approved."
     )
     process.enqueueStderr("Shell cwd was reset to /some/dir")
+    process.enqueueStderr(
+      "[ERROR] [IDEClient] Failed to connect to IDE companion extension. Please ensure the extension is running."
+    )
     process.enqueueStdout("""{"type":"init","session_id":"s"}""")
     process.enqueueStdout(
       """{"type":"message","role":"assistant","content":"ok"}"""

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiIntegrationTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiIntegrationTest.scala
@@ -1,0 +1,73 @@
+package orca.tools.gemini
+
+import orca.llm.{AutoApprove, BackendTag, LlmConfig, Model, SessionId}
+import orca.backend.SupervisedBackend
+import orca.subprocess.OsProcCliRunner
+
+/** End-to-end tests against the real `gemini` CLI. Gated on the
+  * `ORCA_INTEGRATION` environment variable so `sbt test` without the flag
+  * behaves like a pure unit suite. Requires `gemini` to be installed and
+  * authenticated on the host (e.g. `GEMINI_API_KEY` or an OAuth login).
+  *
+  * The tests use [[AutoApprove.All]] (i.e. `--approval-mode yolo`) so a
+  * headless turn that touches tools doesn't block on an approval prompt no one
+  * can answer.
+  */
+class GeminiIntegrationTest extends munit.FunSuite:
+
+  override def munitTests(): Seq[Test] =
+    if sys.env.contains("ORCA_INTEGRATION") then super.munitTests()
+    else Nil
+
+  override def munitTimeout: scala.concurrent.duration.Duration =
+    import scala.concurrent.duration.DurationInt
+    3.minutes
+
+  private def withBackend(body: GeminiBackend => Unit): Unit =
+    SupervisedBackend.using(new GeminiBackend(OsProcCliRunner))(body)
+
+  // A cheap, widely-available model; override via ORCA_GEMINI_MODEL.
+  private val model: Model =
+    Model(sys.env.getOrElse("ORCA_GEMINI_MODEL", "gemini-2.5-flash"))
+
+  private val unsandboxed: LlmConfig =
+    LlmConfig.default.copy(autoApprove = AutoApprove.All, model = Some(model))
+
+  private def fresh = SessionId.fresh[BackendTag.Gemini.type]
+
+  test("headless prompt returns the requested literal output"):
+    withBackend: backend =>
+      val result = backend.runAutonomous(
+        prompt =
+          "Reply with the single word: READY. Reply with that word and nothing else.",
+        session = fresh,
+        config = unsandboxed,
+        workDir = os.temp.dir()
+      )
+      assert(
+        result.output.toUpperCase.contains("READY"),
+        s"expected output to contain READY, got: ${result.output}"
+      )
+      assert(SessionId.value(result.sessionId).nonEmpty)
+
+  test("a resumed call carries conversational context across turns"):
+    withBackend: backend =>
+      val workDir = os.temp.dir()
+      val session = fresh
+      val _ = backend.runAutonomous(
+        prompt = "Remember the number 42. Reply with the single word: stored.",
+        session = session,
+        config = unsandboxed,
+        workDir = workDir
+      )
+      val second = backend.runAutonomous(
+        prompt =
+          "What number did I ask you to remember? Reply with just the number.",
+        session = session,
+        config = unsandboxed,
+        workDir = workDir
+      )
+      assert(
+        second.output.contains("42"),
+        s"expected the resumed turn to recall 42, got: ${second.output}"
+      )

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiSettingsTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiSettingsTest.scala
@@ -29,6 +29,16 @@ class GeminiSettingsTest extends munit.FunSuite:
     assert(servers.contains("orca"), s"expected orca server; got: $servers")
     assert(servers("orca").value.contains("http://127.0.0.1:9999/mcp"))
 
+  test("merge escapes a URL containing JSON metacharacters"):
+    // The URL is serialized through a codec, not interpolated, so a `"` or `\`
+    // can't break out of the string and produce invalid JSON.
+    val merged = GeminiSettings.merge("{}", """http://h/"x\y""")
+    val servers = topLevel(topLevel(merged)("mcpServers").value)
+    val httpUrl = readFromString[Map[String, String]](servers("orca").value)(
+      using JsonCodecMaker.make[Map[String, String]]
+    )
+    assertEquals(httpUrl("httpUrl"), """http://h/"x\y""")
+
   test("register does NOT add an allowlist when the user has none"):
     // allowedMcpServerNames is an allowlist; adding one where there was none
     // would restrict gemini to ONLY orca, hiding the user's other servers.

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiSettingsTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiSettingsTest.scala
@@ -93,3 +93,17 @@ class GeminiSettingsTest extends munit.FunSuite:
     val allowlist = topLevel(os.read(file))("allowedMcpServerNames").value
     assert(allowlist.contains("github"), s"existing entry lost: $allowlist")
     assert(allowlist.contains("orca"), s"orca not allowlisted: $allowlist")
+
+  test("register does not duplicate orca in an allowlist that already has it"):
+    val workDir = os.temp.dir()
+    val file = settingsFile(workDir)
+    os.write(
+      file,
+      """{"allowedMcpServerNames":["orca"]}""",
+      createFolders = true
+    )
+    val _ = GeminiSettings.register(workDir, "http://orca/mcp")
+    val allowlist = readFromString[List[String]](
+      topLevel(os.read(file))("allowedMcpServerNames").value
+    )(using JsonCodecMaker.make[List[String]])
+    assertEquals(allowlist.count(_ == "orca"), 1)

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiSettingsTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiSettingsTest.scala
@@ -1,0 +1,85 @@
+package orca.tools.gemini
+
+import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+
+class GeminiSettingsTest extends munit.FunSuite:
+
+  private given mapCodec
+      : com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[
+        Map[String, orca.util.RawJson]
+      ] = JsonCodecMaker.make
+
+  private def settingsFile(workDir: os.Path): os.Path =
+    workDir / ".gemini" / "settings.json"
+
+  private def topLevel(content: String): Map[String, orca.util.RawJson] =
+    readFromString[Map[String, orca.util.RawJson]](content)
+
+  test(
+    "register creates settings.json with the orca MCP server when none exists"
+  ):
+    val workDir = os.temp.dir()
+    val _ = GeminiSettings.register(workDir, "http://127.0.0.1:9999/mcp")
+    val file = settingsFile(workDir)
+    assert(os.exists(file), "settings.json should be created")
+    val keys = topLevel(os.read(file))
+    assert(keys.contains("mcpServers"), s"expected mcpServers; got: $keys")
+    val servers = topLevel(keys("mcpServers").value)
+    assert(servers.contains("orca"), s"expected orca server; got: $servers")
+    assert(servers("orca").value.contains("http://127.0.0.1:9999/mcp"))
+
+  test("register does NOT add an allowlist when the user has none"):
+    // allowedMcpServerNames is an allowlist; adding one where there was none
+    // would restrict gemini to ONLY orca, hiding the user's other servers.
+    val workDir = os.temp.dir()
+    val _ = GeminiSettings.register(workDir, "http://x/mcp")
+    val keys = topLevel(os.read(settingsFile(workDir)))
+    assert(
+      !keys.contains("allowedMcpServerNames"),
+      s"must not introduce an allowlist; got: $keys"
+    )
+
+  test("close removes the file again when it did not exist before"):
+    val workDir = os.temp.dir()
+    val restore = GeminiSettings.register(workDir, "http://x/mcp")
+    assert(os.exists(settingsFile(workDir)))
+    restore.close()
+    assert(
+      !os.exists(settingsFile(workDir)),
+      "a file we created should be removed on restore"
+    )
+
+  test("register preserves existing keys and restores exact bytes on close"):
+    val workDir = os.temp.dir()
+    val file = settingsFile(workDir)
+    val original =
+      """{"theme":"dark","mcpServers":{"github":{"httpUrl":"http://gh/mcp"}}}"""
+    os.write(file, original, createFolders = true)
+
+    val restore = GeminiSettings.register(workDir, "http://orca/mcp")
+    val keys = topLevel(os.read(file))
+    assertEquals(keys("theme").value, "\"dark\"")
+    val servers = topLevel(keys("mcpServers").value)
+    assert(servers.contains("github"), s"existing server lost; got: $servers")
+    assert(servers.contains("orca"), s"orca not added; got: $servers")
+
+    restore.close()
+    assertEquals(
+      os.read(file),
+      original,
+      "close must restore the original bytes verbatim"
+    )
+
+  test("register appends orca to an existing allowlist"):
+    val workDir = os.temp.dir()
+    val file = settingsFile(workDir)
+    os.write(
+      file,
+      """{"allowedMcpServerNames":["github"]}""",
+      createFolders = true
+    )
+    val _ = GeminiSettings.register(workDir, "http://orca/mcp")
+    val allowlist = topLevel(os.read(file))("allowedMcpServerNames").value
+    assert(allowlist.contains("github"), s"existing entry lost: $allowlist")
+    assert(allowlist.contains("orca"), s"orca not allowlisted: $allowlist")

--- a/gemini/src/test/scala/orca/tools/gemini/jsonl/InboundEventTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/jsonl/InboundEventTest.scala
@@ -1,0 +1,89 @@
+package orca.tools.gemini.jsonl
+
+class InboundEventTest extends munit.FunSuite:
+
+  test("parses init event into Init(sessionId, model)"):
+    val line =
+      """{"type":"init","session_id":"abc123","model":"gemini-2.5-pro"}"""
+    InboundEvent.parse(line) match
+      case InboundEvent.Init(sid, model) =>
+        assertEquals(sid, "abc123")
+        assertEquals(model, Some("gemini-2.5-pro"))
+      case other => fail(s"expected Init, got $other")
+
+  test("init tolerates a missing model"):
+    val line = """{"type":"init","session_id":"s1"}"""
+    InboundEvent.parse(line) match
+      case InboundEvent.Init(sid, model) =>
+        assertEquals(sid, "s1")
+        assertEquals(model, None)
+      case other => fail(s"expected Init, got $other")
+
+  test("parses a message event faithfully (role + content)"):
+    val line = """{"type":"message","role":"user","content":"List files"}"""
+    InboundEvent.parse(line) match
+      case InboundEvent.Message(role, content) =>
+        assertEquals(role, "user")
+        assertEquals(content, "List files")
+      case other => fail(s"expected Message, got $other")
+
+  test("parses a tool_use event"):
+    val line =
+      """{"type":"tool_use","tool_name":"Bash","tool_id":"b-1","parameters":{"command":"ls"}}"""
+    InboundEvent.parse(line) match
+      case InboundEvent.ToolUse(name, id, params) =>
+        assertEquals(name, "Bash")
+        assertEquals(id, "b-1")
+        assertEquals(params, """{"command":"ls"}""")
+      case other => fail(s"expected ToolUse, got $other")
+
+  test("parses a tool_result event"):
+    val line =
+      """{"type":"tool_result","tool_id":"b-1","status":"success","output":"file1\nfile2"}"""
+    InboundEvent.parse(line) match
+      case InboundEvent.ToolResult(id, status, output) =>
+        assertEquals(id, "b-1")
+        assertEquals(status, "success")
+        assertEquals(output, "file1\nfile2")
+      case other => fail(s"expected ToolResult, got $other")
+
+  test("parses an error event"):
+    val line = """{"type":"error","message":"rate limited"}"""
+    InboundEvent.parse(line) match
+      case InboundEvent.Error(msg) => assertEquals(msg, "rate limited")
+      case other                   => fail(s"expected Error, got $other")
+
+  test("parses result event token stats into Usage"):
+    val line =
+      """{"type":"result","status":"success","stats":{"total_tokens":100,"input_tokens":50,"output_tokens":50,"duration_ms":1200,"tool_calls":1}}"""
+    InboundEvent.parse(line) match
+      case InboundEvent.Result(usage, status) =>
+        assertEquals(status, "success")
+        assertEquals(usage.inputTokens, 50L)
+        assertEquals(usage.outputTokens, 50L)
+        assertEquals(usage.cost, None)
+      case other => fail(s"expected Result, got $other")
+
+  test("result maps the wire `cached` field into cachedInputTokens"):
+    // gemini 0.45.2 spells the cache sub-count `cached` (not
+    // `cached_input_tokens`) inside stats.
+    val line =
+      """{"type":"result","status":"success","stats":{"input_tokens":9954,"output_tokens":1,"cached":120}}"""
+    InboundEvent.parse(line) match
+      case InboundEvent.Result(usage, _) =>
+        assertEquals(usage.cachedInputTokens, 120L)
+      case other => fail(s"expected Result, got $other")
+
+  test("result tolerates missing stats"):
+    val line = """{"type":"result","status":"success"}"""
+    InboundEvent.parse(line) match
+      case InboundEvent.Result(usage, _) =>
+        assertEquals(usage.inputTokens, 0L)
+        assertEquals(usage.outputTokens, 0L)
+      case other => fail(s"expected Result, got $other")
+
+  test("unknown top-level type collapses to Unknown"):
+    val line = """{"type":"heartbeat","ts":123}"""
+    InboundEvent.parse(line) match
+      case InboundEvent.Unknown(t) => assertEquals(t, "heartbeat")
+      case other                   => fail(s"expected Unknown, got $other")

--- a/gemini/src/test/scala/orca/tools/gemini/jsonl/InboundEventTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/jsonl/InboundEventTest.scala
@@ -74,6 +74,22 @@ class InboundEventTest extends munit.FunSuite:
         assertEquals(usage.cachedInputTokens, 120L)
       case other => fail(s"expected Result, got $other")
 
+  test("result falls back to `cached_input_tokens` when `cached` is absent"):
+    val line =
+      """{"type":"result","status":"success","stats":{"input_tokens":9,"output_tokens":1,"cached_input_tokens":77}}"""
+    InboundEvent.parse(line) match
+      case InboundEvent.Result(usage, _) =>
+        assertEquals(usage.cachedInputTokens, 77L)
+      case other => fail(s"expected Result, got $other")
+
+  test("result prefers `cached` over `cached_input_tokens` when both present"):
+    val line =
+      """{"type":"result","status":"success","stats":{"input_tokens":9,"output_tokens":1,"cached":120,"cached_input_tokens":77}}"""
+    InboundEvent.parse(line) match
+      case InboundEvent.Result(usage, _) =>
+        assertEquals(usage.cachedInputTokens, 120L)
+      case other => fail(s"expected Result, got $other")
+
   test("result tolerates missing stats"):
     val line = """{"type":"result","status":"success"}"""
     InboundEvent.parse(line) match

--- a/runner/src/main/scala/orca/exports.scala
+++ b/runner/src/main/scala/orca/exports.scala
@@ -18,6 +18,7 @@ export orca.llm.{
   CodexTool,
   OpencodeTool,
   PiTool,
+  GeminiTool,
   LlmCall,
   AutonomousTextCall,
   AutonomousLlmCall,

--- a/runner/src/main/scala/orca/runner/DefaultFlowContext.scala
+++ b/runner/src/main/scala/orca/runner/DefaultFlowContext.scala
@@ -4,7 +4,15 @@ import orca.{FlowContext}
 import orca.tools.{GitTool}
 import orca.tools.{GitHubTool}
 import orca.tools.{FsTool}
-import orca.llm.{ClaudeTool, CodexTool, LlmConfig, OpencodeTool, PiTool, Prompts}
+import orca.llm.{
+  ClaudeTool,
+  CodexTool,
+  GeminiTool,
+  LlmConfig,
+  OpencodeTool,
+  PiTool,
+  Prompts
+}
 import orca.events.{EventDispatcher, OrcaEvent}
 
 import orca.backend.Interaction
@@ -12,6 +20,7 @@ import orca.tools.claude.{ClaudeBackend, DefaultClaudeTool}
 import orca.tools.codex.{CodexBackend, DefaultCodexTool}
 import orca.tools.opencode.{DefaultOpencodeTool, OpencodeBackend}
 import orca.tools.pi.{DefaultPiTool, PiBackend}
+import orca.tools.gemini.{GeminiBackend, DefaultGeminiTool}
 import orca.llm.DefaultPrompts
 import orca.subprocess.OsProcCliRunner
 import orca.tools.OsFsTool
@@ -29,6 +38,7 @@ private[orca] class DefaultFlowContext(
     val codex: CodexTool,
     val opencode: OpencodeTool,
     val pi: PiTool,
+    val gemini: GeminiTool,
     val git: GitTool,
     val gh: GitHubTool,
     val fs: FsTool
@@ -50,6 +60,7 @@ private[orca] object DefaultFlowContext:
       codex: Option[CodexTool] = None,
       opencode: Option[OpencodeTool] = None,
       pi: Option[PiTool] = None,
+      gemini: Option[GeminiTool] = None,
       git: Option[GitTool] = None,
       gh: Option[GitHubTool] = None,
       fs: Option[FsTool] = None,
@@ -96,6 +107,19 @@ private[orca] object DefaultFlowContext:
         new DefaultPiTool(
           backend = new PiBackend(OsProcCliRunner),
           config = LlmConfig.default,
+          prompts = prompts,
+          workDir = workDir,
+          events = dispatcher,
+          interaction = interaction
+        )
+      ),
+      gemini = gemini.getOrElse(
+        new DefaultGeminiTool(
+          backend = new GeminiBackend(OsProcCliRunner),
+          // Bare `gemini` pins Gemini Pro (the strong model, like claude
+          // defaults to Opus for the long-lived implementer); `gemini.flash`
+          // opts down for cheap one-shots.
+          config = LlmConfig.default.copy(model = Some(DefaultGeminiTool.Pro)),
           prompts = prompts,
           workDir = workDir,
           events = dispatcher,

--- a/tools/src/main/scala/orca/backend/SystemPromptComposer.scala
+++ b/tools/src/main/scala/orca/backend/SystemPromptComposer.scala
@@ -11,8 +11,8 @@ import orca.llm.LlmConfig
   * Returns `None` only when nothing applies (a read-only turn with no
   * systemPrompt and no hint). Each backend decides how to deliver the resulting
   * string — claude writes it to a temp file for `--append-system-prompt-file`;
-  * codex folds it into the user prompt as a `"System guidance:"` preamble
-  * (codex has no `--append-system-prompt`).
+  * codex and gemini have no such flag and fold it into the user prompt via
+  * [[foldIntoPrompt]].
   */
 private[orca] object SystemPromptComposer:
 
@@ -44,3 +44,22 @@ private[orca] object SystemPromptComposer:
     List(config.systemPrompt, extraHint, gitRule).flatten match
       case Nil    => None
       case pieces => Some(pieces.mkString("\n\n"))
+
+  /** Deliver the composed system prompt by folding it into `userPrompt` as a
+    * `"System guidance:"` preamble, used by backends whose CLI has no
+    * `--append-system-prompt` flag (codex, gemini). Returns `userPrompt`
+    * unchanged when nothing applies.
+    */
+  def foldIntoPrompt(
+      config: LlmConfig,
+      userPrompt: String,
+      extraHint: Option[String] = None
+  ): String =
+    combine(config, extraHint) match
+      case None => userPrompt
+      case Some(text) =>
+        s"""System guidance:
+           |$text
+           |
+           |User request:
+           |$userPrompt""".stripMargin

--- a/tools/src/main/scala/orca/llm/BackendTag.scala
+++ b/tools/src/main/scala/orca/llm/BackendTag.scala
@@ -12,6 +12,7 @@ enum BackendTag:
   case Codex
   case Opencode
   case Pi
+  case Gemini
 
 opaque type SessionId[B <: BackendTag] = String
 

--- a/tools/src/main/scala/orca/llm/CanAskUser.scala
+++ b/tools/src/main/scala/orca/llm/CanAskUser.scala
@@ -51,3 +51,12 @@ object CanAskUser:
     */
   given CanAskUser[BackendTag.Pi.type] =
     new CanAskUser[BackendTag.Pi.type] {}
+
+  /** Gemini's interactive sessions register the shared
+    * [[orca.backend.mcp.AskUserMcpServer]] via a project-local
+    * `.gemini/settings.json` `mcpServers.orca` entry (gemini has no inline MCP
+    * flag like codex), so the agent calls `ask_user` the same way claude and
+    * codex do. See [[adr/0015-gemini-stream-json-driver.md ADR 0015]].
+    */
+  given CanAskUser[BackendTag.Gemini.type] =
+    new CanAskUser[BackendTag.Gemini.type] {}

--- a/tools/src/main/scala/orca/llm/LlmTool.scala
+++ b/tools/src/main/scala/orca/llm/LlmTool.scala
@@ -110,6 +110,13 @@ trait OpencodeTool extends LlmTool[BackendTag.Opencode.type]:
 
 trait PiTool extends LlmTool[BackendTag.Pi.type]
 
+trait GeminiTool extends LlmTool[BackendTag.Gemini.type]:
+  /** Pin the cheap-and-fast Gemini Flash model for subsequent calls, overriding
+    * `LlmConfig.model`. Bare `gemini` runs on Gemini Pro (pinned in the runtime
+    * wiring); `gemini.flash` opts down for cheap one-shots.
+    */
+  def flash: GeminiTool
+
 /** Free-form text autonomous calls — the `LlmTool.autonomous` shape. Single
   * method: pass a [[SessionId]] (typically from [[LlmTool.newSession]] or the
   * default fresh one) and the library starts the session on the first call,


### PR DESCRIPTION
## What

Adds **`gemini`** as a fifth LLM backend alongside `claude`, `codex`, `opencode`, and `pi`, driven via `gemini --skip-trust -p <prompt> --output-format stream-json`. It follows the codex one-shot + `--resume` shape and matches the conventions the recently-merged `opencode`/`pi` backends established.

```scala
flow(OrcaArgs(args)):
  val answer = gemini.autonomous.run(userPrompt)._2
  val plan   = gemini.flash.resultAs[Plan].autonomous.run(userPrompt)  // cheap one-shot
```

## Design

| Area | Decision |
|---|---|
| Protocol | `--output-format stream-json` → reuses `StreamConversation` + `drainAutonomous` + a `jsonl/InboundEvent` parser |
| Session/resume | `SessionRegistry.ClientToServer` keyed on the `init` event's `session_id`, resumed via `gemini --resume` (same scheme as codex/opencode) |
| Conversation | `StreamConversation` + `BufferedStderrDiagnostics` over `StreamSource.fromProcess` (same as pi) |
| ask_user | Reuses the shared `AskUserMcpServer`; gemini has no inline MCP flag, so it's registered by merging `mcpServers.orca` into a project-local `.gemini/settings.json`, restored on finalize |
| Approval | `readOnly → --approval-mode plan`; `AutoApprove.All`/`Only(_) → yolo` (gemini has no per-tool allowlist; `auto_edit` blocks on shell in headless) |
| `--skip-trust` | unconditional — gemini otherwise refuses headless runs in an untrusted dir (exit 55) and silently overrides the approval mode |
| Structured output | prompt-enforced (gemini has no `--output-schema`); reuses the `DefaultLlmCall` retry loop |
| Models | `gemini.flash` accessor; bare `gemini` pins `gemini-2.5-pro` |

## Shared wiring
`BackendTag.Gemini`, `GeminiTool` trait + export, `CanAskUser[Gemini]` given, `gemini` accessor, `FlowContext`/`DefaultFlowContext`, `gemini-2.5-pro`/`gemini-2.5-flash` pricing, and the module in `build.sbt` (deps + aggregate).

## Docs
[ADR 0015](adr/0015-gemini-stream-json-driver.md) documents the protocol, the `Only→yolo` widening, `--skip-trust`, and the `.gemini/settings.json` merge with its two sharp edges (per-workDir concurrency, crash-safety best-effort restore). README gains a `gemini` row.

## Testing
- **59 unit tests** (Args, InboundEvent parse, Conversation, Settings merge/restore, Backend, DefaultGeminiTool, `CanAskUser`), built test-first.
- `GeminiIntegrationTest` gated on `ORCA_INTEGRATION` (model override via `ORCA_GEMINI_MODEL`).
- **Run against the real `gemini` CLI (0.45.2):** headless literal round-trip ✅ and a resumed turn that recalls prior context ✅ — verifying the `--resume` flow and the stream-json wire shape. The wire-format details below were confirmed from that run.

## Notes for reviewers
- The benign stderr lines gemini prints on every run (256-color warning, "YOLO mode is enabled", "Shell cwd was reset to …") are filtered via `isKnownStderrNoise` (mirrors codex); real errors still surface.
- The cache token sub-count is read from the `cached` stats field (the name gemini 0.45.2 uses).
- Targets `master`; branch is even with upstream (no rebase needed).
