### PR TITLE
updatePr: use REST API instead of gh pr edit

### DIFF
--- a/tools/src/main/scala/orca/tools/GitHubTool.scala
+++ b/tools/src/main/scala/orca/tools/GitHubTool.scala
@@ -319,16 +319,19 @@ private[orca] class OsGitHubTool(
       Comment(author = c.user.login, body = c.body)
 
   def updatePr(pr: PrHandle, title: String, body: String): Unit =
+    // Use the REST API directly rather than `gh pr edit`: the latter runs a
+    // GraphQL metadata query that selects `projectCards` before applying any
+    // edit, which fails outright on repos where GitHub has sunset Projects
+    // (classic). The REST PATCH endpoint doesn't touch projects.
     val _ = gh(
-      "pr",
-      "edit",
-      pr.number.toString,
-      "--repo",
-      s"${pr.owner}/${pr.repo}",
-      "--title",
-      title,
-      "--body",
-      body
+      "api",
+      "-X",
+      "PATCH",
+      s"repos/${pr.owner}/${pr.repo}/pulls/${pr.number}",
+      "-f",
+      s"title=$title",
+      "-f",
+      s"body=$body"
     )
     events.onEvent(OrcaEvent.Step(s"Updated PR: ${pr.url}"))
 

--- a/tools/src/test/scala/orca/tools/OsGitHubToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitHubToolTest.scala
@@ -136,14 +136,14 @@ class OsGitHubToolTest extends munit.FunSuite:
       )
     )
 
-  test("updatePr invokes gh pr edit with the new title and body"):
+  test("updatePr patches the PR via the REST API with the new title and body"):
     val (cli, gh) = stubGh(CliResult(0, "", ""))
     gh.updatePr(samplePr, "Fix overflow", "full description")
     val args = cli.lastCall.getOrElse(fail("expected a call")).args
-    assert(args.containsSlice(Seq("gh", "pr", "edit", "42")))
-    assert(args.containsSlice(Seq("--repo", "acme/widgets")))
-    assert(args.containsSlice(Seq("--title", "Fix overflow")))
-    assert(args.containsSlice(Seq("--body", "full description")))
+    assert(args.containsSlice(Seq("gh", "api", "-X", "PATCH")))
+    assert(args.contains("repos/acme/widgets/pulls/42"))
+    assert(args.containsSlice(Seq("-f", "title=Fix overflow")))
+    assert(args.containsSlice(Seq("-f", "body=full description")))
 
   test("writeComment invokes gh pr comment with the body"):
     val (cli, gh) = stubGh(CliResult(0, "", ""))


### PR DESCRIPTION
`gh pr edit` runs a GraphQL metadata query selecting `projectCards` before applying the edit. On repos where GitHub has sunset Projects (classic), that query fails and the command aborts, so the title/body update never happens.

Switch updatePr to a REST PATCH on the pulls endpoint, which doesn't touch projects. Other gh call sites are unaffected: reads use `gh api`, the comment commands request minimal fields, and buildStatus scopes `pr view` to explicit --json fields.