### PR TITLE
Return to the start branch at the end of the PR flows

### DIFF
--- a/examples/issue-pr-bugfix.sc
+++ b/examples/issue-pr-bugfix.sc
@@ -234,6 +234,10 @@ flow(OrcaArgs(args)):
         )
 
     case Triage.Testable(summary, branchName, failingTestPath) =>
+      // Capture the start branch to return to at the end: the stash below is
+      // taken here, so `git stash pop` only lands WIP right if we come back.
+      val startBranch = git.currentBranch()
+
       // Stash pre-existing local edits before switching branches — otherwise
       // they'd ride onto the bugfix branch and get folded into the
       // failing-test commit. `ensureClean` emits a Step the user can act on
@@ -247,3 +251,7 @@ flow(OrcaArgs(args)):
       confirmReproductionMatches(pr)
       planAndImplementFix(branchName)
       pushAndFinalisePr(pr)
+
+      // Return to the start branch so any stashed WIP pops back onto it.
+      stage(s"Return to $startBranch"):
+        git.checkout(startBranch).orThrow

--- a/examples/issue-pr.sc
+++ b/examples/issue-pr.sc
@@ -57,6 +57,12 @@ flow(OrcaArgs(args)):
   // persist the plan so a crash resumes from the first incomplete task.
   // `Verdict.Rejection` posts the assessment as an issue comment and the
   // flow exits.
+
+  // Capture the start branch to return to at the end: Plan.recover /
+  // checkoutOrCreate below switch away and stash WIP, so `git stash pop`
+  // only lands right if we come back.
+  val startBranch = git.currentBranch()
+
   val planFile = Plan.defaultPath(userPrompt)
   val maybePlan = stage("Acquire plan"):
     Plan
@@ -117,3 +123,7 @@ flow(OrcaArgs(args)):
            |
            |Closes ${issueHandle.shortRef}.""".stripMargin
       val _ = gh.createPr(title = summary.title, body = body).orThrow
+
+    // Return to the start branch so any stashed WIP pops back onto it.
+    stage(s"Return to $startBranch"):
+      git.checkout(startBranch).orThrow


### PR DESCRIPTION
The issue-pr and issue-pr-bugfix example flows stash the user's WIP (via `ensureClean` / `Plan.recover`) before switching to the work branch, and tell the user to `git stash pop` afterwards — but left them on the work branch, so the pop would land on the wrong branch. Capture the start branch up front and check it back out once the PR is open.