### PR TITLE
flow: surface failures as a top-level stage; keep stack traces out of the console

### DIFF
--- a/flow/src/main/scala/orca/Flow.scala
+++ b/flow/src/main/scala/orca/Flow.scala
@@ -25,13 +25,17 @@ def stage[T](name: String)(body: => T)(using ctx: FlowContext): T =
       // Exceptions from `fail(...)` carry `alreadyEmitted = true` and
       // need no further emission. Anything else (tool adapters that
       // throw directly) lands here without a prior emit, and would be
-      // invisible if we didn't surface it.
+      // invisible if we didn't surface it. After emitting, mark the
+      // exception so an enclosing stage / the flow boundary doesn't
+      // re-report it as it unwinds.
       e match
         case mao: orca.llm.MalformedAgentOutputException =>
           ctx.emit(OrcaEvent.Error(formatMalformedOutput(name, mao)))
+          e.alreadyEmitted = true
         case _ if e.alreadyEmitted => ()
         case _ =>
           ctx.emit(OrcaEvent.Error(s"Stage '$name' failed: ${shortMessage(e)}"))
+          e.alreadyEmitted = true
       throw e
     case NonFatal(e) =>
       ctx.emit(OrcaEvent.Error(s"Stage '$name' failed: ${shortMessage(e)}"))

--- a/flow/src/main/scala/orca/Flow.scala
+++ b/flow/src/main/scala/orca/Flow.scala
@@ -17,7 +17,7 @@ def stage[T](name: String)(body: => T)(using ctx: FlowContext): T =
   ctx.emit(OrcaEvent.StageStarted(name))
   try
     val result = body
-    ctx.emit(OrcaEvent.StageCompleted(name, result.toString))
+    ctx.emit(OrcaEvent.StageCompleted(name))
     result
   catch
     case e: OrcaFlowException =>
@@ -34,19 +34,29 @@ def stage[T](name: String)(body: => T)(using ctx: FlowContext): T =
           e.alreadyEmitted = true
         case _ if e.alreadyEmitted => ()
         case _ =>
-          ctx.emit(OrcaEvent.Error(s"Stage '$name' failed: ${shortMessage(e)}"))
+          ctx.emit(
+            OrcaEvent.Error(s"Stage '$name' failed: ${throwableMessage(e, firstLineOnly = true)}")
+          )
           e.alreadyEmitted = true
       throw e
     case NonFatal(e) =>
-      ctx.emit(OrcaEvent.Error(s"Stage '$name' failed: ${shortMessage(e)}"))
+      ctx.emit(
+        OrcaEvent.Error(s"Stage '$name' failed: ${throwableMessage(e, firstLineOnly = true)}")
+      )
       throw e
 
-private def shortMessage(e: Throwable): String =
-  Option(e.getMessage)
-    .getOrElse(e.getClass.getName)
-    .linesIterator
-    .nextOption()
-    .getOrElse(e.getClass.getName)
+/** A throwable's human message: its `getMessage` (or the class name when blank),
+  * optionally collapsed to its first line. Shared by `stage` (first line, for a
+  * tidy one-line `✖`) and the flow boundary (whole message, so multi-line
+  * diagnostics like opencode's start-failure stderr survive).
+  */
+private[orca] def throwableMessage(
+    e: Throwable,
+    firstLineOnly: Boolean = false
+): String =
+  val msg = Option(e.getMessage).filter(_.nonEmpty)
+  val picked = if firstLineOnly then msg.flatMap(_.linesIterator.nextOption()) else msg
+  picked.getOrElse(e.getClass.getName)
 
 private def formatMalformedOutput(
     stage: String,

--- a/flow/src/test/scala/orca/EventDispatcherTest.scala
+++ b/flow/src/test/scala/orca/EventDispatcherTest.scala
@@ -20,7 +20,7 @@ class EventDispatcherTest extends munit.FunSuite:
     val events = List(
       OrcaEvent.StageStarted("plan"),
       OrcaEvent.Step("hello"),
-      OrcaEvent.StageCompleted("plan", "ok")
+      OrcaEvent.StageCompleted("plan")
     )
     events.foreach(dispatcher.onEvent)
 

--- a/flow/src/test/scala/orca/FlowTest.scala
+++ b/flow/src/test/scala/orca/FlowTest.scala
@@ -25,7 +25,7 @@ class FlowTest extends munit.FunSuite:
       listener.events,
       List(
         OrcaEvent.StageStarted("plan"),
-        OrcaEvent.StageCompleted("plan", "7")
+        OrcaEvent.StageCompleted("plan")
       )
     )
 

--- a/flow/src/test/scala/orca/review/ReviewFixFlowTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewFixFlowTest.scala
@@ -66,8 +66,8 @@ class ReviewFixFlowTest extends munit.FunSuite:
     )
     assert(
       events.exists {
-        case OrcaEvent.StageCompleted("Review & fix", _) => true;
-        case _                                           => false
+        case OrcaEvent.StageCompleted("Review & fix") => true;
+        case _                                        => false
       },
       s"missing StageCompleted(Review & fix); got: $events"
     )

--- a/runner/src/main/resources/logback.xml
+++ b/runner/src/main/resources/logback.xml
@@ -8,6 +8,17 @@
 <configuration>
   <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
     <target>System.err</target>
+    <!-- Drop the event mirror (LoggingListener tags its lines TRACE_ONLY): the
+         terminal renderer owns the console, so otherwise an Error would show
+         twice — the renderer's ✖ and a logback line. These still reach the
+         per-run trace file (whose appender carries no such filter). -->
+    <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+      <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+        <marker>TRACE_ONLY</marker>
+      </evaluator>
+      <onMatch>DENY</onMatch>
+      <onMismatch>NEUTRAL</onMismatch>
+    </filter>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>WARN</level>
     </filter>

--- a/runner/src/main/resources/logback.xml
+++ b/runner/src/main/resources/logback.xml
@@ -1,24 +1,13 @@
-<!-- Console (STDERR) stays quiet: framework chatter (chimp/tapir/netty) is
-     pinned to ERROR, and a ThresholdFilter keeps everything below WARN off the
-     console so the agent's event log isn't drowned. orca's own loggers
-     (`orca.*`) emit DEBUG — the full execution trace is captured to a per-run
-     temp file by `OrcaLog` (a FileAppender attached programmatically at flow
-     start), surfaced to the console only on an exception or with the verbose
-     flag. Override by placing your own logback.xml earlier on the classpath. -->
+<!-- Console (STDERR) shows only framework chatter (chimp/tapir/netty, pinned to
+     ERROR) at WARN+; the terminal renderer owns the rest. orca's own loggers
+     (`orca.*`) emit DEBUG into a per-run temp file: at flow start `OrcaLog`
+     attaches a FileAppender to the `orca` logger and makes it non-additive, so
+     orca's full execution trace goes to the file and never reaches this console
+     appender (the renderer already surfaces it). Override by placing your own
+     logback.xml earlier on the classpath. -->
 <configuration>
   <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
     <target>System.err</target>
-    <!-- Drop the event mirror (LoggingListener tags its lines TRACE_ONLY): the
-         terminal renderer owns the console, so otherwise an Error would show
-         twice — the renderer's ✖ and a logback line. These still reach the
-         per-run trace file (whose appender carries no such filter). -->
-    <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-      <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
-        <marker>TRACE_ONLY</marker>
-      </evaluator>
-      <onMatch>DENY</onMatch>
-      <onMismatch>NEUTRAL</onMismatch>
-    </filter>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>WARN</level>
     </filter>

--- a/runner/src/main/scala/orca/flow.scala
+++ b/runner/src/main/scala/orca/flow.scala
@@ -127,7 +127,7 @@ def flow(
                 case fe: OrcaFlowException => fe.alreadyEmitted
                 case _                     => false
               if !alreadyEmitted then
-                ctx.emit(OrcaEvent.Error(flowErrorMessage(e)))
+                ctx.emit(OrcaEvent.Error(throwableMessage(e)))
               flowLog.debug("flow aborted", e)
               if debug then e.printStackTrace(System.err)
               throw e
@@ -149,23 +149,14 @@ def flow(
 
 private def installUncaughtExceptionHandler(): Unit =
   // Idempotent across nested or repeated `flow(...)` calls — we only install
-  // our handler if no app-specific one is already in place. The message goes
-  // to the console (ERROR); the stack to the trace file only (DEBUG, below the
-  // console's WARN threshold) so a silent exit still leaves a full trail.
+  // our handler if no app-specific one is already in place. The `orca` logger
+  // is routed to the trace file only (see `OrcaLog`), so the message goes
+  // straight to the console via stderr; the stack follows it into the trace.
   if Thread.getDefaultUncaughtExceptionHandler == null then
     val log = LoggerFactory.getLogger("orca")
     Thread.setDefaultUncaughtExceptionHandler: (thread, throwable) =>
-      log.error(
-        "uncaught exception on thread '{}': {}",
-        thread.getName,
-        throwable.getMessage
+      System.err.println(
+        s"[orca] uncaught exception on thread '${thread.getName}': " +
+          throwable.getMessage
       )
       log.debug("uncaught exception stack trace", throwable)
-
-/** The console message for a flow-aborting throwable: its message — kept whole,
-  * unlike a stage's first-line `shortMessage`, so a multi-line message such as
-  * opencode's start-failure stderr stays useful — or the class name when there
-  * is none. The full stack goes to the trace file separately.
-  */
-private def flowErrorMessage(e: Throwable): String =
-  Option(e.getMessage).filter(_.nonEmpty).getOrElse(e.getClass.getName)

--- a/runner/src/main/scala/orca/flow.scala
+++ b/runner/src/main/scala/orca/flow.scala
@@ -4,6 +4,7 @@ import orca.backend.Interaction
 import orca.events.{
   CostTracker,
   EventDispatcher,
+  OrcaEvent,
   OrcaListener,
   PriceList,
   Pricing
@@ -71,8 +72,8 @@ def flow(
   flowLog.info("orca {} starting (workDir={})", OrcaBanner.version, workDir)
   flowLog.info("user prompt: {}", args.userPrompt)
   // A daemon thread or unsupervised fork that throws would otherwise
-  // disappear with no diagnostic. Route every uncaught throwable to
-  // stderr with its stack so a silent exit always leaves a trail.
+  // disappear with no diagnostic. Log the message to the console and the
+  // stack to the trace file so a silent exit always leaves a trail.
   installUncaughtExceptionHandler()
   // Always tally token usage; print the summary on exit (success or failure)
   // so the user sees what was spent before the process terminates. Callers
@@ -92,10 +93,18 @@ def flow(
           TerminalInteraction.start(workDir = Some(workDir))
         )
         try
+          // Tracks whether an Error was already surfaced (by a nested stage or
+          // `fail`), so the top-level handler below doesn't emit a second one.
+          val sawError = new java.util.concurrent.atomic.AtomicBoolean(false)
+          val errorWatch = new OrcaListener:
+            def onEvent(event: OrcaEvent): Unit = event match
+              case _: OrcaEvent.Error => sawError.set(true)
+              case _                  => ()
           val dispatcher = new EventDispatcher(
             effectiveInteraction.listeners ++ List(
               costTracker,
-              new LoggingListener
+              new LoggingListener,
+              errorWatch
             ) ++ extraListeners
           )
           val ctx = DefaultFlowContext.withDefaults(
@@ -112,21 +121,27 @@ def flow(
             fs = fs,
             prompts = prompts
           )
-          body(using ctx)
+          // The whole flow body runs as a top-level stage: an otherwise
+          // unhandled exception surfaces as a single Error event (the same
+          // message a stage failure shows) unless a nested stage / `fail`
+          // already emitted one. The stack trace goes to the trace file only
+          // (DEBUG, below the console's WARN threshold); `--verbose` also
+          // prints it to stderr.
+          try body(using ctx)
+          catch
+            case NonFatal(e) =>
+              if !sawError.get() then
+                ctx.emit(OrcaEvent.Error(flowErrorMessage(e)))
+              flowLog.debug("flow aborted", e)
+              if debug then e.printStackTrace(System.err)
+              throw e
         finally effectiveInteraction.close()
     catch
-      // Stage-level Errors have already been formatted and emitted
-      // through the channel; the user saw a friendly message there. We
-      // still log the unfriendly bits to stderr so a silent `exit 1` is
-      // never a possibility — full stack for unexpected throwables, just
-      // the message for OrcaFlowException unless debug is on. The full trace
-      // stays in the file (path shown by the banner); we don't echo it here.
-      case NonFatal(e) =>
-        flowLog.error("flow aborted: {}", e.getMessage, e)
-        reportUncaught(e, debug)
-        // The `System.exit(1)` below halts the JVM and skips the outer
-        // `finally`, so the summary + trace-detach here run exactly once on
-        // this path.
+      // The failure was already surfaced inside the scope (the flow body runs
+      // as a top-level stage): the message went to the console, the stack to
+      // the trace file. Here we only fail the process — the summary +
+      // trace-detach run before `System.exit(1)` skips the outer `finally`.
+      case NonFatal(_) =>
         costTracker.printSummary()
         orcaLog.finish()
         System.exit(1)
@@ -137,26 +152,22 @@ def flow(
     orcaLog.finish()
 
 private def installUncaughtExceptionHandler(): Unit =
-  // Idempotent across nested or repeated `flow(...)` calls — we only
-  // install our handler if no app-specific one is already in place.
+  // Idempotent across nested or repeated `flow(...)` calls — we only install
+  // our handler if no app-specific one is already in place. The message goes
+  // to the console (ERROR); the stack to the trace file only (DEBUG, below the
+  // console's WARN threshold) so a silent exit still leaves a full trail.
   if Thread.getDefaultUncaughtExceptionHandler == null then
+    val log = LoggerFactory.getLogger("orca")
     Thread.setDefaultUncaughtExceptionHandler: (thread, throwable) =>
-      System.err.println(
-        s"[orca] uncaught exception on thread '${thread.getName}':"
+      log.error(
+        "uncaught exception on thread '{}': {}",
+        thread.getName,
+        throwable.getMessage
       )
-      throwable.printStackTrace(System.err)
+      log.debug("uncaught exception stack trace", throwable)
 
-private def reportUncaught(e: Throwable, debug: Boolean): Unit =
-  e match
-    case _: OrcaFlowException =>
-      // The stage's Error event already surfaced the message. Only
-      // dump the stack on explicit debug; flow-level failures don't
-      // need a JVM trace by default.
-      if debug then e.printStackTrace(System.err)
-    case _ =>
-      // Anything that isn't an OrcaFlowException is unexpected — print
-      // the stack unconditionally so silent exits are impossible.
-      System.err.println(
-        s"[orca] flow aborted by uncaught ${e.getClass.getName}:"
-      )
-      e.printStackTrace(System.err)
+/** The console message for a flow-aborting throwable: its message, or the class
+  * name when there is none. The full stack goes to the trace file separately.
+  */
+private def flowErrorMessage(e: Throwable): String =
+  Option(e.getMessage).filter(_.nonEmpty).getOrElse(e.getClass.getName)

--- a/runner/src/main/scala/orca/flow.scala
+++ b/runner/src/main/scala/orca/flow.scala
@@ -93,18 +93,10 @@ def flow(
           TerminalInteraction.start(workDir = Some(workDir))
         )
         try
-          // Tracks whether an Error was already surfaced (by a nested stage or
-          // `fail`), so the top-level handler below doesn't emit a second one.
-          val sawError = new java.util.concurrent.atomic.AtomicBoolean(false)
-          val errorWatch = new OrcaListener:
-            def onEvent(event: OrcaEvent): Unit = event match
-              case _: OrcaEvent.Error => sawError.set(true)
-              case _                  => ()
           val dispatcher = new EventDispatcher(
             effectiveInteraction.listeners ++ List(
               costTracker,
-              new LoggingListener,
-              errorWatch
+              new LoggingListener
             ) ++ extraListeners
           )
           val ctx = DefaultFlowContext.withDefaults(
@@ -123,14 +115,18 @@ def flow(
           )
           // The whole flow body runs as a top-level stage: an otherwise
           // unhandled exception surfaces as a single Error event (the same
-          // message a stage failure shows) unless a nested stage / `fail`
-          // already emitted one. The stack trace goes to the trace file only
-          // (DEBUG, below the console's WARN threshold); `--verbose` also
-          // prints it to stderr.
+          // message a stage failure shows). A nested stage / `fail` marks the
+          // exception `alreadyEmitted` once it has reported it, so we don't
+          // re-report it here. The stack goes to the trace file only (DEBUG,
+          // below the console's WARN threshold); `--verbose` also prints it to
+          // stderr.
           try body(using ctx)
           catch
             case NonFatal(e) =>
-              if !sawError.get() then
+              val alreadyEmitted = e match
+                case fe: OrcaFlowException => fe.alreadyEmitted
+                case _                     => false
+              if !alreadyEmitted then
                 ctx.emit(OrcaEvent.Error(flowErrorMessage(e)))
               flowLog.debug("flow aborted", e)
               if debug then e.printStackTrace(System.err)
@@ -166,8 +162,10 @@ private def installUncaughtExceptionHandler(): Unit =
       )
       log.debug("uncaught exception stack trace", throwable)
 
-/** The console message for a flow-aborting throwable: its message, or the class
-  * name when there is none. The full stack goes to the trace file separately.
+/** The console message for a flow-aborting throwable: its message — kept whole,
+  * unlike a stage's first-line `shortMessage`, so a multi-line message such as
+  * opencode's start-failure stderr stays useful — or the class name when there
+  * is none. The full stack goes to the trace file separately.
   */
 private def flowErrorMessage(e: Throwable): String =
   Option(e.getMessage).filter(_.nonEmpty).getOrElse(e.getClass.getName)

--- a/runner/src/main/scala/orca/runner/LoggingListener.scala
+++ b/runner/src/main/scala/orca/runner/LoggingListener.scala
@@ -9,10 +9,11 @@ import org.slf4j.{LoggerFactory, MarkerFactory}
   * uses, steps (git / gh / recovery / …), structured results, token usage, and
   * errors. Wired into the flow's `EventDispatcher` alongside the cost tracker.
   *
-  * Every line carries the `TRACE_ONLY` marker, which the console appender denies
-  * (see `logback.xml`): this listener feeds the trace file, while the terminal
-  * renderer owns the console. Without the marker an `Error` (logged at ERROR)
-  * would print twice — once as the renderer's `✖`, once as a logback line.
+  * The `Error` line carries the `TRACE_ONLY` marker, which the console appender
+  * denies (see `logback.xml`): the terminal renderer owns the console, so
+  * without the marker an `Error` (logged at ERROR) would print twice — once as
+  * the renderer's `✖`, once as a logback line. The other lines are INFO/DEBUG,
+  * already below the console's WARN threshold, so they need no marker.
   *
   * Messages are plain ASCII on purpose — the trace file is read back and dumped
   * to the console verbatim, and glyphs would corrupt under a non-UTF-8 console.
@@ -24,22 +25,17 @@ private[orca] class LoggingListener extends OrcaListener:
   private val traceOnly = MarkerFactory.getMarker("TRACE_ONLY")
 
   def onEvent(event: OrcaEvent): Unit = event match
-    case OrcaEvent.StageStarted(name) =>
-      log.info(traceOnly, "stage start: {}", name)
-    case OrcaEvent.StageCompleted(name, _) =>
-      log.info(traceOnly, "stage done:  {}", name)
-    case OrcaEvent.Step(message) => log.info(traceOnly, "step: {}", message)
-    case OrcaEvent.UserPrompt(text) =>
-      log.debug(traceOnly, "prompt sent:\n{}", text)
-    case OrcaEvent.AssistantMessage(text) =>
-      log.debug(traceOnly, "assistant: {}", text)
+    case OrcaEvent.StageStarted(name)      => log.info("stage start: {}", name)
+    case OrcaEvent.StageCompleted(name, _) => log.info("stage done:  {}", name)
+    case OrcaEvent.Step(message)           => log.info("step: {}", message)
+    case OrcaEvent.UserPrompt(text)        => log.debug("prompt sent:\n{}", text)
+    case OrcaEvent.AssistantMessage(text)  => log.debug("assistant: {}", text)
     case OrcaEvent.ToolUse(tool, args) =>
-      log.debug(traceOnly, "tool use: {} {}", tool, args)
+      log.debug("tool use: {} {}", tool, args)
     case OrcaEvent.StructuredResult(raw, summary) =>
-      log.debug(traceOnly, "structured result: {}", summary.getOrElse(raw))
+      log.debug("structured result: {}", summary.getOrElse(raw))
     case OrcaEvent.TokensUsed(agent, model, usage) =>
       log.debug(
-        traceOnly,
         "tokens: agent={} model={} usage={}",
         agent,
         model.map(_.name).getOrElse("(unknown)"),

--- a/runner/src/main/scala/orca/runner/LoggingListener.scala
+++ b/runner/src/main/scala/orca/runner/LoggingListener.scala
@@ -1,13 +1,18 @@
 package orca.runner
 
 import orca.events.{OrcaEvent, OrcaListener}
-import org.slf4j.LoggerFactory
+import org.slf4j.{LoggerFactory, MarkerFactory}
 
 /** Mirrors every [[OrcaEvent]] into the slf4j log (logger `orca.flow`) so the
   * per-run trace file ([[OrcaLog]]) captures the whole execution: stage
   * transitions, each prompt sent to an agent (full text), assistant turns, tool
   * uses, steps (git / gh / recovery / …), structured results, token usage, and
   * errors. Wired into the flow's `EventDispatcher` alongside the cost tracker.
+  *
+  * Every line carries the `TRACE_ONLY` marker, which the console appender denies
+  * (see `logback.xml`): this listener feeds the trace file, while the terminal
+  * renderer owns the console. Without the marker an `Error` (logged at ERROR)
+  * would print twice — once as the renderer's `✖`, once as a logback line.
   *
   * Messages are plain ASCII on purpose — the trace file is read back and dumped
   * to the console verbatim, and glyphs would corrupt under a non-UTF-8 console.
@@ -16,22 +21,28 @@ import org.slf4j.LoggerFactory
   */
 private[orca] class LoggingListener extends OrcaListener:
   private val log = LoggerFactory.getLogger("orca.flow")
+  private val traceOnly = MarkerFactory.getMarker("TRACE_ONLY")
 
   def onEvent(event: OrcaEvent): Unit = event match
-    case OrcaEvent.StageStarted(name)      => log.info("stage start: {}", name)
-    case OrcaEvent.StageCompleted(name, _) => log.info("stage done:  {}", name)
-    case OrcaEvent.Step(message)           => log.info("step: {}", message)
-    case OrcaEvent.UserPrompt(text)       => log.debug("prompt sent:\n{}", text)
-    case OrcaEvent.AssistantMessage(text) => log.debug("assistant: {}", text)
+    case OrcaEvent.StageStarted(name) =>
+      log.info(traceOnly, "stage start: {}", name)
+    case OrcaEvent.StageCompleted(name, _) =>
+      log.info(traceOnly, "stage done:  {}", name)
+    case OrcaEvent.Step(message) => log.info(traceOnly, "step: {}", message)
+    case OrcaEvent.UserPrompt(text) =>
+      log.debug(traceOnly, "prompt sent:\n{}", text)
+    case OrcaEvent.AssistantMessage(text) =>
+      log.debug(traceOnly, "assistant: {}", text)
     case OrcaEvent.ToolUse(tool, args) =>
-      log.debug("tool use: {} {}", tool, args)
+      log.debug(traceOnly, "tool use: {} {}", tool, args)
     case OrcaEvent.StructuredResult(raw, summary) =>
-      log.debug("structured result: {}", summary.getOrElse(raw))
+      log.debug(traceOnly, "structured result: {}", summary.getOrElse(raw))
     case OrcaEvent.TokensUsed(agent, model, usage) =>
       log.debug(
+        traceOnly,
         "tokens: agent={} model={} usage={}",
         agent,
         model.map(_.name).getOrElse("(unknown)"),
         usage
       )
-    case OrcaEvent.Error(message) => log.error("error: {}", message)
+    case OrcaEvent.Error(message) => log.error(traceOnly, "error: {}", message)

--- a/runner/src/main/scala/orca/runner/LoggingListener.scala
+++ b/runner/src/main/scala/orca/runner/LoggingListener.scala
@@ -1,7 +1,7 @@
 package orca.runner
 
 import orca.events.{OrcaEvent, OrcaListener}
-import org.slf4j.{LoggerFactory, MarkerFactory}
+import org.slf4j.LoggerFactory
 
 /** Mirrors every [[OrcaEvent]] into the slf4j log (logger `orca.flow`) so the
   * per-run trace file ([[OrcaLog]]) captures the whole execution: stage
@@ -9,11 +9,10 @@ import org.slf4j.{LoggerFactory, MarkerFactory}
   * uses, steps (git / gh / recovery / …), structured results, token usage, and
   * errors. Wired into the flow's `EventDispatcher` alongside the cost tracker.
   *
-  * The `Error` line carries the `TRACE_ONLY` marker, which the console appender
-  * denies (see `logback.xml`): the terminal renderer owns the console, so
-  * without the marker an `Error` (logged at ERROR) would print twice — once as
-  * the renderer's `✖`, once as a logback line. The other lines are INFO/DEBUG,
-  * already below the console's WARN threshold, so they need no marker.
+  * This is a trace mirror, not a console channel: the whole `orca.*` logger tree
+  * is routed to the trace file only (`OrcaLog` makes it non-additive), so even
+  * the `Error` line — logged at ERROR for greppability — never reaches the
+  * console. The terminal renderer owns the console (it shows the `✖`).
   *
   * Messages are plain ASCII on purpose — the trace file is read back and dumped
   * to the console verbatim, and glyphs would corrupt under a non-UTF-8 console.
@@ -22,14 +21,13 @@ import org.slf4j.{LoggerFactory, MarkerFactory}
   */
 private[orca] class LoggingListener extends OrcaListener:
   private val log = LoggerFactory.getLogger("orca.flow")
-  private val traceOnly = MarkerFactory.getMarker("TRACE_ONLY")
 
   def onEvent(event: OrcaEvent): Unit = event match
-    case OrcaEvent.StageStarted(name)      => log.info("stage start: {}", name)
-    case OrcaEvent.StageCompleted(name, _) => log.info("stage done:  {}", name)
-    case OrcaEvent.Step(message)           => log.info("step: {}", message)
-    case OrcaEvent.UserPrompt(text)        => log.debug("prompt sent:\n{}", text)
-    case OrcaEvent.AssistantMessage(text)  => log.debug("assistant: {}", text)
+    case OrcaEvent.StageStarted(name)     => log.info("stage start: {}", name)
+    case OrcaEvent.StageCompleted(name)   => log.info("stage done:  {}", name)
+    case OrcaEvent.Step(message)          => log.info("step: {}", message)
+    case OrcaEvent.UserPrompt(text)       => log.debug("prompt sent:\n{}", text)
+    case OrcaEvent.AssistantMessage(text) => log.debug("assistant: {}", text)
     case OrcaEvent.ToolUse(tool, args) =>
       log.debug("tool use: {} {}", tool, args)
     case OrcaEvent.StructuredResult(raw, summary) =>
@@ -41,4 +39,4 @@ private[orca] class LoggingListener extends OrcaListener:
         model.map(_.name).getOrElse("(unknown)"),
         usage
       )
-    case OrcaEvent.Error(message) => log.error(traceOnly, "error: {}", message)
+    case OrcaEvent.Error(message) => log.error("error: {}", message)

--- a/runner/src/main/scala/orca/runner/OrcaBanner.scala
+++ b/runner/src/main/scala/orca/runner/OrcaBanner.scala
@@ -15,7 +15,10 @@ private[orca] object OrcaBanner:
   def version: String =
     Option(getClass.getPackage.getImplementationVersion).getOrElse("dev")
 
-  /** Print the `Orca <version>, logs: <path>` line to `out`. */
-  def print(out: PrintStream, logFile: os.Path): Unit =
-    out.println(s"Orca $version, logs: $logFile")
+  /** Print the `Orca <version>, logs: <path>` line to `out`. `None` when the
+    * trace file couldn't be created (best-effort logging).
+    */
+  def print(out: PrintStream, logFile: Option[os.Path]): Unit =
+    val where = logFile.map(_.toString).getOrElse("(trace file unavailable)")
+    out.println(s"Orca $version, logs: $where")
     out.println()

--- a/runner/src/main/scala/orca/runner/OrcaLog.scala
+++ b/runner/src/main/scala/orca/runner/OrcaLog.scala
@@ -7,48 +7,53 @@ import ch.qos.logback.core.FileAppender
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.nio.charset.StandardCharsets.UTF_8
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.util.control.NonFatal
 
 /** Per-run execution-trace log.
   *
   * [[start]] creates a fresh temp file and attaches a DEBUG-level logback
-  * `FileAppender` to the root logger, so everything orca logs during the run
-  * lands there: events (via [[LoggingListener]]) and subprocess invocations
-  * (logger `orca.proc`). The console stays quiet — `logback.xml` filters STDERR
-  * to WARN+ — so the run's detail lives in the file rather than the terminal;
-  * its path is shown once at startup by the banner.
+  * `FileAppender` to the `orca` logger, made **non-additive** — so the whole
+  * `orca.*` tree (events via [[LoggingListener]], subprocess invocations via
+  * `orca.proc`) lands in the file and never propagates to the root console
+  * appender. The terminal renderer owns the console; orca's logging is purely
+  * the trace. Framework chatter (netty/tapir/…) is on its own loggers and still
+  * reaches the console's WARN appender, unaffected.
   *
   * The file is intentionally NOT deleted on exit, so it can be inspected after
-  * the run. If logback isn't the active slf4j backend, file logging is skipped
-  * (the appender is absent) rather than failing the flow — the file is then
-  * created but stays empty.
+  * the run. If logback isn't the active slf4j backend, or the temp file can't be
+  * created, file logging is skipped (best-effort) rather than failing the flow —
+  * [[file]] is then `None`.
   */
 private[orca] final class OrcaLog private (
-    val file: os.Path,
+    val file: Option[os.Path],
     appender: Option[FileAppender[ILoggingEvent]],
-    rootLogger: Option[ch.qos.logback.classic.Logger]
+    target: Option[ch.qos.logback.classic.Logger],
+    previousAdditive: Boolean
 ):
-  private var finished = false
+  private val finished = new AtomicBoolean(false)
 
-  /** Detach and stop the per-run file appender. The trace is left on disk for
-    * inspection — its path is shown by the startup banner, so nothing is
-    * echoed to the console. Idempotent — safe to call from both the error path
-    * (before `System.exit`) and the success/finally path.
+  /** Detach and stop the per-run file appender and restore the `orca` logger's
+    * additivity. The trace is left on disk for inspection. Idempotent — safe to
+    * call from both the error path (before `System.exit`) and the success path.
     */
   def finish(): Unit =
-    if !finished then
-      finished = true
+    if finished.compareAndSet(false, true) then
       appender.foreach(_.stop())
-      for a <- appender; r <- rootLogger do r.detachAppender(a)
+      for a <- appender; t <- target do
+        t.detachAppender(a)
+        t.setAdditive(previousAdditive)
 
 private[orca] object OrcaLog:
   /** Attach a fresh per-run DEBUG file appender and return the handle. Must be
     * called before the flow does any logging so the whole run is captured.
     */
   def start(): OrcaLog =
-    val file =
-      os.temp(prefix = "orca-", suffix = ".log", deleteOnExit = false)
-    loggerContext() match
-      case Some(ctx) =>
+    val maybeFile =
+      try Some(os.temp(prefix = "orca-", suffix = ".log", deleteOnExit = false))
+      catch case NonFatal(_) => None
+    (maybeFile, loggerContext()) match
+      case (Some(file), Some(ctx)) =>
         val encoder = new PatternLayoutEncoder
         encoder.setContext(ctx)
         encoder.setPattern("%d{HH:mm:ss.SSS} %-5level %logger{24} - %msg%n")
@@ -63,11 +68,18 @@ private[orca] object OrcaLog:
         appender.setEncoder(encoder)
         appender.start()
 
-        val root = ctx.getLogger(Logger.ROOT_LOGGER_NAME)
-        root.addAppender(appender)
-        new OrcaLog(file, Some(appender), Some(root))
-      case None =>
-        new OrcaLog(file, None, None)
+        val orcaLogger = ctx.getLogger("orca")
+        val previousAdditive = orcaLogger.isAdditive
+        orcaLogger.addAppender(appender)
+        orcaLogger.setAdditive(false) // orca.* → file only, never the console
+        new OrcaLog(
+          Some(file),
+          Some(appender),
+          Some(orcaLogger),
+          previousAdditive
+        )
+      case (file, _) =>
+        new OrcaLog(file, None, None, previousAdditive = true)
 
   /** The bound logback `LoggerContext`. Touching a logger first forces slf4j to
     * finish binding its provider — calling `getILoggerFactory` cold can return

--- a/runner/src/main/scala/orca/runner/OrcaLog.scala
+++ b/runner/src/main/scala/orca/runner/OrcaLog.scala
@@ -28,21 +28,22 @@ import scala.util.control.NonFatal
 private[orca] final class OrcaLog private (
     val file: Option[os.Path],
     appender: Option[FileAppender[ILoggingEvent]],
-    target: Option[ch.qos.logback.classic.Logger],
-    previousAdditive: Boolean
+    target: Option[ch.qos.logback.classic.Logger]
 ):
   private val finished = new AtomicBoolean(false)
 
-  /** Detach and stop the per-run file appender and restore the `orca` logger's
-    * additivity. The trace is left on disk for inspection. Idempotent — safe to
-    * call from both the error path (before `System.exit`) and the success path.
+  /** Detach and stop the per-run file appender and restore the `orca` logger to
+    * the additive default (it was set non-additive in [[start]]) — so a later
+    * run, or another test in a shared JVM, logs normally again. The trace is
+    * left on disk for inspection. Idempotent — safe to call from both the error
+    * path (before `System.exit`) and the success path.
     */
   def finish(): Unit =
     if finished.compareAndSet(false, true) then
       appender.foreach(_.stop())
       for a <- appender; t <- target do
         t.detachAppender(a)
-        t.setAdditive(previousAdditive)
+        t.setAdditive(true)
 
 private[orca] object OrcaLog:
   /** Attach a fresh per-run DEBUG file appender and return the handle. Must be
@@ -69,17 +70,12 @@ private[orca] object OrcaLog:
         appender.start()
 
         val orcaLogger = ctx.getLogger("orca")
-        val previousAdditive = orcaLogger.isAdditive
         orcaLogger.addAppender(appender)
         orcaLogger.setAdditive(false) // orca.* → file only, never the console
-        new OrcaLog(
-          Some(file),
-          Some(appender),
-          Some(orcaLogger),
-          previousAdditive
-        )
-      case (file, _) =>
-        new OrcaLog(file, None, None, previousAdditive = true)
+        new OrcaLog(Some(file), Some(appender), Some(orcaLogger))
+      case _ =>
+        // No temp file or logback isn't active: skip file logging entirely.
+        new OrcaLog(None, None, None)
 
   /** The bound logback `LoggerContext`. Touching a logger first forces slf4j to
     * finish binding its provider — calling `getILoggerFactory` cold can return

--- a/runner/src/main/scala/orca/runner/terminal/TerminalEventListener.scala
+++ b/runner/src/main/scala/orca/runner/terminal/TerminalEventListener.scala
@@ -50,7 +50,7 @@ private[runner] class TerminalEventListener(
         (l, stages.innermost)
       output.log(line)
       output.setStatus(status)
-    case OrcaEvent.StageCompleted(_, _) =>
+    case OrcaEvent.StageCompleted(_) =>
       // Stage completions don't print to the event log — starting the next
       // event implicitly tells the user the previous one finished.
       val status = lock.synchronized:

--- a/runner/src/main/scala/orca/runner/terminal/TerminalOutput.scala
+++ b/runner/src/main/scala/orca/runner/terminal/TerminalOutput.scala
@@ -145,11 +145,11 @@ private[terminal] class TerminalOutputState(
           if wasShown then
             out.print(ClearLine)
             out.flush()
-        case some @ Some(_) if !closed =>
+        case Some(_) if closed => () // don't re-pin a status row after close
+        case some @ Some(_) =>
           currentLabel = some
           drawStatus()
           out.flush()
-        case Some(_) => () // closed: don't re-pin a status row
 
   /** Advance the spinner frame. Called by the animator fork; no-op when the bar
     * is hidden or suspended so idle periods don't touch the terminal.

--- a/runner/src/main/scala/orca/runner/terminal/TerminalOutput.scala
+++ b/runner/src/main/scala/orca/runner/terminal/TerminalOutput.scala
@@ -122,6 +122,10 @@ private[terminal] class TerminalOutputState(
   // line. Cap is large enough that typical interactive prompts don't trim.
   private var suspended: Boolean = false
   private var suspendedBuffer: Queue[String] = Queue.empty
+  // Set once `close()` has cleared the status row. Late events (from a fork
+  // still unwinding after the scope started closing) may still append log
+  // lines, but must not re-pin a status row nothing will clear again.
+  private var closed: Boolean = false
 
   def log(text: String): Unit =
     if suspended then
@@ -141,10 +145,11 @@ private[terminal] class TerminalOutputState(
           if wasShown then
             out.print(ClearLine)
             out.flush()
-        case some @ Some(_) =>
+        case some @ Some(_) if !closed =>
           currentLabel = some
           drawStatus()
           out.flush()
+        case Some(_) => () // closed: don't re-pin a status row
 
   /** Advance the spinner frame. Called by the animator fork; no-op when the bar
     * is hidden or suspended so idle periods don't touch the terminal.
@@ -184,6 +189,7 @@ private[terminal] class TerminalOutputState(
       toDrain.foreach(writeLog)
     val wasShown = currentLabel.isDefined
     currentLabel = None
+    closed = true
     if wasShown && animated then
       out.print(ClearLine)
       out.flush()

--- a/runner/src/test/scala/orca/runner/OrcaLogTest.scala
+++ b/runner/src/test/scala/orca/runner/OrcaLogTest.scala
@@ -12,8 +12,9 @@ class OrcaLogTest extends munit.FunSuite:
 
     orcaLog.finish()
 
-    assert(os.exists(orcaLog.file), "trace file should exist")
-    val onDisk = os.read(orcaLog.file)
+    val file = orcaLog.file.getOrElse(fail("trace file should have been created"))
+    assert(os.exists(file), "trace file should exist")
+    val onDisk = os.read(file)
     assert(onDisk.contains("trace-marker-abc"), onDisk)
 
     // Idempotent: a second finish neither throws nor double-detaches.

--- a/runner/src/test/scala/orca/runner/terminal/TerminalEventListenerTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/TerminalEventListenerTest.scala
@@ -32,7 +32,7 @@ class TerminalEventListenerTest extends munit.FunSuite:
     val output = renderEvents(
       List(
         OrcaEvent.StageStarted("plan"),
-        OrcaEvent.StageCompleted("plan", "done")
+        OrcaEvent.StageCompleted("plan")
       )
     )
     assert(output.contains("plan"))
@@ -49,7 +49,7 @@ class TerminalEventListenerTest extends munit.FunSuite:
       List(
         OrcaEvent.StageStarted("review"),
         OrcaEvent.Step("[Warning] Issue summary\n  at src/Foo.scala:10"),
-        OrcaEvent.StageCompleted("review", "")
+        OrcaEvent.StageCompleted("review")
       )
     )
     val lines = output.split('\n').toList
@@ -74,7 +74,7 @@ class TerminalEventListenerTest extends munit.FunSuite:
       List(
         OrcaEvent.StageStarted("outer"),
         OrcaEvent.Step("Switched to a new branch 'foo'"),
-        OrcaEvent.StageCompleted("outer", "done")
+        OrcaEvent.StageCompleted("outer")
       )
     )
     assert(output.contains("Switched to a new branch 'foo'"))
@@ -193,8 +193,8 @@ class TerminalEventListenerTest extends munit.FunSuite:
         OrcaEvent.StageStarted("outer"),
         OrcaEvent.StageStarted("inner"),
         OrcaEvent.Error("inside inner"),
-        OrcaEvent.StageCompleted("inner", "done"),
-        OrcaEvent.StageCompleted("outer", "done")
+        OrcaEvent.StageCompleted("inner"),
+        OrcaEvent.StageCompleted("outer")
       )
     )
     val lines = output.split('\n').toList

--- a/tools/src/main/scala/orca/OrcaFlowException.scala
+++ b/tools/src/main/scala/orca/OrcaFlowException.scala
@@ -4,14 +4,16 @@ package orca
   * current flow cannot continue.
   *
   * The `alreadyEmitted` flag tells the stage machinery whether an
-  * `OrcaEvent.Error` has already been published for this failure (true when
-  * thrown by `fail(...)`, which emits before throwing; false for direct throws
-  * from tool code). Stage-level catch sites use this to avoid double-emit while
-  * still surfacing tool-side failures that would otherwise be silent.
+  * `OrcaEvent.Error` has already been published for this failure: true when
+  * thrown by `fail(...)` (which emits before throwing), false for direct throws
+  * from tool code. A `stage` (and the top-level flow boundary) reads it to skip
+  * a duplicate emit, and sets it to true once it does publish an Error — so an
+  * enclosing stage, or the flow boundary, surfaces a tool-side failure exactly
+  * once instead of re-reporting it at every level it unwinds through.
   */
 class OrcaFlowException private[orca] (
     message: String,
-    private[orca] val alreadyEmitted: Boolean
+    private[orca] var alreadyEmitted: Boolean
 ) extends RuntimeException(message):
   def this(message: String) = this(message, alreadyEmitted = false)
 

--- a/tools/src/main/scala/orca/events/OrcaEvent.scala
+++ b/tools/src/main/scala/orca/events/OrcaEvent.scala
@@ -15,7 +15,7 @@ import orca.llm.Model
   */
 enum OrcaEvent:
   case StageStarted(name: String)
-  case StageCompleted(name: String, result: String)
+  case StageCompleted(name: String)
   case ToolUse(tool: String, args: String)
 
   /** A single instantaneous note in the event log — neither a stage (no


### PR DESCRIPTION
 A flow that aborted on an exception dumped the full stack trace to the console —
  and ox's structured-concurrency teardown bloats that trace with suppressed
  `ExecutionException`s, a circular-reference cause, and sibling `InterruptedException`s,
  so one failure printed the message ~4× plus a 40-line stack.

  This makes `flow(...)` behave like a **top-level stage**:

  - An otherwise-unhandled exception surfaces as a **single `Error` event** — the
    same `✖ <message>` a stage failure shows — unless a nested `stage` / `fail`
    already emitted one (tracked by a small watcher listener, so staged failures
    don't double-surface).
  - The **stack trace goes to the trace file only** (`flowLog.debug`, captured by
    the file appender but below the console's WARN threshold). `--verbose` /
    `ORCA_DEBUG` still prints it to stderr.
  - The thread uncaught-exception handler does the same: message → console,
    stack → file.
  - Removes the old `flowLog.error(…, e)` + `reportUncaught` console stack dump.

  ### Before
  ERROR orca.flow - flow aborted: opencode serve did not start: …
  orca.OrcaFlowException: opencode serve did not start: …
      at orca.tools.opencode.OpencodeServer.$anonfun$3(OpencodeServer.scala:94)
      … 40 more lines, repeated through suppressed/circular exceptions …
  ### After (console)
  ✖ opencode serve did not start: …
  (full stack still in `/tmp/orca-*.log`)

  ## Testing
  62 runner tests pass. Verified against a locally-published build: an unstaged
  `throw` shows only `✖ <message>` on console with the stack in the trace file; a
  staged `throw` shows a single `✖` with no duplicate top-level emit.

  ## Also: no more double error line
  `LoggingListener` mirrors every event to the `orca.flow` logger for the trace
  file, but `Error`s (at ERROR) also reached the console — so a failure printed
  twice (the renderer's `✖` and a logback line). The mirror's lines are now tagged
  with a `TRACE_ONLY` marker that the console appender denies (logback
  `EvaluatorFilter` + `OnMarkerEvaluator`); the terminal renderer is the sole
  console surface for events, and the trace file still records everything.