### PR TITLE
Format after every edit in reviewAndFixLoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ flow(OrcaArgs(args)):
   // runs read-only and would inherit the restriction on resume.
   val session = claude.newSession
 
-  // Per task: implement, format, review & fix. `implementTaskLoop` ticks
+  // Per task: implement, then review & fix. `implementTaskLoop` ticks
   // the plan's checkbox + commits per task and removes the plan file at
   // the end. The single commit captures the original implementation, the
   // auto-formatted result, and any follow-up fixes the reviewers triggered.
@@ -55,11 +55,6 @@ flow(OrcaArgs(args)):
     stage(s"Implement task: ${task.title}"):
       stage("Implementation"):
         val _ = claude.autonomous.run(task.description, session)
-      // Format before review so reviewers don't burn turns on style nits
-      // the toolchain would fix automatically. Run after the agent
-      // writes — we don't want to demand pre-formatted code from the LLM.
-      stage("Format"):
-        val _ = os.proc("sbt", "scalafmtAll").call(check = false)
       reviewAndFixLoop(
         coder = claude,
         sessionId = session,
@@ -69,6 +64,9 @@ flow(OrcaArgs(args)):
         // ReviewerSelector.allEveryRound to run every reviewer.
         reviewerSelection = ReviewerSelector.llmDriven(claude.haiku),
         task = task.title.value,
+        // Runs after the implementation and after each review fix, so the
+        // committed code is always formatted and reviewers skip style nits.
+        formatCommand = Some("sbt scalafmtAll"),
         // A compile is a cheap sanity gate; correctness is the reviewers'
         // and CI's job, so don't run the heavier full test suite here.
         lintCommand = Some("sbt Test/compile"),

--- a/examples/epic.sc
+++ b/examples/epic.sc
@@ -57,19 +57,15 @@ flow(OrcaArgs(args)):
       stage("Implementation"):
         val _ = claude.autonomous.run(task.description, session)
 
-      // Format before review so reviewers don't burn turns on style nits the
-      // toolchain would fix automatically. Spotless is wired into the seed pom.
-      stage("Format"):
-        val _ = os
-          .proc("mvn", "-q", "spotless:apply")
-          .call(cwd = os.pwd, check = false)
-
       reviewAndFixLoop(
         coder = claude,
         sessionId = session,
         reviewers = reviewers,
         reviewerSelection = ReviewerSelector.llmDriven(claude.haiku),
-        task = task.title.value
+        task = task.title.value,
+        // Format after every edit (the implementation and each review fix);
+        // Spotless is wired into the seed pom.
+        formatCommand = Some("mvn -q spotless:apply")
       )
 
   stage("Update documentation"):

--- a/examples/implement-enhanced.sc
+++ b/examples/implement-enhanced.sc
@@ -55,17 +55,14 @@ flow(OrcaArgs(args)):
         // taskPrompt prepends the shared brief.
         val _ = claude.autonomous.run(plan.taskPrompt(task), session)
 
-      // Format before review so reviewers (and the commit) don't burn turns
-      // on style nits.
-      stage("Format"):
-        val _ = os.proc("cargo", "fmt").call(check = false)
-
       reviewAndFixLoop(
         coder = claude,
         sessionId = session,
         reviewers = allReviewers(claude),
         reviewerSelection = ReviewerSelector.llmDriven(claude.haiku),
         task = task.title.value,
+        // Format after every edit (the implementation and each review fix).
+        formatCommand = Some("cargo fmt"),
         lintCommand = Some("cargo check --tests"),
         lintLlm = Some(claude.haiku)
       )

--- a/examples/implement-interactive.sc
+++ b/examples/implement-interactive.sc
@@ -45,11 +45,6 @@ flow(OrcaArgs(args)):
       stage("Implementation"):
         val _ = claude.autonomous.run(task.description, session)
 
-      // Format before review so reviewers (and the commit) don't burn turns
-      // on style nits.
-      stage("Format"):
-        val _ = os.proc("cargo", "fmt").call(check = false)
-
       reviewAndFixLoop(
         coder = claude,
         sessionId = session,
@@ -58,6 +53,9 @@ flow(OrcaArgs(args)):
         // `ReviewerSelector.allEveryRound` to run every reviewer.
         reviewerSelection = ReviewerSelector.llmDriven(claude.haiku),
         task = task.title.value,
+        // Format after every edit (the implementation and each review fix), so
+        // the committed code stays formatted and reviewers skip style nits.
+        formatCommand = Some("cargo fmt"),
         // A compile is a cheap sanity gate for the reviewers; correctness is
         // the reviewers' and CI's job, so don't run the (much heavier) tests.
         lintCommand = Some("cargo check --tests"),

--- a/examples/implement.sc
+++ b/examples/implement.sc
@@ -47,11 +47,6 @@ flow(OrcaArgs(args)):
       stage("Implementation"):
         val _ = claude.autonomous.run(task.description, session)
 
-      // Format before review so reviewers (and the commit) don't burn turns
-      // on style nits.
-      stage("Format"):
-        val _ = os.proc("cargo", "fmt").call(check = false)
-
       reviewAndFixLoop(
         coder = claude,
         sessionId = session,
@@ -60,6 +55,9 @@ flow(OrcaArgs(args)):
         // `ReviewerSelector.allEveryRound` to run every reviewer.
         reviewerSelection = ReviewerSelector.llmDriven(claude.haiku),
         task = task.title.value,
+        // Format after every edit (the implementation and each review fix), so
+        // the committed code stays formatted and reviewers skip style nits.
+        formatCommand = Some("cargo fmt"),
         // A compile is a cheap sanity gate for the reviewers; correctness is
         // the reviewers' and CI's job, so don't run the (much heavier) tests.
         lintCommand = Some("cargo check --tests"),

--- a/examples/issue-pr-bugfix.sc
+++ b/examples/issue-pr-bugfix.sc
@@ -180,15 +180,14 @@ flow(OrcaArgs(args)):
       stage(s"Implement task: ${task.title}"):
         stage("Implementation"):
           val _ = claude.autonomous.run(task.description, session)
-        // Format before review so reviewers don't burn turns on style nits.
-        stage("Format"):
-          val _ = os.proc("sbt", "scalafmtAll").call(check = false)
         reviewAndFixLoop(
           coder = claude,
           sessionId = session,
           reviewers = allReviewers(claude),
           reviewerSelection = ReviewerSelector.llmDriven(claude.haiku),
           task = task.title.value,
+          // Format after every edit (the implementation and each review fix).
+          formatCommand = Some("sbt scalafmtAll"),
           // A compile (main + test sources) is a cheap sanity gate for the
           // reviewers; the failing test runs in CI and correctness is the
           // reviewers' job, so don't run the (much heavier) full suite.

--- a/examples/issue-pr.sc
+++ b/examples/issue-pr.sc
@@ -90,7 +90,10 @@ flow(OrcaArgs(args)):
           // Haiku picks the per-task reviewer subset; swap for
           // `ReviewerSelector.allEveryRound` to run every reviewer.
           reviewerSelection = ReviewerSelector.llmDriven(claude.haiku),
-          task = task.title.value
+          task = task.title.value,
+          // Format after every edit (the implementation and each review fix);
+          // Prettier for a TypeScript/JS project — swap for your formatter.
+          formatCommand = Some("npx prettier --write .")
         )
 
     stage("Push branch"):

--- a/flow/src/main/scala/orca/review/ReviewLoop.scala
+++ b/flow/src/main/scala/orca/review/ReviewLoop.scala
@@ -167,6 +167,13 @@ def reviewAndFixLoop[B <: BackendTag](
     reviewers: List[LlmTool[?]],
     reviewerSelection: ReviewerSelector,
     task: String,
+    /** Shell command run before each review round — after the implementation
+      * and after every fix — so reviewers and the lint see formatted code and
+      * the committed tree stays formatted. Run via `bash -c`, exit status
+      * ignored (a formatter that fails shouldn't abort the review). E.g. `"sbt
+      * scalafmtAll"`, `"cargo fmt"`, `"prettier -w ."`.
+      */
+    formatCommand: Option[String] = None,
     lintCommand: Option[String] = None,
     /** LLM that summarises lint output into a `ReviewResult`. Required when
       * `lintCommand` is set; ignored otherwise. Use a cheap model
@@ -340,6 +347,12 @@ def reviewAndFixLoop[B <: BackendTag](
       (reviewerOutcomes, lintOutcome, nextState)
 
   def evaluate(): ReviewResult =
+    // Format before reviewing so the implementation's (and each prior fix's)
+    // edits are cleaned up before reviewers and the lint see them, and the
+    // committed tree stays formatted. Exit status ignored — a formatter failure
+    // shouldn't abort the review; output is captured (not printed) by `call`.
+    formatCommand.foreach: cmd =>
+      val _ = os.proc("bash", "-c", cmd).call(check = false)
     val active =
       reviewerSelection(state.history, reviewers, taskTitle, changedFiles)
     val totalAgents = active.size + (if lintCommand.isDefined then 1 else 0)
@@ -425,7 +438,12 @@ def lint(
     // `finally` below removes it, so skip the JVM-exit hook (one per lint call
     // would otherwise accumulate over a long run).
     val outputFile =
-      os.temp(output, prefix = "orca-lint-", suffix = ".log", deleteOnExit = false)
+      os.temp(
+        output,
+        prefix = "orca-lint-",
+        suffix = ".log",
+        deleteOnExit = false
+      )
     try
       llm.withReadOnly
         .resultAs[ReviewResult]

--- a/flow/src/test/scala/orca/review/ReviewAndFixTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewAndFixTest.scala
@@ -478,3 +478,30 @@ class ReviewAndFixTest extends munit.FunSuite:
       reviewerSelection = ReviewerSelector.allEveryRound,
       initialDiff = Some("")
     )
+
+  test("formatCommand runs before every review round (impl + each fix)"):
+    given FlowContext = ctx
+    // The formatter appends one line per run. Two review rounds (issue → fix,
+    // then clean) mean it must run twice — once before reviewing the
+    // implementation, once before re-reviewing the fix.
+    val counter = os.temp.dir() / "fmt-count"
+    val reviewer = new FakeLlmTool(
+      name = "r",
+      outputs =
+        List(ReviewResult(List(issue("needs fixing"))), ReviewResult.empty)
+    )
+    val coder = new FakeLlmTool(
+      name = "coder",
+      outputs = List(FixOutcome(List(Title("needs fixing")), Nil))
+    )
+    val _ = reviewAndFixLoop(
+      coder = coder,
+      sessionId = SessionId[BackendTag.ClaudeCode.type]("s"),
+      reviewers = List(reviewer),
+      task = "format check",
+      reviewerSelection = ReviewerSelector.allEveryRound,
+      formatCommand = Some(s"echo x >> '$counter'"),
+      initialDiff = Some("")
+    )
+    val runs = if os.exists(counter) then os.read.lines(counter).size else 0
+    assertEquals(runs, 2)

--- a/runner/src/test/scala/flowtests/FlowCompilesTest.scala
+++ b/runner/src/test/scala/flowtests/FlowCompilesTest.scala
@@ -78,6 +78,7 @@ object FlowCanary:
             reviewers = allReviewers(claude),
             reviewerSelection = ReviewerSelector.llmDriven(claude.haiku),
             task = task.description,
+            formatCommand = Some("mvn -q spotless:apply"),
             lintCommand = Some("mvn -q test"),
             lintLlm = Some(claude.haiku)
           )


### PR DESCRIPTION
Adds `formatCommand: Option[String]` to `reviewAndFixLoop`, run via `bash -c` at the start of each review round — so the implementation's edits *and* every review-fix's edits
  are formatted before reviewers/lint see them and before the per-task commit. Previously the flows formatted once before review, leaving review-fix edits unformatted in the committed code.

  The example flows drop their standalone `stage("Format")` block and pass `formatCommand` instead (cargo fmt / sbt scalafmtAll / mvn spotless / npx prettier); the README headline example
  does the same. New test pins that the formatter runs before every round (twice across an issue→fix→clean loop); `FlowCompilesTest` pins the param compiles from a script.