### PR TITLE
Planner read-only network access via a ToolSet capability axis

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ The following are available inside a `flow(...) { ... }`:
 
 | Tool | Methods | Purpose |
 |---|---|---|
-| `claude` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `haiku`/`sonnet`/`opus`/`fable`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withSelfManagedGit` | Claude Code coding/reviewing agent. Bare `claude` is **Opus with the 1M-token context window** (the long-lived implementer needs it; reviewers share it); use `claude.sonnet` / `claude.haiku` for cheap one-shot calls (reviewer picker, lint, PR summariser), or `claude.fable` for the most capable tier on the hardest one-shots. `interactive` mode lives only on `resultAs[O]`. |
-| `codex` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `mini`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withSelfManagedGit` | OpenAI Codex coding/reviewing agent. |
-| `opencode` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `anthropicOpus`/`anthropicSonnet`/`anthropicHaiku`, `openaiGpt5`/`openaiGpt5Codex`/`openaiGpt5Mini`, `withModel(providerModel)` / `withModel(provider, modelId)`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withSelfManagedGit` | [OpenCode](https://opencode.ai) coding/reviewing agent, driven over HTTP+SSE against a headless `opencode serve` (started lazily, shared for the run). Spans providers, so models are provider-qualified: use an accessor (`opencode.openaiGpt5Mini`) or `opencode.withModel("openai/gpt-4o-mini")` / `opencode.withModel("ollama", "llama3.1")`. Inherits the user's configured `opencode` providers/auth. |
-| `pi` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withSelfManagedGit` | [Pi](https://pi.dev/) coding agent backend, driven through `pi --mode rpc`. Pi handles provider/model selection through its own CLI configuration; pin a model with `pi.withConfig(LlmConfig(model = Some(Model("provider/model"))))`. Interactive calls can ask clarifying questions via Orca's `ask_user` bridge. |
-| `gemini` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `flash`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withSelfManagedGit` | Google Gemini CLI coding/reviewing agent, driven via `gemini --output-format stream-json`. Bare `gemini` pins **Gemini 2.5 Pro**; use `gemini.flash` for cheaper one-shot calls. Structured output is prompt-enforced (Gemini has no schema flag); `withReadOnly` maps to `--approval-mode plan`. See [ADR 0015](adr/0015-gemini-stream-json-driver.md). |
+| `claude` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `haiku`/`sonnet`/`opus`/`fable`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withNetworkOnly`, `withNetworkTools`, `withSelfManagedGit` | Claude Code coding/reviewing agent. Bare `claude` is **Opus with the 1M-token context window** (the long-lived implementer needs it; reviewers share it); use `claude.sonnet` / `claude.haiku` for cheap one-shot calls (reviewer picker, lint, PR summariser), or `claude.fable` for the most capable tier on the hardest one-shots. `interactive` mode lives only on `resultAs[O]`. |
+| `codex` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `mini`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withNetworkOnly`, `withSelfManagedGit` | OpenAI Codex coding/reviewing agent. |
+| `opencode` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `anthropicOpus`/`anthropicSonnet`/`anthropicHaiku`, `openaiGpt5`/`openaiGpt5Codex`/`openaiGpt5Mini`, `withModel(providerModel)` / `withModel(provider, modelId)`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withNetworkOnly`, `withSelfManagedGit` | [OpenCode](https://opencode.ai) coding/reviewing agent, driven over HTTP+SSE against a headless `opencode serve` (started lazily, shared for the run). Spans providers, so models are provider-qualified: use an accessor (`opencode.openaiGpt5Mini`) or `opencode.withModel("openai/gpt-4o-mini")` / `opencode.withModel("ollama", "llama3.1")`. Inherits the user's configured `opencode` providers/auth. |
+| `pi` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withNetworkOnly`, `withSelfManagedGit` | [Pi](https://pi.dev/) coding agent backend, driven through `pi --mode rpc`. Pi handles provider/model selection through its own CLI configuration; pin a model with `pi.withConfig(LlmConfig(model = Some(Model("provider/model"))))`. Interactive calls can ask clarifying questions via Orca's `ask_user` bridge. |
+| `gemini` | `autonomous.run(prompt, session?)`, `resultAs[O].{autonomous,interactive}.run(input, session?)`, `newSession`, `flash`, `withConfig`, `withSystemPrompt`, `withName`, `withReadOnly`, `withNetworkOnly`, `withSelfManagedGit` | Google Gemini CLI coding/reviewing agent, driven via `gemini --output-format stream-json`. Bare `gemini` pins **Gemini 2.5 Pro**; use `gemini.flash` for cheaper one-shot calls. Structured output is prompt-enforced (Gemini has no schema flag); `withReadOnly` maps to `--approval-mode plan`. See [ADR 0015](adr/0015-gemini-stream-json-driver.md). |
 | `git` | `createBranch`, `checkout`, `checkoutOrCreate`, `ensureClean`, `commit`, `push`, `currentBranch`, `diff`, `log`, `addWorktree`, `removeWorktree`, `listWorktrees` | Git operations against the working tree. Recoverable failures (`BranchAlreadyExists`, `BranchNotFound`, `NothingToCommit`, `PushRejected`, `WorktreeAddFailed`, `WorktreeNotFound`) surface as `Either`; `.orThrow` converts a `Left` back to an exception when the case is unexpected. |
 | `gh` | `createPr`, `updatePr`, `readIssue`, `readIssueComments`, `readPrComments`, `writeComment(pr, body)` / `writeComment(issue, body)`, `buildStatus`, `waitForBuild` | GitHub PR + CI integration via the `gh` CLI. `createPr` returns `Either[PrCreateFailed, …]` (covers `PrAlreadyExists` / `NoCommitsToPr`); `updatePr` replaces a PR's title + body (refresh a tentative description once the fix lands); `waitForBuild` returns `Either[BuildWaitFailed, …]`. |
 | `fs` | `read`, `write`, `list` | Working-tree file I/O. `read` returns `Option[String]` so a missing file is a branch point, not an exception. |
@@ -141,16 +141,33 @@ flow(OrcaArgs(args)):
 ## Coding agent tools
 
 > [!WARNING]
-> **Coding agent tool usage is auto-approved by default** (`autoApprove = AutoApprove.All`):
-> write-capable turns let the agent edit files and run shell commands without
-> prompting. Constrain this in code, or isolate the whole run in a sandbox.
+> **Coding agent tool usage is auto-approved by default** (`tools =
+> ToolSet.Full`, `autoApprove = AutoApprove.All`): write-capable turns let the
+> agent edit files and run shell commands without prompting. Constrain this in
+> code, or isolate the whole run in a sandbox.
 
-Tighten approval per tool with `withReadOnly` / `withConfig`:
+Two axes constrain an agent. **Capability** (`LlmConfig.tools: ToolSet`) is
+which tools exist at all:
 
 ```scala
-// Read-only: no writes, no edits, no side-effecting shell (planning, review).
-val planner = claude.withReadOnly
+// ReadOnly — reads only, no shell, no edits (reviewers, plan review, brief).
+val reviewer = claude.withReadOnly
 
+// NetworkOnly — reads plus read-only network (web + GitHub), for planners that
+// must read an issue/PR. Hard no-edit on claude (a command-scoped
+// `--allowedTools` set, configurable via `claude.withNetworkTools(...)`); on
+// pi/codex network needs a writable shell, so there the no-edit guarantee is
+// prompt-only; gemini/opencode get no network on this tier. See ADR 0016.
+val planner = claude.withNetworkOnly
+
+// Full (the default) — write-capable.
+```
+
+**Prompting** (`autoApprove`) is which of the available tools auto-approve
+without a y/n prompt — only meaningful for interactive turns, and consulted
+only on `Full`:
+
+```scala
 // Restrict auto-approval to a named tool set (honoured by claude/codex).
 val limited = claude.withConfig(
   LlmConfig(autoApprove = AutoApprove.Only(Set("Read", "Edit", "Grep")))
@@ -182,7 +199,7 @@ orthogonal — every combination is valid. Mode is picked at the call site
 (`Plan.autonomous.*` vs `Plan.interactive.*`), mirroring how `LlmTool` itself
 splits `autonomous` / `interactive`:
 
-| Operation | Result | `autonomous` (read-only, no human) | `interactive` (agent can `ask_user`) |
+| Operation | Result | `autonomous` (read-only + network, no human) | `interactive` (agent can `ask_user`) |
 |---|---|---|---|
 | `from(userPrompt, llm, instructions?)` | `Plan` | plan in one agentic turn | drive the planner conversationally |
 | `assessThenPlan(userPrompt, llm, instructions?)` | `Verdict[Plan]` | assess, then `Proceed(plan)` or `Rejection(kind, body)` | same, but can ask the reporter to clarify instead of rejecting |
@@ -190,8 +207,8 @@ splits `autonomous` / `interactive`:
 
 Every cell returns `Sessioned[B, <result>]` — the result paired with the agent
 session that produced it. Continue that session into implementation
-(`llm.autonomous.run(task, sessioned.sessionId)` — the read-only planning turn's
-session is still resumable with write access), or `.value` it and mint a fresh
+(`llm.autonomous.run(task, sessioned.sessionId)` — the planning turn's session
+is still resumable with write access), or `.value` it and mint a fresh
 session via `llm.newSession`. Destructure positionally when you want both:
 `val Sessioned(session, plan) = Plan.autonomous.from(...)`.
 

--- a/README.md
+++ b/README.md
@@ -154,10 +154,10 @@ which tools exist at all:
 val reviewer = claude.withReadOnly
 
 // NetworkOnly — reads plus read-only network (web + GitHub), for planners that
-// must read an issue/PR. Hard no-edit on claude (a command-scoped
-// `--allowedTools` set, configurable via `claude.withNetworkTools(...)`); on
-// pi/codex network needs a writable shell, so there the no-edit guarantee is
-// prompt-only; gemini/opencode get no network on this tier. See ADR 0016.
+// must read an issue/PR. Hard no-edit on claude (command-scoped `--allowedTools`,
+// configurable via `claude.withNetworkTools(...)`), gemini (scoped `web_fetch`),
+// and opencode (web); on pi/codex network needs a writable shell, so there the
+// no-edit guarantee is prompt-only. See ADR 0016.
 val planner = claude.withNetworkOnly
 
 // Full (the default) — write-capable.

--- a/adr/0016-toolset-capability-axis-and-planner-network.md
+++ b/adr/0016-toolset-capability-axis-and-planner-network.md
@@ -1,0 +1,71 @@
+# 0016. `ToolSet` capability axis and planner read-only network access
+
+Status: Accepted · Date: 2026-06-11
+Related: [ADR 0003](0003-pluggable-llm-backends.md) (backend surface), [ADR 0011](0011-reviewer-roster.md) (reviewers run read-only)
+
+## Context
+
+Planning turns run autonomously (stdin closed, no `ask_user` MCP) and
+read-only. On every backend the read-only mode also blocks the network the
+planner needs to read an issue/PR it was pointed at: claude's
+`--permission-mode plan` prompts for `WebFetch`/`gh` (and an autonomous turn
+can't answer), codex's `--sandbox read-only` blocks all network, pi's read-only
+`--tools` has no web tool, gemini's `--approval-mode plan` gates web/shell.
+
+Capability was previously encoded as a boolean `LlmConfig.readOnly` layered over
+the `AutoApprove` enum, munged together in each backend's args mapping. Two
+problems: (1) the boolean couldn't express "read-only **plus** network"; (2)
+`withReadOnly` is the shared hard no-edit gate for *seven* turn kinds (two
+planners, plan-review, brief, triage, code reviewers, reviewer-selection /
+lint-summary), and `Reviewers.scala` relies on it so reviewers can't edit
+mid-review — so network must not be tied to "read-only" in general.
+
+## Decision
+
+Replace `readOnly: Boolean` with a capability enum on `LlmConfig`:
+
+```scala
+enum ToolSet: case ReadOnly, NetworkOnly, Full
+```
+
+`ToolSet` is the **capability axis** (which tools exist); `AutoApprove` stays
+the orthogonal **prompting axis** (which available tools auto-approve, only
+meaningful interactively and consulted only on `Full`). Only the two autonomous
+planner entry points (`Plan.autonomousResult` → `from`/`assessThenPlan`/`triage`)
+select `NetworkOnly`; reviewers, `reviewed`/`briefed`, selection and lint keep
+`ReadOnly`, hard everywhere.
+
+### Per-backend `NetworkOnly` mapping
+
+| Backend | `NetworkOnly` | No-edit guarantee | Network |
+| --- | --- | --- | --- |
+| claude | `plan` + `--allowedTools <networkTools>` | **hard** (command-scoped allowlist; plan mode blocks general bash + edits) | web + scoped `gh` |
+| pi | `--tools …,bash` | **prompt-only** (bash permits writes) | shell (`gh`/`curl`) |
+| codex | `--full-auto` + `-c sandbox_workspace_write.network_access=true` | **prompt-only** (workspace-write permits writes) | shell + web |
+| gemini | `--approval-mode plan` | hard | **none** |
+| opencode | write tools disabled (= `ReadOnly`) | hard | web only, server-dependent |
+
+pi and codex have no read-only-with-network mode, so granting network forces a
+writable surface; there the no-edit guarantee rests on the planner prompts
+(`planning.md` / `assess-then-plan.md` / `triage.md` all forbid edits), not the
+sandbox. **Verified** that gemini's `web_fetch` works under `yolo` but is blocked
+under `plan` headless, so gemini `NetworkOnly` grants no network; opencode keeps
+`bash` off, so no writable-shell network. Those flows pre-fetch context (e.g.
+`gh.readIssue`) instead.
+
+### Claude allowlist placement
+
+The claude network allowlist (`--allowedTools` strings like `Bash(gh api:*)`) is
+claude-specific, so it lives on `ClaudeBackend` (default
+`DefaultNetworkTools`), not the shared `LlmConfig`. It is configurable per flow
+via `claude.withNetworkTools(...)`. The default includes `Bash(gh api:*)` for
+broad GitHub reads — note `gh api -X POST` can mutate GitHub (not local files);
+flows wanting a tighter set override it.
+
+## Consequences
+
+- Claude planners get scoped read-only network with the hard no-edit guarantee
+  intact; pi/codex planners get network with a prompt-only guarantee;
+  gemini/opencode planners stay network-free and rely on pre-fetching.
+- `withReadOnly` semantics are unchanged for the six non-planner turn kinds.
+- `AutoApprove.Only` remains unused by flows (latent); not removed here.

--- a/adr/0016-toolset-capability-axis-and-planner-network.md
+++ b/adr/0016-toolset-capability-axis-and-planner-network.md
@@ -42,16 +42,18 @@ select `NetworkOnly`; reviewers, `reviewed`/`briefed`, selection and lint keep
 | claude | `plan` + `--allowedTools <networkTools>` | **hard** (command-scoped allowlist; plan mode blocks general bash + edits) | web + scoped `gh` |
 | pi | `--tools …,bash` | **prompt-only** (bash permits writes) | shell (`gh`/`curl`) |
 | codex | `--full-auto` + `-c sandbox_workspace_write.network_access=true` | **prompt-only** (workspace-write permits writes) | shell + web |
-| gemini | `--approval-mode plan` | hard | **none** |
+| gemini | `--approval-mode plan --allowed-tools web_fetch` | hard | web |
 | opencode | write tools disabled (= `ReadOnly`) | hard | web only, server-dependent |
 
 pi and codex have no read-only-with-network mode, so granting network forces a
 writable surface; there the no-edit guarantee rests on the planner prompts
 (`planning.md` / `assess-then-plan.md` / `triage.md` all forbid edits), not the
-sandbox. **Verified** that gemini's `web_fetch` works under `yolo` but is blocked
-under `plan` headless, so gemini `NetworkOnly` grants no network; opencode keeps
-`bash` off, so no writable-shell network. Those flows pre-fetch context (e.g.
-`gh.readIssue`) instead.
+sandbox. **Verified** on the gemini CLI: plain `plan` mode blocks `web_fetch`,
+but `plan` + `--allowed-tools web_fetch` runs it (returns content), so gemini
+keeps its hard no-edit guarantee *and* gets web reads (no shell `gh`).
+`--allowed-tools` is deprecated (gemini 1.0 → Policy Engine); migrate then.
+opencode keeps `bash` off (no writable-shell network); its web tool isn't in the
+disabled set, so web may work (server-dependent, unverified).
 
 ### Claude allowlist placement
 

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -27,7 +27,8 @@ private[claude] object ClaudeArgs:
       systemPromptFile: Option[os.Path],
       dispatch: Dispatch[BackendTag.ClaudeCode.type],
       jsonSchema: Option[String] = None,
-      mcpConfig: Option[os.Path] = None
+      mcpConfig: Option[os.Path] = None,
+      networkTools: Seq[String] = Seq.empty
   ): Seq[String] =
     Seq(
       "claude",
@@ -42,7 +43,7 @@ private[claude] object ClaudeArgs:
       CliArgs.modelArgs(config) ++
       systemPromptFileArgs(systemPromptFile) ++
       sessionArgs(dispatch) ++
-      autoApproveArgs(config) ++
+      autoApproveArgs(config, networkTools) ++
       jsonSchemaArgs(jsonSchema) ++
       mcpConfigArgs(mcpConfig)
 
@@ -71,19 +72,34 @@ private[claude] object ClaudeArgs:
   private def mcpConfigArgs(file: Option[os.Path]): Seq[String] =
     file.toSeq.flatMap(f => Seq("--mcp-config", f.toString))
 
-  /** Maps [[LlmConfig.tools]] to claude's permission flags. The read-only tiers
-    * use `--permission-mode plan`, which makes Edit/Write/Bash unavailable (not
-    * just non-auto-approved) — turning the planner's advisory "don't edit"
-    * prompt into a hard guarantee. `Full` follows [[LlmConfig.autoApprove]].
+  /** Maps [[LlmConfig.tools]] to claude's permission flags. Both read-only
+    * tiers use `--permission-mode plan`, which makes Edit/Write/Bash
+    * unavailable (not just non-auto-approved) — turning the planner's advisory
+    * "don't edit" prompt into a hard guarantee. `Full` follows
+    * [[LlmConfig.autoApprove]].
     *
-    * `NetworkOnly` is plan mode here too for now; the network allowlist that
-    * distinguishes it (a command-scoped `--allowedTools` set) is layered on the
-    * backend in a later step.
+    * `NetworkOnly` additionally pre-approves `networkTools` via
+    * `--allowedTools`, layering read-only network access (web + scoped `gh`)
+    * onto plan mode so an autonomous planner can fetch issues/PRs without a
+    * permission prompt it can't answer. The list is command-scoped, so plan
+    * mode still hard-blocks general bash and every edit. An empty list leaves
+    * plain plan mode.
     */
-  private def autoApproveArgs(config: LlmConfig): Seq[String] =
+  private def autoApproveArgs(
+      config: LlmConfig,
+      networkTools: Seq[String]
+  ): Seq[String] =
     config.tools match
-      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+      case ToolSet.ReadOnly => Seq("--permission-mode", "plan")
+      case ToolSet.NetworkOnly if networkTools.isEmpty =>
         Seq("--permission-mode", "plan")
+      case ToolSet.NetworkOnly =>
+        Seq(
+          "--permission-mode",
+          "plan",
+          "--allowedTools",
+          networkTools.mkString(",")
+        )
       case ToolSet.Full =>
         config.autoApprove match
           case AutoApprove.All =>

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -71,13 +71,41 @@ private[claude] object ClaudeArgs:
   private def mcpConfigArgs(file: Option[os.Path]): Seq[String] =
     file.toSeq.flatMap(f => Seq("--mcp-config", f.toString))
 
+  /** Read-only network/GitHub tools pre-approved for planning turns. Plan mode
+    * blocks these behind a permission prompt; layering them via `--allowedTools`
+    * lets an autonomous planner (no one to answer prompts) fetch issues, PRs,
+    * and web pages. Scoped to non-mutating commands only — `gh api` and bare
+    * `curl` are excluded because they can also write.
+    */
+  private val readOnlyNetworkTools: Seq[String] = Seq(
+    "WebFetch",
+    "WebSearch",
+    "Bash(gh issue view:*)",
+    "Bash(gh pr view:*)",
+    "Bash(gh search:*)",
+    "Bash(gh repo view:*)"
+  )
+
   /** `readOnly` overrides any `autoApprove` setting: claude's
     * `--permission-mode plan` makes Edit/Write/Bash unavailable to the agent
     * (not just non-auto-approved). The planner's "don't edit files" instruction
     * in the prompt is advisory; this turns it into a hard guarantee.
+    *
+    * Plan mode also gates read-only network exploration (WebFetch, and
+    * `gh`/`curl` via Bash) behind a permission prompt — harmless interactively,
+    * but an autonomous planner has no one to answer it, so every issue/PR fetch
+    * dies. [[readOnlyNetworkTools]] is layered on via `--allowedTools` so the
+    * planner can read from GitHub and the web while plan mode still hard-blocks
+    * every edit.
     */
   private def autoApproveArgs(config: LlmConfig): Seq[String] =
-    if config.readOnly then Seq("--permission-mode", "plan")
+    if config.readOnly then
+      Seq(
+        "--permission-mode",
+        "plan",
+        "--allowedTools",
+        readOnlyNetworkTools.mkString(",")
+      )
     else
       config.autoApprove match
         case AutoApprove.All =>

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -1,7 +1,7 @@
 package orca.tools.claude
 
 import orca.backend.{CliArgs, Dispatch}
-import orca.llm.{AutoApprove, BackendTag, LlmConfig, SessionId}
+import orca.llm.{AutoApprove, BackendTag, LlmConfig, SessionId, ToolSet}
 
 /** Maps LlmConfig fields to Claude Code CLI flags. `systemPrompt` is consumed
   * by the backend (written to a file whose path is passed in via
@@ -71,51 +71,29 @@ private[claude] object ClaudeArgs:
   private def mcpConfigArgs(file: Option[os.Path]): Seq[String] =
     file.toSeq.flatMap(f => Seq("--mcp-config", f.toString))
 
-  /** Read-only network/GitHub tools pre-approved for planning turns. Plan mode
-    * blocks these behind a permission prompt; layering them via `--allowedTools`
-    * lets an autonomous planner (no one to answer prompts) fetch issues, PRs,
-    * and web pages. Scoped to non-mutating commands only — `gh api` and bare
-    * `curl` are excluded because they can also write.
-    */
-  private val readOnlyNetworkTools: Seq[String] = Seq(
-    "WebFetch",
-    "WebSearch",
-    "Bash(gh issue view:*)",
-    "Bash(gh pr view:*)",
-    "Bash(gh search:*)",
-    "Bash(gh repo view:*)"
-  )
-
-  /** `readOnly` overrides any `autoApprove` setting: claude's
-    * `--permission-mode plan` makes Edit/Write/Bash unavailable to the agent
-    * (not just non-auto-approved). The planner's "don't edit files" instruction
-    * in the prompt is advisory; this turns it into a hard guarantee.
+  /** Maps [[LlmConfig.tools]] to claude's permission flags. The read-only tiers
+    * use `--permission-mode plan`, which makes Edit/Write/Bash unavailable (not
+    * just non-auto-approved) — turning the planner's advisory "don't edit"
+    * prompt into a hard guarantee. `Full` follows [[LlmConfig.autoApprove]].
     *
-    * Plan mode also gates read-only network exploration (WebFetch, and
-    * `gh`/`curl` via Bash) behind a permission prompt — harmless interactively,
-    * but an autonomous planner has no one to answer it, so every issue/PR fetch
-    * dies. [[readOnlyNetworkTools]] is layered on via `--allowedTools` so the
-    * planner can read from GitHub and the web while plan mode still hard-blocks
-    * every edit.
+    * `NetworkOnly` is plan mode here too for now; the network allowlist that
+    * distinguishes it (a command-scoped `--allowedTools` set) is layered on the
+    * backend in a later step.
     */
   private def autoApproveArgs(config: LlmConfig): Seq[String] =
-    if config.readOnly then
-      Seq(
-        "--permission-mode",
-        "plan",
-        "--allowedTools",
-        readOnlyNetworkTools.mkString(",")
-      )
-    else
-      config.autoApprove match
-        case AutoApprove.All =>
-          Seq("--permission-mode", "bypassPermissions")
-        case AutoApprove.Only(tools) if tools.isEmpty =>
-          Seq("--permission-mode", "acceptEdits")
-        case AutoApprove.Only(tools) =>
-          Seq(
-            "--permission-mode",
-            "acceptEdits",
-            "--allowedTools",
-            tools.toSeq.sorted.mkString(",")
-          )
+    config.tools match
+      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+        Seq("--permission-mode", "plan")
+      case ToolSet.Full =>
+        config.autoApprove match
+          case AutoApprove.All =>
+            Seq("--permission-mode", "bypassPermissions")
+          case AutoApprove.Only(tools) if tools.isEmpty =>
+            Seq("--permission-mode", "acceptEdits")
+          case AutoApprove.Only(tools) =>
+            Seq(
+              "--permission-mode",
+              "acceptEdits",
+              "--allowedTools",
+              tools.toSeq.sorted.mkString(",")
+            )

--- a/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
@@ -37,8 +37,19 @@ import ox.channels.BufferCapacity
   * long flow with many interactive calls doesn't leak Netty bindings.
   * Autonomous calls skip the bridge entirely.
   */
-private[orca] class ClaudeBackend(cli: CliRunner)(using Ox, BufferCapacity)
+private[orca] class ClaudeBackend(
+    cli: CliRunner,
+    networkTools: Seq[String] = ClaudeBackend.DefaultNetworkTools
+)(using Ox, BufferCapacity)
     extends LlmBackend[BackendTag.ClaudeCode.type]:
+
+  /** Return a sibling backend that, on [[ToolSet.NetworkOnly]] turns,
+    * pre-approves `tools` (claude `--allowedTools` syntax). The configuration
+    * seam behind `ClaudeTool.withNetworkTools`; lives on the backend, not
+    * `LlmConfig`, since the strings are claude-specific.
+    */
+  def withNetworkTools(tools: Seq[String]): ClaudeBackend =
+    new ClaudeBackend(cli, tools)
 
   /** Tracks which session ids we've already claimed via `--session-id` so
     * subsequent calls use `--resume` (the CLI refuses to reuse `--session-id`
@@ -176,7 +187,8 @@ private[orca] class ClaudeBackend(cli: CliRunner)(using Ox, BufferCapacity)
         systemPromptFile,
         dispatch = sessions.dispatchFor(session),
         outputSchema,
-        mcpConfig = askUser.map(r => mcpConfigPath(r.server, workDir))
+        mcpConfig = askUser.map(r => mcpConfigPath(r.server, workDir)),
+        networkTools = networkTools
       )
       val process = cli.spawnPiped(args, cwd = workDir)
       try
@@ -253,6 +265,23 @@ private[orca] class ClaudeBackend(cli: CliRunner)(using Ox, BufferCapacity)
         os.temp(prefix = "orca-system-prompt-", suffix = ".md", contents = text)
 
 object ClaudeBackend:
+
+  /** Read-only network tools pre-approved on [[ToolSet.NetworkOnly]] turns, so
+    * an autonomous planner can read issues/PRs/web without a permission prompt
+    * it can't answer. Command-scoped, so plan mode still blocks general bash
+    * and all edits. `Bash(gh api:*)` is broad GitHub reads — note `gh api -X
+    * POST` can mutate GitHub (not local files); flows wanting a tighter set
+    * pass their own via `claude.withNetworkTools(...)`.
+    */
+  private[claude] val DefaultNetworkTools: Seq[String] = Seq(
+    "WebFetch",
+    "WebSearch",
+    "Bash(gh issue view:*)",
+    "Bash(gh pr view:*)",
+    "Bash(gh search:*)",
+    "Bash(gh repo view:*)",
+    "Bash(gh api:*)"
+  )
 
   /** Returns an `AutoCloseable` that best-effort deletes the given file when
     * closed. Used as an `AskUserSession.extras` entry so each conversation's

--- a/claude/src/main/scala/orca/tools/claude/DefaultClaudeTool.scala
+++ b/claude/src/main/scala/orca/tools/claude/DefaultClaudeTool.scala
@@ -3,7 +3,7 @@ package orca.tools.claude
 import orca.llm.{BackendTag, ClaudeTool, LlmConfig, Model, Prompts}
 import orca.events.{OrcaListener}
 
-import orca.backend.{Interaction, LlmBackend}
+import orca.backend.Interaction
 import orca.llm.BaseLlmTool
 
 /** Default ClaudeTool implementation. Inherits the autonomous-text +
@@ -17,7 +17,7 @@ import orca.llm.BaseLlmTool
   * completion.
   */
 private[orca] class DefaultClaudeTool(
-    backend: LlmBackend[BackendTag.ClaudeCode.type],
+    backend: ClaudeBackend,
     config: LlmConfig,
     prompts: Prompts,
     workDir: os.Path,
@@ -38,6 +38,22 @@ private[orca] class DefaultClaudeTool(
   def sonnet: ClaudeTool = withModel(Model("claude-sonnet-4-6"))
   def opus: ClaudeTool = withModel(DefaultClaudeTool.Opus1M)
   def fable: ClaudeTool = withModel(DefaultClaudeTool.Fable)
+
+  /** Per the trait: configure the read-only network allowlist by swapping in a
+    * reconfigured backend (the allowlist is claude-specific, so it lives there
+    * rather than in the shared `LlmConfig`). Constructs directly rather than
+    * via [[copyTool]] because the latter threads the current backend unchanged.
+    */
+  def withNetworkTools(tools: Seq[String]): ClaudeTool =
+    new DefaultClaudeTool(
+      backend.withNetworkTools(tools),
+      config,
+      prompts,
+      workDir,
+      events,
+      interaction,
+      name
+    )
 
   protected def copyTool(
       config: LlmConfig = config,

--- a/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
@@ -11,12 +11,14 @@ class ClaudeArgsTest extends munit.FunSuite:
 
   private def streamJson(
       config: LlmConfig,
-      dispatch: Dispatch[BackendTag.ClaudeCode.type] = Dispatch.Fresh(testSid)
+      dispatch: Dispatch[BackendTag.ClaudeCode.type] = Dispatch.Fresh(testSid),
+      networkTools: Seq[String] = Seq.empty
   ): Seq[String] =
     ClaudeArgs.streamJson(
       config = config,
       systemPromptFile = None,
-      dispatch = dispatch
+      dispatch = dispatch,
+      networkTools = networkTools
     )
 
   test("stream-json shape: --print, --input/--output-format stream-json, etc."):
@@ -76,12 +78,30 @@ class ClaudeArgsTest extends munit.FunSuite:
     assert(!args.contains("bypassPermissions"), args)
     assert(!args.contains("--allowedTools"), args)
 
-  // For now NetworkOnly is plain plan mode; a later step layers its network
-  // allowlist on the backend (and strengthens this assertion).
   test(
-    "ToolSet.NetworkOnly stays --permission-mode plan with no inline allowlist"
+    "ToolSet.NetworkOnly layers networkTools onto plan mode via --allowedTools"
   ):
+    val args = streamJson(
+      LlmConfig(tools = ToolSet.NetworkOnly),
+      networkTools = Seq("WebFetch", "Bash(gh api:*)")
+    )
+    assert(args.containsSlice(Seq("--permission-mode", "plan")), args)
+    assert(
+      args.containsSlice(Seq("--allowedTools", "WebFetch,Bash(gh api:*)")),
+      args
+    )
+
+  test("ToolSet.NetworkOnly with no networkTools stays plain plan mode"):
     val args = streamJson(LlmConfig(tools = ToolSet.NetworkOnly))
+    assert(args.containsSlice(Seq("--permission-mode", "plan")), args)
+    assert(!args.contains("--allowedTools"), args)
+
+  test("ToolSet.ReadOnly never emits networkTools even when supplied"):
+    // Reviewers/triage use ReadOnly and must stay network-free.
+    val args = streamJson(
+      LlmConfig(tools = ToolSet.ReadOnly),
+      networkTools = Seq("WebFetch")
+    )
     assert(args.containsSlice(Seq("--permission-mode", "plan")), args)
     assert(!args.contains("--allowedTools"), args)
 

--- a/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
@@ -1,7 +1,7 @@
 package orca.tools.claude
 
 import orca.backend.Dispatch
-import orca.llm.{AutoApprove, BackendTag, LlmConfig, Model, SessionId}
+import orca.llm.{AutoApprove, BackendTag, LlmConfig, Model, SessionId, ToolSet}
 class ClaudeArgsTest extends munit.FunSuite:
 
   private val testSid =
@@ -63,29 +63,27 @@ class ClaudeArgsTest extends munit.FunSuite:
     assert(args.containsSlice(Seq("--permission-mode", "acceptEdits")))
     assert(!args.contains("--allowedTools"))
 
-  test("readOnly=true maps to --permission-mode plan, overriding autoApprove"):
-    // `readOnly` is the planner's hard restriction — Edit/Write/Bash must be
-    // unavailable, not just non-auto-approved. It wins over `autoApprove`
-    // because the use case is "the agent is verifying claims, not editing".
-    val args =
-      streamJson(LlmConfig(autoApprove = AutoApprove.All, readOnly = true))
+  test(
+    "ToolSet.ReadOnly maps to --permission-mode plan, overriding autoApprove"
+  ):
+    // The read-only tier is the planner/reviewer hard restriction —
+    // Edit/Write/Bash unavailable, not just non-auto-approved. It wins over
+    // `autoApprove` (the agent is verifying claims, not editing).
+    val args = streamJson(
+      LlmConfig(autoApprove = AutoApprove.All, tools = ToolSet.ReadOnly)
+    )
     assert(args.containsSlice(Seq("--permission-mode", "plan")), args)
     assert(!args.contains("bypassPermissions"), args)
+    assert(!args.contains("--allowedTools"), args)
 
-  test("readOnly=true pre-approves read-only network tools via --allowedTools"):
-    // Plan mode otherwise prompts for WebFetch / gh, which an autonomous
-    // planner can't answer; the layered allowlist lets it read issues and PRs.
-    val args = streamJson(LlmConfig(readOnly = true))
-    assert(
-      args.containsSlice(
-        Seq(
-          "--allowedTools",
-          "WebFetch,WebSearch,Bash(gh issue view:*)," +
-            "Bash(gh pr view:*),Bash(gh search:*),Bash(gh repo view:*)"
-        )
-      ),
-      args
-    )
+  // For now NetworkOnly is plain plan mode; a later step layers its network
+  // allowlist on the backend (and strengthens this assertion).
+  test(
+    "ToolSet.NetworkOnly stays --permission-mode plan with no inline allowlist"
+  ):
+    val args = streamJson(LlmConfig(tools = ToolSet.NetworkOnly))
+    assert(args.containsSlice(Seq("--permission-mode", "plan")), args)
+    assert(!args.contains("--allowedTools"), args)
 
   test("Dispatch.Fresh emits --session-id <uuid>"):
     val args = streamJson(LlmConfig.default, dispatch = Dispatch.Fresh(testSid))

--- a/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
@@ -71,7 +71,21 @@ class ClaudeArgsTest extends munit.FunSuite:
       streamJson(LlmConfig(autoApprove = AutoApprove.All, readOnly = true))
     assert(args.containsSlice(Seq("--permission-mode", "plan")), args)
     assert(!args.contains("bypassPermissions"), args)
-    assert(!args.contains("--allowedTools"), args)
+
+  test("readOnly=true pre-approves read-only network tools via --allowedTools"):
+    // Plan mode otherwise prompts for WebFetch / gh, which an autonomous
+    // planner can't answer; the layered allowlist lets it read issues and PRs.
+    val args = streamJson(LlmConfig(readOnly = true))
+    assert(
+      args.containsSlice(
+        Seq(
+          "--allowedTools",
+          "WebFetch,WebSearch,Bash(gh issue view:*)," +
+            "Bash(gh pr view:*),Bash(gh search:*),Bash(gh repo view:*)"
+        )
+      ),
+      args
+    )
 
   test("Dispatch.Fresh emits --session-id <uuid>"):
     val args = streamJson(LlmConfig.default, dispatch = Dispatch.Fresh(testSid))

--- a/claude/src/test/scala/orca/tools/claude/ClaudeBackendTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeBackendTest.scala
@@ -1,7 +1,7 @@
 package orca.tools.claude
 
 import orca.backend.SupervisedBackend
-import orca.llm.{BackendTag, LlmConfig, SessionId}
+import orca.llm.{BackendTag, LlmConfig, SessionId, ToolSet}
 import orca.{OrcaFlowException}
 import orca.subprocess.{FakePipedCliProcess, SpawnStubCliRunner}
 
@@ -56,6 +56,35 @@ class ClaudeBackendTest extends munit.FunSuite:
       assert(args.containsSlice(Seq("--output-format", "stream-json")))
       // No ask_user MCP on the autonomous path.
       assert(!args.contains("--mcp-config"), args)
+
+  test("NetworkOnly autonomous call pre-approves the default network tools"):
+    val runner = new SpawnStubCliRunner(List(successfulProcess()))
+    withBackend(runner): backend =>
+      val _ = backend.runAutonomous(
+        "x",
+        freshSid,
+        LlmConfig.default.copy(tools = ToolSet.NetworkOnly),
+        os.temp.dir()
+      )
+      val args = runner.calls.head
+      assert(args.containsSlice(Seq("--permission-mode", "plan")), args)
+      val allowed = args(args.indexOf("--allowedTools") + 1)
+      assert(allowed.contains("WebFetch"), allowed)
+      assert(allowed.contains("Bash(gh api:*)"), allowed)
+
+  test("withNetworkTools overrides the default allowlist"):
+    val runner = new SpawnStubCliRunner(List(successfulProcess()))
+    SupervisedBackend.using(
+      new ClaudeBackend(runner).withNetworkTools(Seq("WebFetch"))
+    ): backend =>
+      val _ = backend.runAutonomous(
+        "x",
+        freshSid,
+        LlmConfig.default.copy(tools = ToolSet.NetworkOnly),
+        os.temp.dir()
+      )
+      val args = runner.calls.head
+      assert(args.containsSlice(Seq("--allowedTools", "WebFetch")), args)
 
   test(
     "runAutonomous passes --json-schema when an output schema is supplied"

--- a/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
@@ -26,6 +26,7 @@ private[codex] object CodexArgs:
   ): Seq[String] =
     Seq("codex") ++
       mcpServerArgs(mcpServerUrl) ++
+      networkConfigArgs(config) ++
       Seq("exec", "--json") ++
       sandboxArgs(config) ++
       CliArgs.modelArgs(config) ++
@@ -59,6 +60,7 @@ private[codex] object CodexArgs:
   ): Seq[String] =
     Seq("codex") ++
       mcpServerArgs(mcpServerUrl) ++
+      networkConfigArgs(config) ++
       Seq("exec", "resume", "--json", SessionId.value(sessionId)) ++
       sandboxArgs(config) ++
       CliArgs.modelArgs(config) ++
@@ -95,28 +97,43 @@ private[codex] object CodexArgs:
   private def outputSchemaArgs(file: Option[os.Path]): Seq[String] =
     file.toSeq.flatMap(p => Seq("--output-schema", p.toString))
 
-  /** Maps [[LlmConfig.tools]] to codex's sandbox flags. The read-only tiers use
-    * `--sandbox read-only` (no writes, no shell side-effects), matching
-    * claude's `--permission-mode plan`. `Full` follows
+  /** Maps [[LlmConfig.tools]] to codex's sandbox flags (placed after the `exec`
+    * subcommand). `ReadOnly` uses `--sandbox read-only` (no writes, no shell
+    * side-effects), matching claude's `--permission-mode plan`. `Full` follows
     * [[LlmConfig.autoApprove]]; codex has no per-tool CLI allowlist, so
-    * [[AutoApprove.Only]] is approximated with `--full-auto` (sandboxed
-    * automatic execution).
+    * [[AutoApprove.Only]] is approximated with `--full-auto`.
     *
-    *   - `ReadOnly` / `NetworkOnly` → `--sandbox read-only`
+    *   - `ReadOnly` → `--sandbox read-only`
+    *   - `NetworkOnly` → `--full-auto` (workspace-write + non-interactive
+    *     approval), paired with the network override in [[networkConfigArgs]]
     *   - `Full` + `AutoApprove.All` →
     *     `--dangerously-bypass-approvals-and-sandbox`
     *   - `Full` + `AutoApprove.Only(_)` → `--full-auto`
     *
-    * `NetworkOnly` is read-only here too; the network-capable variant (codex
-    * needs `--sandbox workspace-write` for network, which also permits writes)
-    * is layered on in a later step.
+    * `NetworkOnly` has no read-only-with-network sandbox on codex: network
+    * needs `workspace-write`, which also permits workspace writes, so the
+    * no-edit guarantee there is prompt-only (the planning prompts forbid
+    * edits).
     */
   private def sandboxArgs(config: LlmConfig): Seq[String] =
     config.tools match
-      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
-        Seq("--sandbox", "read-only")
+      case ToolSet.ReadOnly    => Seq("--sandbox", "read-only")
+      case ToolSet.NetworkOnly => Seq("--full-auto")
       case ToolSet.Full =>
         config.autoApprove match
           case AutoApprove.All =>
             Seq("--dangerously-bypass-approvals-and-sandbox")
           case AutoApprove.Only(_) => Seq("--full-auto")
+
+  /** Global `-c` overrides that must precede the `exec` subcommand (codex reads
+    * them into its top-level config, which `exec` inherits). On
+    * [[ToolSet.NetworkOnly]], enable network for the workspace-write sandbox
+    * that [[sandboxArgs]] selects via `--full-auto`; off by default, so without
+    * this the planner's `gh`/`curl` calls would be blocked. Empty for the other
+    * tiers.
+    */
+  private def networkConfigArgs(config: LlmConfig): Seq[String] =
+    config.tools match
+      case ToolSet.NetworkOnly =>
+        Seq("-c", "sandbox_workspace_write.network_access=true")
+      case ToolSet.ReadOnly | ToolSet.Full => Nil

--- a/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
@@ -2,7 +2,7 @@ package orca.tools.codex
 
 import orca.backend.CliArgs
 import orca.backend.mcp.AskUserMcpServer
-import orca.llm.{AutoApprove, BackendTag, LlmConfig, SessionId}
+import orca.llm.{AutoApprove, BackendTag, LlmConfig, SessionId, ToolSet}
 
 /** Maps `LlmConfig` fields to `codex exec` CLI flags. `systemPrompt` is not
   * handled here — codex doesn't accept an `--append-system-prompt` equivalent
@@ -95,22 +95,28 @@ private[codex] object CodexArgs:
   private def outputSchemaArgs(file: Option[os.Path]): Seq[String] =
     file.toSeq.flatMap(p => Seq("--output-schema", p.toString))
 
-  /** Approval-policy mapping. `readOnly` overrides any `autoApprove` setting —
-    * `--sandbox read-only` makes file writes and shelling-out unavailable to
-    * the agent, matching claude's `--permission-mode plan`. Otherwise codex
-    * doesn't accept a per-tool allowlist on the CLI, so [[AutoApprove.Only]] is
-    * approximated with `--full-auto` (sandboxed automatic execution) — narrower
-    * than the all-bypass and matches the user-stated intent of "auto-approve a
-    * known-safe set".
+  /** Maps [[LlmConfig.tools]] to codex's sandbox flags. The read-only tiers use
+    * `--sandbox read-only` (no writes, no shell side-effects), matching
+    * claude's `--permission-mode plan`. `Full` follows
+    * [[LlmConfig.autoApprove]]; codex has no per-tool CLI allowlist, so
+    * [[AutoApprove.Only]] is approximated with `--full-auto` (sandboxed
+    * automatic execution).
     *
-    *   - `readOnly = true` → `--sandbox read-only`
-    *   - `AutoApprove.All` → `--dangerously-bypass-approvals-and-sandbox`
-    *   - `AutoApprove.Only(_)` → `--full-auto`
+    *   - `ReadOnly` / `NetworkOnly` → `--sandbox read-only`
+    *   - `Full` + `AutoApprove.All` →
+    *     `--dangerously-bypass-approvals-and-sandbox`
+    *   - `Full` + `AutoApprove.Only(_)` → `--full-auto`
+    *
+    * `NetworkOnly` is read-only here too; the network-capable variant (codex
+    * needs `--sandbox workspace-write` for network, which also permits writes)
+    * is layered on in a later step.
     */
   private def sandboxArgs(config: LlmConfig): Seq[String] =
-    if config.readOnly then Seq("--sandbox", "read-only")
-    else
-      config.autoApprove match
-        case AutoApprove.All =>
-          Seq("--dangerously-bypass-approvals-and-sandbox")
-        case AutoApprove.Only(_) => Seq("--full-auto")
+    config.tools match
+      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+        Seq("--sandbox", "read-only")
+      case ToolSet.Full =>
+        config.autoApprove match
+          case AutoApprove.All =>
+            Seq("--dangerously-bypass-approvals-and-sandbox")
+          case AutoApprove.Only(_) => Seq("--full-auto")

--- a/codex/src/test/scala/orca/tools/codex/CodexArgsTest.scala
+++ b/codex/src/test/scala/orca/tools/codex/CodexArgsTest.scala
@@ -1,6 +1,6 @@
 package orca.tools.codex
 
-import orca.llm.{AutoApprove, BackendTag, LlmConfig, Model, SessionId}
+import orca.llm.{AutoApprove, BackendTag, LlmConfig, Model, SessionId, ToolSet}
 class CodexArgsTest extends munit.FunSuite:
 
   test("exec emits codex exec --json with the prompt as the trailing arg"):
@@ -63,7 +63,9 @@ class CodexArgsTest extends munit.FunSuite:
     assert(args.contains("--full-auto"))
     assert(!args.contains("--dangerously-bypass-approvals-and-sandbox"))
 
-  test("readOnly maps to --sandbox read-only and overrides autoApprove"):
+  test(
+    "ToolSet.ReadOnly maps to --sandbox read-only and overrides autoApprove"
+  ):
     // Pins the gate used by `.withReadOnly` callers — reviewers,
     // ReviewerSelector.llmDriven, lint, Plan.autonomous.from. Without
     // this mapping codex's reviewers inherit the base tool's permissions
@@ -71,7 +73,7 @@ class CodexArgsTest extends munit.FunSuite:
     val args = CodexArgs.exec(
       "x",
       LlmConfig.default.copy(
-        readOnly = true,
+        tools = ToolSet.ReadOnly,
         autoApprove = AutoApprove.All
       ),
       None,

--- a/codex/src/test/scala/orca/tools/codex/CodexArgsTest.scala
+++ b/codex/src/test/scala/orca/tools/codex/CodexArgsTest.scala
@@ -83,6 +83,22 @@ class CodexArgsTest extends munit.FunSuite:
     assert(!args.contains("--dangerously-bypass-approvals-and-sandbox"))
     assert(!args.contains("--full-auto"))
 
+  test("ToolSet.NetworkOnly uses --full-auto + network override before exec"):
+    // codex has no read-only-with-network sandbox: network needs
+    // workspace-write (via --full-auto), enabled by the global `-c` override
+    // which must precede the `exec` subcommand.
+    val args = CodexArgs.exec(
+      "x",
+      LlmConfig.default.copy(tools = ToolSet.NetworkOnly),
+      None,
+      os.pwd
+    )
+    assert(args.contains("--full-auto"), args.toString)
+    assert(!args.containsSlice(Seq("--sandbox", "read-only")), args.toString)
+    val execIdx = args.indexOf("exec")
+    val cIdx = args.indexOf("sandbox_workspace_write.network_access=true")
+    assert(cIdx >= 0 && cIdx < execIdx, args.toString)
+
   test(
     "exec emits -c mcp_servers.orca.{url,tool_timeout_sec} when an MCP url is supplied"
   ):

--- a/flow/src/main/resources/orca/plan/prompts/brief.md
+++ b/flow/src/main/resources/orca/plan/prompts/brief.md
@@ -9,5 +9,6 @@ why; the key types, functions, and APIs it will build on, with signatures; the
 conventions to follow (error handling, naming, testing, build); and anything
 non-obvious you learned that would otherwise cost a re-read.
 
-Do NOT restate the tasks or the plan — the agent already has those. Output only
-the briefing, as plain markdown.
+Do NOT restate the tasks or the plan — the agent already has those, and do NOT
+edit files or run mutating commands. Output only the briefing, as plain
+markdown.

--- a/flow/src/main/resources/orca/plan/prompts/brief.md
+++ b/flow/src/main/resources/orca/plan/prompts/brief.md
@@ -1,13 +1,13 @@
-The plan we just produced will be implemented by separate coding agents, each
-starting from an empty context — they have NOT seen your exploration of this
-codebase. Write a single briefing they can rely on so they don't have to
+The plan we just produced will be implemented by a separate coding agent,
+starting from a fresh context — it has NOT seen your exploration of this
+codebase. Write a single briefing it can rely on so it doesn't have to
 rediscover it.
 
 Include, as concise notes: the modules and directories involved and what each is
-responsible for; the specific files (with paths) they will read or change, and
-why; the key types, functions, and APIs they will build on, with signatures; the
+responsible for; the specific files (with paths) it will read or change, and
+why; the key types, functions, and APIs it will build on, with signatures; the
 conventions to follow (error handling, naming, testing, build); and anything
 non-obvious you learned that would otherwise cost a re-read.
 
-Do NOT restate the tasks or the plan — the agents already have those. Output only
+Do NOT restate the tasks or the plan — the agent already has those. Output only
 the briefing, as plain markdown.

--- a/flow/src/main/resources/orca/plan/prompts/review.md
+++ b/flow/src/main/resources/orca/plan/prompts/review.md
@@ -16,3 +16,6 @@ Focus your review on four dimensions:
 Keep the same epicId unless it is clearly wrong. If the plan includes a Brief
 section, refine it in the same spirit; do not invent one if it has none. Return
 the complete improved plan, not just the changes.
+
+Do NOT edit files or run mutating commands — the improved plan is your only
+output.

--- a/flow/src/main/resources/orca/plan/prompts/triage.md
+++ b/flow/src/main/resources/orca/plan/prompts/triage.md
@@ -9,3 +9,7 @@ Triage this bug report and produce a structured verdict:
   one-line PR title.
 - If `isBug` is true but `canTest` is false, fill in `reproductionSteps`
   — they'll be posted back on the issue.
+
+Do NOT edit files or run mutating commands during this turn — your only output
+is the triage verdict. You may read the repo and read-only network sources to
+verify the report.

--- a/flow/src/main/scala/orca/plan/Plan.scala
+++ b/flow/src/main/scala/orca/plan/Plan.scala
@@ -118,11 +118,12 @@ object Plan:
     digest.iterator.take(6).map(b => f"${b & 0xff}%02x").mkString
 
   /** Autonomous planning — a single agentic turn, no human in the loop. The
-    * agent runs read-only (`.withReadOnly`), so it can verify claims via
-    * Read/Grep but can't edit during the planning turn. Sibling of
-    * [[interactive]]; the choice between the two is visible at the call site
-    * (`Plan.autonomous.from(...)` vs `Plan.interactive.from(...)`), mirroring
-    * `LlmTool`'s own `autonomous` / `interactive` split.
+    * agent runs `NetworkOnly` (`.withNetworkOnly`): it can verify claims via
+    * Read/Grep and read-only network (issues/PRs/web) but can't edit during the
+    * planning turn (see [[autonomousResult]] for the per-backend guarantee).
+    * Sibling of [[interactive]]; the choice between the two is visible at the
+    * call site (`Plan.autonomous.from(...)` vs `Plan.interactive.from(...)`),
+    * mirroring `LlmTool`'s own `autonomous` / `interactive` split.
     *
     * Each operation returns a [[Sessioned]]: the read-only planning turn's
     * session is still resumable by a later writable call, so the caller can
@@ -274,16 +275,23 @@ object Plan:
       os.write.over(file, render(plan), createFolders = true)
       plan
 
-  /** Run one read-only autonomous turn producing wire type `O`, convert it to
-    * the public result `A`, and pair it with the session. Shared by every
-    * `autonomous.*` operation.
+  /** Run one autonomous turn producing wire type `O`, convert it to the public
+    * result `A`, and pair it with the session. Shared by every `autonomous.*`
+    * operation (`from`, `assessThenPlan`, `triage`).
+    *
+    * Runs `NetworkOnly`: reads plus read-only network, so the planner can fetch
+    * an issue/PR it was pointed at and verify external claims. Edits stay
+    * blocked (hard on claude/gemini/opencode; prompt-only on pi/codex — the
+    * planning prompts forbid edits). Reviewers and the post-planning
+    * `reviewed`/`briefed` turns use plain `withReadOnly` instead — no network,
+    * hard no-edit everywhere.
     */
   private def autonomousResult[B <: BackendTag, O: JsonData: Announce, A](
       llm: LlmTool[B],
       input: String,
       instructions: String
   )(convert: O => A)(using FlowContext): Sessioned[B, A] =
-    val (sessionId, raw) = llm.withReadOnly
+    val (sessionId, raw) = llm.withNetworkOnly
       .resultAs[O]
       .autonomous
       .run(withInstructions(input, instructions))

--- a/flow/src/test/scala/orca/plan/AssessThenPlanTest.scala
+++ b/flow/src/test/scala/orca/plan/AssessThenPlanTest.scala
@@ -1,6 +1,7 @@
 package orca.plan
 
 import orca.events.EventDispatcher
+import orca.llm.ToolSet
 
 class AssessThenPlanTest extends munit.FunSuite:
 
@@ -77,6 +78,14 @@ class AssessThenPlanTest extends munit.FunSuite:
       result.value,
       Verdict.Rejection(Verdict.RejectionKind.Rebuff, "duplicate of #42")
     )
+
+  test("Plan.autonomous planner runs NetworkOnly (reads + read-only network)"):
+    given orca.FlowContext = new orca.TestFlowContext(new EventDispatcher(Nil))
+    val stub = new CannedResultLlm(
+      AssessedPlan("proceed", Some(samplePlan), None, None)
+    )
+    val _ = Plan.autonomous.assessThenPlan("the report", stub)
+    assertEquals(stub.lastToolSet, Some(ToolSet.NetworkOnly))
 
   test(
     "Plan.autonomous.assessThenPlan throws OrcaFlowException on malformed payload"

--- a/flow/src/test/scala/orca/plan/StubLlmTools.scala
+++ b/flow/src/test/scala/orca/plan/StubLlmTools.scala
@@ -23,11 +23,18 @@ import orca.llm.{
 private[plan] class CannedResultLlm[T](value: T)
     extends LlmTool[BackendTag.ClaudeCode.type]:
   val name: String = "stub"
+
+  /** Records the most recent `withTools` tier so tests can assert which
+    * capability a helper selected (e.g. planners use `NetworkOnly`).
+    */
+  var lastToolSet: Option[ToolSet] = None
   def autonomous: AutonomousTextCall[BackendTag.ClaudeCode.type] = ???
   def withConfig(c: LlmConfig): LlmTool[BackendTag.ClaudeCode.type] = this
   def withSystemPrompt(p: String): LlmTool[BackendTag.ClaudeCode.type] = this
   def withName(n: String): LlmTool[BackendTag.ClaudeCode.type] = this
-  def withTools(tools: ToolSet): LlmTool[BackendTag.ClaudeCode.type] = this
+  def withTools(tools: ToolSet): LlmTool[BackendTag.ClaudeCode.type] =
+    lastToolSet = Some(tools)
+    this
 
   def resultAs[O: JsonData: Announce]: LlmCall[BackendTag.ClaudeCode.type, O] =
     new LlmCall[BackendTag.ClaudeCode.type, O]:

--- a/flow/src/test/scala/orca/plan/StubLlmTools.scala
+++ b/flow/src/test/scala/orca/plan/StubLlmTools.scala
@@ -11,7 +11,8 @@ import orca.llm.{
   LlmCall,
   LlmConfig,
   LlmTool,
-  SessionId
+  SessionId,
+  ToolSet
 }
 
 /** Test double whose `resultAs[O].autonomous.run` returns a pre-built `value`
@@ -26,7 +27,7 @@ private[plan] class CannedResultLlm[T](value: T)
   def withConfig(c: LlmConfig): LlmTool[BackendTag.ClaudeCode.type] = this
   def withSystemPrompt(p: String): LlmTool[BackendTag.ClaudeCode.type] = this
   def withName(n: String): LlmTool[BackendTag.ClaudeCode.type] = this
-  def withReadOnly: LlmTool[BackendTag.ClaudeCode.type] = this
+  def withTools(tools: ToolSet): LlmTool[BackendTag.ClaudeCode.type] = this
 
   def resultAs[O: JsonData: Announce]: LlmCall[BackendTag.ClaudeCode.type, O] =
     new LlmCall[BackendTag.ClaudeCode.type, O]:
@@ -61,7 +62,7 @@ private[plan] class CannedTextLlm(text: String)
   def withConfig(c: LlmConfig): LlmTool[BackendTag.ClaudeCode.type] = this
   def withSystemPrompt(p: String): LlmTool[BackendTag.ClaudeCode.type] = this
   def withName(n: String): LlmTool[BackendTag.ClaudeCode.type] = this
-  def withReadOnly: LlmTool[BackendTag.ClaudeCode.type] = this
+  def withTools(tools: ToolSet): LlmTool[BackendTag.ClaudeCode.type] = this
   def resultAs[O: JsonData: Announce]: LlmCall[BackendTag.ClaudeCode.type, O] =
     ???
 
@@ -76,6 +77,6 @@ private[plan] class ExplodingLlm(reason: String)
   def withConfig(c: LlmConfig): LlmTool[BackendTag.ClaudeCode.type] = this
   def withSystemPrompt(p: String): LlmTool[BackendTag.ClaudeCode.type] = this
   def withName(n: String): LlmTool[BackendTag.ClaudeCode.type] = this
-  def withReadOnly: LlmTool[BackendTag.ClaudeCode.type] = this
+  def withTools(tools: ToolSet): LlmTool[BackendTag.ClaudeCode.type] = this
   def resultAs[O: JsonData: Announce]: LlmCall[BackendTag.ClaudeCode.type, O] =
     throw new AssertionError(reason)

--- a/flow/src/test/scala/orca/review/AllReviewersTest.scala
+++ b/flow/src/test/scala/orca/review/AllReviewersTest.scala
@@ -7,7 +7,8 @@ import orca.llm.{
   JsonData,
   LlmCall,
   LlmConfig,
-  LlmTool
+  LlmTool,
+  ToolSet
 }
 class AllReviewersTest extends munit.FunSuite:
 
@@ -29,7 +30,7 @@ class AllReviewersTest extends munit.FunSuite:
       this
     def withName(n: String): LlmTool[BackendTag.ClaudeCode.type] =
       new RecordingTool(n, systemPromptsSeen)
-    def withReadOnly: LlmTool[BackendTag.ClaudeCode.type] = this
+    def withTools(tools: ToolSet): LlmTool[BackendTag.ClaudeCode.type] = this
     def resultAs[O: JsonData: Announce]
         : LlmCall[BackendTag.ClaudeCode.type, O] =
       ???

--- a/flow/src/test/scala/orca/review/LintTest.scala
+++ b/flow/src/test/scala/orca/review/LintTest.scala
@@ -13,7 +13,8 @@ import orca.llm.{
   LlmCall,
   LlmConfig,
   LlmTool,
-  SessionId
+  SessionId,
+  ToolSet
 }
 import orca.events.{EventDispatcher}
 import orca.{TestFlowContext}
@@ -38,7 +39,7 @@ class LintTest extends munit.FunSuite:
     def withConfig(c: LlmConfig): LlmTool[BackendTag.ClaudeCode.type] = this
     def withSystemPrompt(p: String): LlmTool[BackendTag.ClaudeCode.type] = this
     def withName(n: String): LlmTool[BackendTag.ClaudeCode.type] = this
-    def withReadOnly: LlmTool[BackendTag.ClaudeCode.type] = this
+    def withTools(tools: ToolSet): LlmTool[BackendTag.ClaudeCode.type] = this
     def resultAs[O: JsonData: Announce]
         : LlmCall[BackendTag.ClaudeCode.type, O] =
       new LlmCall[BackendTag.ClaudeCode.type, O]:
@@ -92,7 +93,9 @@ class LintTest extends munit.FunSuite:
     val filePath = "`([^`]+\\.log)`".r
       .findFirstMatchIn(mock.captured)
       .map(_.group(1))
-      .getOrElse(fail(s"prompt should reference a .log file, got: ${mock.captured}"))
+      .getOrElse(
+        fail(s"prompt should reference a .log file, got: ${mock.captured}")
+      )
     assert(!os.exists(os.Path(filePath)), "lint should delete the temp file")
 
   test("lint short-circuits to ReviewResult.empty when the command is silent"):

--- a/flow/src/test/scala/orca/review/ReviewAndFixTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewAndFixTest.scala
@@ -13,7 +13,8 @@ import orca.llm.{
   LlmCall,
   LlmConfig,
   LlmTool,
-  SessionId
+  SessionId,
+  ToolSet
 }
 import orca.events.{EventDispatcher, OrcaEvent, OrcaListener}
 import orca.{TestFlowContext}
@@ -65,7 +66,7 @@ class FakeLlmTool(
   def withConfig(c: LlmConfig): LlmTool[BackendTag.ClaudeCode.type] = this
   def withSystemPrompt(p: String): LlmTool[BackendTag.ClaudeCode.type] = this
   def withName(n: String): LlmTool[BackendTag.ClaudeCode.type] = this
-  def withReadOnly: LlmTool[BackendTag.ClaudeCode.type] = this
+  def withTools(tools: ToolSet): LlmTool[BackendTag.ClaudeCode.type] = this
 
 class ReviewAndFixTest extends munit.FunSuite:
 
@@ -211,7 +212,7 @@ class ReviewAndFixTest extends munit.FunSuite:
       def withSystemPrompt(p: String): LlmTool[BackendTag.ClaudeCode.type] =
         this
       def withName(n: String): LlmTool[BackendTag.ClaudeCode.type] = this
-      def withReadOnly: LlmTool[BackendTag.ClaudeCode.type] = this
+      def withTools(tools: ToolSet): LlmTool[BackendTag.ClaudeCode.type] = this
       def resultAs[O: JsonData: Announce]
           : LlmCall[BackendTag.ClaudeCode.type, O] =
         new LlmCall[BackendTag.ClaudeCode.type, O]:
@@ -368,7 +369,7 @@ class ReviewAndFixTest extends munit.FunSuite:
       def withSystemPrompt(p: String): LlmTool[BackendTag.ClaudeCode.type] =
         this
       def withName(n: String): LlmTool[BackendTag.ClaudeCode.type] = this
-      def withReadOnly: LlmTool[BackendTag.ClaudeCode.type] = this
+      def withTools(tools: ToolSet): LlmTool[BackendTag.ClaudeCode.type] = this
       def resultAs[O: JsonData: Announce]
           : LlmCall[BackendTag.ClaudeCode.type, O] =
         new LlmCall[BackendTag.ClaudeCode.type, O]:
@@ -435,7 +436,7 @@ class ReviewAndFixTest extends munit.FunSuite:
       def withSystemPrompt(p: String): LlmTool[BackendTag.ClaudeCode.type] =
         this
       def withName(n: String): LlmTool[BackendTag.ClaudeCode.type] = this
-      def withReadOnly: LlmTool[BackendTag.ClaudeCode.type] = this
+      def withTools(tools: ToolSet): LlmTool[BackendTag.ClaudeCode.type] = this
       def resultAs[O: JsonData: Announce]
           : LlmCall[BackendTag.ClaudeCode.type, O] =
         new LlmCall[BackendTag.ClaudeCode.type, O]:

--- a/flow/src/test/scala/orca/review/ReviewerSelectorTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewerSelectorTest.scala
@@ -12,7 +12,8 @@ import orca.llm.{
   LlmCall,
   LlmConfig,
   LlmTool,
-  SessionId
+  SessionId,
+  ToolSet
 }
 import orca.plan.Title
 
@@ -30,7 +31,7 @@ private class RecordingPicker(
   def withConfig(c: LlmConfig): LlmTool[BackendTag.ClaudeCode.type] = this
   def withSystemPrompt(p: String): LlmTool[BackendTag.ClaudeCode.type] = this
   def withName(n: String): LlmTool[BackendTag.ClaudeCode.type] = this
-  def withReadOnly: LlmTool[BackendTag.ClaudeCode.type] = this
+  def withTools(tools: ToolSet): LlmTool[BackendTag.ClaudeCode.type] = this
   def resultAs[O: JsonData: Announce]: LlmCall[BackendTag.ClaudeCode.type, O] =
     new LlmCall[BackendTag.ClaudeCode.type, O]:
       val autonomous: AutonomousLlmCall[BackendTag.ClaudeCode.type, O] =
@@ -59,7 +60,7 @@ private class NamedTool(override val name: String)
   def withConfig(c: LlmConfig): LlmTool[BackendTag.ClaudeCode.type] = this
   def withSystemPrompt(p: String): LlmTool[BackendTag.ClaudeCode.type] = this
   def withName(n: String): LlmTool[BackendTag.ClaudeCode.type] = this
-  def withReadOnly: LlmTool[BackendTag.ClaudeCode.type] = this
+  def withTools(tools: ToolSet): LlmTool[BackendTag.ClaudeCode.type] = this
   def resultAs[O: JsonData: Announce]: LlmCall[BackendTag.ClaudeCode.type, O] =
     ???
 

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
@@ -1,7 +1,7 @@
 package orca.tools.gemini
 
 import orca.backend.CliArgs
-import orca.llm.{AutoApprove, BackendTag, LlmConfig, SessionId}
+import orca.llm.{AutoApprove, BackendTag, LlmConfig, SessionId, ToolSet}
 
 /** Maps `LlmConfig` fields to `gemini` headless CLI flags. `systemPrompt` is
   * not handled here — gemini has no `--append-system-prompt` equivalent (it
@@ -54,21 +54,24 @@ private[gemini] object GeminiArgs:
     */
   private val trustArgs: Seq[String] = Seq("--skip-trust")
 
-  /** Approval-policy mapping. `readOnly` overrides any `autoApprove` setting —
-    * `--approval-mode plan` makes file writes and shelling-out unavailable to
-    * the agent, matching claude's `--permission-mode plan` and codex's
-    * `--sandbox read-only`. Otherwise gemini has no per-tool allowlist on the
-    * CLI, and in headless mode `auto_edit` blocks on shell approvals no one can
-    * answer, so both [[AutoApprove.All]] and [[AutoApprove.Only]] map to `yolo`
-    * (auto-approve all). The `Only` widening is documented in ADR 0015.
+  /** Maps [[LlmConfig.tools]] to gemini's approval mode. The read-only tiers
+    * use `--approval-mode plan` (no writes, no shelling out), matching claude's
+    * `--permission-mode plan` and codex's `--sandbox read-only`. `Full` has no
+    * per-tool CLI allowlist, and in headless mode `auto_edit` blocks on shell
+    * approvals no one can answer, so both [[AutoApprove.All]] and
+    * [[AutoApprove.Only]] map to `yolo`. The `Only` widening is in ADR 0015.
     *
-    *   - `readOnly = true` → `--approval-mode plan`
-    *   - `AutoApprove.All` → `--approval-mode yolo`
-    *   - `AutoApprove.Only(_)` → `--approval-mode yolo`
+    *   - `ReadOnly` / `NetworkOnly` → `--approval-mode plan`
+    *   - `Full` + `AutoApprove.All` / `Only(_)` → `--approval-mode yolo`
+    *
+    * `NetworkOnly` is plan mode here too — gemini already allows web reads in
+    * plan mode, and shell `gh` would require dropping to `yolo` (out of scope).
     */
   private def approvalArgs(config: LlmConfig): Seq[String] =
-    if config.readOnly then Seq("--approval-mode", "plan")
-    else
-      config.autoApprove match
-        case AutoApprove.All | AutoApprove.Only(_) =>
-          Seq("--approval-mode", "yolo")
+    config.tools match
+      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+        Seq("--approval-mode", "plan")
+      case ToolSet.Full =>
+        config.autoApprove match
+          case AutoApprove.All | AutoApprove.Only(_) =>
+            Seq("--approval-mode", "yolo")

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
@@ -54,6 +54,15 @@ private[gemini] object GeminiArgs:
     */
   private val trustArgs: Seq[String] = Seq("--skip-trust")
 
+  /** Web tools pre-approved on [[ToolSet.NetworkOnly]] turns. Plan mode gates
+    * `web_fetch` behind an approval no autonomous turn can answer; listing it
+    * in `--allowed-tools` pre-approves it (verified), so the planner gets web
+    * reads while plan mode still blocks edits and shell — a hard no-edit
+    * guarantee like claude's. `--allowed-tools` is deprecated (gemini 1.0
+    * removes it for a `settings.json` Policy Engine); migrate then.
+    */
+  private val NetworkTools: Seq[String] = Seq("web_fetch")
+
   /** Maps [[LlmConfig.tools]] to gemini's approval mode. The read-only tiers
     * use `--approval-mode plan` (no writes, no shelling out), matching claude's
     * `--permission-mode plan` and codex's `--sandbox read-only`. `Full` has no
@@ -61,20 +70,24 @@ private[gemini] object GeminiArgs:
     * approvals no one can answer, so both [[AutoApprove.All]] and
     * [[AutoApprove.Only]] map to `yolo`. The `Only` widening is in ADR 0015.
     *
-    *   - `ReadOnly` / `NetworkOnly` → `--approval-mode plan`
+    *   - `ReadOnly` → `--approval-mode plan`
+    *   - `NetworkOnly` → `--approval-mode plan --allowed-tools <web tools>`
     *   - `Full` + `AutoApprove.All` / `Only(_)` → `--approval-mode yolo`
     *
-    * `NetworkOnly` maps to plan mode too, which means **no network** on gemini:
-    * verified that `web_fetch` works under `yolo` but is blocked under `plan`
-    * in headless runs, so `NetworkOnly` grants nothing beyond `ReadOnly` here.
-    * Real network would require `yolo`, which also drops the hard no-edit
-    * guarantee (out of scope) — gemini flows pre-fetch issue/PR context (e.g.
-    * via `gh.readIssue`) instead.
+    * `NetworkOnly` stays in plan mode (hard no-edit) and adds [[NetworkTools]]
+    * so the planner can fetch issue/PR/web content — no shell `gh`, so no
+    * authed GitHub, but web reads work.
     */
   private def approvalArgs(config: LlmConfig): Seq[String] =
     config.tools match
-      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
-        Seq("--approval-mode", "plan")
+      case ToolSet.ReadOnly => Seq("--approval-mode", "plan")
+      case ToolSet.NetworkOnly =>
+        Seq(
+          "--approval-mode",
+          "plan",
+          "--allowed-tools",
+          NetworkTools.mkString(",")
+        )
       case ToolSet.Full =>
         config.autoApprove match
           case AutoApprove.All | AutoApprove.Only(_) =>

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
@@ -64,8 +64,12 @@ private[gemini] object GeminiArgs:
     *   - `ReadOnly` / `NetworkOnly` → `--approval-mode plan`
     *   - `Full` + `AutoApprove.All` / `Only(_)` → `--approval-mode yolo`
     *
-    * `NetworkOnly` is plan mode here too — gemini already allows web reads in
-    * plan mode, and shell `gh` would require dropping to `yolo` (out of scope).
+    * `NetworkOnly` maps to plan mode too, which means **no network** on gemini:
+    * verified that `web_fetch` works under `yolo` but is blocked under `plan`
+    * in headless runs, so `NetworkOnly` grants nothing beyond `ReadOnly` here.
+    * Real network would require `yolo`, which also drops the hard no-edit
+    * guarantee (out of scope) — gemini flows pre-fetch issue/PR context (e.g.
+    * via `gh.readIssue`) instead.
     */
   private def approvalArgs(config: LlmConfig): Seq[String] =
     config.tools match

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiArgsTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiArgsTest.scala
@@ -59,13 +59,17 @@ class GeminiArgsTest extends munit.FunSuite:
     assert(args.containsSlice(Seq("--approval-mode", "plan")), args.toString)
     assert(!args.containsSlice(Seq("--approval-mode", "yolo")))
 
-  test("ToolSet.NetworkOnly also maps to --approval-mode plan"):
+  test("ToolSet.NetworkOnly stays in plan mode and pre-approves web_fetch"):
     val args =
       GeminiArgs.headless(
         "x",
         LlmConfig.default.copy(tools = ToolSet.NetworkOnly)
       )
     assert(args.containsSlice(Seq("--approval-mode", "plan")), args.toString)
+    assert(
+      args.containsSlice(Seq("--allowed-tools", "web_fetch")),
+      args.toString
+    )
 
   test("resume builds gemini ... --resume <id> with the prompt"):
     val sid = SessionId[BackendTag.Gemini.type]("uuid-123")

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiArgsTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiArgsTest.scala
@@ -1,6 +1,6 @@
 package orca.tools.gemini
 
-import orca.llm.{AutoApprove, BackendTag, LlmConfig, Model, SessionId}
+import orca.llm.{AutoApprove, BackendTag, LlmConfig, Model, SessionId, ToolSet}
 
 class GeminiArgsTest extends munit.FunSuite:
 
@@ -46,13 +46,26 @@ class GeminiArgsTest extends munit.FunSuite:
     assert(args.containsSlice(Seq("--approval-mode", "yolo")), args.toString)
     assert(!args.contains("plan"))
 
-  test("readOnly maps to --approval-mode plan and overrides autoApprove"):
+  test(
+    "ToolSet.ReadOnly maps to --approval-mode plan and overrides autoApprove"
+  ):
     val args = GeminiArgs.headless(
       "x",
-      LlmConfig.default.copy(readOnly = true, autoApprove = AutoApprove.All)
+      LlmConfig.default.copy(
+        tools = ToolSet.ReadOnly,
+        autoApprove = AutoApprove.All
+      )
     )
     assert(args.containsSlice(Seq("--approval-mode", "plan")), args.toString)
     assert(!args.containsSlice(Seq("--approval-mode", "yolo")))
+
+  test("ToolSet.NetworkOnly also maps to --approval-mode plan"):
+    val args =
+      GeminiArgs.headless(
+        "x",
+        LlmConfig.default.copy(tools = ToolSet.NetworkOnly)
+      )
+    assert(args.containsSlice(Seq("--approval-mode", "plan")), args.toString)
 
   test("resume builds gemini ... --resume <id> with the prompt"):
     val sid = SessionId[BackendTag.Gemini.type]("uuid-123")

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
@@ -59,10 +59,13 @@ private[opencode] object OpencodeArgs:
     * `question` tool on an autonomous turn. Returns `None` when nothing is
     * gated so the body omits `tools` and the server's defaults apply.
     *
-    * Both read-only tiers disable the same write tools. `NetworkOnly` is no
-    * different here: opencode's web tool is not in this disabled set, so web
-    * reads already work in read-only; enabling shell `gh` would mean keeping
-    * `bash` on (dropping the hard no-edit guarantee), which is out of scope.
+    * Both read-only tiers disable the same write tools, so `NetworkOnly`
+    * behaves like `ReadOnly` here — opencode gets no dedicated network
+    * handling. opencode's web tool isn't in the disabled set, so web reads may
+    * remain available (server-dependent; not verified here); shell `gh` stays
+    * off (`bash` disabled). Scoped network would require enabling `bash`
+    * (dropping the hard no-edit guarantee) — out of scope; opencode flows
+    * pre-fetch issue/PR context instead.
     */
   private def toolFlags(
       config: LlmConfig,

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
@@ -1,7 +1,7 @@
 package orca.tools.opencode
 
 import orca.backend.{SessionMode, SystemPromptComposer}
-import orca.llm.{LlmConfig, Model}
+import orca.llm.{LlmConfig, Model, ToolSet}
 import orca.tools.opencode.OpencodeApi.{
   MessageBody,
   MessagePart,
@@ -58,23 +58,29 @@ private[opencode] object OpencodeArgs:
   /** Per-turn tool gate: disable the write tools on a read-only turn, and the
     * `question` tool on an autonomous turn. Returns `None` when nothing is
     * gated so the body omits `tools` and the server's defaults apply.
+    *
+    * Both read-only tiers disable the same write tools. `NetworkOnly` is no
+    * different here: opencode's web tool is not in this disabled set, so web
+    * reads already work in read-only; enabling shell `gh` would mean keeping
+    * `bash` on (dropping the hard no-edit guarantee), which is out of scope.
     */
   private def toolFlags(
       config: LlmConfig,
       mode: SessionMode
   ): Option[Map[String, Boolean]] =
-    val readOnly =
-      if config.readOnly then
-        Map(
-          "write" -> false,
-          "edit" -> false,
-          "bash" -> false,
-          "patch" -> false
-        )
-      else Map.empty[String, Boolean]
+    val writeGate =
+      config.tools match
+        case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+          Map(
+            "write" -> false,
+            "edit" -> false,
+            "bash" -> false,
+            "patch" -> false
+          )
+        case ToolSet.Full => Map.empty[String, Boolean]
     val question = mode match
       case SessionMode.Autonomous     => Map("question" -> false)
       case SessionMode.Interactive(_) => Map.empty[String, Boolean]
     // The two key sets are disjoint, so the merge order is irrelevant.
-    val flags = readOnly ++ question
+    val flags = writeGate ++ question
     Option.when(flags.nonEmpty)(flags)

--- a/opencode/src/test/scala/orca/tools/opencode/DefaultOpencodeToolTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/DefaultOpencodeToolTest.scala
@@ -2,7 +2,14 @@ package orca.tools.opencode
 
 import orca.backend.{Conversation, Interaction, LlmBackend, LlmResult}
 import orca.events.{OrcaListener, Usage}
-import orca.llm.{BackendTag, DefaultPrompts, LlmConfig, OpencodeTool, SessionId}
+import orca.llm.{
+  BackendTag,
+  DefaultPrompts,
+  LlmConfig,
+  OpencodeTool,
+  SessionId,
+  ToolSet
+}
 
 class DefaultOpencodeToolTest extends munit.FunSuite:
 
@@ -84,10 +91,10 @@ class DefaultOpencodeToolTest extends munit.FunSuite:
       Some("ollama/llama3.1")
     )
 
-  test("withReadOnly flips the read-only flag, keeping the model pin"):
+  test("withReadOnly pins tools to ReadOnly, keeping the model pin"):
     val b = new RecordingBackend
     val _ = toolWith(b).anthropicOpus.withReadOnly.autonomous.run("x")
-    assertEquals(b.lastConfig.map(_.readOnly), Some(true))
+    assertEquals(b.lastConfig.map(_.tools), Some(ToolSet.ReadOnly))
     assertEquals(
       b.lastConfig.flatMap(_.model).map(_.name),
       Some("anthropic/claude-opus-4-8")

--- a/opencode/src/test/scala/orca/tools/opencode/OpencodeArgsTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/OpencodeArgsTest.scala
@@ -89,6 +89,18 @@ class OpencodeArgsTest extends munit.FunSuite:
     assertEquals(tools.get("bash"), Some(false))
     assertEquals(tools.get("patch"), Some(false))
 
+  test("NetworkOnly keeps bash disabled (no writable-shell network)"):
+    // opencode has no scoped network: NetworkOnly gates the same write tools as
+    // ReadOnly, so the planner can't shell out to `gh`.
+    val cfg = LlmConfig.default.copy(tools = ToolSet.NetworkOnly)
+    val tools =
+      OpencodeArgs
+        .message(cfg, "hi", None, interactive)
+        .tools
+        .getOrElse(Map.empty)
+    assertEquals(tools.get("bash"), Some(false))
+    assertEquals(tools.get("edit"), Some(false))
+
   test("read-only autonomous turn gates both write tools and question"):
     val cfg = LlmConfig.default.copy(tools = ToolSet.ReadOnly)
     val tools =

--- a/opencode/src/test/scala/orca/tools/opencode/OpencodeArgsTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/OpencodeArgsTest.scala
@@ -1,7 +1,7 @@
 package orca.tools.opencode
 
 import orca.backend.{SessionMode, SystemPromptComposer}
-import orca.llm.{AutoApprove, LlmConfig, Model}
+import orca.llm.{AutoApprove, LlmConfig, Model, ToolSet}
 
 class OpencodeArgsTest extends munit.FunSuite:
 
@@ -75,7 +75,10 @@ class OpencodeArgsTest extends munit.FunSuite:
 
   test("read-only turn disables the write tools (write/edit/bash/patch)"):
     val cfg =
-      LlmConfig.default.copy(readOnly = true, autoApprove = AutoApprove.All)
+      LlmConfig.default.copy(
+        tools = ToolSet.ReadOnly,
+        autoApprove = AutoApprove.All
+      )
     val tools =
       OpencodeArgs
         .message(cfg, "hi", None, interactive)
@@ -87,7 +90,7 @@ class OpencodeArgsTest extends munit.FunSuite:
     assertEquals(tools.get("patch"), Some(false))
 
   test("read-only autonomous turn gates both write tools and question"):
-    val cfg = LlmConfig.default.copy(readOnly = true)
+    val cfg = LlmConfig.default.copy(tools = ToolSet.ReadOnly)
     val tools =
       OpencodeArgs
         .message(cfg, "hi", None, autonomous)

--- a/opencode/src/test/scala/orca/tools/opencode/OpencodeIntegrationTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/OpencodeIntegrationTest.scala
@@ -1,7 +1,7 @@
 package orca.tools.opencode
 
 import orca.backend.SupervisedBackend
-import orca.llm.{BackendTag, LlmConfig, Model, SessionId}
+import orca.llm.{BackendTag, LlmConfig, Model, SessionId, ToolSet}
 import orca.subprocess.OsProcCliRunner
 
 /** End-to-end tests against a real `opencode serve`. Gated on the
@@ -91,7 +91,7 @@ class OpencodeIntegrationTest extends munit.FunSuite:
       val _ = backend.runAutonomous(
         prompt = "Create a file named marker.txt containing the word hello.",
         session = fresh,
-        config = config.copy(readOnly = true),
+        config = config.copy(tools = ToolSet.ReadOnly),
         workDir = workDir
       )
       assert(

--- a/pi/src/main/scala/orca/tools/pi/PiArgs.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiArgs.scala
@@ -17,6 +17,13 @@ private[pi] object PiArgs:
 
   val ReadOnlyTools: Seq[String] = Seq("read", "grep", "find", "ls")
 
+  /** Pi has no web/fetch tool, so the only network path is the general `bash`
+    * tool — which also permits writes. Added on [[ToolSet.NetworkOnly]] turns;
+    * the no-edit guarantee is then prompt-only (the planner prompts forbid
+    * edits), not enforced by the allowlist.
+    */
+  val NetworkTool: String = "bash"
+
   def rpc(
       sessionDir: os.Path,
       resume: Boolean,
@@ -35,24 +42,27 @@ private[pi] object PiArgs:
     file.toSeq.flatMap(f => Seq("--append-system-prompt", f.toString))
 
   /** Maps [[LlmConfig.tools]] to pi's `--tools` allowlist. `Full` omits the
-    * flag (all built-in tools enabled); the read-only tiers restrict to
-    * [[ReadOnlyTools]] (plus the ask-user extension when present).
-    *
-    * `NetworkOnly` is the same allowlist here; the network-capable variant (pi
-    * has no web tool, so network means re-enabling `bash`, which also permits
-    * writes) is layered on in a later step.
+    * flag (all built-in tools enabled); `ReadOnly` restricts to
+    * [[ReadOnlyTools]]; `NetworkOnly` adds [[NetworkTool]] (`bash`) for network
+    * access. The ask-user extension tool is appended when present.
     */
   private def toolsArgs(
       config: LlmConfig,
       includeAskUser: Boolean
   ): Seq[String] =
     config.tools match
-      case ToolSet.Full => Seq.empty
-      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
-        val tools =
-          if includeAskUser then ReadOnlyTools :+ PiAskUserExtension.ToolName
-          else ReadOnlyTools
-        Seq("--tools", tools.mkString(","))
+      case ToolSet.Full     => Seq.empty
+      case ToolSet.ReadOnly => toolsFlag(ReadOnlyTools, includeAskUser)
+      case ToolSet.NetworkOnly =>
+        toolsFlag(ReadOnlyTools :+ NetworkTool, includeAskUser)
+
+  private def toolsFlag(
+      tools: Seq[String],
+      includeAskUser: Boolean
+  ): Seq[String] =
+    val all =
+      if includeAskUser then tools :+ PiAskUserExtension.ToolName else tools
+    Seq("--tools", all.mkString(","))
 
   private def extensionArgs(file: Option[os.Path]): Seq[String] =
     file.toSeq.flatMap(f => Seq("--extension", f.toString))

--- a/pi/src/main/scala/orca/tools/pi/PiArgs.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiArgs.scala
@@ -1,7 +1,7 @@
 package orca.tools.pi
 
 import orca.backend.CliArgs
-import orca.llm.LlmConfig
+import orca.llm.{LlmConfig, ToolSet}
 
 /** Maps Orca backend configuration to Pi CLI arguments. The backend drives Pi
   * through RPC mode and sends prompts over stdin, so the argv carries only
@@ -34,16 +34,25 @@ private[pi] object PiArgs:
   private def systemPromptArgs(file: Option[os.Path]): Seq[String] =
     file.toSeq.flatMap(f => Seq("--append-system-prompt", f.toString))
 
+  /** Maps [[LlmConfig.tools]] to pi's `--tools` allowlist. `Full` omits the
+    * flag (all built-in tools enabled); the read-only tiers restrict to
+    * [[ReadOnlyTools]] (plus the ask-user extension when present).
+    *
+    * `NetworkOnly` is the same allowlist here; the network-capable variant (pi
+    * has no web tool, so network means re-enabling `bash`, which also permits
+    * writes) is layered on in a later step.
+    */
   private def toolsArgs(
       config: LlmConfig,
       includeAskUser: Boolean
   ): Seq[String] =
-    if !config.readOnly then Seq.empty
-    else
-      val tools =
-        if includeAskUser then ReadOnlyTools :+ PiAskUserExtension.ToolName
-        else ReadOnlyTools
-      Seq("--tools", tools.mkString(","))
+    config.tools match
+      case ToolSet.Full => Seq.empty
+      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+        val tools =
+          if includeAskUser then ReadOnlyTools :+ PiAskUserExtension.ToolName
+          else ReadOnlyTools
+        Seq("--tools", tools.mkString(","))
 
   private def extensionArgs(file: Option[os.Path]): Seq[String] =
     file.toSeq.flatMap(f => Seq("--extension", f.toString))

--- a/pi/src/test/scala/orca/tools/pi/PiArgsTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiArgsTest.scala
@@ -41,6 +41,15 @@ class PiArgsTest extends munit.FunSuite:
     )
     assert(args.containsSlice(Seq("--tools", "read,grep,find,ls")), args)
 
+  test("NetworkOnly adds bash for network access"):
+    val args = PiArgs.rpc(
+      dir,
+      resume = false,
+      LlmConfig.default.copy(tools = ToolSet.NetworkOnly),
+      None
+    )
+    assert(args.containsSlice(Seq("--tools", "read,grep,find,ls,bash")), args)
+
   test("interactive ask-user extension adds extension and ask_user tool"):
     val args = PiArgs.rpc(
       dir,

--- a/pi/src/test/scala/orca/tools/pi/PiArgsTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiArgsTest.scala
@@ -1,6 +1,6 @@
 package orca.tools.pi
 
-import orca.llm.{LlmConfig, Model}
+import orca.llm.{LlmConfig, Model, ToolSet}
 
 class PiArgsTest extends munit.FunSuite:
 
@@ -33,15 +33,19 @@ class PiArgsTest extends munit.FunSuite:
     )
 
   test("read-only tools exclude writes"):
-    val args =
-      PiArgs.rpc(dir, resume = false, LlmConfig.default.copy(readOnly = true), None)
+    val args = PiArgs.rpc(
+      dir,
+      resume = false,
+      LlmConfig.default.copy(tools = ToolSet.ReadOnly),
+      None
+    )
     assert(args.containsSlice(Seq("--tools", "read,grep,find,ls")), args)
 
   test("interactive ask-user extension adds extension and ask_user tool"):
     val args = PiArgs.rpc(
       dir,
       resume = false,
-      LlmConfig.default.copy(readOnly = true),
+      LlmConfig.default.copy(tools = ToolSet.ReadOnly),
       None,
       askUserExtension = Some(os.Path("/tmp/ask-user.ts"))
     )

--- a/pi/src/test/scala/orca/tools/pi/PiBackendTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiBackendTest.scala
@@ -2,7 +2,7 @@ package orca.tools.pi
 
 import orca.backend.SystemPromptComposer
 import orca.events.Usage
-import orca.llm.{BackendTag, LlmConfig, Model, SessionId}
+import orca.llm.{BackendTag, LlmConfig, Model, SessionId, ToolSet}
 import orca.subprocess.{FakePipedCliProcess, SpawnStubCliRunner}
 
 class PiBackendTest extends munit.FunSuite:
@@ -95,7 +95,7 @@ class PiBackendTest extends munit.FunSuite:
       sid,
       LlmConfig.default.copy(
         model = Some(Model("anthropic/claude-sonnet")),
-        readOnly = true
+        tools = ToolSet.ReadOnly
       ),
       os.temp.dir()
     )
@@ -114,7 +114,7 @@ class PiBackendTest extends munit.FunSuite:
       "q",
       sid,
       displayPrompt = "q",
-      LlmConfig.default.copy(readOnly = true),
+      LlmConfig.default.copy(tools = ToolSet.ReadOnly),
       os.temp.dir(),
       outputSchema = Some("{}")
     )

--- a/pi/src/test/scala/orca/tools/pi/PiIntegrationTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiIntegrationTest.scala
@@ -1,6 +1,6 @@
 package orca.tools.pi
 
-import orca.llm.{BackendTag, LlmConfig, SessionId}
+import orca.llm.{BackendTag, LlmConfig, SessionId, ToolSet}
 import orca.subprocess.OsProcCliRunner
 
 /** End-to-end smoke test against the real `pi` CLI. Gated on `ORCA_INTEGRATION`
@@ -24,7 +24,7 @@ class PiIntegrationTest extends munit.FunSuite:
     val result = backend.runAutonomous(
       prompt = "Reply with the single word: READY",
       session = fresh,
-      config = LlmConfig.default.copy(readOnly = true),
+      config = LlmConfig.default.copy(tools = ToolSet.ReadOnly),
       workDir = os.temp.dir()
     )
     assert(

--- a/runner/src/main/scala/orca/exports.scala
+++ b/runner/src/main/scala/orca/exports.scala
@@ -25,6 +25,7 @@ export orca.llm.{
   InteractiveLlmCall,
   LlmConfig,
   AutoApprove,
+  ToolSet,
   BackendTag,
   CanAskUser,
   Model,

--- a/runner/src/test/scala/orca/runner/OpencodeFlowTest.scala
+++ b/runner/src/test/scala/orca/runner/OpencodeFlowTest.scala
@@ -15,7 +15,8 @@ import orca.llm.{
   LlmCall,
   LlmConfig,
   OpencodeTool,
-  SessionId
+  SessionId,
+  ToolSet
 }
 import orca.plan.{Plan, Task, Title}
 import orca.tools.opencode.DefaultOpencodeTool
@@ -120,7 +121,7 @@ class OpencodeFlowTest extends munit.FunSuite:
     def withConfig(c: LlmConfig): OpencodeTool = this
     def withSystemPrompt(p: String): OpencodeTool = this
     def withName(n: String): OpencodeTool = this
-    def withReadOnly: OpencodeTool = this
+    def withTools(tools: ToolSet): OpencodeTool = this
     def autonomous: AutonomousTextCall[BackendTag.Opencode.type] =
       throw new UnsupportedOperationException
     def resultAs[O: JsonData: Announce]: LlmCall[BackendTag.Opencode.type, O] =

--- a/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
+++ b/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
@@ -13,7 +13,8 @@ import orca.llm.{
   LlmConfig,
   Model,
   OpencodeTool,
-  SessionId
+  SessionId,
+  ToolSet
 }
 import orca.events.{CostTracker, OrcaEvent, Usage}
 import _root_.orca.runner.terminal.TerminalInteraction
@@ -49,7 +50,7 @@ class OrcaOverridesTest extends munit.FunSuite:
       def withConfig(c: LlmConfig) = this
       def withSystemPrompt(p: String) = this
       def withName(n: String) = this
-      def withReadOnly = this
+      def withTools(tools: ToolSet) = this
       val autonomous: AutonomousTextCall[BackendTag.ClaudeCode.type] =
         new AutonomousTextCall[BackendTag.ClaudeCode.type]:
           def run(
@@ -90,7 +91,7 @@ class OrcaOverridesTest extends munit.FunSuite:
       def withConfig(c: LlmConfig) = this
       def withSystemPrompt(p: String) = this
       def withName(n: String) = this
-      def withReadOnly = this
+      def withTools(tools: ToolSet) = this
       val autonomous: AutonomousTextCall[BackendTag.Opencode.type] =
         new AutonomousTextCall[BackendTag.Opencode.type]:
           def run(
@@ -123,7 +124,7 @@ class OrcaOverridesTest extends munit.FunSuite:
       def withConfig(c: LlmConfig) = this
       def withSystemPrompt(p: String) = this
       def withName(n: String) = this
-      def withReadOnly = this
+      def withTools(tools: ToolSet) = this
       val autonomous: AutonomousTextCall[BackendTag.Pi.type] =
         new AutonomousTextCall[BackendTag.Pi.type]:
           def run(

--- a/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
+++ b/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
@@ -47,6 +47,7 @@ class OrcaOverridesTest extends munit.FunSuite:
       def sonnet = this
       def opus = this
       def fable = this
+      def withNetworkTools(t: Seq[String]) = this
       def withConfig(c: LlmConfig) = this
       def withSystemPrompt(p: String) = this
       def withName(n: String) = this

--- a/tools/src/main/scala/orca/backend/SystemPromptComposer.scala
+++ b/tools/src/main/scala/orca/backend/SystemPromptComposer.scala
@@ -1,6 +1,6 @@
 package orca.backend
 
-import orca.llm.LlmConfig
+import orca.llm.{LlmConfig, ToolSet}
 
 /** Shared helper for assembling a backend-agnostic "system prompt body" from
   * the configured [[LlmConfig.systemPrompt]], an optional caller-supplied
@@ -39,7 +39,7 @@ private[orca] object SystemPromptComposer:
       extraHint: Option[String] = None
   ): Option[String] =
     val gitRule =
-      if config.readOnly || config.selfManagedGit then None
+      if config.tools != ToolSet.Full || config.selfManagedGit then None
       else Some(RuntimeOwnsGit)
     List(config.systemPrompt, extraHint, gitRule).flatten match
       case Nil    => None

--- a/tools/src/main/scala/orca/llm/BaseLlmTool.scala
+++ b/tools/src/main/scala/orca/llm/BaseLlmTool.scala
@@ -41,8 +41,10 @@ abstract class BaseLlmTool[B <: BackendTag, Self <: LlmTool[B]](
   def withSystemPrompt(prompt: String): Self =
     copyTool(config = config.copy(systemPrompt = Some(prompt)))
   def withName(newName: String): Self = copyTool(name = newName)
-  def withReadOnly: Self =
-    copyTool(config = config.copy(readOnly = true))
+  def withTools(tools: ToolSet): Self =
+    copyTool(config = config.copy(tools = tools))
+  override def withReadOnly: Self = withTools(ToolSet.ReadOnly)
+  override def withNetworkOnly: Self = withTools(ToolSet.NetworkOnly)
   override def withSelfManagedGit: Self =
     copyTool(config = config.copy(selfManagedGit = true))
 

--- a/tools/src/main/scala/orca/llm/LlmConfig.scala
+++ b/tools/src/main/scala/orca/llm/LlmConfig.scala
@@ -77,13 +77,15 @@ enum AutoApprove:
   *     planners and reviewers rely on (claude `--permission-mode plan`, codex
   *     `--sandbox read-only`, pi `--tools read,grep,find,ls`, gemini
   *     `--approval-mode plan`, opencode write/edit/bash/patch disabled).
-  *   - **NetworkOnly** — reads plus network (web + GitHub), for planners that
-  *     must read an issue/PR they were pointed at. Edits stay blocked where the
-  *     backend can scope tools (claude adds a command-scoped allowlist;
-  *     opencode / gemini already allow web in read-only). On pi and codex there
-  *     is no network without a writable shell (`pi bash`, `codex
-  *     workspace-write`), so there the no-edit guarantee is **prompt-only** —
-  *     the planner prompts forbid edits.
+  *   - **NetworkOnly** — reads plus read-only network (web + GitHub), for
+  *     planners that must read an issue/PR they were pointed at. Backend
+  *     support varies: claude grants it with a command-scoped allowlist (hard
+  *     no-edit preserved); pi and codex grant it only via a writable shell (`pi
+  *     bash`, `codex workspace-write`), so there the no-edit guarantee is
+  *     **prompt-only** — the planner prompts forbid edits; opencode and gemini
+  *     have no dedicated network on this tier (it behaves like `ReadOnly`,
+  *     since their read-only modes gate the network tools in headless runs), so
+  *     those flows pre-fetch context instead.
   *   - **Full** — every tool, write-capable; prompting then follows
   *     [[LlmConfig.autoApprove]].
   */

--- a/tools/src/main/scala/orca/llm/LlmConfig.scala
+++ b/tools/src/main/scala/orca/llm/LlmConfig.scala
@@ -79,13 +79,12 @@ enum AutoApprove:
   *     `--approval-mode plan`, opencode write/edit/bash/patch disabled).
   *   - **NetworkOnly** — reads plus read-only network (web + GitHub), for
   *     planners that must read an issue/PR they were pointed at. Backend
-  *     support varies: claude grants it with a command-scoped allowlist (hard
-  *     no-edit preserved); pi and codex grant it only via a writable shell (`pi
-  *     bash`, `codex workspace-write`), so there the no-edit guarantee is
-  *     **prompt-only** — the planner prompts forbid edits; opencode and gemini
-  *     have no dedicated network on this tier (it behaves like `ReadOnly`,
-  *     since their read-only modes gate the network tools in headless runs), so
-  *     those flows pre-fetch context instead.
+  *     support varies: claude and gemini keep a **hard** no-edit guarantee and
+  *     add a scoped web allowlist (claude also pre-approves read-only `gh`);
+  *     opencode keeps its web tool available (server-dependent), also hard; pi
+  *     and codex can only grant network via a writable shell (`pi bash`, `codex
+  *     workspace-write`), so there the no-edit guarantee is **prompt-only** —
+  *     the planner prompts forbid edits.
   *   - **Full** — every tool, write-capable; prompting then follows
   *     [[LlmConfig.autoApprove]].
   */

--- a/tools/src/main/scala/orca/llm/LlmConfig.scala
+++ b/tools/src/main/scala/orca/llm/LlmConfig.scala
@@ -7,15 +7,24 @@ import scala.concurrent.duration.DurationInt
 case class LlmConfig(
     model: Option[Model] = None,
     systemPrompt: Option[String] = None,
-    autoApprove: AutoApprove = AutoApprove.All,
-    /** Restrict the agent to read-only tools (Read / Glob / Grep / read-only
-      * Bash). No file writes, no edits, no shelling out for side effects. Maps
-      * to claude's `--permission-mode plan`. Used by planning helpers so the
-      * agent can verify claims against the repo without making changes — an
-      * over-eager planner editing files during a "plan-only" turn was the
-      * motivating case.
+    /** Which tools auto-approve without a permission prompt. Only meaningful
+      * for **interactive** sessions — autonomous turns have no prompt to
+      * answer, so the field is inert there. Backends consult it only when
+      * [[tools]] is [[ToolSet.Full]] (the read-only tiers are autonomous
+      * planners/reviewers). `Only(set)` should list a subset of the tools
+      * [[tools]] makes available; entries outside it are dead. Neither
+      * invariant is type-enforced (one `LlmConfig` feeds both the interactive
+      * and autonomous paths).
       */
-    readOnly: Boolean = false,
+    autoApprove: AutoApprove = AutoApprove.All,
+    /** Which tools exist for the agent at all — the capability axis (distinct
+      * from [[autoApprove]], the prompting axis). See [[ToolSet]] for the tiers
+      * and their per-backend mapping. `Full` is write-capable; the read-only
+      * tiers gate writes (hard on claude / gemini / opencode; prompt-only on pi
+      * / codex under [[ToolSet.NetworkOnly]], where granting network forces a
+      * writable shell).
+      */
+    tools: ToolSet = ToolSet.Full,
     /** Let the agent manage git itself — suppresses the standing "runtime owns
       * git" rule that [[orca.backend.SystemPromptComposer]] otherwise appends
       * to every write-capable turn. Off by default: orca's model is that the
@@ -59,3 +68,26 @@ object LlmConfig:
 enum AutoApprove:
   case All
   case Only(tools: Set[String])
+
+/** The set of tools available to the agent — the capability tier on
+  * [[LlmConfig.tools]]. Each backend maps the tiers onto its own permission
+  * model:
+  *
+  *   - **ReadOnly** — reads only; no shell, no edits. The hard no-edit gate
+  *     planners and reviewers rely on (claude `--permission-mode plan`, codex
+  *     `--sandbox read-only`, pi `--tools read,grep,find,ls`, gemini
+  *     `--approval-mode plan`, opencode write/edit/bash/patch disabled).
+  *   - **NetworkOnly** — reads plus network (web + GitHub), for planners that
+  *     must read an issue/PR they were pointed at. Edits stay blocked where the
+  *     backend can scope tools (claude adds a command-scoped allowlist;
+  *     opencode / gemini already allow web in read-only). On pi and codex there
+  *     is no network without a writable shell (`pi bash`, `codex
+  *     workspace-write`), so there the no-edit guarantee is **prompt-only** —
+  *     the planner prompts forbid edits.
+  *   - **Full** — every tool, write-capable; prompting then follows
+  *     [[LlmConfig.autoApprove]].
+  */
+enum ToolSet:
+  case ReadOnly
+  case NetworkOnly
+  case Full

--- a/tools/src/main/scala/orca/llm/LlmTool.scala
+++ b/tools/src/main/scala/orca/llm/LlmTool.scala
@@ -95,6 +95,14 @@ trait ClaudeTool extends LlmTool[BackendTag.ClaudeCode.type]:
   def opus: ClaudeTool
   def fable: ClaudeTool
 
+  /** Set the read-only network allowlist used on [[ToolSet.NetworkOnly]] turns
+    * (claude `--allowedTools` syntax, e.g. `Bash(gh api:*)`, `WebFetch`).
+    * Claude-specific, so it's here rather than on `LlmConfig`; defaults to
+    * `ClaudeBackend.DefaultNetworkTools`. Pass it before handing the tool to a
+    * planning helper: `claude.opus.withNetworkTools(Seq("WebFetch"))`.
+    */
+  def withNetworkTools(tools: Seq[String]): ClaudeTool
+
 trait CodexTool extends LlmTool[BackendTag.Codex.type]:
   def mini: CodexTool
 

--- a/tools/src/main/scala/orca/llm/LlmTool.scala
+++ b/tools/src/main/scala/orca/llm/LlmTool.scala
@@ -44,13 +44,24 @@ trait LlmTool[B <: BackendTag]:
   def withSystemPrompt(prompt: String): LlmTool[B]
   def withName(name: String): LlmTool[B]
 
-  /** Return a sibling tool whose config has [[LlmConfig.readOnly]] flipped on —
-    * claude maps this to `--permission-mode plan`, so Edit/Write/Bash are
-    * unavailable to the agent. Preserves the rest of the tool's config (model,
-    * system prompt, autoApprove). Used by planning helpers so
+  /** Return a sibling tool whose config pins [[LlmConfig.tools]] to `tools` —
+    * the capability tier (see [[ToolSet]]). The primitive behind
+    * [[withReadOnly]] and [[withNetworkOnly]]; preserves the rest of the tool's
+    * config (model, system prompt, autoApprove).
+    */
+  def withTools(tools: ToolSet): LlmTool[B]
+
+  /** Sibling tool restricted to read-only tools ([[ToolSet.ReadOnly]]): no
+    * edits, no shell. Used by planning and review helpers so e.g.
     * `claude.opus.withReadOnly` keeps the opus pin while gating writes.
     */
-  def withReadOnly: LlmTool[B]
+  def withReadOnly: LlmTool[B] = withTools(ToolSet.ReadOnly)
+
+  /** Sibling tool restricted to reads plus network ([[ToolSet.NetworkOnly]]) —
+    * for planner turns that must read an issue/PR. See [[ToolSet]] for the
+    * per-backend no-edit guarantee (hard on most; prompt-only on pi / codex).
+    */
+  def withNetworkOnly: LlmTool[B] = withTools(ToolSet.NetworkOnly)
 
   /** Return a sibling tool that manages git itself — flips
     * [[LlmConfig.selfManagedGit]] on, suppressing the standing "runtime owns

--- a/tools/src/test/scala/orca/backend/SystemPromptComposerTest.scala
+++ b/tools/src/test/scala/orca/backend/SystemPromptComposerTest.scala
@@ -1,6 +1,6 @@
 package orca.backend
 
-import orca.llm.LlmConfig
+import orca.llm.{LlmConfig, ToolSet}
 
 class SystemPromptComposerTest extends munit.FunSuite:
 
@@ -14,7 +14,14 @@ class SystemPromptComposerTest extends munit.FunSuite:
     // Read-only turns can't commit, so the git rule is omitted — and with no
     // systemPrompt or hint there's nothing left to compose.
     val out = SystemPromptComposer.combine(
-      LlmConfig.default.copy(readOnly = true),
+      LlmConfig.default.copy(tools = ToolSet.ReadOnly),
+      None
+    )
+    assertEquals(out, None)
+
+  test("network-only turn also omits the git rule (not Full)"):
+    val out = SystemPromptComposer.combine(
+      LlmConfig.default.copy(tools = ToolSet.NetworkOnly),
       None
     )
     assertEquals(out, None)
@@ -28,7 +35,10 @@ class SystemPromptComposerTest extends munit.FunSuite:
 
   test("read-only config keeps just its systemPrompt (no git rule)"):
     val out = SystemPromptComposer.combine(
-      LlmConfig.default.copy(systemPrompt = Some("be terse"), readOnly = true),
+      LlmConfig.default.copy(
+        systemPrompt = Some("be terse"),
+        tools = ToolSet.ReadOnly
+      ),
       extraHint = None
     )
     assertEquals(out, Some("be terse"))


### PR DESCRIPTION
Replaces the boolean LlmConfig.readOnly with enum ToolSet { ReadOnly, NetworkOnly, Full } — the capability axis, distinct from AutoApprove (prompting). Only the autonomous planner path (from/assessThenPlan/triage) selects NetworkOnly; reviewers, reviewed/briefed, selection and lint stay ReadOnly (the hard no-edit gate Reviewers.scala relies on). Per-backend network and guarantees are in ADR 0016. claude keeps a hard no-edit guarantee (command-scoped --allowedTools, configurable via claude.withNetworkTools); pi/codex are prompt-only (network needs a writable surface); gemini/opencode get no network (verified gemini blocks web in plan mode) and pre-fetch context instead.