### PR TITLE
Tighten comments in example flows and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,27 +30,24 @@ Save this as `implement.sc` and run it with your task:
 import orca.{*, given}
 
 flow(OrcaArgs(args)):
-  // Plan persists to `.orca/plan-<hash>.md` so a re-run with the same
-  // prompt resumes from the first incomplete task. Plan.autonomous.from
-  // runs the planner as a single agentic turn (use Plan.interactive.from
-  // to let the planner ask clarifying questions). It returns the plan
-  // paired with the planner's session; `.value` keeps just the plan (the
-  // implementer below opens its own session). `recoverOrCreate` ensures the
-  // branch is checked out and the file is on disk before we start.
+  // Plan persists to `.orca/plan-<hash>.md` so a re-run with the same prompt
+  // resumes from the first incomplete task. Plan.autonomous.from runs the
+  // planner as one agentic turn (Plan.interactive.from lets it ask clarifying
+  // questions); `.value` keeps just the plan, dropping the planner's session.
+  // `recoverOrCreate` checks out the branch and writes the file before we start.
   val planFile = Plan.defaultPath(userPrompt)
   val plan = stage("Acquire plan"):
     Plan.recoverOrCreate(planFile, "orca: starting work"):
       Plan.autonomous.from(userPrompt, claude).value
 
-  // Stable session reused across every task so the implementer retains
-  // cross-task context. The planner's session isn't carried forward — it
-  // runs read-only and would inherit the restriction on resume.
+  // Stable session reused across tasks so the implementer retains context.
+  // The planner's isn't carried forward — it's read-only and would stay so
+  // on resume.
   val session = claude.newSession
 
-  // Per task: implement, then review & fix. `implementTaskLoop` ticks
-  // the plan's checkbox + commits per task and removes the plan file at
-  // the end. The single commit captures the original implementation, the
-  // auto-formatted result, and any follow-up fixes the reviewers triggered.
+  // Per task: implement, then review & fix. `implementTaskLoop` ticks the
+  // checkbox, commits per task, and removes the plan file at the end. The one
+  // commit captures the implementation, formatting, and any reviewer fixes.
   Plan.implementTaskLoop(planFile, plan): task =>
     stage(s"Implement task: ${task.title}"):
       stage("Implementation"):
@@ -59,16 +56,15 @@ flow(OrcaArgs(args)):
         coder = claude,
         sessionId = session,
         reviewers = allReviewers(claude),
-        // Cheap model picks which reviewers run per task — sees each
-        // one's description plus the changed files. Swap for
-        // ReviewerSelector.allEveryRound to run every reviewer.
+        // Cheap model picks the per-task reviewers from their descriptions and
+        // the changed files. Swap for ReviewerSelector.allEveryRound to run all.
         reviewerSelection = ReviewerSelector.llmDriven(claude.haiku),
         task = task.title.value,
-        // Runs after the implementation and after each review fix, so the
-        // committed code is always formatted and reviewers skip style nits.
+        // Runs after every edit so commits stay formatted and reviewers skip
+        // style nits.
         formatCommand = Some("sbt scalafmtAll"),
-        // A compile is a cheap sanity gate; correctness is the reviewers'
-        // and CI's job, so don't run the heavier full test suite here.
+        // Cheap sanity gate; correctness is the reviewers' and CI's job, so
+        // skip the heavier test suite.
         lintCommand = Some("sbt Test/compile"),
         lintLlm = Some(claude.haiku)
       )

--- a/examples/epic.sc
+++ b/examples/epic.sc
@@ -5,19 +5,18 @@
   *
   * Two layers stack here:
   *
-  *   - **On-disk epic.** `.orca/plan-<hash>.md` holds the task list; on a
-  *     fresh run the agent generates it, on a resume the existing file is
-  *     recovered (pending edits stashed, branch re-attached) and execution
-  *     restarts from the first incomplete task. Each task's `Status: [x]`
-  *     checkbox is committed back to the plan file as the task lands, so a
-  *     crash mid-flow loses no progress.
-  *   - **Cross-agent review.** Claude implements; codex reviews. The
-  *     implementing agent is its own worst critic — running reviewers on a
-  *     separate model widens coverage without much extra cost. Fixes go back
-  *     to the same Claude session. Both CLIs need to be logged in.
+  *   - **On-disk epic.** `.orca/plan-<hash>.md` holds the task list — generated
+  *     on a fresh run, recovered on a resume (pending edits stashed, branch
+  *     re-attached) to restart from the first incomplete task. Each task's
+  *     `Status: [x]` is committed as the task lands, so a crash loses no
+  *     progress.
+  *   - **Cross-agent review.** Claude implements; codex reviews — the
+  *     implementer is its own worst critic, so a separate model widens coverage
+  *     cheaply. Fixes go back to the same Claude session. Both CLIs must be
+  *     logged in.
   *
-  * At the end of a successful run the plan file is removed, then the
-  * documentation step updates the project README based on what changed.
+  * On success the plan file is removed, then a docs step updates the README
+  * based on what changed.
   *
   * Run it from a git repository, with `claude` and `codex` logged in:
   *
@@ -41,15 +40,13 @@ flow(OrcaArgs(args)):
       // below mints a fresh one.
       Plan.autonomous.from(userPrompt, claude.opus).value
 
-  // Stable coder session reused across every task (and the docs pass at the
-  // end) so the agent retains cross-task context. Fresh session (not the
-  // planner's, which ran read-only). The runtime owns git commits — the agent
-  // is told not to commit by the default system prompt, so a stray `git
-  // commit` can't empty the working tree before `implementTaskLoop` commits.
+  // Stable coder session reused across every task (and the docs pass) so the
+  // agent retains context. Fresh — not the planner's (read-only). The runtime
+  // owns git: the default system prompt tells the agent not to commit, so a
+  // stray `git commit` can't empty the tree before `implementTaskLoop` does.
   val session = claude.newSession
 
-  // Reviewers on codex (not claude — the implementer is its own worst critic);
-  // fixes go back to the same Claude session that implemented the task.
+  // Reviewers on codex; fixes go back to the Claude session that implemented.
   val reviewers: List[LlmTool[?]] = allReviewers(codex)
 
   Plan.implementTaskLoop(planFile, plan): task =>
@@ -63,8 +60,7 @@ flow(OrcaArgs(args)):
         reviewers = reviewers,
         reviewerSelection = ReviewerSelector.llmDriven(claude.haiku),
         task = task.title.value,
-        // Format after every edit (the implementation and each review fix);
-        // Spotless is wired into the seed pom.
+        // Format after every edit; Spotless is wired into the seed pom.
         formatCommand = Some("mvn -q spotless:apply")
       )
 

--- a/examples/implement-enhanced.sc
+++ b/examples/implement-enhanced.sc
@@ -6,24 +6,23 @@
   *
   * Same backbone as `implement.sc` (autonomous planning → persistent
   * `.orca/plan-<hash>.md` → per-task implement + review-and-fix loop), with two
-  * extra steps chained onto planning — both running on the planner's read-only
-  * session, so they cost no extra codebase exploration:
+  * steps chained onto planning — both on the planner's read-only session, so
+  * they cost no extra exploration:
   *
   *   1. **`.reviewed(claude)`** — the planner critiques its own draft and
   *      returns an improved plan (missing/duplicated tasks, ordering, vague
   *      descriptions, steps that don't fit the code).
   *   1. **`.briefed(claude)`** — the planner writes a one-off codebase brief
-  *      (modules, file paths, key APIs, conventions) and attaches it, producing
-  *      a `PlanWithBrief`. `plan.taskPrompt(task)` prepends the brief to every
-  *      task, so the coding agents — which start cold — don't re-discover what
-  *      the planner already learned. The brief excludes the task prompts.
+  *      (modules, paths, key APIs, conventions), producing a `PlanWithBrief`.
+  *      `plan.taskPrompt(task)` prepends it to every task so the cold-starting
+  *      coding agents don't re-discover what the planner already learned.
   *
-  * The brief rides in the single plan file (a trailing `## Brief` section), so
-  * `recoverOrCreate` / `implementTaskLoop` persist it on a fresh run, reuse it
-  * on resume, and remove it with the file when the plan completes — no sidecar.
+  * The brief rides in the plan file (a trailing `## Brief` section), so
+  * `recoverOrCreate` / `implementTaskLoop` persist, reuse, and remove it with
+  * the file — no sidecar.
   *
-  * Swap the order to `.briefed(claude).reviewed(claude)` to also review the
-  * brief; both are well-typed.
+  * Swap to `.briefed(claude).reviewed(claude)` to also review the brief; both
+  * are well-typed.
   *
   * ```bash
   * scala-cli run implement-enhanced.sc -- "Add a multiply function to the calculator crate"

--- a/examples/implement-interactive.sc
+++ b/examples/implement-interactive.sc
@@ -3,22 +3,20 @@
 
 /** Interactive planning + coding flow (persistent).
   *
-  * Same shape as `implement.sc` but the planner opens a conversation the user
-  * can drive: if the prompt is underspecified, the agent calls the `ask_user`
-  * tool to clarify before producing the plan. The resulting plan is persisted
-  * to `.orca/plan-<hash>.md` so a re-run resumes from the first incomplete
-  * task.
+  * Same shape as `implement.sc`, but the planner can drive a conversation: on an
+  * underspecified prompt it calls the `ask_user` tool to clarify before
+  * producing the plan. The plan persists to `.orca/plan-<hash>.md` so a re-run
+  * resumes from the first incomplete task.
   *
   * `examples/runnable/02-interactive/create-test-project.sh` seeds the calculator
-  * crate into a temp directory and copies this script alongside it; run
-  * from the seeded directory the seeder prints:
+  * crate into a temp dir and copies this script alongside it; from there:
   *
   * ```bash
   * scala-cli run implement-interactive.sc -- "Add a new arithmetic operation to the calculator crate. Ask the user which."
   * ```
   *
   * The trailing "Ask the user which." pushes the planner to call `ask_user`
-  * rather than guessing which operation to add.
+  * rather than guessing.
   *
   * Requires `claude` logged in and `cargo` on PATH.
   */
@@ -32,12 +30,12 @@ flow(OrcaArgs(args)):
   // (the planner can call `ask_user` to clarify) and branch.
   val plan = stage("Acquire plan"):
     Plan.recoverOrCreate(planFile):
-      // `.value` drops the planner's session — the implementer below mints a
-      // fresh one (ask_user was only needed for planning).
+      // `.value` drops the planner's session; the implementer mints its own
+      // (ask_user was only needed for planning).
       Plan.interactive.from(userPrompt, claude).value
 
-  // Stable autonomous session reused across every task — ask_user was only
-  // needed for planning. Implementer and fixer share it.
+  // Stable autonomous session shared by implementer and fixer (ask_user was
+  // only needed for planning).
   val session = claude.newSession
 
   Plan.implementTaskLoop(planFile, plan): task =>
@@ -53,11 +51,11 @@ flow(OrcaArgs(args)):
         // `ReviewerSelector.allEveryRound` to run every reviewer.
         reviewerSelection = ReviewerSelector.llmDriven(claude.haiku),
         task = task.title.value,
-        // Format after every edit (the implementation and each review fix), so
-        // the committed code stays formatted and reviewers skip style nits.
+        // Format after every edit so commits stay formatted and reviewers
+        // skip style nits.
         formatCommand = Some("cargo fmt"),
-        // A compile is a cheap sanity gate for the reviewers; correctness is
-        // the reviewers' and CI's job, so don't run the (much heavier) tests.
+        // Cheap sanity gate; correctness is the reviewers' and CI's job, so
+        // skip the heavier tests.
         lintCommand = Some("cargo check --tests"),
         lintLlm = Some(claude.haiku)
       )

--- a/examples/implement.sc
+++ b/examples/implement.sc
@@ -3,17 +3,15 @@
 
 /** Persistent planning + coding flow (autonomous planning).
   *
-  * Mirrors the README example. The agent breaks the user's prompt into a list
-  * of tasks; the plan is persisted to `.orca/plan-<hash>.md` so a re-run with
-  * the same prompt resumes from the first incomplete task. Each task is
-  * implemented in sequence on a single epic branch with a review-and-fix loop,
-  * the plan's checkbox is ticked, and the work plus the tick are committed
-  * together. When every task is done the plan file is removed and the removal
-  * is committed.
+  * Mirrors the README example. The agent breaks the prompt into tasks, persisted
+  * to `.orca/plan-<hash>.md` so a re-run with the same prompt resumes from the
+  * first incomplete task. Each task is implemented on a single epic branch with
+  * a review-and-fix loop; the work and the ticked checkbox are committed
+  * together. When every task is done the plan file is removed and that removal
+  * committed.
   *
-  * `examples/runnable/01-simple/create-test-project.sh` seeds the calculator crate
-  * into a temp directory and copies this script alongside it; run from
-  * the seeded directory the seeder prints:
+  * `examples/runnable/01-simple/create-test-project.sh` seeds the calculator
+  * crate into a temp dir and copies this script alongside it; from there:
   *
   * ```bash
   * scala-cli run implement.sc -- "Add a multiply function to the calculator crate"
@@ -21,8 +19,8 @@
   *
   * Requires `claude` logged in and `cargo` on PATH.
   *
-  * For the variant where the planner can ask the user clarifying questions
-  * (open-ended prompts, underspecified asks), see `implement-interactive.sc`.
+  * For the variant where the planner can ask clarifying questions, see
+  * `implement-interactive.sc`.
   */
 
 import orca.{*, given}
@@ -33,13 +31,12 @@ flow(OrcaArgs(args)):
   // Resume `.orca/plan-<hash>.md` if it exists; otherwise plan + branch.
   val plan = stage("Acquire plan"):
     Plan.recoverOrCreate(planFile):
-      // `.value` drops the planner's read-only session — the implementer
-      // below mints a fresh one.
+      // `.value` drops the planner's read-only session; the implementer
+      // mints its own.
       Plan.autonomous.from(userPrompt, claude).value
 
-  // Stable session reused across every task — implementer and fixer share
-  // it so review comments land against the same context that produced the
-  // code. Fresh session (not the planner's, which was in plan mode).
+  // Stable session shared by implementer and fixer, so reviews land against
+  // the code's own context. Fresh — not the planner's (plan mode).
   val session = claude.newSession
 
   Plan.implementTaskLoop(planFile, plan): task =>
@@ -55,11 +52,11 @@ flow(OrcaArgs(args)):
         // `ReviewerSelector.allEveryRound` to run every reviewer.
         reviewerSelection = ReviewerSelector.llmDriven(claude.haiku),
         task = task.title.value,
-        // Format after every edit (the implementation and each review fix), so
-        // the committed code stays formatted and reviewers skip style nits.
+        // Format after every edit so commits stay formatted and reviewers
+        // skip style nits.
         formatCommand = Some("cargo fmt"),
-        // A compile is a cheap sanity gate for the reviewers; correctness is
-        // the reviewers' and CI's job, so don't run the (much heavier) tests.
+        // Cheap sanity gate; correctness is the reviewers' and CI's job, so
+        // skip the heavier tests.
         lintCommand = Some("cargo check --tests"),
         lintLlm = Some(claude.haiku)
       )

--- a/examples/issue-pr-bugfix.sc
+++ b/examples/issue-pr-bugfix.sc
@@ -48,10 +48,9 @@ flow(OrcaArgs(args)):
   val issue = stage(s"Read issue ${issueHandle.shortRef}"):
     gh.readIssue(issueHandle)
 
-  // Autonomous triage — no human in the loop. Runs read-only (read/grep to
-  // verify the report), but the session it returns is reused below for the
-  // failing-test write and the fix: resuming it with a writable call restores
-  // write access, and the implementer inherits the triage's exploration.
+  // Autonomous triage, read-only (read/grep to verify the report). The session
+  // it returns is reused for the failing-test write and the fix: a writable
+  // call restores write access, and the implementer inherits the exploration.
   val Sessioned(session, triage) = stage("Triage"):
     Plan.autonomous.triage(
       s"""Title: ${issue.title}
@@ -62,14 +61,14 @@ flow(OrcaArgs(args)):
     )
 
   // ============================ pipeline phases ============================
-  // Each phase below is one step of the testable-bug pipeline; the `Testable`
-  // branch at the bottom reads as the sequence of these. They close over
-  // `session`, `issue`, `issueHandle` and `CiTimeout`.
+  // One def per step of the testable-bug pipeline; the `Testable` branch at the
+  // bottom reads as their sequence. They close over `session`, `issue`,
+  // `issueHandle` and `CiTimeout`.
 
-  /** Generate a PR title + body from the full branch diff, with the issue
-    * context and a phase-specific `note` folded in. Used for both the tentative
-    * (test-only) and final (test + fix) descriptions. `git.diffVsBase` (not
-    * `git.diff()` vs HEAD) because the changes are already committed.
+  /** PR title + body from the full branch diff, with issue context and a
+    * phase-specific `note`. Used for both the tentative (test-only) and final
+    * (test + fix) descriptions. `git.diffVsBase` (not `git.diff()` vs HEAD)
+    * because the changes are already committed.
     */
   def prSummary(note: String): PrSummary =
     summarisePr(
@@ -125,9 +124,8 @@ flow(OrcaArgs(args)):
         )
 
   /** Sonnet inspects the failed run via `gh` — the flow never pulls the log
-    * into memory. Each sonnet turn is a fresh one-shot session (only the
-    * implementer holds a long-lived session), so each re-inspects the run by id
-    * and is self-contained. Posts a focused failure comment, then strictly
+    * into memory. Each sonnet turn is a fresh one-shot session, so it
+    * re-inspects the run by id. Posts a focused failure comment, then strictly
     * verifies the failure matches the original report.
     */
   def confirmReproductionMatches(pr: PrHandle): Unit =
@@ -161,13 +159,12 @@ flow(OrcaArgs(args)):
       if !verdict.matches then
         fail(s"Reproduction doesn't match the report: ${verdict.explanation}")
 
-  /** Plan + implement the fix on the same branch. No `.orca/plan-*.md`: the
+  /** Plan + implement the fix on the same branch. No `.orca/plan-*.md` — the
     * earlier stages (triage, CI red, repro verification) aren't restartable from
-    * a plan file alone, so use the in-memory `implementTaskLoop`. The draft plan
-    * is self-reviewed and given a codebase brief (`reviewed`/`briefed`, both
-    * resuming the planning session read-only); that planning session is then
-    * discarded via `.value`, and the fix tasks — each carrying the brief via
-    * `taskPrompt` — run on the triage `session`.
+    * a plan file alone, so use the in-memory `implementTaskLoop`. The draft is
+    * self-reviewed and briefed (`reviewed`/`briefed`, both read-only), then
+    * `.value` drops the planning session; the fix tasks carry the brief via
+    * `taskPrompt` and run on the triage `session`.
     */
   def planAndImplementFix(branchName: String): Unit =
     val fixPlan = stage("Plan the fix"):
@@ -190,16 +187,15 @@ flow(OrcaArgs(args)):
           task = task.title.value,
           // Format after every edit (the implementation and each review fix).
           formatCommand = Some("sbt scalafmtAll"),
-          // A compile (main + test sources) is a cheap sanity gate for the
-          // reviewers; the failing test runs in CI and correctness is the
-          // reviewers' job, so don't run the (much heavier) full suite.
+          // Compile (main + test) is a cheap sanity gate; the failing test runs
+          // in CI and correctness is the reviewers' job, so skip the full suite.
           lintCommand = Some("sbt Test/compile"),
           lintLlm = Some(claude.haiku)
         )
 
   /** Push the fix and regenerate the PR title + body from the full branch diff,
-    * so the PR now reads as a fix rather than "add a test". Does not wait for CI
-    * green — a human takes it from here.
+    * so it reads as a fix, not "add a test". Doesn't wait for CI green — a human
+    * takes it from here.
     */
   def pushAndFinalisePr(pr: PrHandle): Unit =
     stage("Push the fix"):
@@ -238,10 +234,9 @@ flow(OrcaArgs(args)):
       // taken here, so `git stash pop` only lands WIP right if we come back.
       val startBranch = git.currentBranch()
 
-      // Stash pre-existing local edits before switching branches — otherwise
-      // they'd ride onto the bugfix branch and get folded into the
-      // failing-test commit. `ensureClean` emits a Step the user can act on
-      // (`git stash pop`) once the flow finishes.
+      // Stash pre-existing edits before switching branches, or they'd ride onto
+      // the bugfix branch into the failing-test commit. `ensureClean` emits a
+      // Step the user can act on (`git stash pop`) once the flow finishes.
       val _ = git.ensureClean("orca: pre-bugfix stash")
       git.checkoutOrCreate(branchName)
 

--- a/examples/issue-pr.sc
+++ b/examples/issue-pr.sc
@@ -6,21 +6,17 @@
   * Given a `<owner>/<repo>#<number>` reference (the user's prompt), the flow:
   *
   *   1. Reads the issue from GitHub (title, body, author).
-  *   1. Resumes `.orca/plan-<hash>.md` if one exists for this issue (crash
-  *      recovery); otherwise skeptically assesses the report against the repo —
-  *      verifies claims, looks for missing detail, duplicates, scope problems.
-  *      The agent returns either a plan or a critique / follow-up question /
-  *      rebuff.
+  *   1. Resumes `.orca/plan-<hash>.md` if one exists (crash recovery);
+  *      otherwise skeptically assesses the report against the repo — claims,
+  *      missing detail, duplicates, scope. The agent returns a plan or a
+  *      critique / follow-up question / rebuff.
   *   1. On rejection: posts the agent's reply on the issue and exits.
   *   1. On proceed: creates the epic branch, persists the plan, and runs
   *      `Plan.implementTaskLoop` — each task gets the review-and-fix loop, a
-  *      checkbox tick on disk, and a `task: <title>` commit; the plan file is
-  *      removed and the removal committed once every task is done.
-  *   1. Pushes the branch (only PR-bound flows push; `Plan.implementTaskLoop`
-  *      itself only commits).
-  *   1. Asks a cheap model (`claude.haiku`) via `summarisePr` to fold the diff
-  *      into a PR title + description.
-  *   1. Opens the PR via `gh`.
+  *      checkbox tick, and a `task: <title>` commit; the plan file is removed
+  *      once every task is done.
+  *   1. Pushes the branch, folds the diff into a PR title + description via a
+  *      cheap model (`summarisePr`), and opens the PR via `gh`.
   *
   * Usage — pass `<owner>/<repo>#<number>`:
   *
@@ -50,13 +46,10 @@ flow(OrcaArgs(args)):
        |
        |${issue.body}""".stripMargin
 
-  // Resume an in-progress plan if one exists for this issue (the planFile
-  // path is keyed off `userPrompt = <owner>/<repo>#<number>`). Otherwise
-  // assess — Opus runs read-only so it can verify claims via Read/Grep
-  // without editing during the assess turn — and on `Verdict.Proceed`
-  // persist the plan so a crash resumes from the first incomplete task.
-  // `Verdict.Rejection` posts the assessment as an issue comment and the
-  // flow exits.
+  // Resume an in-progress plan for this issue if one exists; otherwise assess
+  // (Opus runs read-only to verify claims via Read/Grep). `Verdict.Proceed`
+  // persists the plan so a crash resumes from the first incomplete task;
+  // `Verdict.Rejection` posts the assessment on the issue and exits.
 
   // Capture the start branch to return to at the end: Plan.recover /
   // checkoutOrCreate below switch away and stash WIP, so `git stash pop`
@@ -79,9 +72,8 @@ flow(OrcaArgs(args)):
             Some(plan)
 
   maybePlan.foreach: plan =>
-    // Fresh implementation session (the assess session was in plan mode
-    // and can't write). Reused across tasks so the implementer retains
-    // context.
+    // Fresh session — the assess session was read-only (plan mode). Reused
+    // across tasks so the implementer retains context.
     val session = claude.newSession
 
     Plan.implementTaskLoop(planFile, plan): task =>
@@ -97,8 +89,8 @@ flow(OrcaArgs(args)):
           // `ReviewerSelector.allEveryRound` to run every reviewer.
           reviewerSelection = ReviewerSelector.llmDriven(claude.haiku),
           task = task.title.value,
-          // Format after every edit (the implementation and each review fix);
-          // Prettier for a TypeScript/JS project — swap for your formatter.
+          // Format after every edit; Prettier for a TS/JS project — swap for
+          // your formatter.
           formatCommand = Some("npx prettier --write .")
         )
 
@@ -108,8 +100,8 @@ flow(OrcaArgs(args)):
     val summary = stage("Generate PR title and description"):
       summarisePr(
         llm = claude.haiku,
-        // Branch-vs-default-branch diff — `git.diff()` (vs HEAD) would be
-        // empty here since `implementTaskLoop` already committed every task.
+        // Branch-vs-base diff — `git.diff()` (vs HEAD) would be empty, since
+        // `implementTaskLoop` already committed every task.
         diff = git.diffVsBase(git.defaultBase()),
         context = Some(
           s"""Originating issue: ${issueHandle.shortRef}


### PR DESCRIPTION
Trim wordiness, hedging, and repetition across the example flow scripts and the README's example block while preserving the rationale each comment carries. Comments only — no code changes.