### PR TITLE
opencode serve: lifecycle logging + configurable launcher (Ollama)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,18 @@ Each CLI manages its own auth; Orca stores no secrets. Before running a flow,
 log in to the backend you use — `claude`, `codex`, `opencode`, or `pi` — and to
 `gh` (for the GitHub helpers), each per its own instructions.
 
+For OpenCode with a local **Ollama** model, two options:
+
+- **Launcher (zero config):** `flow(OrcaArgs(args), opencodeLauncher =
+  OpencodeLauncher.ollama("qwen3-coder"))`. Orca starts the server via `ollama
+  launch opencode`, which injects Ollama's provider config and pins that one
+  model — use bare `opencode`, no `withModel`. Needs the `ollama` CLI and the
+  model pulled.
+- **Manual config:** declare an `ollama` provider in
+  `~/.config/opencode/opencode.json` (baseURL `http://localhost:11434/v1`, your
+  models, `num_ctx` raised for tool use), then `opencode.withModel("ollama",
+  "qwen3-coder")`. Supports several models and per-turn switching.
+
 ## Getting set up
 
 Orca is published to Maven Central — `scala-cli` fetches the artifacts on first

--- a/adr/0017-opencode-configurable-launcher.md
+++ b/adr/0017-opencode-configurable-launcher.md
@@ -1,0 +1,61 @@
+# 0017. Configurable OpenCode serve launcher
+
+Status: Proposed · Date: 2026-06-13
+Related: [ADR 0014](0014-opencode-server-driver.md) (OpenCode server driver), issue #10
+
+## Context
+
+ADR 0014 drives a shared `opencode serve` spawned as the hardcoded `opencode`
+binary, with `--pure` deliberately omitted so the server reads the user's
+config (`~/.config/opencode/opencode.json` + ambient env). Any provider declared
+there — including a local Ollama provider — already works: orca just passes the
+`provider/model` id through (`opencode.withModel("ollama", …)`).
+
+Issue #10 asks for the *easy* path. The convenient way to wire Ollama is `ollama
+launch opencode`, which injects Ollama's generated provider config inline via
+`OPENCODE_CONFIG_CONTENT` (no hand-written `opencode.json`). Hand-writing that
+config — npm package, baseURL, exact model ids, raised `num_ctx` for tool use —
+is fiddly and error-prone, so the launcher is the genuine zero-config path. But
+the `opencode` binary name was hardcoded, so the launcher couldn't be used.
+
+## Decision
+
+Make the serve launch command configurable via a public `OpencodeLauncher`,
+threaded `flow(opencodeLauncher = …) → DefaultFlowContext → OpencodeBackend →
+OpencodeServer → OpencodeArgs.serve`. orca appends `serve --port 0 --log-level
+WARN` to the launcher prefix.
+
+- `OpencodeLauncher.default` = `opencode` (unchanged behaviour).
+- `OpencodeLauncher.ollama(model)` = `ollama launch opencode --model <model> --`.
+- `OpencodeLauncher(Seq(...))` for any other wrapper.
+
+`--model` is required for the Ollama launcher: empirically, `ollama launch`
+otherwise falls back to interactive model selection, which fails in orca's
+headless server context. The launcher injects config for, and sets as the server
+**default**, exactly that one model — so a bare `opencode` turn (orca sends
+`model = None`) routes to it with no `withModel`. The server declares only that
+model and rejects any other Ollama id, so switching models means relaunching
+with a different `ollama(...)`.
+
+Teardown SIGINTs the process **tree** (`CliProcess.sendSigIntTree`, used only by
+the OpenCode server), not just the spawned PID: a launch wrapper that forks the
+real `opencode serve` would otherwise leave it orphaned.
+
+This partially realises the "orca-supplied provider config" future-work note in
+ADR 0014 — by delegating config generation to `ollama launch` rather than orca
+writing `OPENCODE_CONFIG_CONTENT` itself. The latter (for non-Ollama providers,
+or to avoid the `ollama` CLI dependency) remains open.
+
+## Consequences
+
+- Two documented ways to use a local Ollama model: the launcher (zero config,
+  one pinned model, no `withModel`) or a manual `opencode.json` provider block +
+  `withModel` (several models, per-turn switching). README covers both.
+- New public surface: `OpencodeLauncher` and the `flow(opencodeLauncher = …)`
+  parameter.
+- Not verified end-to-end against a live model in this environment (CPU-only,
+  Ollama model registry firewalled). Validated via unit tests and live
+  inspection of a launcher-started server's injected `/config` (the `ollama`
+  provider and default model are present); a real agentic turn was too slow to
+  complete on a 0.5B model under OpenCode's system prompt. A real-model run on
+  capable hardware is recommended before relying on it.

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
@@ -21,15 +21,19 @@ import orca.util.RawJson
   */
 private[opencode] object OpencodeArgs:
 
-  /** The `opencode` executable; resolved from `PATH`. */
-  val ServeBinary: String = "opencode"
-
-  /** `opencode serve` launch args. Port 0 = an OS-assigned free port (read back
-    * from the server's "listening on …" line). `--pure` is deliberately omitted
-    * so the spawned server inherits the user's configured providers.
+  /** `opencode serve` launch args. The `launcher` prefix (default: the bare
+    * `opencode` binary, resolved from `PATH`) is followed by `serve …`; an
+    * alternative like [[OpencodeLauncher.ollama]] wraps the binary to inject
+    * provider config. Port 0 = an OS-assigned free port (read back from the
+    * server's "listening on …" line). `--pure` is deliberately omitted so the
+    * spawned server inherits the user's configured providers.
     */
-  def serve(port: Int = 0): Seq[String] =
-    Seq(ServeBinary, "serve", "--port", port.toString, "--log-level", "WARN")
+  def serve(
+      launcher: OpencodeLauncher = OpencodeLauncher.default,
+      port: Int = 0
+  ): Seq[String] =
+    launcher.prefix ++
+      Seq("serve", "--port", port.toString, "--log-level", "WARN")
 
   /** Assemble the body for `POST …/prompt_async`. `model = None` omits the
     * field so the server falls back to its configured default. `outputSchema`

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeBackend.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeBackend.scala
@@ -40,8 +40,13 @@ import java.util.concurrent.atomic.AtomicReference
   * flow's own timeout) is the backstop for a server that wedges mid-turn.
   */
 private[orca] object OpencodeBackend:
-  def apply(cli: CliRunner)(using Ox): OpencodeBackend =
-    new OpencodeBackend(workDir => new OpencodeServer(cli, workDir).http)
+  def apply(
+      cli: CliRunner,
+      launcher: OpencodeLauncher = OpencodeLauncher.default
+  )(using Ox): OpencodeBackend =
+    new OpencodeBackend(workDir =>
+      new OpencodeServer(cli, workDir, launcher).http
+    )
 
 private[orca] class OpencodeBackend(httpFor: os.Path => OpencodeHttp)(using Ox)
     extends LlmBackend[BackendTag.Opencode.type]:

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeLauncher.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeLauncher.scala
@@ -1,0 +1,41 @@
+package orca.tools.opencode
+
+/** How orca launches the shared `opencode serve` process. orca always appends
+  * `serve --port <n> --log-level WARN` to the prefix below.
+  *
+  *   - [[default]] runs the `opencode` binary directly.
+  *   - [[ollama]] wraps it in `ollama launch opencode --model <model> --`, so
+  *     the spawned server inherits Ollama's generated provider config (injected
+  *     via `OPENCODE_CONFIG_CONTENT`) — the zero-config path for local Ollama
+  *     models, instead of hand-writing that config into `opencode.json`.
+  *
+  * Select it per flow: `flow(OrcaArgs(args), opencodeLauncher =
+  * OpencodeLauncher.ollama("qwen3-coder"))`.
+  */
+opaque type OpencodeLauncher = Seq[String]
+
+object OpencodeLauncher:
+  /** Run `opencode` directly. */
+  val default: OpencodeLauncher = Seq("opencode")
+
+  /** `ollama launch opencode --model <model> --` — injects Ollama's provider
+    * config for `model` and makes it the server's **default**, so a bare
+    * `opencode` turn routes to it with no `withModel` call. The model must
+    * already be pulled (`ollama pull <model>`) and the `ollama` CLI on PATH.
+    * `--model` is required: `ollama launch` otherwise falls back to interactive
+    * model selection, which fails in orca's headless server context.
+    *
+    * The launcher pins exactly this one model — the spawned server declares
+    * only it and rejects any other Ollama model id — so switching models means
+    * relaunching with a different `ollama(...)`, not `withModel`.
+    */
+  def ollama(model: String): OpencodeLauncher =
+    Seq("ollama", "launch", "opencode", "--model", model, "--")
+
+  /** A custom launch prefix; orca appends `serve …` after it. Include a
+    * trailing `--` if your wrapper needs one to separate its own flags from
+    * opencode's (as `ollama launch` does).
+    */
+  def apply(prefix: Seq[String]): OpencodeLauncher = prefix
+
+  extension (l: OpencodeLauncher) private[opencode] def prefix: Seq[String] = l

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeServer.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeServer.scala
@@ -24,6 +24,7 @@ import java.util.UUID
 private[opencode] class OpencodeServer(
     cli: CliRunner,
     workDir: os.Path,
+    launcher: OpencodeLauncher = OpencodeLauncher.default,
     httpFor: (String, String) => OpencodeHttp = JavaNetOpencodeHttp.start
 )(using Ox):
 
@@ -45,12 +46,14 @@ private[opencode] class OpencodeServer(
   private def start(): OpencodeHttp =
     val password = UUID.randomUUID.toString
     val process = cli.spawnPiped(
-      OpencodeArgs.serve(),
+      OpencodeArgs.serve(launcher),
       env = Map("OPENCODE_SERVER_PASSWORD" -> password),
       cwd = workDir
     )
     process.closeStdin()
-    releaseAfterScope(process.sendSigInt())
+    // Tree, not single-PID: a launch wrapper (e.g. `ollama launch opencode`)
+    // may fork the real serve process, which a PID-only SIGINT would orphan.
+    releaseAfterScope(process.sendSigIntTree())
     // serve prints "listening on …" within ~1s of binding; a serve that exits
     // without it surfaces as EOF → the throw below. (A serve that stays alive
     // yet never prints would block here — not observed in practice.)

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeServer.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeServer.scala
@@ -7,6 +7,7 @@ import ox.{releaseAfterScope, Ox}
 import org.slf4j.LoggerFactory
 
 import java.util.UUID
+import java.util.concurrent.ConcurrentLinkedDeque
 
 /** Lifecycle owner for a shared `opencode serve` process (ADR 0014): it spawns
   * the server, reads its base URL, and tears the process down at scope end. The
@@ -45,25 +46,53 @@ private[opencode] class OpencodeServer(
 
   private def start(): OpencodeHttp =
     val password = UUID.randomUUID.toString
+    // Pipe stderr (don't inherit it): a failed launch — e.g. `ollama launch`
+    // reporting a missing model — writes the reason here, so we can put it in
+    // the start-failure error below instead of losing it to the console.
     val process = cli.spawnPiped(
       OpencodeArgs.serve(launcher),
       env = Map("OPENCODE_SERVER_PASSWORD" -> password),
-      cwd = workDir
+      cwd = workDir,
+      pipeStderr = true
     )
     process.closeStdin()
     // Tree, not single-PID: a launch wrapper (e.g. `ollama launch opencode`)
     // may fork the real serve process, which a PID-only SIGINT would orphan.
     releaseAfterScope(process.sendSigIntTree())
+    // Drain stderr in a daemon (a chatty launcher mustn't fill the pipe and
+    // stall startup), tracing each line and keeping a bounded tail to report if
+    // the server never binds.
+    val errTail = new ConcurrentLinkedDeque[String]()
+    val errDrain = new Thread(
+      () => {
+        process.stderrLines.foreach { line =>
+          log.debug("opencode serve stderr: {}", line)
+          errTail.addLast(line)
+          while errTail.size > OpencodeServer.MaxErrTailLines do
+            val _ = errTail.poll()
+        }
+      },
+      "opencode-stderr-drain"
+    )
+    errDrain.setDaemon(true)
+    errDrain.start()
     // serve prints "listening on …" within ~1s of binding; a serve that exits
-    // without it surfaces as EOF → the throw below. (A serve that stays alive
-    // yet never prints would block here — not observed in practice.)
+    // without it surfaces as EOF here.
     val out = process.stdoutLines
     val baseUrl = out
       .flatMap(OpencodeServer.parseBaseUrl)
       .nextOption()
-      .getOrElse(
-        throw OrcaFlowException("opencode serve did not report a listening URL")
-      )
+      .getOrElse:
+        // stdout closed with no listening line — the launcher/serve exited.
+        // Surface its stderr (e.g. ollama's "model not found; run 'ollama pull
+        // …'") rather than a bare "no URL" message.
+        errDrain.join(OpencodeServer.StderrFlushMillis)
+        val tail = String.join("\n", errTail)
+        throw OrcaFlowException(
+          "opencode serve did not start" +
+            (if tail.nonEmpty then s":\n$tail"
+             else " and produced no error output")
+        )
     log.debug("opencode server started, listening on {}", baseUrl)
     // Keep draining stdout — resuming the *same* lazy iterator past the bind
     // line — so the server's log output can't back-fill the pipe and stall it.
@@ -84,6 +113,12 @@ private[opencode] class OpencodeServer(
 
 private[opencode] object OpencodeServer:
   private val ListeningLine = """listening on (https?://\S+)""".r
+
+  /** Cap on stderr lines kept for a start-failure message. */
+  private val MaxErrTailLines = 50
+
+  /** Grace for the stderr drain to finish after stdout EOF, before reporting. */
+  private val StderrFlushMillis = 2000L
 
   /** The base URL from a serve startup line (`opencode server listening on
     * http://127.0.0.1:4096`), or `None`.

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeServer.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeServer.scala
@@ -4,6 +4,8 @@ import orca.OrcaFlowException
 import orca.subprocess.CliRunner
 import ox.{releaseAfterScope, Ox}
 
+import org.slf4j.LoggerFactory
+
 import java.util.UUID
 
 /** Lifecycle owner for a shared `opencode serve` process (ADR 0014): it spawns
@@ -24,6 +26,12 @@ private[opencode] class OpencodeServer(
     workDir: os.Path,
     httpFor: (String, String) => OpencodeHttp = JavaNetOpencodeHttp.start
 )(using Ox):
+
+  // Server lifecycle goes to the per-run trace (/tmp/orca-*.log). The raw
+  // `spawn:` line (orca.proc) shows `--port 0`, so log the resolved URL — and a
+  // teardown line, since a long-lived shared server starting/stopping silently
+  // is otherwise invisible.
+  private val log = LoggerFactory.getLogger(classOf[OpencodeServer])
 
   /** The HTTP/SSE client against this server. Forcing it spawns `opencode serve`
     * exactly once: a `lazy val` gives one spawn under concurrent first use and
@@ -53,6 +61,7 @@ private[opencode] class OpencodeServer(
       .getOrElse(
         throw OrcaFlowException("opencode serve did not report a listening URL")
       )
+    log.debug("opencode server started, listening on {}", baseUrl)
     // Keep draining stdout — resuming the *same* lazy iterator past the bind
     // line — so the server's log output can't back-fill the pipe and stall it.
     // A daemon thread, not an Ox fork: the drain blocks in a native `readLine`
@@ -65,6 +74,9 @@ private[opencode] class OpencodeServer(
     drain.start()
     val client = httpFor(baseUrl, password)
     releaseAfterScope(client.close()) // runs before the SIGINT (LIFO)
+    // Registered last → runs first at teardown, announcing the stop before the
+    // client close + SIGINT above.
+    releaseAfterScope(log.debug("opencode server at {} stopping", baseUrl))
     client
 
 private[opencode] object OpencodeServer:

--- a/opencode/src/test/scala/orca/tools/opencode/OpencodeArgsTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/OpencodeArgsTest.scala
@@ -17,7 +17,14 @@ class OpencodeArgsTest extends munit.FunSuite:
     assert(!args.contains("--pure"))
 
   test("serve renders an explicit port"):
-    assert(OpencodeArgs.serve(4096).containsSlice(Seq("--port", "4096")))
+    assert(OpencodeArgs.serve(port = 4096).containsSlice(Seq("--port", "4096")))
+
+  test("serve prefixes a custom launcher before the serve args"):
+    assertEquals(
+      OpencodeArgs.serve(OpencodeLauncher.ollama("qwen3-coder")),
+      Seq("ollama", "launch", "opencode", "--model", "qwen3-coder", "--",
+        "serve", "--port", "0", "--log-level", "WARN")
+    )
 
   test("message splits the model into provider/id"):
     val body = OpencodeArgs.message(

--- a/opencode/src/test/scala/orca/tools/opencode/OpencodeServerTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/OpencodeServerTest.scala
@@ -1,5 +1,6 @@
 package orca.tools.opencode
 
+import orca.OrcaFlowException
 import orca.backend.StreamSource
 import orca.subprocess.{
   CliResult,
@@ -97,4 +98,23 @@ class OpencodeServerTest extends munit.FunSuite:
         runner.lastArgs,
         Seq("ollama", "launch", "opencode", "--model", "qwen3-coder", "--",
           "serve", "--port", "0", "--log-level", "WARN")
+      )
+
+  test("a server that exits without binding surfaces its stderr"):
+    supervised:
+      val proc = new FakePipedCliProcess()
+      proc.enqueueStderr(
+        "Error: model \"gemma4\" not found; run 'ollama pull gemma4' first"
+      )
+      proc.closeStderr()
+      proc.closeStdout() // EOF with no "listening on" line
+      val server = new OpencodeServer(
+        new RecordingRunner(proc),
+        os.temp.dir(),
+        httpFor = (_, _) => fail("client must not be built on a failed start")
+      )
+      val ex = intercept[OrcaFlowException](server.http)
+      assert(
+        ex.getMessage.contains("model \"gemma4\" not found"),
+        ex.getMessage
       )

--- a/opencode/src/test/scala/orca/tools/opencode/OpencodeServerTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/OpencodeServerTest.scala
@@ -61,7 +61,7 @@ class OpencodeServerTest extends munit.FunSuite:
       val server = new OpencodeServer(
         runner,
         os.temp.dir(),
-        (url, pwd) =>
+        httpFor = (url, pwd) =>
           built = Some(url -> pwd)
           stub
       )
@@ -78,3 +78,23 @@ class OpencodeServerTest extends munit.FunSuite:
 
       val _ = server.http.postJson("/y", "{}") // reuse: no second spawn
       assertEquals(runner.spawns.get(), 1)
+
+  test("a custom launcher wraps the serve argv at spawn"):
+    supervised:
+      val runner = new RecordingRunner(listeningProcess)
+      val stub = new OpencodeHttp:
+        def postJson(path: String, body: String): String = "ok"
+        def events(): StreamSource =
+          throw new UnsupportedOperationException
+      val server = new OpencodeServer(
+        runner,
+        os.temp.dir(),
+        launcher = OpencodeLauncher.ollama("qwen3-coder"),
+        httpFor = (_, _) => stub
+      )
+      val _ = server.http.postJson("/x", "{}") // force the spawn
+      assertEquals(
+        runner.lastArgs,
+        Seq("ollama", "launch", "opencode", "--model", "qwen3-coder", "--",
+          "serve", "--port", "0", "--log-level", "WARN")
+      )

--- a/runner/src/main/scala/orca/exports.scala
+++ b/runner/src/main/scala/orca/exports.scala
@@ -66,4 +66,5 @@ export orca.tools.{
   IssueHandle,
   PrHandle
 }
+export orca.tools.opencode.OpencodeLauncher
 export ox.either.orThrow

--- a/runner/src/main/scala/orca/flow.scala
+++ b/runner/src/main/scala/orca/flow.scala
@@ -9,6 +9,7 @@ import orca.events.{
   Pricing
 }
 import orca.llm.{ClaudeTool, DefaultPrompts, OpencodeTool, PiTool, Prompts}
+import orca.tools.opencode.OpencodeLauncher
 import orca.runner.{DefaultFlowContext, LoggingListener, OrcaBanner, OrcaLog}
 import orca.runner.terminal.TerminalInteraction
 import org.slf4j.LoggerFactory
@@ -52,6 +53,7 @@ def flow(
     extraListeners: List[OrcaListener] = Nil,
     claude: Option[ClaudeTool] = None,
     opencode: Option[OpencodeTool] = None,
+    opencodeLauncher: OpencodeLauncher = OpencodeLauncher.default,
     pi: Option[PiTool] = None,
     git: Option[GitTool] = None,
     gh: Option[GitHubTool] = None,
@@ -103,6 +105,7 @@ def flow(
             interaction = effectiveInteraction,
             claude = claude,
             opencode = opencode,
+            opencodeLauncher = opencodeLauncher,
             pi = pi,
             git = git,
             gh = gh,

--- a/runner/src/main/scala/orca/runner/DefaultFlowContext.scala
+++ b/runner/src/main/scala/orca/runner/DefaultFlowContext.scala
@@ -18,7 +18,11 @@ import orca.events.{EventDispatcher, OrcaEvent}
 import orca.backend.Interaction
 import orca.tools.claude.{ClaudeBackend, DefaultClaudeTool}
 import orca.tools.codex.{CodexBackend, DefaultCodexTool}
-import orca.tools.opencode.{DefaultOpencodeTool, OpencodeBackend}
+import orca.tools.opencode.{
+  DefaultOpencodeTool,
+  OpencodeBackend,
+  OpencodeLauncher
+}
 import orca.tools.pi.{DefaultPiTool, PiBackend}
 import orca.tools.gemini.{GeminiBackend, DefaultGeminiTool}
 import orca.llm.DefaultPrompts
@@ -59,6 +63,7 @@ private[orca] object DefaultFlowContext:
       claude: Option[ClaudeTool] = None,
       codex: Option[CodexTool] = None,
       opencode: Option[OpencodeTool] = None,
+      opencodeLauncher: OpencodeLauncher = OpencodeLauncher.default,
       pi: Option[PiTool] = None,
       gemini: Option[GeminiTool] = None,
       git: Option[GitTool] = None,
@@ -95,7 +100,7 @@ private[orca] object DefaultFlowContext:
       ),
       opencode = opencode.getOrElse(
         new DefaultOpencodeTool(
-          backend = OpencodeBackend(OsProcCliRunner),
+          backend = OpencodeBackend(OsProcCliRunner, opencodeLauncher),
           config = LlmConfig.default,
           prompts = prompts,
           workDir = workDir,

--- a/tools/src/main/scala/orca/subprocess/CliProcess.scala
+++ b/tools/src/main/scala/orca/subprocess/CliProcess.scala
@@ -5,6 +5,12 @@ trait CliProcess:
   def isAlive: Boolean
   def waitForExit(): Int
 
+  /** SIGINT this process and any descendants. Default = just this process;
+    * override where a launch wrapper (e.g. `ollama launch opencode`) may fork
+    * the real process — a single-PID SIGINT would orphan it.
+    */
+  def sendSigIntTree(): Unit = sendSigInt()
+
 /** A spawned process whose stdin / stdout / stderr are connected to pipes the
   * caller controls. The backend writes the opening user turn (or any further
   * input) via `writeLine` and consumes responses as they arrive from

--- a/tools/src/main/scala/orca/subprocess/OsProcCliRunner.scala
+++ b/tools/src/main/scala/orca/subprocess/OsProcCliRunner.scala
@@ -3,6 +3,7 @@ package orca.subprocess
 import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters.given
+import scala.jdk.StreamConverters.*
 
 /** Runs external commands via os-lib. `check = false` is intentional — callers
   * inspect `exitCode` and `stderr` rather than handling thrown exceptions,
@@ -91,6 +92,18 @@ private final class OsPipedSubProcess(
 
   def sendSigInt(): Unit =
     val _ = QuietProc.call(Seq("kill", "-INT", sub.wrapped.pid.toString))
+
+  override def sendSigIntTree(): Unit =
+    // Descendants first, then the root: if the spawned process is a launch
+    // wrapper that forked the real `opencode serve`, SIGINT-ing only the root
+    // PID would leave the server orphaned. Snapshot is best-effort.
+    val handle = sub.wrapped.toHandle
+    val pids =
+      (handle.descendants().toScala(List) :+ handle)
+        .filter(_.isAlive)
+        .map(_.pid.toString)
+    if pids.nonEmpty then
+      val _ = QuietProc.call(Seq("kill", "-INT") ++ pids)
 
   def isAlive: Boolean = sub.isAlive()
 


### PR DESCRIPTION
Closes #10 - @JD557 let me know if this would work for you

 Two related improvements to how orca runs the shared `opencode serve` process.

  ## 1. Log server start/stop to the run trace
  The shared server started and stopped silently — the raw `spawn:` line shows
  `--port 0` (not the bound port) and there was no teardown line, so a long-lived
  process was invisible in the trace. Now logs the resolved listening URL on start
  and a stopping line at teardown (DEBUG → `/tmp/orca-*.log`).

  This came out of issue #10, where a user was confused that orca had silently
  started its own opencode server.

  ## 2. Configurable serve launcher (`OpencodeLauncher`)
  The `opencode` binary was hardcoded, so there was no way to start the server via
  `ollama launch opencode` — which injects Ollama's generated provider config
  (`OPENCODE_CONFIG_CONTENT`) and is the zero-config path for local Ollama models
  (issue #10). Hand-writing that provider config (npm package, baseURL, exact model
  ids, raised `num_ctx`) is fiddly, so the launcher is the genuine easy path.

  - New public `OpencodeLauncher`: `default` (plain `opencode`), `ollama(model)`,
    and `apply(Seq)` for any wrapper. Threaded `flow(opencodeLauncher = …) →
    DefaultFlowContext → OpencodeBackend → OpencodeServer → OpencodeArgs.serve`
    (orca appends `serve --port 0 --log-level WARN`).
  - `ollama(model)` → `ollama launch opencode --model <model> --`. `--model` is
    required (headless `ollama launch` otherwise falls back to interactive
    selection). It pins that one model as the server **default**, so a bare
    `opencode` turn routes to it — no `withModel`. Other Ollama ids are rejected,
    so switching models means relaunching.
  - Teardown SIGINTs the process **tree** (`CliProcess.sendSigIntTree`, used only
    by the server) so a forking launcher can't orphan the real `opencode serve`.

  ```scala
  flow(OrcaArgs(args), opencodeLauncher = OpencodeLauncher.ollama("qwen3-coder")):
    opencode.autonomous.run("…")   // routes to ollama/qwen3-coder
```

  Docs

  README documents both Ollama paths (launcher vs. manual opencode.json +
  withModel); ADR 0017 records the decision.

  Testing

  65 opencode unit tests pass, including one asserting orca spawns the
  launcher-wrapped argv. Not verified end-to-end against a live model here
  (CPU-only + Ollama's model registry firewalled): validated by inspecting a
  launcher-started server's injected /config (the ollama provider and default
  model are present); a real agentic turn was too slow to finish on a 0.5B model.
  A real-model run on capable hardware is recommended before relying on it.