### PR TITLE
Trim verbose comments across the codebase

### DIFF
--- a/claude/src/main/scala/orca/tools/claude/ClaudeAgents.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeAgents.scala
@@ -4,18 +4,14 @@ import orca.agents.{AgentConfig, ClaudeAgent}
 import orca.backend.AgentWiring
 import orca.subprocess.OsProcCliRunner
 
-/** Public constructors for the default claude agent. The concrete
-  * [[DefaultClaudeAgent]] / [[ClaudeBackend]] stay `private[orca]`; this object
-  * is the user-facing way to build a standard claude wired into a run (from a
-  * `flow(...)` override factory) and reconfigure it with the trait's fluent
-  * accessors (`.opus`, `.sonnet`, `.withConfig(...)`).
+/** Public constructors for the default claude agent: the concrete
+  * [[DefaultClaudeAgent]] / [[ClaudeBackend]] stay `private[orca]`, so this is
+  * the user-facing way to build a standard claude wired into a run.
   */
 object ClaudeAgents:
 
   /** The default claude agent for a run: Opus-1M lead model, standard config.
-    * Bare `claude` needs the big window — the implementer session is
-    * long-lived; `.sonnet` / `.haiku` opt down for cheap one-shots. The
-    * backend's `workDir` is the run's `workDir` so a resumed worktree flow
+    * The backend's `workDir` is the run's `workDir` so a resumed worktree flow
     * probes the same directory the transcript lands under (see
     * [[ClaudeBackend.workDir]]).
     */

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -20,14 +20,10 @@ private[claude] object ClaudeArgs:
   /** Stream-json invocation: `claude --print --input-format stream-json
     * --output-format stream-json --verbose --include-partial-messages`. Used by
     * both the autonomous and interactive paths — they only differ in whether
-    * the `--mcp-config` arg (and the `ask_user` tool that comes with it) is
-    * wired. The prompt goes in as the first user turn on stdin; for single-turn
-    * (autonomous) calls the backend closes stdin immediately, for multi-turn
-    * (interactive) it stays open.
+    * the `--mcp-config` arg (and the `ask_user` tool it wires) is present.
     *
     * `--print` is required by the CLI for `--input-format stream-json` to take
-    * effect — despite the name, the session runs multi-turn because stdin can
-    * stay open.
+    * effect.
     */
   def streamJson(
       config: AgentConfig,
@@ -67,9 +63,8 @@ private[claude] object ClaudeArgs:
     case Dispatch.Fresh(Some(id)) =>
       Seq("--session-id", WireSessionId.value(id))
     // Unreachable: claude is `IdScheme.ClientClaimed`, which always supplies the
-    // claim id on a fresh dispatch (the client id IS the wire id). A defensive
-    // error rather than a silent fallback, so a future scheme-wiring mistake
-    // fails loudly instead of spawning claude with no `--session-id`.
+    // claim id on a fresh dispatch. A defensive error rather than a silent
+    // fallback, so a future scheme-wiring mistake fails loudly.
     case Dispatch.Fresh(None) =>
       throw new IllegalStateException(
         "claude's ClientClaimed scheme must supply a fresh claim id"
@@ -77,10 +72,8 @@ private[claude] object ClaudeArgs:
     case Dispatch.Resume(id) => Seq("--resume", WireSessionId.value(id))
 
   /** claude's CLI only accepts `--json-schema <inline>` — there's no
-    * `--json-schema-file` form. For typical Orca schemas (a few KB) inlining is
-    * fine; `ARG_MAX` gives us ~128KB of headroom on Linux and ~256KB of total
-    * argv on macOS. If someone builds a flow with a schema that large, the exec
-    * will fail loudly.
+    * `--json-schema-file` form. Typical Orca schemas (a few KB) inline fine
+    * within `ARG_MAX`; a pathologically large schema fails the exec loudly.
     */
   private def jsonSchemaArgs(schema: Option[String]): Seq[String] =
     CliArgs.flag("--json-schema", schema)(identity)
@@ -90,21 +83,17 @@ private[claude] object ClaudeArgs:
 
   /** Maps [[AgentConfig.tools]] to claude's permission flags. Both read-only
     * tiers use `--permission-mode plan`, which makes Edit/Write/Bash
-    * unavailable (not just non-auto-approved) — turning the planner's advisory
-    * "don't edit" prompt into a hard guarantee. `Full` follows
-    * [[AgentConfig.autoApprove]].
+    * unavailable (not just non-auto-approved) — a hard no-edit guarantee.
     *
     * `NetworkOnly` additionally pre-approves `networkTools` via
-    * `--allowedTools`, layering read-only network access (web + scoped `gh`)
-    * onto plan mode so an autonomous planner can fetch issues/PRs without a
-    * permission prompt it can't answer. The list is command-scoped, so plan
-    * mode still hard-blocks general bash and every edit. An empty list leaves
-    * plain plan mode.
+    * `--allowedTools`, layering read-only network access onto plan mode. The
+    * list is command-scoped, so plan mode still blocks general bash and every
+    * edit; an empty list leaves plain plan mode.
     *
-    * `Full` is the only tier whose approval policy claude mechanically honours
-    * (see [[enforcement]]): `All` → `bypassPermissions`; `Only(_)` → default
-    * permission mode plus an `--allowedTools` allowlist, so ONLY the listed
-    * tools are pre-approved and everything else (edits included) still prompts.
+    * `Full` follows [[AgentConfig.autoApprove]]: `All` → `bypassPermissions`;
+    * `Only(_)` → default permission mode plus an `--allowedTools` allowlist, so
+    * only listed tools are pre-approved and everything else (edits included)
+    * still prompts.
     */
   private def autoApproveArgs(
       config: AgentConfig,
@@ -125,32 +114,21 @@ private[claude] object ClaudeArgs:
         config.autoApprove match
           case AutoApprove.All =>
             Seq("--permission-mode", "bypassPermissions")
-          // Honest Only semantics: default permission mode — nothing is
-          // pre-approved except the listed tools. Edits are NOT implicitly
-          // approved (an earlier revision pre-approved them via acceptEdits);
-          // in autonomous mode an unlisted tool's prompt is auto-denied by
-          // the drain.
+          // Default permission mode — nothing pre-approved except the listed
+          // tools. Edits are not implicitly approved; in autonomous mode an
+          // unlisted tool's prompt is auto-denied by the drain.
           case AutoApprove.Only(tools) if tools.isEmpty => Seq.empty
           case AutoApprove.Only(tools) =>
             Seq("--allowedTools", tools.toSeq.sorted.mkString(","))
 
   /** How strongly claude enforces each `(tools, autoApprove)` combination — see
-    * [[autoApproveArgs]] for the flags this classifies.
-    *
-    *   - `ReadOnly` / `NetworkOnly` → `Hard`: `--permission-mode plan` makes
-    *     edits/shell mechanically unavailable; `NetworkOnly` only layers a
-    *     command-scoped `--allowedTools`, so the no-edit gate stays hard.
-    *   - `Full` + `AutoApprove.All` → `Hard`: `bypassPermissions` is exactly
-    *     "approve everything" — the requested policy is honoured verbatim.
-    *   - `Full` + `AutoApprove.Only(_)` → `Hard`: default permission mode with
-    *     an `--allowedTools` allowlist is a mechanical per-tool gate; unlisted
-    *     tools still prompt (post finding 2.1), so the policy is enforced, not
-    *     approximated. `Only(empty)` emits no allowlist at all — plain default
-    *     mode where every tool prompts — which is still a hard per-tool gate.
+    * [[autoApproveArgs]] for the flags this classifies. Every combination is
+    * `Hard`: plan mode makes edits/shell mechanically unavailable, and every
+    * `--allowedTools`/`bypassPermissions` variant is a mechanical per-tool
+    * gate.
     *
     * Written as an exhaustive match (all arms `Hard`) rather than a bare
-    * constant so a future `ToolSet`/`AutoApprove` case fails compilation here,
-    * as it does on the other four backends.
+    * constant so a future `ToolSet`/`AutoApprove` case fails compilation here.
     */
   def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
     tools match

--- a/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
@@ -32,75 +32,52 @@ import ox.Ox
 /** Claude Code backend. All calls — autonomous and interactive — drive a
   * stream-json subprocess through [[ClaudeConversation]]; the only difference
   * is the [[ConversationMode]] passed to `openConversation` (autonomous omits
-  * the ask_user MCP, interactive wires it). The prompt is injected as the first
-  * user turn on stdin, the subprocess emits typed NDJSON responses, the driver
-  * translates them into `ConversationEvent`s.
-  *
-  * The autonomous path drains those events via
-  * [[orca.backend.Conversations.drainAutonomous]] and returns the awaited
-  * `AgentResult`. The interactive path hands the `Conversation` back to the
-  * caller who runs `Interaction.drive`.
+  * the ask_user MCP, interactive wires it). The autonomous path drains events
+  * and returns the awaited `AgentResult`; the interactive path hands the
+  * `Conversation` back to the caller who runs `Interaction.drive`.
   *
   * Interactive calls also stand up an MCP host bridge: a tiny HTTP server (via
-  * [[AskUserMcpServer]]) exposes an `ask_user` tool the agent can call to
-  * surface a free-form clarifying question. The server's lifetime tracks the
+  * [[AskUserMcpServer]]) exposing an `ask_user` tool. Its lifetime tracks the
   * conversation (via `ClaudeConversation.onFinalize`), not the backend, so a
   * long flow with many interactive calls doesn't leak Netty bindings.
-  * Autonomous calls skip the bridge entirely.
   */
 private[orca] class ClaudeBackend(
     cli: CliRunner,
     networkTools: Seq[String] = ClaudeBackend.DefaultNetworkTools,
     private[claude] val projectsDir: os.Path = os.home / ".claude" / "projects",
-    /** Fixed at construction and shared, by construction, between the spawn
-      * path ([[openConversation]]) and the existence probe (see [[sessions]]):
-      * claude writes a session's transcript under
+    /** Shared between the spawn path ([[openConversation]]) and the existence
+      * probe (see [[sessions]]): claude writes a session's transcript under
       * `<projectsDir>/<cwdSlug(workDir)>/<id>.jsonl`, so both sides reading the
-      * SAME field is what keeps the probe honest — no separate value can drift
-      * out of sync with where agents actually spawn. The `os.pwd` default
-      * serves only bare/test construction (`new ClaudeBackend(cli)`) where no
-      * flow workDir exists; the runtime (`WiredAgents.build`) passes the flow's
-      * real `workDir`.
+      * SAME field keeps the probe honest. The `os.pwd` default serves only
+      * bare/test construction; the runtime passes the flow's real `workDir`.
       */
     override val workDir: os.Path = os.pwd,
-    /** Threaded straight into [[AgentBackend]]'s `closedFlag` parameter. Bare
-      * construction gets a fresh flag; [[withNetworkTools]] passes THIS
-      * instance's flag so the sibling it builds shares one latch with its
-      * parent — see the parameter's scaladoc on `AgentBackend` for why a
-      * backend-swapping builder must do this.
+    /** Threaded into [[AgentBackend]]'s `closedFlag`. Bare construction gets a
+      * fresh flag; [[withNetworkTools]] passes THIS instance's flag so the
+      * sibling shares one latch with its parent — see `AgentBackend` for why.
       */
     sharedClosedFlag: AtomicBoolean = new AtomicBoolean(false)
 ) extends AgentBackend[BackendTag.ClaudeCode.type](sharedClosedFlag):
 
   /** Return a sibling backend that, on [[ToolSet.NetworkOnly]] turns,
-    * pre-approves `tools` (claude `--allowedTools` syntax). The configuration
-    * seam behind `ClaudeAgent.withNetworkTools`; lives on the backend, not
-    * `AgentConfig`, since the strings are claude-specific.
+    * pre-approves `tools` (claude `--allowedTools` syntax). Lives on the
+    * backend, not `AgentConfig`, since the strings are claude-specific.
     *
-    * Shares `closedFlag` with `this` rather than starting a fresh one: the
-    * sibling is a genuinely different `AgentBackend` instance (not a
-    * `copyTool`-style clone reusing the same backend), so without threading the
-    * SAME `AtomicBoolean` through, a handle derived here and leaked past
-    * flow-end would carry its own always-open latch and bypass the
-    * use-after-close guard entirely.
+    * Shares `closedFlag` with `this`: the sibling is a genuinely different
+    * `AgentBackend` instance, so without threading the SAME flag through, a
+    * handle derived here and leaked past flow-end would bypass the
+    * use-after-close guard.
     */
   def withNetworkTools(tools: Seq[String]): ClaudeBackend =
     new ClaudeBackend(cli, tools, projectsDir, workDir, closedFlag)
 
   /** Claude's sessions live on disk (`~/.claude/projects/.../<id>.jsonl`) and
     * outlive the process, so it is durable: the claim survives a restart
-    * (persisted to the progress log, rehydrated on resume so a resumed task
-    * uses `--resume` rather than re-creating an already-existing
-    * `--session-id`), and existence is a best-effort transcript-file probe.
-    *
-    * The probe checks `<projectsDir>/<cwdSlug>/<id>.jsonl` — the project-dir
-    * slug replaces every `/` in the working directory with `-` (e.g.
-    * `/home/foo/orca` → `-home-foo-orca`). Because
+    * (rehydrated on resume so a resumed task uses `--resume`), and existence is
+    * a best-effort transcript-file probe. Because
     * [[SessionSupport.willContinue]] resolves the recorded mapping first, the
-    * probe only runs for an id already known (claimed this run, or rehydrated
-    * from the log): a stray transcript file for an id never claimed reports
-    * `false` — safe, since the caller re-seeds. The write-door guard rejects
-    * unsafe ids (path traversal such as `../../etc/passwd`).
+    * probe only runs for an id already known: a stray transcript for a
+    * never-claimed id reports `false`, which is safe since the caller re-seeds.
     */
   val tag: BackendTag.ClaudeCode.type = BackendTag.ClaudeCode
 
@@ -120,10 +97,7 @@ private[orca] class ClaudeBackend(
 
   /** The sole session handle. [[IdScheme.ClientClaimed]]: ids are claimed via
     * `--session-id` so subsequent calls use `--resume` (the CLI refuses to
-    * reuse `--session-id` once the session exists). The bookkeeping is
-    * encapsulated, so the spawn/commit paths go through `sessions.dispatchFor`
-    * / `sessions.register` / `Conversations.runAutonomous(session, sessions,
-    * …)`.
+    * reuse `--session-id` once the session exists).
     */
   val sessions: SessionSupport[BackendTag.ClaudeCode.type] =
     SessionSupport.durable(
@@ -141,12 +115,10 @@ private[orca] class ClaudeBackend(
       events: OrcaListener,
       outputSchema: Option[String]
   ): AgentResult[BackendTag.ClaudeCode.type] =
-    // drainAndCommit commits only after a successful drain: a subprocess that
-    // crashed before claude could register the session id (e.g. exit before
-    // `system.init`) would otherwise leave the registry wedged. That crash
-    // surfaces as AgentTurnFailed and is never auto-retried — the commit
-    // ordering matters for the NEXT `session(...)` call (or a resumed run),
-    // which must see a registry that agrees with what claude actually did.
+    // Commit happens only after a successful drain: a subprocess that crashed
+    // before claude registered the session id would otherwise leave the registry
+    // wedged. The ordering matters for the NEXT `session(...)` call, which must
+    // see a registry that agrees with what claude actually did.
     Conversations.runAutonomous(session, sessions, events):
       openConversation(
         prompt = prompt,
@@ -171,45 +143,29 @@ private[orca] class ClaudeBackend(
       outputSchema = outputSchema
     )
     // Interactive has no in-backend drain to gate on; commit once the
-    // conversation is up (the spawn succeeded, claude has parsed args).
-    // A crash mid-conversation will still leave the mark in place, but
-    // interactive sessions aren't auto-retried by the orchestrator —
-    // the user reruns with a fresh session. Through `register`
-    // (log-and-skip guard, the correct policy for the interactive path) —
-    // claude claims its ids client-side, so the client id IS the wire id
-    // (`onWire`), which is always safe.
+    // conversation is up. A crash mid-conversation leaves the mark in place, but
+    // interactive sessions aren't auto-retried — the user reruns with a fresh
+    // session. claude claims ids client-side, so the client id IS the wire id
+    // (`onWire`), which is always safe to `register`.
     sessions.register(session, session.onWire)
     conv
 
   /** Spawn `claude` in stream-json mode, write the opening user turn, close
-    * stdin, and wrap the process in a live [[ClaudeConversation]]. Used by both
-    * the interactive path ([[ConversationMode.Interactive]]) and the autonomous
-    * path ([[ConversationMode.Autonomous]]).
+    * stdin, and wrap the process in a live [[ClaudeConversation]]. Closing
+    * stdin after the initial turn is what makes `claude --print` stop waiting
+    * for EOF and start producing output.
     *
-    * The initial user turn is the only thing we feed through stdin; once it's
-    * written we close the pipe so `claude --print --input-format stream-json`
-    * stops waiting for EOF and starts producing output.
-    *
-    * `Interactive` mode wires the MCP `ask_user` tool: we stand up an
+    * `Interactive` mode wires the MCP `ask_user` tool: stand up an
     * [[AskUserMcpServer]] on an ephemeral port, write a workDir-local
-    * `.orca-mcp-<port>.json` pointing at it, tell claude about it via
-    * `--mcp-config`, and add the tool name to the auto-approve set so the user
-    * isn't prompted to authorise it. The mode also carries the `displayPrompt`
-    * the conversation surfaces to the renderer as an opening `UserMessage`.
+    * `.orca-mcp-<port>.json`, point claude at it via `--mcp-config`, and
+    * auto-approve the tool. `Autonomous` skips all of that: those calls have no
+    * renderer to drive the prompt, so exposing the tool would let the agent
+    * deadlock the call.
     *
-    * `Autonomous` mode skips all of that — no MCP server, no config file, no
-    * system-prompt hint, no auto-approve entry, no opening `UserMessage`.
-    * Autonomous calls have no renderer to drive the prompt, so exposing the
-    * tool would just give the agent a way to deadlock the call.
-    *
-    * The MCP server (when present) is handed to ClaudeConversation as a session
-    * resource; its `close()` runs from `onFinalize` after the read loop drains,
-    * so the binding releases when the conversation ends rather than when the
-    * outer flow scope tears down.
-    *
-    * If anything between resource allocation and conversation construction
-    * throws we tear down the server (and SIGINT the process if we'd already
-    * spawned it) so no Netty binding or subprocess leaks.
+    * The MCP server (when present) is a session resource closed from
+    * `onFinalize` after the read loop drains. If anything between resource
+    * allocation and conversation construction throws we tear down the server
+    * (and SIGINT the process if already spawned) so nothing leaks.
     */
   private def openConversation(
       prompt: String,
@@ -218,10 +174,9 @@ private[orca] class ClaudeBackend(
       config: AgentConfig,
       outputSchema: Option[String]
   )(using Ox): Conversation[BackendTag.ClaudeCode.type] =
-    // Allocate ask_user resources up front so we can close them
-    // deterministically on a downstream failure. `None` for autonomous —
-    // those calls don't expose the tool. Claude's `extras` deletes the
-    // workDir-local `.orca-mcp-<port>.json` when the conversation ends.
+    // Allocate ask_user resources up front so a downstream failure can close
+    // them deterministically. `None` for autonomous — those calls don't expose
+    // the tool.
     val displayPrompt = mode.displayPrompt
     val askUser: Option[AskUserSession] =
       Option.when(mode.isInteractive):
@@ -240,16 +195,10 @@ private[orca] class ClaudeBackend(
         if askUser.isDefined then
           config.autoApproveAlso(ClaudeBackend.AskUserToolName)
         else config
-      // The registry decides fresh-vs-resume; commit happens only after the
-      // conversation is up (in the runAutonomous/runInteractive shells) so
-      // a spawn that fails before claude registers the session doesn't
-      // leave the registry wedged. This is not about enabling an automatic
-      // retry (a post-spawn failure is AgentTurnFailed and is never
-      // auto-retried) — it's so the NEXT `session(...)` call, whenever it
-      // comes, still sees `--session-id` as the correct dispatch.
-      // Callers must not share a session id across concurrent calls;
-      // `reviewAndFixLoop`'s parallel reviewer fan-out is safe because each
-      // reviewer mints its own distinct conversation via `agent.chat()`.
+      // The registry decides fresh-vs-resume. Callers must not share a session
+      // id across concurrent calls; `reviewAndFixLoop`'s parallel reviewer
+      // fan-out is safe because each reviewer mints its own conversation via
+      // `agent.chat()`.
       val args = ClaudeArgs.streamJson(
         effectiveConfig,
         systemPromptFile,
@@ -285,14 +234,12 @@ private[orca] class ClaudeBackend(
   /** Write the MCP config file at [[mcpConfigPath]].
     *
     * The `timeout` field extends claude's per-server tool-call timeout from its
-    * default (60s in the MCP TS SDK claude uses) to
-    * [[AskUserMcpServer.ToolTimeout]]. Without this, claude's MCP client gives
-    * up on `ask_user` if the human takes more than 60s to type their answer —
-    * claude then synthesises a tool failure, fires a follow-up `ask_user` with
-    * a similar question, and the user ends up answering twice.
+    * 60s default to [[AskUserMcpServer.ToolTimeout]]. Without it, claude gives
+    * up on `ask_user` if the human takes more than 60s to answer, then fires a
+    * follow-up `ask_user` and the user answers twice.
     *
-    * One of three renderings of `AskUserMcpServer.ToolTimeout` — claude JSON ms
-    * / codex TOML sec / gemini settings.json ms; keep in sync.
+    * One of three renderings of `AskUserMcpServer.ToolTimeout` (claude JSON ms
+    * / codex TOML sec / gemini settings.json ms); keep in sync.
     */
   private def writeMcpConfig(
       server: AskUserMcpServer,
@@ -304,11 +251,10 @@ private[orca] class ClaudeBackend(
       s"""{"mcpServers":{"${AskUserMcpServer.ServerName}":{"type":"http","url":"${server.url}","timeout":$timeoutMs}}}"""
     )
 
-  /** Build the per-session system-prompt file. Composes `config.systemPrompt`
-    * with the shared ask_user hint (interactive only), then writes to a JVM
-    * temp file (auto-cleaned on exit) rather than the user's workDir — the file
-    * is purely an IPC mechanism between orca and the `claude` subprocess (read
-    * once on startup via `--append-system-prompt-file`).
+  /** Build the per-session system-prompt file: compose `config.systemPrompt`
+    * with the ask_user hint (interactive only), then write to a JVM temp file
+    * (auto-cleaned on exit) rather than the user's workDir — it's purely an IPC
+    * mechanism, read once via `--append-system-prompt-file`.
     */
   private def writeSystemPromptIfPresent(
       config: AgentConfig,
@@ -329,12 +275,11 @@ object ClaudeBackend:
   private[claude] def cwdSlug(cwd: os.Path): String =
     cwd.toString.replace('/', '-')
 
-  /** Read-only network tools pre-approved on [[ToolSet.NetworkOnly]] turns, so
-    * an autonomous planner can read issues/PRs/web without a permission prompt
-    * it can't answer. Command-scoped, so plan mode still blocks general bash
-    * and all edits. `Bash(gh api:*)` is broad GitHub reads — note `gh api -X
-    * POST` can mutate GitHub (not local files); flows wanting a tighter set
-    * pass their own via `claude.withNetworkTools(...)`.
+  /** Read-only network tools pre-approved on [[ToolSet.NetworkOnly]] turns.
+    * Command-scoped, so plan mode still blocks general bash and all edits.
+    * `Bash(gh api:*)` is broad GitHub reads — note `gh api -X POST` can mutate
+    * GitHub (not local files); flows wanting a tighter set pass their own via
+    * `claude.withNetworkTools(...)`.
     */
   private[claude] val DefaultNetworkTools: Seq[String] = Seq(
     "WebFetch",
@@ -346,19 +291,17 @@ object ClaudeBackend:
     "Bash(gh api:*)"
   )
 
-  /** Fully-qualified tool name the agent uses, derived from the MCP server name
-    * + the tool's bare slug. Always auto-approved on the interactive path — the
-    * user is already typing an answer, no need for a y/n prompt first.
+  /** Fully-qualified tool name (MCP server name + tool slug). Always
+    * auto-approved on the interactive path — the user is already typing an
+    * answer, no need for a y/n prompt first.
     */
   private[claude] val AskUserToolName: String =
     s"mcp__${AskUserMcpServer.ServerName}__${AskUserMcpServer.ToolSlug}"
 
-  /** Tool name the claude CLI injects for `--json-schema` structured output
-    * (observed on 2.1.207): the model "exits" the turn by calling this tool
-    * with the payload as its input, so the wire carries a visible `tool_use`
-    * for it. The conversation suppresses that echo — the payload reaches the
-    * caller via the result message and surfaces as
-    * `OrcaEvent.StructuredResult`, and rendering the tool call too would show
-    * the same JSON twice.
+  /** Tool name the claude CLI injects for `--json-schema` structured output:
+    * the model "exits" the turn by calling this tool with the payload as its
+    * input. The conversation suppresses that echo — the payload reaches the
+    * caller via the result message as `OrcaEvent.StructuredResult`, so
+    * rendering the tool call too would show the same JSON twice.
     */
   private[claude] val StructuredOutputToolName: String = "StructuredOutput"

--- a/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
@@ -36,10 +36,9 @@ private[claude] class ClaudeConversation(
       initialPrompt = initialPrompt
     ):
 
-  // The reader thread is the sole writer for all four fields below.
-  // No cross-thread visibility concerns: reads happen on the same thread
-  // immediately after writes, within `handle(...)` dispatch. Plain `var`s
-  // suffice — atomics would be theatre.
+  // The reader thread is the sole writer for the fields below, and reads happen
+  // on the same thread within `handle(...)` dispatch — no cross-thread
+  // visibility concerns, so plain `var`s suffice.
 
   /** Captured from the `system.init` message so `handleResult` can fall back to
     * it when the `result` message itself doesn't carry the resolved model id.
@@ -48,41 +47,32 @@ private[claude] class ClaudeConversation(
   private var initModel: Option[String] = None
 
   /** Set when a text or thinking delta streams, cleared when the next full-turn
-    * `assistant` message lands (reset at the top of `handleAssistantTurn`).
-    * Both consumers rely on claude's wire ordering — the full `assistant`
-    * message arrives AFTER any partials for the same turn — and ask the same
-    * question: "did the model's prose already stream as deltas since the last
-    * full-turn boundary?"
+    * `assistant` message lands. Answers "did the model's prose already stream
+    * as deltas since the last full-turn boundary?" for two consumers:
     *   - `handleAssistantTurn` gates its fallback that re-emits Text/Thinking
-    *     blocks when no partials arrived (older claude builds, partials
-    *     disabled);
-    *   - `handleResultError` shows a short marker instead of repeating the full
-    *     body when an `is_error`'s body already streamed as deltas this turn.
+    *     blocks when no partials arrived;
+    *   - `handleResultError` shows a short marker instead of repeating an
+    *     `is_error` body that already streamed as deltas.
     *
-    * NOTE: this is deliberately NOT the base's `turnIsOpen`. `turnIsOpen`
-    * counts a `ToolResult` as turn-opening activity (correct for the grammar),
-    * but a tool result is not streamed prose. After `tool_use → tool_result →
-    * is_error` with no assistant text, `turnIsOpen` is `true` while this flag
-    * is `false`; wiring `handleResultError` to `turnIsOpen` would then show
-    * "session failed (see message above)" pointing at a tool result instead of
-    * surfacing the actual error body. So the flag stays delta-specific.
+    * Deliberately NOT the base's `turnIsOpen`, which counts a `ToolResult` as
+    * turn-opening activity. After `tool_use → tool_result → is_error` with no
+    * assistant text, `turnIsOpen` is `true` while this flag is `false`; wiring
+    * `handleResultError` to `turnIsOpen` would point "session failed (see
+    * message above)" at a tool result instead of the actual error body.
     */
   private var deltasSinceLastFullTurn: Boolean = false
 
-  /** Tool-use ids of calls suppressed in `handleAssistantTurn` — `ask_user`
-    * invocations and (in structured mode) the CLI-injected `StructuredOutput`
-    * exit call. `handleUserTurn` drops the matching `tool_result` so the
-    * suppressed exchange doesn't re-render halfway: the user's typed answer as
-    * `⎿ <answer>` right after the UserQuestion prompt already surfaced it, or
-    * the structured payload's acknowledgement. See
-    * [[orca.backend.AskUserEchoes]].
+  /** Tool-use ids suppressed in `handleAssistantTurn` — `ask_user` invocations
+    * and (in structured mode) the CLI-injected `StructuredOutput` exit call.
+    * `handleUserTurn` drops the matching `tool_result` so the suppressed
+    * exchange doesn't re-render. See [[orca.backend.AskUserEchoes]].
     */
   private val askUserEchoes = new orca.backend.AskUserEchoes
 
-  // `canAskUser` + ask_user bridge drainer + onFinalize close are owned by
-  // the base; this subclass just declares `askUser` on the ctor param
-  // above. Stdin-as-user-channel is closed right after the initial prompt,
-  // so mid-session input flows through the MCP tool result either way.
+  // The ask_user bridge drainer and onFinalize close are owned by the base;
+  // this subclass just declares `askUser` on the ctor param. Stdin is closed
+  // right after the initial prompt, so mid-session input flows through the MCP
+  // tool result.
 
   // --- Reader hook ---
 
@@ -121,38 +111,31 @@ private[claude] class ClaudeConversation(
         eventQueue.enqueue(evt)
       }
     case InboundMessage.Unknown(_) =>
-      // Unknown top-level message types are protocol drift (new
-      // message kinds in newer CLI versions, etc.) — nothing the user
+      // Unknown top-level message types are protocol drift — nothing the user
       // can act on, so drop silently rather than rendering ✖.
       ()
 
-  /** Full assistant turn arrives after partials have streamed. This is the
-    * single source of truth for tool calls — claude's protocol emits the
-    * `assistant` message BEFORE the matching `content_block_stop`, so we can't
-    * usefully stream tool-use events earlier. Text and thinking are normally
-    * already streamed as deltas; if no deltas preceded this turn (older claude
-    * builds, partials disabled) we fall back to emitting each block as a single
-    * delta.
+  /** Full assistant turn, arriving after partials have streamed. Single source
+    * of truth for tool calls — claude emits the `assistant` message BEFORE the
+    * matching `content_block_stop`, so tool-use events can't stream earlier.
+    * Text and thinking normally already streamed as deltas; if none preceded
+    * this turn we fall back to emitting each block as a single delta.
     */
   private def handleAssistantTurn(content: List[ContentBlock]): Unit =
     val sawDeltasThisTurn = deltasSinceLastFullTurn
     deltasSinceLastFullTurn = false
     content.foreach:
-      // Suppress the agent's own ToolCall block for `ask_user` — the
-      // host-side bridge emits a UserQuestion event for the same exchange
-      // and rendering the tool-call line on top of it is just noise.
-      // Remember the id so `handleUserTurn` can also drop the matching
-      // tool_result (otherwise the user's typed answer re-renders as
-      // `⎿ <answer>` after the prompt already surfaced it).
+      // Suppress the agent's own `ask_user` ToolCall — the host-side bridge
+      // emits a UserQuestion for the same exchange. Remember the id so
+      // `handleUserTurn` also drops the matching tool_result (else the typed
+      // answer re-renders).
       case ContentBlock.ToolUse(id, name, _)
           if name == ClaudeBackend.AskUserToolName =>
         askUserEchoes.suppress(id)
       // The CLI-injected structured-output "exit" call (`--json-schema`): the
-      // payload reaches the caller via the result message and surfaces as
-      // `OrcaEvent.StructuredResult`, so rendering the tool call would show
-      // the same JSON twice. Gated on structured mode so a genuine user tool
-      // that happens to be named `StructuredOutput` is unaffected in plain
-      // runs.
+      // payload reaches the caller via the result message, so rendering the
+      // tool call would show the same JSON twice. Gated on structured mode so a
+      // genuine user tool named `StructuredOutput` is unaffected in plain runs.
       case ContentBlock.ToolUse(id, name, _)
           if outputSchema.isDefined &&
             name == ClaudeBackend.StructuredOutputToolName =>
@@ -174,9 +157,9 @@ private[claude] class ClaudeConversation(
     content.foreach:
       case ContentBlock.ToolResult(toolUseId, _, _)
           if askUserEchoes.consume(toolUseId) =>
-        // Paired with a suppressed `ask_user` ToolUse; the user has already
-        // seen their own typed answer at the prompt, so don't echo it back.
-        // `consume` removes the id as it matches.
+        // Paired with a suppressed `ask_user` ToolUse; the user already saw
+        // their typed answer at the prompt, so don't echo it. `consume` removes
+        // the id.
         ()
       case ContentBlock.ToolResult(_, body, isError) =>
         eventQueue.enqueue(
@@ -207,13 +190,11 @@ private[claude] class ClaudeConversation(
     )
 
   /** Claude sets `is_error: true` for out-of-band failures (API errors, rate
-    * limits, auth problems) that happen at the CLI boundary rather than inside
-    * a turn. Treat these as session-ending failures rather than feeding the
-    * error body into the downstream response parser, which might otherwise
-    * accept a `{"type":"error",...}` payload as a structurally valid agent
-    * output. `failWith` carries the full message for `awaitResult` to surface;
-    * the in-stream `Error` event is short if the user already saw the body as
-    * part of a streamed turn.
+    * limits, auth) at the CLI boundary rather than inside a turn. Treat these
+    * as session-ending rather than feeding the error body into the response
+    * parser, which might otherwise accept a `{"type":"error",...}` payload as
+    * valid output. `failWith` carries the full message; the in-stream `Error`
+    * event is short if the body already streamed as part of a turn.
     */
   private def handleResultError(output: Option[String]): Unit =
     val message =
@@ -248,15 +229,10 @@ private[claude] class ClaudeConversation(
     case AutoApprove.Only(tools) => tools.contains(toolName)
 
   /** Translate one stream-event payload into a `ConversationEvent`, or `None`
-    * if the payload contributes only to state we'll surface elsewhere.
-    *
-    * Text and thinking deltas pass straight through — claude chunks them and
-    * the renderer handles re-assembly. Tool-use deltas (start / json / stop)
-    * are NOT translated here: in the live protocol the full `assistant` message
-    * arrives BEFORE the matching `content_block_stop`, so emitting from a stop
-    * event would always be a duplicate of what `handleAssistantTurn` already
-    * emitted. The full-turn message is the single source of truth for tool
-    * calls.
+    * if it contributes only to state surfaced elsewhere. Text and thinking
+    * deltas pass straight through; tool-use deltas are NOT translated here,
+    * since the full-turn message is the single source of truth for tool calls
+    * (see [[handleAssistantTurn]]).
     */
   private def translateStreamEvent(
       payload: StreamEventPayload

--- a/claude/src/main/scala/orca/tools/claude/DefaultClaudeAgent.scala
+++ b/claude/src/main/scala/orca/tools/claude/DefaultClaudeAgent.scala
@@ -8,13 +8,7 @@ import orca.agents.BaseAgent
 
 /** Default ClaudeAgent implementation. Inherits the autonomous-text +
   * `resultAs[O]` plumbing from [[BaseAgent]] and only adds the Claude-specific
-  * model accessors (`haiku` / `sonnet` / `opus`).
-  *
-  * Free-form text `autonomous.run` and structured `resultAs[O].autonomous.run`
-  * go through the backend's headless mode. Interactive structured calls
-  * (`resultAs[O].interactive.run`) spawn claude in stream-json mode and wrap
-  * the subprocess in a `Conversation` that the supplied `interaction` drives to
-  * completion.
+  * model accessors (`haiku` / `sonnet` / `opus` / `fable`).
   */
 private[orca] class DefaultClaudeAgent(
     backend: ClaudeBackend,
@@ -38,10 +32,10 @@ private[orca] class DefaultClaudeAgent(
   def opus: ClaudeAgent = withModel(DefaultClaudeAgent.Opus1M)
   def fable: ClaudeAgent = withModel(DefaultClaudeAgent.Fable)
 
-  /** Per the trait: configure the read-only network allowlist by swapping in a
-    * reconfigured backend (the allowlist is claude-specific, so it lives there
-    * rather than in the shared `AgentConfig`). Constructs directly rather than
-    * via [[copyTool]] because the latter threads the current backend unchanged.
+  /** Configure the read-only network allowlist by swapping in a reconfigured
+    * backend (the allowlist is claude-specific, so it lives there, not in
+    * shared `AgentConfig`). Constructs directly rather than via [[copyTool]],
+    * which threads the current backend unchanged.
     */
   def withNetworkTools(tools: Seq[String]): ClaudeAgent =
     new DefaultClaudeAgent(
@@ -70,18 +64,16 @@ private[orca] class DefaultClaudeAgent(
     )
 
 private[orca] object DefaultClaudeAgent:
-  /** The default coding model: Opus with the 1M-token context window, selected
-    * via the documented `[1m]` model-alias suffix (Claude Code model-config; no
-    * beta header needed). The main implementer session is long-lived and
-    * accumulates context across tasks, so 1M is what keeps it from overflowing
-    * ("Prompt is too long"). Both bare `claude` (see `DefaultFlowContext`) and
-    * `claude.opus` resolve to this; cheaper one-shot / auxiliary calls go
-    * through `claude.sonnet` / `claude.haiku`.
+  /** The default coding model: Opus with the 1M-token context window, via the
+    * `[1m]` model-alias suffix. The main implementer session is long-lived and
+    * accumulates context across tasks, so 1M keeps it from overflowing ("Prompt
+    * is too long"). Cheaper one-shot calls go through `claude.sonnet` /
+    * `claude.haiku`.
     */
   val Opus1M: Model = Model("claude-opus-4-8[1m]")
 
   /** Fable: the most capable tier, above Opus. Opt in via `claude.fable` for
     * the hardest one-shots; the long-lived implementer stays on Opus (the
-    * default — see [[Opus1M]]) for cost. 1M context at standard pricing.
+    * default) for cost. 1M context at standard pricing.
     */
   val Fable: Model = Model("claude-fable-5")

--- a/claude/src/main/scala/orca/tools/claude/streamjson/ContentBlock.scala
+++ b/claude/src/main/scala/orca/tools/claude/streamjson/ContentBlock.scala
@@ -33,7 +33,7 @@ private[claude] object ContentBlock:
       case "tool_result" => readFromString[ToolResultWire](rawJson).toBlock
       case other         => Unknown(other)
 
-  // --- Wire-level shapes (jsoniter-derived; kept private). ---
+  // --- Wire shapes ---
 
   private case class BlockEnvelope(`type`: String)
       derives ConfiguredJsonValueCodec
@@ -54,9 +54,8 @@ private[claude] object ContentBlock:
       ToolUse(id = id, name = name, rawInput = input.value)
 
   /** Claude's tool_result `content` field is either a plain string or a list of
-    * nested blocks (text / tool_reference / etc.). Capture it as RawJson and
-    * reduce to a displayable string at the domain boundary; callers that need
-    * structure can re-parse.
+    * nested blocks; captured as RawJson and reduced to a displayable string at
+    * the domain boundary.
     */
   private case class ToolResultWire(
       tool_use_id: String,
@@ -70,11 +69,10 @@ private[claude] object ContentBlock:
         isError = is_error.getOrElse(false)
       )
 
-  /** Claude sends `content` as either a JSON string literal or an array of
-    * nested blocks (currently: text blocks and tool_reference blocks). We
-    * flatten to a human-readable string so the renderer can truncate without
-    * leaking `[{"type":"text",...}]` scaffolding into the terminal. Unknown
-    * shapes fall back to the raw JSON.
+  /** Flatten `content` (a JSON string literal, or an array of text/
+    * tool_reference blocks) to a human-readable string, so the renderer doesn't
+    * leak `[{"type":"text",...}]` scaffolding into the terminal. Unknown shapes
+    * fall back to the raw JSON.
     */
   private def renderToolResultContent(raw: String): String =
     val trimmed = raw.trim
@@ -86,11 +84,9 @@ private[claude] object ContentBlock:
     try readFromString[String](raw)(using stringCodec)
     catch
       case NonFatal(t) =>
-        // The fallback to the raw payload is intentional — claude
-        // occasionally sends malformed string literals and we'd rather
-        // show something than crash. Surface the detail under
-        // ORCA_DEBUG so a real bug isn't masked. Fatal errors (VM
-        // errors, InterruptedException, etc.) propagate.
+        // Claude occasionally sends malformed string literals; fall back to the
+        // raw payload rather than crash, surfacing the detail under ORCA_DEBUG
+        // so a real bug isn't masked.
         logSwallowedDecode("decodeStringLiteral", raw, t)
         raw
 
@@ -119,10 +115,8 @@ private[claude] object ContentBlock:
       )
 
   /** Concatenate the legible bits of each block: text prose as-is, and
-    * tool_reference lists (ToolSearch results) as a comma-joined name list —
-    * easier to skim than `<Name1> <Name2>`. Returns an empty string if the
-    * blocks carry nothing renderable, so the caller can fall back to the raw
-    * JSON.
+    * tool_reference lists as a comma-joined name list. Returns an empty string
+    * if nothing is renderable, so the caller can fall back to the raw JSON.
     */
   private def flattenBlocks(blocks: List[NestedBlock]): String =
     val texts =

--- a/claude/src/main/scala/orca/tools/claude/streamjson/InboundMessage.scala
+++ b/claude/src/main/scala/orca/tools/claude/streamjson/InboundMessage.scala
@@ -41,9 +41,8 @@ private[claude] enum InboundMessage:
 
 private[claude] object InboundMessage:
 
-  /** Parse one NDJSON line. The dispatch reads the `type` field, then re-reads
-    * the line into the appropriate case class. Malformed JSON propagates
-    * `JsonReaderException` — callers decide whether to skip or fail.
+  /** Parse one NDJSON line. Malformed JSON propagates `JsonReaderException` —
+    * callers decide whether to skip or fail.
     */
   def parse(line: String): InboundMessage =
     val envelope = readFromString[TopEnvelope](line)
@@ -73,11 +72,10 @@ private[claude] object InboundMessage:
   private def parseResult(line: String): InboundMessage =
     val wire = readFromString[ResultWire](line)
     val u = wire.usage.getOrElse(UsageWire())
-    // Claude Code splits input across `input_tokens` (new portion of the
-    // turn), `cache_creation_input_tokens` (first turn pays for the cached
-    // system prompt + tool defs), and `cache_read_input_tokens` (every later
-    // turn re-reads the cached prefix). The three are separate categories,
-    // so the billed total is the sum, with cached = creation + read.
+    // Claude Code splits input across `input_tokens` (new this turn),
+    // `cache_creation_input_tokens`, and `cache_read_input_tokens` — three
+    // separate categories, so the billed total is their sum, with
+    // cached = creation + read.
     val cached = u.cache_creation_input_tokens.getOrElse(0L) +
       u.cache_read_input_tokens.getOrElse(0L)
     Result(

--- a/claude/src/main/scala/orca/tools/claude/streamjson/OutboundMessage.scala
+++ b/claude/src/main/scala/orca/tools/claude/streamjson/OutboundMessage.scala
@@ -13,7 +13,6 @@ import com.github.plokhotnyuk.jsoniter_scala.macros.ConfiguredJsonValueCodec
   * version so drift is caught on CI.
   */
 private[claude] enum OutboundMessage:
-  /** A user turn, as text. */
   case UserText(text: String)
 
   /** Response to a `control_request` tool-approval prompt. */

--- a/claude/src/main/scala/orca/tools/claude/streamjson/StreamEventPayload.scala
+++ b/claude/src/main/scala/orca/tools/claude/streamjson/StreamEventPayload.scala
@@ -6,11 +6,10 @@ import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
 import com.github.plokhotnyuk.jsoniter_scala.macros.ConfiguredJsonValueCodec
 
 /** The inner `event` of a `stream_event` message: one chunk of a partial turn.
-  * We care about the block-delta events (text, thinking, tool-input chunks)
-  * because they drive responsive UI. Events we recognise but don't act on
-  * (message_start, message_stop, etc.) collapse to `Unhandled(eventType)` so
-  * the driver has one no-op path for them; this is deliberately distinct from
-  * `Unknown` in the other ADTs, which covers types we don't recognise at all.
+  * We route on the block-delta events (text, thinking, tool-input chunks) that
+  * drive responsive UI. Events we recognise but don't act on collapse to
+  * `Unhandled(eventType)`; this is deliberately distinct from `Unknown` in the
+  * other ADTs, which covers types we don't recognise at all.
   */
 private[claude] enum StreamEventPayload:
   case TextDelta(index: Int, text: String)

--- a/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
@@ -63,8 +63,8 @@ class ClaudeArgsTest extends munit.FunSuite:
   test(
     "AutoApprove.Only(tools) maps to sorted --allowedTools in default mode"
   ):
-    // Honest Only (finding 2.1): default permission mode, only the listed
-    // tools pre-approved — no acceptEdits blanket-approving every edit.
+    // Default permission mode, only the listed tools pre-approved — no
+    // acceptEdits blanket-approving every edit.
     val args = streamJson(
       AgentConfig(autoApprove =
         AutoApprove.Only(Set("Zeta", "Alpha", "Middle"))

--- a/claude/src/test/scala/orca/tools/claude/ClaudeBackendTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeBackendTest.scala
@@ -109,14 +109,11 @@ class ClaudeBackendTest extends munit.FunSuite:
     "a withNetworkTools sibling shares the parent's closed latch"
   ):
     // withNetworkTools is the one builder that swaps in a genuinely NEW
-    // ClaudeBackend instance rather than reusing the caller's (every other
-    // builder — withConfig/withModel/opus/withName/… — goes through
-    // BaseAgent.copyTool, which keeps the same backend). Before this fix each
-    // fresh instance got its own closedFlag, so a handle derived via
-    // `agent.withNetworkTools(...)` while the flow was open and used AFTER
-    // the leading agent's flow closed would silently bypass the
-    // use-after-close guard. `run` never reaches the (empty) stub runner: the
-    // guard must throw first.
+    // ClaudeBackend instance rather than reusing the caller's; the new instance
+    // must still share the parent's closedFlag, or a handle derived while the
+    // flow was open and used after the leading agent's flow closed would bypass
+    // the use-after-close guard. `run` never reaches the (empty) stub runner:
+    // the guard must throw first.
     val backend = new ClaudeBackend(new SpawnStubCliRunner(Nil))
     val agent = new DefaultClaudeAgent(
       backend,
@@ -242,12 +239,11 @@ class ClaudeBackendTest extends munit.FunSuite:
   test(
     "registerSession (rehydrate on resume) makes the first call use --resume, not --session-id"
   ):
-    // Regression for the cross-process resume bug: claude's sessions are
-    // durable on disk, so a resumed run re-claims the recorded id via
-    // `registerSession` (what `rehydrateSessions` calls). The very first call in
-    // THIS process must then `--resume` the existing session rather than
-    // re-create it with `--session-id` (which the CLI rejects as "already in
-    // use"). Before the fix, claude wired neither hook, so it always re-created.
+    // Claude's sessions are durable on disk, so a resumed run re-claims the
+    // recorded id via `registerSession` (what `rehydrateSessions` calls). The
+    // very first call in THIS process must then `--resume` the existing session
+    // rather than re-create it with `--session-id` (which the CLI rejects as
+    // "already in use").
     val sid = SessionId[BackendTag.ClaudeCode.type](
       "44444444-4444-4444-4444-444444444444"
     )
@@ -268,8 +264,8 @@ class ClaudeBackendTest extends munit.FunSuite:
     "resumeWireId reflects the claim so the runtime records the resumable id"
   ):
     // `resumeWireId` is the source the runtime reads to write the resume wire id
-    // into the progress log; without it (the old default `None`) the claim was
-    // never persisted and resume re-created the session.
+    // into the progress log; without the claim, resume would re-create the
+    // session.
     val sid = SessionId[BackendTag.ClaudeCode.type](
       "55555555-5555-5555-5555-555555555555"
     )
@@ -289,8 +285,7 @@ class ClaudeBackendTest extends munit.FunSuite:
   ):
     // The session mapping is recorded only after `new ClaudeConversation`
     // succeeds, so a first call that throws (e.g. is_error from the result
-    // message) doesn't wedge the bookkeeping. Pins the post-success ordering
-    // against regressions back to mark-then-spawn.
+    // message) doesn't wedge the bookkeeping.
     val sid = SessionId[BackendTag.ClaudeCode.type](
       "33333333-3333-3333-3333-333333333333"
     )
@@ -337,14 +332,12 @@ class ClaudeBackendTest extends munit.FunSuite:
   test(
     "workDir is shared, by construction, between the actual spawn cwd and the session-existence probe"
   ):
-    // Pins the workDir unification: `workDir` is fixed once at construction
-    // and BOTH the probe (via `sessions.willContinue`) and the real subprocess
-    // spawn (via `runAutonomous` → `cli.spawnPiped(..., cwd = workDir)`) read
-    // that SAME field — no separate per-call value can drift out of sync,
-    // which is exactly what the old `cwdForProbe`-vs-per-call-`workDir` split
-    // allowed. A backend constructed with a worktree-style
-    // `workDir` (!= the process cwd) must probe AND spawn under that same
-    // directory.
+    // `workDir` is fixed once at construction and BOTH the probe (via
+    // `sessions.willContinue`) and the real subprocess spawn (via
+    // `runAutonomous` → `cli.spawnPiped(..., cwd = workDir)`) read that SAME
+    // field, so no per-call value can drift out of sync. A backend constructed
+    // with a worktree-style `workDir` (!= the process cwd) must probe AND spawn
+    // under that same directory.
     val tmpProjects = TempDirs.dir()
     val flowWorkDir =
       TempDirs.dir() // stands in for a worktree checkout, != os.pwd
@@ -390,10 +383,10 @@ class ClaudeBackendTest extends munit.FunSuite:
   test(
     "willContinue returns false when the transcript is present but never claimed"
   ):
-    // Mapping gate: existence is only answered for an id the bookkeeping
-    // knows (claimed this run or rehydrated). A stray transcript for an id we
-    // never claimed reports false — outcome-preserving, since dispatch would say
-    // `Fresh` and the CLI would refuse the duplicate `--session-id` anyway.
+    // Existence is only answered for an id the bookkeeping knows (claimed this
+    // run or rehydrated). A stray transcript for an id we never claimed reports
+    // false — outcome-preserving, since dispatch would say `Fresh` and the CLI
+    // would refuse the duplicate `--session-id` anyway.
     val tmpProjects = TempDirs.dir()
     val cwd = TempDirs.dir()
     val slug = ClaudeBackend.cwdSlug(cwd)

--- a/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
@@ -35,8 +35,7 @@ class ClaudeConversationTest extends munit.FunSuite:
 
     val events = conv.events.toList
     // The delta opens a turn; `result:success` settles it, and the base-class
-    // auto-close injects the owed AssistantTurnEnd (before 4A this turn settled
-    // open — a grammar violation).
+    // auto-close injects the owed AssistantTurnEnd.
     assertEquals(
       events,
       List(
@@ -87,8 +86,8 @@ class ClaudeConversationTest extends munit.FunSuite:
       s"the error event should not duplicate the streamed body; got: ${errors.head}"
     )
     // The delta opened a turn; the out-of-band is_error settles via `failWith`,
-    // whose base-class auto-close now injects the owed AssistantTurnEnd — so the
-    // settled-failure sequence is grammar-clean (was routed around before 4A).
+    // whose base-class auto-close injects the owed AssistantTurnEnd — so the
+    // settled-failure sequence is grammar-clean.
     assertEquals(events.last, ConversationEvent.AssistantTurnEnd)
     ConversationEventConformance.assertGrammar(events, completedNormally = true)
     val failure = intercept[OrcaFlowException](conv.awaitResult())
@@ -125,10 +124,10 @@ class ClaudeConversationTest extends munit.FunSuite:
   convTest(
     "is_error after a tool-only turn (no assistant text) surfaces the full error body"
   ):
-    // Pins the deltasSinceLastFullTurn-vs-turnIsOpen distinction (see that
-    // field's scaladoc): the ToolResult below makes turnIsOpen true, but no
-    // text/thinking delta ever streamed, so is_error must NOT collapse into
-    // the "see message above" marker — there IS no message above.
+    // The deltasSinceLastFullTurn-vs-turnIsOpen distinction (see that field's
+    // scaladoc): the ToolResult below makes turnIsOpen true, but no text/
+    // thinking delta ever streamed, so is_error must NOT collapse into the "see
+    // message above" marker — there IS no message above.
     val process = new FakePipedCliProcess()
     val conv = new ClaudeConversation(process, AgentConfig())
 
@@ -236,14 +235,13 @@ class ClaudeConversationTest extends munit.FunSuite:
   convTest(
     "tool_use surrounding streaming events are ignored; emission comes from the full-turn message"
   ):
-    // In claude's live protocol the `assistant` message arrives BEFORE
-    // the matching `content_block_stop`, so the full-turn message is the
-    // single source of truth for tool calls. Streaming events for a
-    // tool_use block (start/json_delta/stop) accumulate no state and
-    // produce no events — emitting from them would either duplicate the
-    // full-turn emit (if the order is assistant→stop) or be too late
-    // (if it ever flipped). Pin both: feed the streaming events, then
-    // the full-turn message, and expect exactly one AssistantToolCall.
+    // In claude's live protocol the `assistant` message arrives BEFORE the
+    // matching `content_block_stop`, so the full-turn message is the single
+    // source of truth for tool calls. Streaming events for a tool_use block
+    // (start/json_delta/stop) accumulate no state and produce no events —
+    // emitting from them would duplicate the full-turn emit. Feed the streaming
+    // events, then the full-turn message, and expect exactly one
+    // AssistantToolCall.
     val process = new FakePipedCliProcess()
     val conv = new ClaudeConversation(process, AgentConfig())
 
@@ -317,8 +315,7 @@ class ClaudeConversationTest extends munit.FunSuite:
 
     val events = conv.events.toList
     // The ToolResult opens a turn (a tool ran); `result:success` settles it and
-    // the base-class auto-close injects the owed AssistantTurnEnd (before 4A
-    // this turn settled open).
+    // the base-class auto-close injects the owed AssistantTurnEnd.
     assertEquals(
       events,
       List(
@@ -470,11 +467,10 @@ class ClaudeConversationTest extends munit.FunSuite:
     val process = new FakePipedCliProcess()
     val conv = new ClaudeConversation(process, AgentConfig())
 
-    // Assistant turn carrying a tool_use block for the MCP-prefixed
-    // ask_user tool name. Our renderer-side suppression drops the
-    // AssistantToolCall event, so this turn bears no assistant activity at all —
-    // the trailing AssistantTurnEnd is therefore an empty turn and the base
-    // funnel drops it (before 4A it leaked through as an empty-turn violation).
+    // Assistant turn carrying a tool_use block for the MCP-prefixed ask_user
+    // tool name. Renderer-side suppression drops the AssistantToolCall event, so
+    // this turn bears no assistant activity — the trailing AssistantTurnEnd is
+    // therefore an empty turn and the base funnel drops it.
     process.enqueueStdout(
       s"""{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu_1","name":"${ClaudeBackend.AskUserToolName}","input":{"question":"x"}}]}}"""
     )

--- a/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
@@ -49,7 +49,7 @@ class SequencedBackend(
 
   /** Listeners the backend was called with, in invocation order. Lets tests
     * assert that `DefaultAgentCall` threaded its own `events` through rather
-    * than silently dropping it on the floor.
+    * than dropping it.
     */
   def events: List[orca.events.OrcaListener] = seenEvents.get().reverse
 
@@ -118,8 +118,7 @@ class SequencedBackend(
 
 class DefaultAgentCallTest extends munit.FunSuite:
 
-  // LLM `run` is now gated on `InStage`; mint the token once for the suite
-  // (package `orca.tools.claude` can reach `InStage.unsafe`).
+  // LLM `run` is gated on `InStage`; mint the token once for the suite.
   private given orca.InStage = orca.InStage.unsafe
 
   import scala.concurrent.duration.DurationInt
@@ -265,11 +264,9 @@ class DefaultAgentCallTest extends munit.FunSuite:
   test(
     "autonomous forwards a Some(schema) to backend.runAutonomous"
   ):
-    // Pins the SPI-level wiring: structured calls must carry their
-    // generated schema down to the backend so the conversation knows it's
-    // in structured mode (drain suppresses raw JSON) and the CLI gets
-    // `--json-schema`/`--output-schema`. A regression that dropped the
-    // schema to None would compile and pass every other test.
+    // Structured calls must carry their generated schema down to the backend so
+    // the conversation knows it's in structured mode (drain suppresses raw JSON)
+    // and the CLI gets `--json-schema`/`--output-schema`.
     val backend = new SequencedBackend(List("""{"value":1}"""))
     supervised:
       val _ = makeCall(backend).autonomous.run("anything")
@@ -420,9 +417,9 @@ class DefaultAgentCallTest extends munit.FunSuite:
       assertEquals(calls.get(), 1, "AgentTurnFailed must not be retried")
       assert(ex.getMessage.contains("agent 'claude'"), ex.getMessage)
       assert(ex.getMessage.contains("Prompt is too long"), ex.getMessage)
-      // 12.1: runAutonomousWithRetry's re-attribution rewrap must thread the
-      // original AgentTurnFailed through as the cause, not just splice its
-      // message into the new one and drop it.
+      // runAutonomousWithRetry's re-attribution rewrap must thread the original
+      // AgentTurnFailed through as the cause, not just splice its message into
+      // the new one and drop it.
       assert(
         ex.getCause != null && ex.getCause.getMessage == "Prompt is too long",
         s"expected the original AgentTurnFailed as cause; got: ${ex.getCause}"
@@ -463,12 +460,10 @@ class DefaultAgentCallTest extends munit.FunSuite:
   test(
     "autonomous passes the effective (tool-resolved) config to prompts.autonomous"
   ):
-    // Pins the prompt-resolved-config fix: the prompt builder must see the
-    // EFFECTIVE config (tool defaults folded in), not the raw/empty per-call
-    // config. Here the tool-level config carries systemPrompt =
-    // Some("tool-prompt") via effectiveConfig; the call omits config, so the
-    // old code (which handed the raw None-derived config to prompts.autonomous)
-    // would capture None here.
+    // The prompt builder must see the EFFECTIVE config (tool defaults folded
+    // in), not the raw/empty per-call config. Here the tool-level config carries
+    // systemPrompt = Some("tool-prompt") via effectiveConfig, and the call omits
+    // config, so a builder given the raw None-derived config would capture None.
     val captured = new AtomicReference[Option[AgentConfig]](None)
     val recordingPrompts = new orca.agents.Prompts:
       def autonomous(
@@ -505,11 +500,9 @@ class DefaultAgentCallTest extends munit.FunSuite:
       assertEquals(captured.get().flatMap(_.systemPrompt), Some("tool-prompt"))
 
   test("interactive.runWithSession registers the (clientSid, serverSid) map"):
-    // Pins the codex-interactive bug fix end-to-end: the framework must call
-    // `backend.sessions.register(session, result.wireId)` after
-    // `interaction.drive` returns, so a follow-up turn on the same session
-    // resumes the right thread. Removing the `backend.sessions.register` call
-    // in `DefaultAgentCall.runInteractiveOnce` would fail this test.
+    // The framework must call `backend.sessions.register(session, result.wireId)`
+    // after `interaction.drive` returns, so a follow-up turn on the same session
+    // resumes the right thread.
     val clientSid =
       SessionId[BackendTag.ClaudeCode.type]("client-uuid-aaaa")
     val serverSid =

--- a/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
@@ -38,9 +38,8 @@ private[codex] object CodexArgs:
       sandboxArgs(config) ++
       CliArgs.modelArgs(config) ++
       cwdArgs(workDir) ++
-      // --skip-git-repo-check is permissive — codex bails if it can't
-      // tell whether cwd is a git repo, which is a poor fit for tests
-      // and one-off invocations against arbitrary directories.
+      // codex bails if it can't tell whether cwd is a git repo, a poor fit
+      // for tests and one-off invocations against arbitrary directories.
       Seq("--skip-git-repo-check") ++
       outputSchemaArgs(outputSchemaFile) ++
       Seq(prompt)
@@ -48,22 +47,18 @@ private[codex] object CodexArgs:
   /** Multi-turn continuation: `codex exec resume <id> <prompt>`.
     *
     * Three limitations vs. [[exec]]:
-    *   - `exec resume` doesn't accept `--cd / -C`, so cwd is set on the OS
-    *     process spawn rather than the argv.
-    *   - `exec resume` doesn't accept `--output-schema`, so the resumed turn's
-    *     structured-output validation falls to the prompt template + the
-    *     post-hoc parser. The retry-with- corrective-prompt loop in
-    *     `DefaultAgentCall` handles parse failures.
-    *   - `exec resume` rejects `--sandbox <mode>` and `--full-auto` (it errors
-    *     with "unexpected argument"): a resumed session inherits the sandbox it
-    *     was created with. Only `--dangerously-bypass-approvals-and-sandbox` is
-    *     still accepted, so [[resumeSandboxArgs]] keeps that one and drops the
-    *     rest. Without this, every resumed turn (a fix iteration, a follow-up
-    *     task on the same session, or a cross-process resume) fails.
+    *   - no `--cd / -C`, so cwd is set on the OS process spawn, not the argv.
+    *   - no `--output-schema`, so the resumed turn's structured-output
+    *     validation falls to the prompt template + post-hoc parser; the
+    *     retry-with-corrective-prompt loop in `DefaultAgentCall` handles parse
+    *     failures.
+    *   - rejects `--sandbox <mode>` and `--full-auto` ("unexpected argument"):
+    *     a resumed session inherits the sandbox it was created with. Only
+    *     `--dangerously-bypass-approvals-and-sandbox` is still accepted, so
+    *     [[resumeSandboxArgs]] keeps that one and drops the rest.
     *
-    * codex also enforces that the resumed session was not started with
-    * `--ephemeral`; the backend never passes `--ephemeral` on `exec`, so resume
-    * always finds a rollout.
+    * codex also rejects resuming a session started with `--ephemeral`; the
+    * backend never passes `--ephemeral`, so resume always finds a rollout.
     */
   def execResume(
       sessionId: WireSessionId[BackendTag.Codex.type],
@@ -80,12 +75,11 @@ private[codex] object CodexArgs:
       Seq("--skip-git-repo-check") ++
       Seq(prompt)
 
-  /** Sandbox flags accepted by `exec resume` (a subset of [[sandboxArgs]]). The
-    * resumed session inherits its sandbox from creation, and `exec resume`
-    * rejects `--sandbox <mode>` / `--full-auto` outright, so those map to no
-    * flag here. Only `--dangerously-bypass-approvals-and-sandbox` (Full +
-    * [[AutoApprove.All]]) is accepted and is re-asserted each turn to keep
-    * approvals off.
+  /** Sandbox flags accepted by `exec resume` (a subset of [[sandboxArgs]]).
+    * Only `--dangerously-bypass-approvals-and-sandbox` (Full +
+    * [[AutoApprove.All]]) is accepted, re-asserted each turn to keep approvals
+    * off; the other tiers map to no flag since the resumed session inherits its
+    * sandbox from creation.
     */
   private def resumeSandboxArgs(config: AgentConfig): Seq[String] =
     config.tools match
@@ -96,18 +90,16 @@ private[codex] object CodexArgs:
           case AutoApprove.Only(_) => Seq.empty
       case ToolSet.ReadOnly | ToolSet.NetworkOnly => Seq.empty
 
-  /** Top-level `-c mcp_servers.<name>.{url,tool_timeout_sec}` overrides. Placed
-    * BEFORE the subcommand so they land in codex's global-config slot (the
-    * subcommand inherits them). URL value is wrapped in TOML double-quotes
-    * since codex parses `-c` values as TOML literals.
+  /** Top-level `-c mcp_servers.<name>.{url,tool_timeout_sec}` overrides, placed
+    * BEFORE the subcommand so they land in codex's global-config slot. The URL
+    * is wrapped in TOML double-quotes since codex parses `-c` values as TOML.
     *
-    * The `tool_timeout_sec` override extends codex's per-tool timeout from its
-    * 60s default to [[AskUserMcpServer.ToolTimeout]]. Without it, codex gives
-    * up on `ask_user` after 60s and fires a follow-up — the user ends up
-    * answering twice.
+    * `tool_timeout_sec` extends codex's 60s per-tool default to
+    * [[AskUserMcpServer.ToolTimeout]]; without it codex gives up on `ask_user`
+    * after 60s and fires a duplicate follow-up.
     *
-    * One of three renderings of `AskUserMcpServer.ToolTimeout` — claude JSON ms
-    * / codex TOML sec / gemini settings.json ms; keep in sync.
+    * One of three renderings of `AskUserMcpServer.ToolTimeout` (claude JSON ms
+    * / codex TOML sec / gemini settings.json ms); keep in sync.
     */
   private def mcpServerArgs(url: Option[String]): Seq[String] =
     url.toSeq.flatMap: u =>
@@ -130,22 +122,12 @@ private[codex] object CodexArgs:
     CliArgs.flag("--output-schema", file)(_.toString)
 
   /** Maps [[AgentConfig.tools]] to codex's sandbox flags (placed after the
-    * `exec` subcommand). `ReadOnly` uses `--sandbox read-only` (no writes, no
-    * shell side-effects), matching claude's `--permission-mode plan`. `Full`
-    * follows [[AgentConfig.autoApprove]]; codex has no per-tool CLI allowlist,
-    * so [[AutoApprove.Only]] is approximated with `--full-auto`.
-    *
-    *   - `ReadOnly` → `--sandbox read-only`
-    *   - `NetworkOnly` → `--full-auto` (workspace-write + non-interactive
-    *     approval), paired with the network override in [[networkConfigArgs]]
-    *   - `Full` + `AutoApprove.All` →
-    *     `--dangerously-bypass-approvals-and-sandbox`
-    *   - `Full` + `AutoApprove.Only(_)` → `--full-auto`
+    * `exec` subcommand). codex has no per-tool CLI allowlist, so
+    * [[AutoApprove.Only]] is approximated with the coarser `--full-auto`.
     *
     * `NetworkOnly` has no read-only-with-network sandbox on codex: network
-    * needs `workspace-write`, which also permits workspace writes, so the
-    * no-edit guarantee there is prompt-only (the planning prompts forbid
-    * edits).
+    * needs `workspace-write` (via `--full-auto`), which also permits writes, so
+    * its no-edit guarantee is prompt-only.
     */
   private def sandboxArgs(config: AgentConfig): Seq[String] =
     config.tools match
@@ -157,12 +139,10 @@ private[codex] object CodexArgs:
             Seq("--dangerously-bypass-approvals-and-sandbox")
           case AutoApprove.Only(_) => Seq("--full-auto")
 
-  /** Global `-c` overrides that must precede the `exec` subcommand (codex reads
-    * them into its top-level config, which `exec` inherits). On
-    * [[ToolSet.NetworkOnly]], enable network for the workspace-write sandbox
-    * that [[sandboxArgs]] selects via `--full-auto`; off by default, so without
-    * this the planner's `gh`/`curl` calls would be blocked. Empty for the other
-    * tiers.
+  /** Global `-c` override (must precede `exec` so codex reads it into top-level
+    * config). On [[ToolSet.NetworkOnly]], enables network for the
+    * workspace-write sandbox; off by default, so without it the planner's
+    * `gh`/`curl` calls would be blocked. Empty for the other tiers.
     */
   private def networkConfigArgs(config: AgentConfig): Seq[String] =
     config.tools match
@@ -173,19 +153,12 @@ private[codex] object CodexArgs:
   /** How strongly codex enforces each `(tools, autoApprove)` combination — see
     * [[sandboxArgs]] / [[networkConfigArgs]] for the flags this classifies.
     *
-    *   - `ReadOnly` → `Hard`: `--sandbox read-only` mechanically blocks writes
-    *     and shell side-effects.
-    *   - `NetworkOnly` → `PromptOnly`: codex has no read-only-with-network
-    *     sandbox — network needs `--full-auto`'s workspace-write, which also
-    *     permits edits, so the no-edit guarantee rests only on the planner
-    *     prompt.
-    *   - `Full` + `AutoApprove.All` → `Hard`:
-    *     `--dangerously-bypass-approvals-and-sandbox` is exactly "approve
-    *     everything".
-    *   - `Full` + `AutoApprove.Only(_)` → `SandboxApprox`: codex has no
-    *     per-tool CLI allowlist, so an `Only` set is approximated by the
-    *     coarser `--full-auto` sandbox (workspace-write, no prompts) — wider
-    *     than the requested subset.
+    *   - `ReadOnly` → `Hard`: `--sandbox read-only` mechanically blocks writes.
+    *   - `NetworkOnly` → `PromptOnly`: no read-only-with-network sandbox, so
+    *     the no-edit guarantee rests only on the planner prompt.
+    *   - `Full` + `AutoApprove.All` → `Hard`: bypass flag approves everything.
+    *   - `Full` + `AutoApprove.Only(_)` → `SandboxApprox`: no per-tool
+    *     allowlist, so `--full-auto` is wider than the requested subset.
     */
   def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
     tools match

--- a/codex/src/main/scala/orca/tools/codex/CodexBackend.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexBackend.scala
@@ -56,22 +56,18 @@ private[orca] class CodexBackend(
     override val workDir: os.Path = os.pwd
 ) extends AgentBackend[BackendTag.Codex.type]:
 
-  /** Codex's threads are server-side and durable: the client→server mapping is
-    * persisted to the progress log and rehydrated on resume, and existence
-    * probes the SERVER id resolved for a client (the caller's stable id never
-    * appears in a rollout filename). The probe walks [[sessionsDir]] for a file
-    * whose name matches `rollout-*-<server-id>.jsonl`.
+  /** Codex's threads are server-side and durable: the probe walks
+    * [[sessionsDir]] for a file matching `rollout-*-<server-id>.jsonl` (the
+    * caller's stable id never appears in a rollout filename).
     *
-    * Because [[SessionSupport.willContinue]] resolves the recorded mapping
-    * first, `false` results when no server id is mapped — which includes a
-    * server id that failed the [[orca.agents.SessionId.isSafe]] guard at commit
-    * time (blocks regex injection; e.g. a server id of `.*` would otherwise
-    * match every rollout file): `register`/`commitAfterDrain` refuse to record
-    * it — as well as map-not-rehydrated-yet, or the sessions dir not existing.
+    * `false` results whenever no server id is mapped — including one that
+    * failed the [[orca.agents.SessionId.isSafe]] guard (blocks regex injection;
+    * e.g. `.*` would match every rollout file), the map not yet rehydrated, or
+    * the sessions dir missing.
     *
-    * Note: the installed codex on some machines uses SQLite
-    * (`~/.codex/state_5.sqlite`) rather than `rollout-*.jsonl` files. If no
-    * matching files exist, the probe returns `false` → re-seed, always safe.
+    * Some machines' codex uses SQLite (`~/.codex/state_5.sqlite`) instead of
+    * `rollout-*.jsonl`; with no matching files the probe returns `false` →
+    * re-seed, always safe.
     */
   val tag: BackendTag.Codex.type = BackendTag.Codex
 
@@ -90,9 +86,7 @@ private[orca] class CodexBackend(
   /** The sole session handle. [[IdScheme.ServerMinted]]: the client-allocated
     * id (the UUID the caller passes around) maps to codex's server-allocated
     * thread id (learned from `thread.started`), so subsequent calls dispatch
-    * through `codex exec resume <server-id>`. The bookkeeping is encapsulated;
-    * the spawn/commit paths go through `sessions.dispatchFor` /
-    * `Conversations.runAutonomous(session, sessions, …)`.
+    * through `codex exec resume <server-id>`.
     */
   val sessions: SessionSupport[BackendTag.Codex.type] =
     SessionSupport.durable(
@@ -112,9 +106,9 @@ private[orca] class CodexBackend(
       events: OrcaListener,
       outputSchema: Option[String]
   ): AgentResult[BackendTag.Codex.type] =
-    // drainAndCommit records the client→server mapping so a follow-up call on
-    // this client id resumes the right thread; the result carries the server
-    // thread id as its wireId, and the caller keeps using the client id.
+    // Records the client→server mapping so a follow-up call on this client id
+    // resumes the right thread; the result carries the server thread id as its
+    // wireId, and the caller keeps using the client id.
     Conversations.runAutonomous(session, sessions, events):
       openConversation(
         prompt = prompt,
@@ -123,11 +117,9 @@ private[orca] class CodexBackend(
         config = config,
         // Forwarded so (a) `conv.outputSchema` signals structured mode to the
         // drain (suppressing the raw JSON payload from the user log) and (b)
-        // `--output-schema` enforces the contract on the codex side too.
-        // `exec resume` rejects `--output-schema`, so retries against an
-        // existing session fall back to prompt-only enforcement; the
-        // retry-with-corrective-prompt loop in `DefaultAgentCall` handles a
-        // resume that produces malformed JSON.
+        // `--output-schema` enforces the contract on the codex side too. A
+        // resume can't pass `--output-schema`, so it falls back to prompt-only
+        // enforcement.
         outputSchema = outputSchema
       )
 
@@ -147,24 +139,17 @@ private[orca] class CodexBackend(
     )
 
   /** Spawn `codex exec --json` (fresh) or `codex exec resume <server-id>`
-    * (continuation), and wrap the process in a live [[CodexConversation]].
-    * Stdin is closed immediately — codex consumes the prompt argv-side.
-    *
-    * The fresh-vs-resume decision is driven by `sessions.dispatchFor`: if we've
-    * seen this client id before we resume against its mapped server thread,
-    * otherwise we start fresh and the post-drain commit (via `commitAfterDrain`
-    * on the autonomous path, `sessions.register` on the interactive path)
-    * records the mapping.
+    * (continuation), and wrap the process in a live [[CodexConversation]]. The
+    * fresh-vs-resume decision comes from `sessions.dispatchFor`; on a fresh
+    * spawn the post-drain commit records the client→server mapping.
     *
     * `Interactive` mode wires the MCP `ask_user` tool: stand up the bridge +
-    * Netty server, hand the URL to `CodexArgs` for the `-c mcp_servers.orca`
+    * Netty server, hand its URL to `CodexArgs` for the `-c mcp_servers.orca`
     * override, fold the system-prompt hint into the user prompt (codex has no
-    * `--append-system-prompt`), and hand the bridge + server to
-    * `CodexConversation` so it can surface `UserQuestion` events and close the
-    * binding on finalize. `Autonomous` skips all of it.
-    *
-    * If anything between resource allocation and conversation construction
-    * throws we tear down the server so no Netty binding leaks.
+    * `--append-system-prompt`), and hand the bridge to `CodexConversation` to
+    * surface `UserQuestion` events and close the binding on finalize.
+    * `Autonomous` skips all of it. Any throw before conversation construction
+    * tears down the server so no Netty binding leaks.
     */
   private def openConversation(
       prompt: String,
@@ -173,14 +158,10 @@ private[orca] class CodexBackend(
       config: AgentConfig,
       outputSchema: Option[String]
   )(using Ox): Conversation[BackendTag.Codex.type] =
-    // Write the schema temp file FIRST — before ANY resource is allocated — so
-    // a temp-write failure (e.g. disk full) can't leak the Netty bridge that
-    // `AskUserSession.allocate()` would spin up: with nothing allocated yet,
-    // there's nothing to tear down. It's threaded into `resources` (failure-path
-    // cleanup) and the conversation below (success-path cleanup via
-    // `onFinalize`). A unique temp file outside the tree — never `workDir` — so
-    // concurrent structured calls (the reviewer fan-out) each get their own file
-    // and `git add -A` never sees it.
+    // Write the schema temp file FIRST — before any resource is allocated — so
+    // a temp-write failure can't leak the Netty bridge `AskUserSession.allocate()`
+    // would spin up. Threaded into `resources` (failure-path cleanup) and the
+    // conversation below (success-path cleanup via `onFinalize`).
     val schemaFile = writeSchemaIfPresent(outputSchema)
     val displayPrompt = mode.displayPrompt
     val askUser: Option[AskUserSession] =
@@ -218,9 +199,8 @@ private[orca] class CodexBackend(
           )
       cli.spawnPiped(args, cwd = workDir, pipeStderr = true)
     } { process =>
-      // codex doesn't accept user turns over stdin once the initial prompt has
-      // been argv-supplied; close immediately so the child stops waiting on
-      // stdin EOF. Same reflex as claude's single-shot stream-json path.
+      // codex doesn't accept user turns over stdin once the prompt is
+      // argv-supplied; close immediately so the child stops waiting on EOF.
       process.closeStdin()
       new CodexConversation(
         process,
@@ -234,11 +214,10 @@ private[orca] class CodexBackend(
 
   /** Write the `--output-schema` payload (if any) to a unique temp file OUTSIDE
     * the working tree — never `workDir` — so it can't race a concurrent
-    * structured call for the same directory (the reviewer fan-out) and never
-    * gets swept into a flow's `git add -A`. `deleteOnExit = false`: cleanup is
-    * explicit, via [[SubprocessSpawn.deleteFileResource]] wired into the
-    * conversation's finalize (success path) and `SubprocessSpawn.open`'s
-    * `resources` (failure path) — not left to JVM-exit best-effort.
+    * structured call (the reviewer fan-out) or get swept into a flow's `git add
+    * -A`. `deleteOnExit = false`: cleanup is explicit, via
+    * [[SubprocessSpawn.deleteFileResource]] wired into both success and failure
+    * paths, not left to JVM-exit best-effort.
     */
   private def writeSchemaIfPresent(schema: Option[String]): Option[os.Path] =
     schema.map: body =>

--- a/codex/src/main/scala/orca/tools/codex/CodexConversation.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexConversation.scala
@@ -43,12 +43,9 @@ private[codex] class CodexConversation(
       * [[orca.backend.SubprocessSpawn.deleteFileResource]] and [[onFinalize]].
       */
     schemaFile: Option[os.Path] = None,
-    /** The model this agent was configured with, if any. Used as the cost-
-      * attribution fallback when codex's `thread.started` omits the resolved
-      * model id (some `codex exec` invocations, notably `resume`, do) — without
-      * it those turns' tokens land under `(unknown)` and go unpriced, so the
-      * estimated total disagrees with the by-agent breakdown. Mirrors claude's
-      * `system.init` → `result` model fallback ([[ClaudeConversation]]).
+    /** Cost-attribution fallback when codex's `thread.started` omits the
+      * resolved model id (notably on `resume`); without it those turns' tokens
+      * land under `(unknown)` and go unpriced.
       */
     configuredModel: Option[Model] = None
 ) extends ForkedConversation[BackendTag.Codex.type](
@@ -68,31 +65,21 @@ private[codex] class CodexConversation(
   private var sessionId: String = ""
   private var model: Option[String] = None
 
-  /** The most recent agent_message text the model produced (reader-thread-
-    * confined; see the group comment above). See the class scaladoc for why we
-    * synthesise rather than receive.
+  /** The most recent agent_message text (reader-thread-confined). See the class
+    * scaladoc for why we synthesise the result rather than receive it.
     */
   private var lastAgentMessage: String = ""
 
   /** MCP item ids whose `AssistantToolCall` echo we drop — the host-side bridge
-    * has already surfaced the corresponding `UserQuestion` event, so rendering
-    * the tool call on top would be noise. The matching `item.completed` is also
-    * suppressed: the user's typed answer would otherwise re-render as `⎿
-    * <answer>` after the prompt surfaced it. See
-    * [[orca.backend.AskUserEchoes]].
+    * has already surfaced the corresponding `UserQuestion`, so rendering the
+    * tool call (and its `item.completed` answer echo) on top would be noise.
+    * See [[orca.backend.AskUserEchoes]].
     */
   private val askUserEchoes = new orca.backend.AskUserEchoes
 
   // No `start()`: the base spawns its reader / stderr / ask-user forks lazily
   // on first touch of the conversation surface, after this subclass's fields
   // are initialised.
-
-  // --- Conversation surface ---
-
-  // `canAskUser` is owned by the base — true when this conversation was
-  // constructed with `askUser = Some(...)`. Codex exec has no in-session
-  // stdin channel (ADR 0007), but the agent CAN reach the user via the
-  // ask_user MCP tool when the bridge is wired.
 
   // --- Reader hooks ---
 
@@ -102,25 +89,22 @@ private[codex] class CodexConversation(
   /** codex prints known-benign noise on every exec invocation:
     *
     *   - `Reading additional input from stdin…` whenever stdin is piped (we
-    *     always pipe stdin, even though we immediately close it).
+    *     always pipe, even though we immediately close it).
     *   - `ERROR codex_core::session: failed to record rollout items: thread
-    *     <id> not found` during shutdown — fires inside codex's cleanup after
-    *     the rollout writer is already torn down. The rollout file is still
-    *     written correctly to `~/.codex/sessions/`; the message is harmless.
+    *     <id> not found` during shutdown, after the rollout writer is torn
+    *     down. The rollout file is still written correctly; the message is
+    *     harmless.
     *
-    * Filter both; anything else passes through [[StderrPipeline]]'s hoisted
-    * `handleStderr` (strip → trim → filter → Error event → recorded
-    * diagnostic).
+    * Filter both; anything else passes through [[StderrPipeline]]'s
+    * `handleStderr`.
     */
   override protected def isStderrNoise(line: String): Boolean =
     CodexConversation.isKnownStderrNoise(line)
 
   /** Best-effort delete the `--output-schema` temp file (if any), then defer to
-    * [[StderrPipeline.onFinalize]] to join the stderr drain. Runs exactly once
-    * (reader happy-path OR `cancel()` — see `ForkedConversation.runFinalize`),
-    * so the file never outlives the turn that wrote it. The delete runs in a
-    * `finally` so a throw from it (e.g. the file already gone) can't skip
-    * `super.onFinalize()` — and with it, the stderr-drain join it depends on.
+    * [[StderrPipeline.onFinalize]] to join the stderr drain. The delete runs in
+    * a `finally` so a throw from it can't skip `super.onFinalize()` and the
+    * stderr-drain join it depends on.
     */
   override protected def onFinalize(): Unit =
     try schemaFile.foreach(p => SubprocessSpawn.deleteFileResource(p).close())
@@ -217,10 +201,9 @@ private[codex] class CodexConversation(
     case Item.Other(_, _) =>
       ()
 
-  /** Compose the user-facing tool name from codex's `(server, tool)` pair.
-    * Codex namespaces MCP tools by server, so a dotted form reads naturally in
-    * the renderer log and stays distinct from the bare `bash` / `file_change`
-    * names used by codex's built-in items.
+  /** User-facing tool name from codex's `(server, tool)` pair. The dotted form
+    * stays distinct from the bare `bash` / `file_change` names of codex's
+    * built-in items.
     */
   private def mcpToolName(server: String, tool: String): String =
     s"$server.$tool"
@@ -230,9 +213,8 @@ private[codex] class CodexConversation(
       wireId = sessionId,
       output = lastAgentMessage,
       usage = usage,
-      // Fall back to the configured model when the wire omitted it (e.g.
-      // `thread.started` on a resume), so the turn's tokens are priced rather
-      // than attributed to `(unknown)`.
+      // Fall back to the configured model when the wire omitted it (e.g. on a
+      // resume) so the turn's tokens are priced, not attributed to `(unknown)`.
       modelId = model.orElse(configuredModel.map(_.name))
     )
 

--- a/codex/src/test/scala/orca/tools/codex/CodexArgsTest.scala
+++ b/codex/src/test/scala/orca/tools/codex/CodexArgsTest.scala
@@ -111,11 +111,9 @@ class CodexArgsTest extends munit.FunSuite:
   test(
     "exec emits -c mcp_servers.orca.{url,tool_timeout_sec} when an MCP url is supplied"
   ):
-    // The `-c` overrides register an MCP server for the duration of the
-    // codex invocation (this is how we plug in the ask_user bridge) and
-    // raise its tool timeout from codex's 60s default to one hour — long
-    // enough that a slow human typing an answer doesn't trigger codex's
-    // internal MCP timeout and a duplicate follow-up question.
+    // The `-c` overrides register the ask_user MCP server for the codex
+    // invocation and raise its tool timeout from codex's 60s default to one
+    // hour, so a slow human answering doesn't trigger a duplicate follow-up.
     val args = CodexArgs.exec(
       "x",
       AgentConfig(),

--- a/codex/src/test/scala/orca/tools/codex/CodexBackendTest.scala
+++ b/codex/src/test/scala/orca/tools/codex/CodexBackendTest.scala
@@ -51,9 +51,9 @@ class CodexBackendTest extends munit.FunSuite:
           clientSid,
           AgentConfig()
         )
-      // The result reports the WIRE id — the server-minted thr-42 — while the
-      // client→server mapping is recorded in the registry so subsequent calls
-      // resume it without the caller threading a new id back in.
+      // The result reports the WIRE (server-minted) id; the client→server
+      // mapping lives in the registry so later calls resume without the caller
+      // threading a new id back in.
       assertEquals(
         result.wireId,
         WireSessionId[BackendTag.Codex.type]("thr-42")
@@ -183,19 +183,18 @@ class CodexBackendTest extends munit.FunSuite:
       val firstArgs = runner.calls(0)
       val secondArgs = runner.calls(1)
       assert(!firstArgs.contains("resume"), firstArgs)
-      // Second call routes through `codex exec resume … <server-id>` — the
-      // server id was learned from the first call's thread.started.
+      // Second call resumes the server id learned from the first call's
+      // thread.started.
       assert(secondArgs.contains("resume"), secondArgs)
       assert(secondArgs.contains("thr-server-1"), secondArgs)
 
   test(
     "registerSession after an interactive call lets a follow-up autonomous call resume"
   ):
-    // Codex's server thread id is learned inside the conversation drain
-    // (not at spawn time), so the framework calls `registerSession`
-    // post-drain to record the client→server mapping. Pin that mechanism:
-    // once registered, a subsequent autonomous call with the same client id
-    // routes through `codex exec resume <server-id>`, not a fresh `exec`.
+    // Codex's server thread id is learned inside the conversation drain, so the
+    // framework registers the client→server mapping post-drain. Once
+    // registered, a follow-up autonomous call resumes rather than starting a
+    // fresh `exec`.
     val runner = new SpawnStubCliRunner(
       List(
         successfulProcess("thr-via-interactive"),
@@ -203,9 +202,8 @@ class CodexBackendTest extends munit.FunSuite:
       )
     )
     withBackend(runner): backend =>
-      // Simulate the post-interactive-drain registration that DefaultAgentCall
-      // performs (this test exercises the backend in isolation; the
-      // integration path is wired in AgentCall.runInteractiveOnce).
+      // Simulate the post-interactive-drain registration; the integration path
+      // is wired in AgentCall.runInteractiveOnce.
       backend.sessions.register(
         clientSid,
         WireSessionId[BackendTag.Codex.type]("thr-via-interactive")
@@ -217,8 +215,6 @@ class CodexBackendTest extends munit.FunSuite:
       assert(args.contains("thr-via-interactive"), args)
 
   test("distinct client ids both start fresh — no cross-client mapping"):
-    // Pins the per-client isolation of the session registry: a different
-    // client id must NOT resume the prior call's server thread.
     val runner = new SpawnStubCliRunner(
       List(
         successfulProcess("thr-server-A"),
@@ -252,14 +248,10 @@ class CodexBackendTest extends munit.FunSuite:
   test(
     "runAutonomous writes the output schema to a temp file outside workDir, and removes it once the turn finalizes"
   ):
-    // Autonomous structured calls (reviewers) get codex-side schema
-    // enforcement: the drain needs `conv.outputSchema` set so it suppresses
-    // the raw JSON payload, and `--output-schema` adds codex-side
-    // validation on top of the prompt template. The file must live OUTSIDE
-    // workDir — a fixed workDir-relative path would race the parallel
-    // reviewer fan-out and get swept into the flow's `git add -A` — and must
-    // not survive the call, or long flows would accumulate orphan schema
-    // files.
+    // The schema file must live OUTSIDE workDir — a workDir-relative path would
+    // race the parallel reviewer fan-out and get swept into the flow's
+    // `git add -A` — and must not survive the call, or long flows would
+    // accumulate orphan schema files.
     val runner = new SpawnStubCliRunner(List(successfulProcess()))
     val workDir = TempDirs.dir()
     withBackend(runner, workDir = workDir): backend =>
@@ -283,9 +275,8 @@ class CodexBackendTest extends munit.FunSuite:
         Nil,
         "nothing should be written under workDir for a structured call"
       )
-      // runAutonomous drains the conversation to completion synchronously, so
-      // by the time it returns, `onFinalize` has already run and removed the
-      // temp file.
+      // runAutonomous drains synchronously, so `onFinalize` has already removed
+      // the temp file by the time it returns.
       assert(
         !os.exists(schemaFile),
         "schema temp file should be deleted once the turn finalizes"
@@ -352,9 +343,8 @@ class CodexBackendTest extends munit.FunSuite:
         AgentConfig(),
         Some("""{"type":"object"}""")
       )
-      // Unlike runAutonomous, runInteractive hands back a Conversation the
-      // test never drains, so `onFinalize` hasn't fired yet — the file is
-      // still there to inspect.
+      // runInteractive hands back an undrained Conversation, so `onFinalize`
+      // hasn't fired — the file is still there to inspect.
       val schemaFile = schemaPathFrom(runner.calls.head)
       assert(
         !schemaFile.startsWith(workDir),
@@ -367,10 +357,9 @@ class CodexBackendTest extends munit.FunSuite:
   test(
     "runInteractive registers an MCP server and folds the ask_user hint"
   ):
-    // Interactive mode stands up the ask_user bridge: codex sees the MCP
-    // server via `-c mcp_servers.orca.url=…`, and the agent sees a short
-    // hint about the tool in the system-prompt preamble (codex has no
-    // --append-system-prompt, so it's folded into the user prompt).
+    // Interactive mode stands up the ask_user bridge: codex sees the MCP server
+    // via `-c mcp_servers.orca.url=…`, and the tool hint is folded into the
+    // user prompt (codex has no --append-system-prompt).
     val runner = new SpawnStubCliRunner(List(successfulProcess()))
     withBackend(runner): backend =>
       val _ = backend.runInteractive(
@@ -397,10 +386,8 @@ class CodexBackendTest extends munit.FunSuite:
   test(
     "runInteractive with a systemPrompt folds BOTH it and the ask_user hint"
   ):
-    // The 4-way combination of (systemPrompt, askUserHint) is concat-prone;
-    // pin the both-present case explicitly (the other three are exercised
-    // by adjacent tests: (None,false) via runAutonomous, (Some,false) via
-    // "systemPrompt is folded", (None,true) via the test above).
+    // The (systemPrompt, askUserHint) combination is concat-prone; pin the
+    // both-present case (the other three are covered by adjacent tests).
     val runner = new SpawnStubCliRunner(List(successfulProcess()))
     withBackend(runner): backend =>
       val _ = backend.runInteractive(
@@ -424,9 +411,8 @@ class CodexBackendTest extends munit.FunSuite:
   test(
     "willContinue is registry-gated: true when the mapped SERVER id has a rollout file"
   ):
-    // Codex mints its own thread id; a rollout file is named with that SERVER
-    // id, never the client id. `exists` resolves client→server via the registry
-    // (rehydrated from the log on resume) and probes THAT id.
+    // A rollout file is named with codex's SERVER id, never the client id.
+    // willContinue resolves client→server via the registry and probes THAT id.
     val serverId = "test-session-id-123"
     val tmpSessions = TempDirs.dir()
     os.write(tmpSessions / s"rollout-2024-01-01-$serverId.jsonl", "")
@@ -441,8 +427,7 @@ class CodexBackendTest extends munit.FunSuite:
 
   test("willContinue returns false when there is no client→server mapping"):
     // No registration: the client id resolves to no server id, so the probe
-    // never runs — even if a rollout file happens to be named with the client
-    // id (which codex never does in practice).
+    // never runs even if a rollout file is named with the client id.
     val tmpSessions = TempDirs.dir()
     os.write(
       tmpSessions / s"rollout-2024-01-01-${SessionId.value(clientSid)}.jsonl",
@@ -479,14 +464,12 @@ class CodexBackendTest extends munit.FunSuite:
     "willContinue returns false for a mapped SERVER id `.*` even when rollout files exist (blocks regex injection)"
   ):
     val tmpSessions = TempDirs.dir()
-    // Create a rollout file that the old regex `rollout-.*-.*\.jsonl` would match
     os.write(tmpSessions / "rollout-2024-01-01-some-real-id.jsonl", "")
     SupervisedBackend.using(
       new CodexBackend(new SpawnStubCliRunner(Nil), tmpSessions)
     ): backend =>
-      // The malicious id is the resolved WIRE id; `register`'s SessionId.isSafe
-      // guard must refuse to record it in the first place, so `exists` never
-      // even reaches the walk (no mapping to resolve).
+      // `register`'s SessionId.isSafe guard must refuse to record the `.*` wire
+      // id, so willContinue has no mapping to resolve and never walks the dir.
       backend.sessions.register(
         clientSid,
         WireSessionId[BackendTag.Codex.type](".*")

--- a/codex/src/test/scala/orca/tools/codex/CodexConversationTest.scala
+++ b/codex/src/test/scala/orca/tools/codex/CodexConversationTest.scala
@@ -9,10 +9,9 @@ import ox.{Ox, supervised}
 
 class CodexConversationTest extends munit.FunSuite:
 
-  /** `CodexConversation` forks its reader/stderr/ask-user workers into the
-    * caller's per-turn Ox, so construction needs a `using Ox`. Run each test
-    * body in a fresh supervised scope that provides it. Tests managing their
-    * own scope (the ask-user ones) stay on plain `test`.
+  /** Runs each test body in a fresh supervised scope, which `CodexConversation`
+    * needs to fork its reader/stderr/ask-user workers. Tests managing their own
+    * scope (the ask-user ones) stay on plain `test`.
     */
   private def convTest(name: String)(body: Ox ?=> Unit): Unit =
     test(name)(supervised(body))
@@ -51,9 +50,9 @@ class CodexConversationTest extends munit.FunSuite:
   convTest(
     "usage attributes to the configured model when the wire omits it"
   ):
-    // `thread.started` here carries no `model` field (as codex's `resume`
-    // exec often doesn't), so without the configured-model fallback the turn's
-    // tokens would land under `(unknown)` and go unpriced.
+    // `thread.started` here carries no `model` field (as codex's `resume` exec
+    // often doesn't); without the configured-model fallback the turn's tokens
+    // would land under `(unknown)` and go unpriced.
     val process = new FakePipedCliProcess()
     val conv = new CodexConversation(
       process,
@@ -136,9 +135,8 @@ class CodexConversationTest extends munit.FunSuite:
     process.closeStderr()
 
     val events = conv.events.toList
-    // Each agent_message item closes its own turn (see CodexConversation's
-    // scaladoc); two agent_message items means two turns are KEPT, not
-    // merged — "last wins" only picks the final result text, below.
+    // Each agent_message item closes its own turn, so two items means two turns
+    // are KEPT; "last wins" only picks the final result text, below.
     assertEquals(events.count(_ == ConversationEvent.AssistantTurnEnd), 2)
     val Right(result) = conv.awaitResult(): @unchecked
     assertEquals(result.output, "final answer")
@@ -163,10 +161,9 @@ class CodexConversationTest extends munit.FunSuite:
     process.closeStderr()
 
     val events = conv.events.toList
-    // A tool-only turn: the AssistantToolCall + ToolResult open the turn, and
-    // `turn.completed` → `succeedWith`, whose base-class auto-close now injects
-    // the owed AssistantTurnEnd (was routed around before 4A — the turn used to
-    // settle open).
+    // A tool-only turn: AssistantToolCall + ToolResult open the turn, and
+    // `turn.completed` → `succeedWith` auto-closes it with the owed
+    // AssistantTurnEnd.
     assertEquals(events.size, 3)
     events(0) match
       case ConversationEvent.AssistantToolCall(name, rawInput) =>
@@ -296,7 +293,7 @@ class CodexConversationTest extends munit.FunSuite:
 
     val events = conv.events.toList
     // Abnormal termination: the stream ends before turn.completed, so a
-    // trailing open turn (none here) is legal — completedNormally = false.
+    // trailing open turn is legal — completedNormally = false.
     ConversationEventConformance.assertGrammar(
       events,
       completedNormally = false
@@ -362,10 +359,9 @@ class CodexConversationTest extends munit.FunSuite:
   convTest(
     "`failed to record rollout items` shutdown noise is filtered out"
   ):
-    // Codex emits this ERROR line on stderr during its shutdown sequence
-    // after the rollout writer is already torn down. The rollout file is
-    // written correctly to ~/.codex/sessions/; the message is harmless and
-    // would otherwise spam the user log on every codex call.
+    // Codex emits this ERROR line during shutdown after the rollout writer is
+    // torn down; the rollout file is still written correctly, so it's harmless
+    // noise that would otherwise spam the user log on every call.
     val process = new FakePipedCliProcess()
     val conv = new CodexConversation(process)
 
@@ -417,9 +413,8 @@ class CodexConversationTest extends munit.FunSuite:
     val _ = conv.awaitResult()
 
   convTest("consecutive identical stderr lines collapse to a single Error"):
-    // Some CLIs repeat the same warning on every invocation (claude's
-    // `ANTHROPIC_API_KEY overrides…` fired ~8×/run). StderrPipeline suppresses
-    // a line identical to the one just surfaced.
+    // StderrPipeline suppresses a line identical to the one just surfaced (some
+    // CLIs repeat the same warning on every invocation).
     val process = new FakePipedCliProcess()
     val conv = new CodexConversation(process)
 
@@ -445,8 +440,8 @@ class CodexConversationTest extends munit.FunSuite:
     val _ = conv.awaitResult()
 
   convTest("interleaved different stderr lines all surface"):
-    // Dedup only collapses CONSECUTIVE identical lines; distinct lines (even an
-    // a/b/a run, where the second `a` isn't adjacent to the first) all pass.
+    // Dedup only collapses CONSECUTIVE identical lines; an a/b/a run, where the
+    // second `a` isn't adjacent to the first, surfaces all three.
     val process = new FakePipedCliProcess()
     val conv = new CodexConversation(process)
 
@@ -473,10 +468,8 @@ class CodexConversationTest extends munit.FunSuite:
     val _ = conv.awaitResult()
 
   convTest("stderr strips terminal controls before surfacing as an Error"):
-    // Pinning Task 8.4's hoist: pre-hoist, only pi's handleStderr stripped
-    // ANSI/terminal control sequences before surfacing stderr as an Error
-    // event — codex and gemini did not. StderrPipeline now strips
-    // for all three uniformly.
+    // StderrPipeline strips ANSI/terminal control sequences before surfacing
+    // stderr as an Error event.
     val process = new FakePipedCliProcess()
     val conv = new CodexConversation(process)
 
@@ -502,9 +495,8 @@ class CodexConversationTest extends munit.FunSuite:
     val _ = conv.awaitResult()
 
   convTest("mcp_tool_call emits AssistantToolCall + ToolResult"):
-    // A non-ask_user MCP tool: started and completed items round-trip
-    // into matching AssistantToolCall + ToolResult events using the
-    // dotted `server.tool` naming.
+    // A non-ask_user MCP tool round-trips into matching AssistantToolCall +
+    // ToolResult events using the dotted `server.tool` naming.
     val process = new FakePipedCliProcess()
     val conv = new CodexConversation(process)
 
@@ -543,9 +535,9 @@ class CodexConversationTest extends munit.FunSuite:
   convTest(
     "mcp_tool_call ToolResult drops non-text content fragments"
   ):
-    // The MCP content array can carry text + image + resource fragments;
-    // we only know how to render text. Non-text fragments must not leak
-    // their wire shape into the user-facing ToolResult.
+    // The MCP content array can carry text + image + resource fragments; only
+    // text is rendered, and non-text fragments must not leak their wire shape
+    // into the ToolResult.
     val process = new FakePipedCliProcess()
     val conv = new CodexConversation(process)
 
@@ -574,8 +566,8 @@ class CodexConversationTest extends munit.FunSuite:
   convTest(
     "mcp_tool_call ToolResult surfaces raw JSON when result fails to parse"
   ):
-    // MCP servers in the wild emit non-standard result shapes too; the
-    // parser must fall back to the raw JSON so the diagnostic isn't lost.
+    // For non-standard result shapes the parser falls back to the raw JSON so
+    // the diagnostic isn't lost.
     val process = new FakePipedCliProcess()
     val conv = new CodexConversation(process)
 
@@ -606,9 +598,8 @@ class CodexConversationTest extends munit.FunSuite:
   test(
     "ask_user mcp_tool_call items are suppressed (no echo in event stream)"
   ):
-    // The host-side AskUserBridge raises a UserQuestion for the same
-    // exchange (covered by its own test below); rendering the agent's
-    // tool call and the answer-as-tool-result on top would be noise.
+    // The host-side AskUserBridge raises a UserQuestion for the same exchange
+    // (covered below); echoing the tool call and answer on top would be noise.
     import ox.supervised
     import ox.channels.BufferCapacity
     import orca.backend.mcp.AskUserSession
@@ -660,9 +651,8 @@ class CodexConversationTest extends munit.FunSuite:
   test(
     "askUserBridge: questions surface as UserQuestion events; respond unblocks ask"
   ):
-    // Mirror of the equivalent ClaudeConversation test. Verifies the
-    // drainer thread converts bridge questions into UserQuestion events
-    // and the respond closure unblocks the originating `ask`.
+    // The drainer converts bridge questions into UserQuestion events and the
+    // respond closure unblocks the originating `ask`.
     import ox.{forkUser, supervised}
     import ox.channels.BufferCapacity
     import orca.backend.mcp.AskUserSession

--- a/flow/src/main/scala/orca/AgentSet.scala
+++ b/flow/src/main/scala/orca/AgentSet.scala
@@ -11,12 +11,11 @@ import orca.agents.{
 }
 
 /** The five per-backend agents a run wires. The runtime resolves the three role
-  * agents (ADR 0020) from settings against this set BEFORE the [[FlowContext]]
-  * exists, so each resolved role is a plain constructor fact of the context
-  * rather than late-bound state; the per-role programmatic overrides on
-  * `flow(...)` (`planningAgent = Some(_.claude.opus)`, …) are also selectors
-  * resolved against it. [[FlowContext]] extends this trait, so inside a flow
-  * body the same accessors resolve through the context.
+  * agents (ADR 0020) from settings against this set before the [[FlowContext]]
+  * exists; the per-role programmatic overrides on `flow(...)` (`planningAgent =
+  * Some(_.claude.opus)`, …) are also selectors resolved against it.
+  * [[FlowContext]] extends this trait, so inside a flow body the same accessors
+  * resolve through the context.
   */
 trait AgentSet:
   def claude: ClaudeAgent
@@ -25,13 +24,10 @@ trait AgentSet:
   def pi: PiAgent
   def gemini: GeminiAgent
 
-  /** Resolve the per-backend agent named by `tag` — the single definition
-    * session rehydration (`FlowLifecycle.targetAgent`) resolves a persisted
-    * record's backend tag against, so a renamed or added [[BackendTag]] case is
-    * one match to update, not one per call site. This default dispatches to the
-    * five accessors above (only the matched one is touched, so it's used as-is
-    * by every implementation — nothing to override). `private[orca]`: user code
-    * never needs it, `claude`/`codex`/… cover every use it has.
+  /** Resolve the per-backend agent named by `tag` — the single point session
+    * rehydration (`FlowLifecycle.targetAgent`) resolves a persisted record's
+    * backend tag against, so a renamed or added [[BackendTag]] case is one
+    * match to update, not one per call site.
     */
   private[orca] def agentFor(tag: BackendTag): Agent[?] = tag match
     case BackendTag.ClaudeCode => claude

--- a/flow/src/main/scala/orca/BranchNamingStrategy.scala
+++ b/flow/src/main/scala/orca/BranchNamingStrategy.scala
@@ -34,14 +34,12 @@ object BranchNamingStrategy:
     if capped.isEmpty || capped.startsWith("-") then fallback(text)
     else capped
 
-  /** Deterministic `"flow-<8-hex-chars>"` name for `text` — the exact fallback
-    * shape [[slug]] uses internally when it can't produce a safe non-empty
-    * result from its input. Exposed as a public entry point so callers that
-    * need a guaranteed-safe deterministic rename OUTSIDE of `slug`'s own
-    * trigger conditions (e.g. [[orca.progress.FeatureBranch]]'s
-    * protected-name-collision fallback, keyed on the prompt rather than the
-    * rejected name so the rename is stable across retries of the same prompt)
-    * reuse this one format rather than inventing a second one.
+  /** Deterministic `"flow-<8-hex-chars>"` name for `text` — the same fallback
+    * shape [[slug]] uses internally. Exposed so callers needing a
+    * guaranteed-safe deterministic rename outside `slug`'s own trigger
+    * conditions (e.g. [[orca.progress.FeatureBranch]]'s
+    * protected-name-collision fallback) reuse this format rather than inventing
+    * a second one.
     */
   def flowFallbackName(text: String): String = fallback(text)
 
@@ -49,11 +47,10 @@ object BranchNamingStrategy:
   private[orca] def isSlugChar(c: Char): Boolean =
     (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-'
 
-  /** True iff `s` is a single git-ref-safe segment of the exact shape [[slug]]
-    * produces: non-empty, leading alphanumeric, only `[a-z0-9-]`. The producer
-    * ([[slug]]) and validators (e.g. recovery's untrusted-header check, which
-    * splits on `/` and checks each segment) share this one definition so they
-    * cannot drift.
+  /** True iff `s` is a single git-ref-safe segment of the shape [[slug]]
+    * produces: non-empty, leading alphanumeric, only `[a-z0-9-]`. Shared by the
+    * producer ([[slug]]) and validators (e.g. recovery's untrusted-header
+    * check) so they cannot drift.
     */
   private[orca] def isSlugSegment(s: String): Boolean =
     s.nonEmpty && isSlugChar(s.head) && s.head != '-' && s.forall(isSlugChar)

--- a/flow/src/main/scala/orca/Flow.scala
+++ b/flow/src/main/scala/orca/Flow.scala
@@ -16,23 +16,14 @@ private val log = LoggerFactory.getLogger("orca.flow")
 
 /** Run `body` as a named, resumable, committing stage (ADR 0018 §2.1).
   *
-  * Control flow:
-  *
-  *   - Open the stage frame ([[FlowControl.enterStage]]) to compute its path id
-  *     `parent/name#occurrence` (just `name#occurrence` at the flow-body top
-  *     level), where `occurrence` counts prior same-named stages under the same
-  *     parent frame in this run. The frame is opened before the resume decision
-  *     and closed in a `finally`.
-  *   - Resume: if the progress log already holds an entry for this id whose
-  *     stored JSON decodes to `T`, emit StageStarted/StageCompleted and return
-  *     the decoded value without running `body`. A decode failure (the stage's
-  *     result type changed under this id) is fail-safe: fall through and run.
-  *   - Run: emit StageStarted, supply the `InStage` (LLM-call) and
-  *     `WorkspaceWrite` (index-mutation) tokens, evaluate `body`.
-  *   - Record & commit: append a `StageEntry(id, name, resultJson)` to the log,
-  *     force-add the log file, then commit (the commit also `add -A`s code
-  *     changes, so a stage yields one commit covering code + progress). Emit
-  *     StageCompleted.
+  * The stage id is a path `parent/name#occurrence` (`occurrence` counts prior
+  * same-named stages under the same parent frame). On resume, if the progress
+  * log holds an entry for this id whose JSON decodes to `T`, the decoded value
+  * is returned without running `body`; a decode failure (result type changed
+  * under this id) falls through and re-runs. A fresh run appends a
+  * `StageEntry(id, name, resultJson)`, force-adds the log, and commits — the
+  * commit also `add -A`s code changes, so a stage yields one commit covering
+  * code + progress.
   *
   * A nested stage's commit stages the whole tree, so it sweeps up any
   * uncommitted edits the outer stage's body made before the nesting point. If
@@ -42,10 +33,9 @@ private val log = LoggerFactory.getLogger("orca.flow")
   * leftovers. Prefer doing edits inside their own stage rather than around a
   * nested one.
   *
-  * Error handling mirrors `fail`/tool-adapter semantics: a non-fatal failure in
-  * `body` emits an Error event (once — `fail` and malformed-output already
-  * carry their own emission state) and re-raises. Fatal throwables propagate
-  * unreported, as they signal shutdown rather than a stage outcome.
+  * A non-fatal failure in `body` emits an Error event once (`fail` and
+  * malformed-output carry their own emission state) and re-raises. Fatal
+  * throwables propagate unreported — they signal shutdown, not a stage outcome.
   */
 def stage[T: JsonData](
     name: String,
@@ -69,10 +59,8 @@ private def resumeFrom[T: JsonData](id: String, name: String)(using
     .flatMap(_.entries.find(_.id == id))
     .flatMap: entry =>
       // The try is scoped to the decode only: a decode failure means the
-      // stage's result type changed under this id, so we fall through and
-      // re-run (None). The emits sit outside the try because listener throws
-      // no longer escape `emit` — there's nothing left for the try to guard
-      // against there.
+      // stage's result type changed under this id, so fall through and re-run
+      // (None).
       val decoded =
         try
           Some(
@@ -105,12 +93,10 @@ private def runStage[T: JsonData](
   catch
     case NonFatal(e) =>
       // Report the failure once, then mark it so an enclosing stage / the flow
-      // boundary doesn't re-report it as it unwinds. `reportOnce` covers every
-      // non-fatal throwable by identity: exceptions from `fail(...)` arrive
-      // already marked (skipped), tool adapters that throw directly and plain
-      // RuntimeExceptions arrive unmarked (surfaced here, else the user would
-      // see `exit 1` with no diagnostic). Malformed-output keeps its richer
-      // render context.
+      // boundary doesn't re-report it as it unwinds. Exceptions from `fail(...)`
+      // arrive already marked; unmarked ones (tool adapters, plain
+      // RuntimeExceptions) are surfaced here, else the user would see `exit 1`
+      // with no diagnostic. Malformed-output gets a richer render.
       fc.reportOnce(e):
         e match
           case mao: orca.agents.MalformedAgentOutputException =>
@@ -125,10 +111,7 @@ private def runStage[T: JsonData](
 
 /** Append the stage's result to the log and commit code + log as one commit.
   * The progress file is force-added (so it lands even when `.orca/` is
-  * gitignored); `git.commit`'s own `add -A` picks up any code changes. The log
-  * always changed, so a `NothingToCommit` is unexpected — logged at DEBUG (so
-  * it's observable) rather than failed, since the recorded result is what
-  * matters for resume.
+  * gitignored); `git.commit`'s own `add -A` picks up any code changes.
   */
 private def recordAndCommit[T: JsonData](
     id: String,
@@ -137,11 +120,10 @@ private def recordAndCommit[T: JsonData](
     commitMessage: Option[T => String]
 )(using fc: FlowControl): Unit =
   val resultJson = writeToString(result)(using summon[JsonData[T]].codec)
-  // Deliberately mints fresh runtime tokens rather than threading the body's:
-  // recording + committing the stage result is the runtime's own privileged
-  // step, not part of the user body. Both are needed here: `InStage` for the
-  // cheap-model commit-message fallback (`defaultCommitMessage`), `WorkspaceWrite`
-  // for the progress-store append + git force-add/commit below.
+  // Fresh runtime tokens rather than the body's: recording + committing is the
+  // runtime's own privileged step, not part of the user body. `InStage` is for
+  // the cheap-model commit-message fallback, `WorkspaceWrite` for the
+  // progress-store append + git force-add/commit below.
   given InStage = RuntimeInStage.token()
   given WorkspaceWrite = RuntimeInStage.workspaceToken()
   // Capture the code diff BEFORE force-adding the progress file so the LLM
@@ -150,9 +132,8 @@ private def recordAndCommit[T: JsonData](
     commitMessage.map(_(result)).getOrElse(defaultCommitMessage(name))
   fc.progressStore.appendEntry(StageEntry(id, name, RawJson(resultJson)))
   fc.git.forceAdd(fc.progressStore.path)
-  // The log always changed, so a clean tree here is unexpected (a prior partial
-  // run may already have committed this entry). Surface it at DEBUG so it's
-  // observable rather than silent; never fail the stage over it.
+  // The log always changed, so a clean tree is unexpected (a prior partial run
+  // may already have committed this entry): log at DEBUG, never fail the stage.
   fc.git.commit(message) match
     case Right(()) => ()
     case Left(_) =>

--- a/flow/src/main/scala/orca/FlowContext.scala
+++ b/flow/src/main/scala/orca/FlowContext.scala
@@ -29,7 +29,7 @@ import scala.annotation.implicitNotFound
 trait FlowContext extends AgentSet:
   /** Backend tag of the planning-role agent (ADR 0020): resolved from
     * `planningAgent = harness[:model]` in settings, default claude. A type
-    * *member*, not a parameter, so `FlowContext` stays unparametrised; pins
+    * member, not a parameter, so `FlowContext` stays unparametrised; pins
     * [[planningAgent]]'s backend so sessions minted from it thread. See
     * [[CodeB]] for the helper-authoring caveat shared by all three role types.
     */
@@ -37,37 +37,30 @@ trait FlowContext extends AgentSet:
 
   /** Backend tag of the coding-role agent (ADR 0020): resolved from
     * `codingAgent = harness[:model]` in settings, default claude — the run's
-    * primary backend. A type *member*, not a parameter, so `FlowContext` stays
+    * primary backend. A type member, not a parameter, so `FlowContext` stays
     * unparametrised; pins [[codingAgent]]'s backend so sessions minted from it
     * thread.
     *
-    * '''Helper authoring:''' the path-dependent `Agent[ctx.CodeB]` (the same
-    * holds for `ctx.PlanB` / `ctx.ReviewB`) is convenient in a straight-line
-    * `flow(...)` body. When you factor flow logic into a helper *function*,
-    * prefer an explicit `[B <: BackendTag]` type parameter instead: an
-    * `Agent[B]` / `FlowSession[B]` carries its backend in its own type, so the
-    * helper works for whichever backend the settings named, stays callable
-    * wherever the session is held (a `FlowSession` is a value passed around
-    * freely, not only used where the originating context is in scope), and
-    * composes with the library's other session-carrying APIs. Two ways the
-    * library does this:
+    * '''Helper authoring:''' the path-dependent `Agent[ctx.CodeB]` (likewise
+    * `ctx.PlanB` / `ctx.ReviewB`) is fine in a straight-line `flow(...)` body,
+    * but a helper *function* should take an explicit `[B <: BackendTag]` type
+    * parameter instead, so it works for whichever backend settings named and
+    * stays callable wherever the session value is held. Two shapes the library
+    * uses:
     *
-    *   - Type the helper's own parameters against the `[B <: BackendTag]`
-    *     parameter — `B` is a genuine type variable the caller instantiates
-    *     once, not a path into someone else's context. See
+    *   - Type the helper's parameters against `[B <: BackendTag]` — see
     *     [[orca.review.reviewAndFixLoop]]`(coderSession: FlowSession[B], ...)`,
-    *     whose single [[orca.FlowSession]] bundles the agent and its session so
-    *     `B` is pinned once at the call site.
-    *   - Bundle the agent's session with its result as a single
-    *     [[orca.plan.Sessioned]]`[B, A]` value, so callers pass one thing
-    *     instead of two that have to agree on `B`. See `Plan.autonomous.*` /
-    *     `Plan.interactive.*`.
+    *     whose [[orca.FlowSession]] bundles the agent and its session so `B` is
+    *     pinned once at the call site.
+    *   - Bundle session and result as a single [[orca.plan.Sessioned]]`[B, A]`
+    *     so callers pass one thing, not two that must agree on `B`. See
+    *     `Plan.autonomous.*` / `Plan.interactive.*`.
     */
   type CodeB <: BackendTag
 
   /** Backend tag of the review-role agent (ADR 0020): resolved from
     * `reviewAgent = harness[:model]` in settings, default claude. A type
-    * *member*, not a parameter, so `FlowContext` stays unparametrised; pins
+    * member, not a parameter, so `FlowContext` stays unparametrised; pins
     * [[reviewAgent]]'s backend so sessions minted from it thread. See [[CodeB]]
     * for the helper-authoring caveat shared by all three role types.
     */
@@ -107,14 +100,11 @@ trait FlowContext extends AgentSet:
   /** Exactly-once error reporting: the runtime marks a throwable here when it
     * publishes an `OrcaEvent.Error` for it, and every enclosing frame (nested
     * stages, the flow boundary) checks before re-reporting. Identity-based
-    * (`eq`) — the mark travels with the object, not its type or message, so
-    * plain RuntimeExceptions are covered too. `private[orca]`: user code never
-    * participates.
+    * (`eq`), so it covers plain RuntimeExceptions too.
     *
-    * The contract assumes a freshly-constructed throwable per failure (as every
-    * failure site in orca produces): identity marking would suppress a
-    * semantically-new failure that happened to reuse a cached/singleton
-    * exception instance — nothing in orca does that today.
+    * Assumes a freshly-constructed throwable per failure (as every orca failure
+    * site produces): identity marking would wrongly suppress a semantically-new
+    * failure that reused a cached/singleton exception instance.
     */
   private[orca] def markErrorReported(e: Throwable): Unit
   private[orca] def errorAlreadyReported(e: Throwable): Boolean

--- a/flow/src/main/scala/orca/FlowControl.scala
+++ b/flow/src/main/scala/orca/FlowControl.scala
@@ -6,44 +6,30 @@ import orca.progress.ProgressStore
 
 import scala.annotation.implicitNotFound
 
-/** Marker capability: the holder is permitted to start a new stage.
+/** Marker capability: the holder is permitted to start a new stage. Carries the
+  * run-state `stage` needs — the progress store and a stack of per-stage
+  * occurrence counters yielding each stage a hierarchical, path-structured id
+  * (ADR 0018 §2.1). `stage` requires `(using FlowControl)`; `flow` supplies it.
   *
-  * `FlowControl` is a subtype of [[FlowContext]] so that any code requiring
-  * only a `FlowContext` can be given a `FlowControl` without an explicit cast.
-  * The reverse is not true — a plain `FlowContext` cannot be widened to
-  * `FlowControl` — which lets `flow` hand forks only the narrow type,
-  * preventing them from starting nested stages.
+  * A subtype of [[FlowContext]] but not the reverse, so `flow` can hand forks
+  * only the narrow `FlowContext`, preventing them from starting nested stages.
   *
   * Thread-affine: one `FlowControl` exists per top-level `flow(...)` invocation
   * and must not be shared across threads (ADR 0018 §2.2). Extending
-  * `caps.ExclusiveCapability` is the capture-checking encoding of that
-  * affinity: once CC is adopted, separation checking forbids two concurrent
-  * closures from both capturing this exclusive capability, so a `fork` cannot
-  * smuggle the authority to start a stage onto another thread. (That marker is
-  * `@experimental` on 3.8.4, hence this file's `captureChecking` language
-  * import; the taint stays local to this compilation unit — see ADR 0018 §6.)
+  * `caps.ExclusiveCapability` encodes that affinity: separation checking
+  * forbids two concurrent closures from both capturing this exclusive
+  * capability, so a `fork` cannot smuggle the authority to start a stage onto
+  * another thread. (That marker is `@experimental` on 3.8.4, hence this file's
+  * `captureChecking` import; the taint stays local to this compilation unit —
+  * see ADR 0018 §6.) At runtime, [[StageFrames]]'s owner-thread assert enforces
+  * it for `enterStage`/`exitStage` and [[nextSessionOccurrence]].
   *
   * Not sealed: its implementation (`DefaultFlowContext`) lives in the `runner`
-  * module, which depends on `flow`, not the reverse. This is an accepted
-  * guard-rail — the open trait is not part of the public extension surface.
+  * module, which depends on `flow`, not the reverse. An accepted guard-rail —
+  * the open trait is not part of the public extension surface.
   *
-  * Carries the run-state the `stage` primitive needs: the progress store to
-  * read/append against and a stack of per-stage occurrence counters that gives
-  * each stage a hierarchical, path-structured id (ADR 0018 §2.1). `stage`
-  * requires `(using FlowControl)`; `flow` supplies it.
-  *
-  * '''Stage-identity protocol.''' `stage` computes a stage's id via
-  * [[enterStage]]/[[exitStage]] before deciding skip-vs-run. The frame-stack
-  * mechanism and its invariants (exactly-once bump, structural unreachability,
-  * opaque paths) are the canonical [[StageFrames]] scaladoc — the mixin shared
-  * by every implementation, so it can't drift from production; see ADR 0018
-  * §2.1 for the design rationale.
-  *
-  * Thread-affine: `enterStage`/`exitStage` (and the occurrence counters they
-  * drive) are covered by the same single-thread affinity contract as the rest
-  * of `FlowControl` (see below); [[StageFrames]]'s runtime owner-thread assert
-  * enforces it, alongside [[nextSessionOccurrence]] — see that trait's scaladoc
-  * for why it's the only enforcement of this for user flow scripts.
+  * The frame-stack mechanism and its invariants are documented on
+  * [[StageFrames]], the mixin shared by every implementation.
   */
 @implicitNotFound(
   "`stage(...)`, `agent.session(...)`, and `session.run(...)` on a FlowSession can only be called inside a `flow(...)` body — and not inside a `fork` (forks can read and emit, but can't start stages). If this is a helper that starts stages, declare it `(using FlowControl)` so its caller supplies it."

--- a/flow/src/main/scala/orca/RuntimeInStage.scala
+++ b/flow/src/main/scala/orca/RuntimeInStage.scala
@@ -1,16 +1,12 @@
 package orca
 
-/** The runtime's ONE named door to forged stage-bound tokens — the shared
+/** The runtime's one named door to forged stage-bound tokens — the shared
   * [[InStage]] (LLM-call gate) and the exclusive [[WorkspaceWrite]]
-  * (index-mutation gate). Every privileged mint (stage bookkeeping, session
-  * recording, lifecycle setup/teardown) calls [[token]] or [[workspaceToken]],
-  * so auditing "who can act outside a stage?" is a single grep for
-  * `RuntimeInStage` — the call sites ARE the whitelist. Library code must never
-  * call `InStage.unsafe` / `WorkspaceWrite.unsafe` directly.
-  *
-  * Test code is the sanctioned second caller of the `unsafe` mints: tests mint
-  * directly rather than going through this funnel, since they are exercising
-  * stage-bound code in isolation rather than acting as the runtime.
+  * (index-mutation gate). Every privileged mint goes through [[token]] /
+  * [[workspaceToken]], so a grep for `RuntimeInStage` is the whitelist of "who
+  * can act outside a stage?". Library code must never call `InStage.unsafe` /
+  * `WorkspaceWrite.unsafe` directly; tests are the sanctioned exception,
+  * minting directly to exercise stage-bound code in isolation.
   */
 private[orca] object RuntimeInStage:
   def token(): InStage = InStage.unsafe

--- a/flow/src/main/scala/orca/Session.scala
+++ b/flow/src/main/scala/orca/Session.scala
@@ -16,10 +16,9 @@ import scala.annotation.implicitNotFound
 import scala.util.NotGiven
 
 /** Compile-time evidence that no [[InStage]] capability is in scope — i.e. the
-  * call site is lexically outside a `stage(...)` body. Derived automatically
-  * wherever `InStage` is absent; never constructed by hand. Lexical only: a
-  * helper that takes just `(using FlowControl)` and mints inside it still
-  * compiles, so `agent.session`'s runtime in-stage check remains the backstop.
+  * call site is lexically outside a `stage(...)` body. Lexical only: a helper
+  * taking just `(using FlowControl)` that mints inside a stage still compiles,
+  * so `agent.session`'s runtime in-stage check remains the backstop.
   */
 @implicitNotFound(
   "agent.session(...) must be called outside a stage: mint sessions at the " +
@@ -32,59 +31,51 @@ object OutsideStage:
 
 /** A durable, resumable LLM-session handle — the single door for sessions that
   * must survive a flow crash and resume. Obtain one with `agent.session(name,
-  * seed)`; it bundles the [[Agent]] with the reserved [[SessionId]] and owns
-  * the entire probe → seed/preamble → run → persist protocol, so a durable run
-  * can never silently skip seeding or wire-id persistence the way a bare
-  * `agent.run` / `chat.run` turn does.
+  * seed)`. It owns the probe → seed/preamble → run → persist protocol, so a
+  * durable run can never silently skip seeding or wire-id persistence the way a
+  * bare `agent.run` / `chat.run` turn does.
   *
   * Use [[run]] for free-form text and [[resultAs]]`.run` for a structured `O`.
   * Both prime the conversation with the recorded seed and a progress preamble
   * when the backend conversation isn't live (first use or lost on resume), then
-  * persist the backend's learned resume wire id — mirror images of the same
-  * protocol on the two doors.
+  * persist the backend's learned resume wire id.
   *
   * '''Escape hatch:''' [[id]] exposes the underlying [[SessionId]];
   * `agent.chat(session.id)` adopts it as an EPHEMERAL [[orca.agents.Chat]] —
   * the way to continue this conversation from inside a fork (where the doors
-  * here are banned), interactive turns included. Chat turns FORFEIT seeding and
+  * here are banned), interactive turns included. Chat turns forfeit seeding and
   * wire-id persistence: they are in-run only and never write back to the log,
   * so on crash/resume the durable side finds nothing recorded for them.
   *
-  * The handle is a plain immutable value ([[Agent]] + [[SessionId]]): mint it
-  * once at the flow-body top level (minting inside a stage is rejected — see
-  * `agent.session`) and freely close over it into any later `stage(...)`. Only
-  * the capabilities its methods require ([[InStage]], [[WorkspaceWrite]]) are
-  * stage-scoped — the handle itself carries no stage affinity.
+  * The handle is a plain immutable value: mint it once at the flow-body top
+  * level (minting inside a stage is rejected — see `agent.session`) and close
+  * over it into any later `stage(...)`. Only the capabilities its methods
+  * require ([[InStage]], [[WorkspaceWrite]]) are stage-scoped — the handle
+  * itself carries no stage affinity.
   */
 final class FlowSession[B <: BackendTag] private[orca] (
-    /** The bundled agent. `private[orca]` — not part of the user surface, but
-      * reachable within the library so helpers taking a session handle can
-      * reach the coder's own tool.
-      */
     private[orca] val agent: Agent[B],
-    /** The underlying reserved session id — the documented escape hatch (see
-      * the class scaladoc). Prefer [[run]] / [[resultAs]]; reach for `.id` only
-      * to mint an ephemeral continuation via `agent.chat(id)`.
+    /** The underlying reserved session id — the escape hatch (see the class
+      * scaladoc). Prefer [[run]] / [[resultAs]]; reach for `.id` only to mint
+      * an ephemeral continuation via `agent.chat(id)`.
       */
     val id: SessionId[B]
 ):
 
   /** Run the agent autonomously against this session on free-form `prompt`,
-    * priming it with the recorded seed + a progress preamble IF the backend
-    * conversation isn't live (a fresh first use, or lost on resume). If the
-    * session is live, runs `prompt` as-is (continues the conversation). Returns
-    * the run's output.
+    * priming it with the recorded seed + a progress preamble if the backend
+    * conversation isn't live (fresh first use, or lost on resume); otherwise
+    * runs `prompt` as-is. Returns the run's output.
     *
-    * The seed is looked up from the progress log by matching [[id]]; if no
-    * record is found the seed is treated as empty (does not throw). The
-    * progress preamble names completed stages and is only included when there
-    * is at least one completed entry — a true first use gets just `seed +
-    * prompt`, with no misleading "resuming" text.
+    * The seed is looked up from the progress log by matching [[id]]; a missing
+    * record is treated as an empty seed (does not throw). The preamble names
+    * completed stages and is included only when there is at least one, so a
+    * true first use gets just `seed + prompt` with no misleading "resuming"
+    * text.
     *
-    * The [[WorkspaceWrite]] token is supplied explicitly (not self-minted):
-    * inside a stage body it is already ambient, so this costs the caller
-    * nothing, while making "durable runs are flow-thread-only, never from a
-    * `fork`" a signature-level fact (ADR 0018 §6).
+    * The [[WorkspaceWrite]] token is taken explicitly rather than self-minted,
+    * making "durable runs are flow-thread-only, never from a `fork`" a
+    * signature-level fact (ADR 0018 §6); inside a stage it is already ambient.
     */
   def run(prompt: String)(using
       fc: FlowControl,
@@ -106,37 +97,29 @@ final class FlowSession[B <: BackendTag] private[orca] (
     new FlowSessionCall(agent, id)
 
 /** Structured-durable gateway for a [[FlowSession]] (obtained via
-  * [[FlowSession.resultAs]]). Mirrors the raw `agent.resultAs[O]` gateway's `O`
-  * fixing, but — unlike that gateway — exposes a single `run`, not an
-  * `autonomous`/`interactive` split: interactive durable sessions are
-  * deliberately not offered (see the [[FlowSession]] class scaladoc), so there
-  * is no sibling mode for `autonomous` to distinguish itself from.
+  * [[FlowSession.resultAs]]). Fixes the output type `O`, and exposes a single
+  * `run` (no `autonomous`/`interactive` split): interactive durable sessions
+  * are deliberately not offered — see the [[FlowSession]] class scaladoc.
   */
 final class FlowSessionCall[B <: BackendTag, O] private[orca] (
     agent: Agent[B],
     id: SessionId[B]
 )(using JsonData[O], Announce[O]):
 
-  /** Held as a val (not re-derived per `run` call) so a structured session
-    * hoisted to a top-level `val` gets `resultAs[O]`'s fail-fast schema
-    * derivation (`JsonSchemaGen`) at construction time, matching the raw
-    * `agent.resultAs[O]` gateway's contract, instead of surfacing on the first
+  /** Held as a val so schema derivation (`JsonSchemaGen`) fails fast at
+    * construction time — matching `agent.resultAs[O]` — instead of on the first
     * `run()` after stage work has already started.
     */
   private val call: AgentCall[B, O] = agent.resultAs[O]
 
   /** Autonomous structured turn against the durable session. Applies the same
-    * seed/probe/persist protocol as [[FlowSession.run]]: on a lost/fresh
-    * session it prepends the recorded seed + progress preamble to the
-    * serialized `input`, runs the structured `resultAs[O].autonomous` door,
-    * then persists the learned resume wire id.
+    * seed/probe/persist protocol as [[FlowSession.run]] to the serialized
+    * `input`.
     *
-    * `emitPrompt` has no default-driving asymmetry with [[FlowSession.run]]'s
-    * free-text prompt beyond its existence: a free-text prompt is the caller's
-    * own authored text, so it is always worth emitting as a `UserPrompt` event,
-    * while a structured `input` is serialized to (potentially large) JSON, so
-    * callers that produce near-identical inputs in quick succession (e.g. a
-    * per-task fix turn) can pass `false` to suppress it.
+    * `emitPrompt` gates the `UserPrompt` event: a structured `input` serializes
+    * to (potentially large) JSON, so callers producing near-identical inputs in
+    * quick succession (e.g. a per-task fix turn) can pass `false` to suppress
+    * it.
     */
   def run[I](input: I, emitPrompt: Boolean = true)(using
       fc: FlowControl,
@@ -157,8 +140,7 @@ final class FlowSessionCall[B <: BackendTag, O] private[orca] (
     output
 
 /** Get-or-create session extension for `Agent`. Lives in the `flow` module so
-  * it can depend on [[FlowControl]] (which is in `flow`) while [[Agent]]
-  * remains in `tools` (which `flow` depends on, not the reverse).
+  * it can depend on [[FlowControl]] while [[Agent]] stays in `tools`.
   */
 extension [B <: BackendTag](agent: Agent[B])
   /** Get-or-create a durable [[FlowSession]] keyed by `name` + call-occurrence
@@ -166,44 +148,35 @@ extension [B <: BackendTag](agent: Agent[B])
     * §2.1).
     *
     * Reserves a [[SessionId]] and records `(name, occurrence, id, seed)` in the
-    * progress log, then returns a [[FlowSession]] handle wrapping it; the
-    * backend conversation is created lazily on the handle's first gated `run`.
-    * On resume, wraps the id recorded at this `(name, occurrence)`, matching
-    * `fc.nextSessionOccurrence(name)` against the same-named calls so far in
-    * this run (does not mint a second). The seed is only recorded here;
-    * [[FlowSession.run]] applies it on first use and replays it on loss.
+    * progress log, then returns a [[FlowSession]] wrapping it; the backend
+    * conversation is created lazily on the handle's first gated `run`. On
+    * resume, wraps the id recorded at this `(name, occurrence)` rather than
+    * minting a second. The seed is only recorded here; [[FlowSession.run]]
+    * applies it on first use and replays it on loss.
     *
-    * Because the key is `name` + occurrence rather than call position, identity
-    * survives inserting/reordering *other* `session(...)` calls between runs —
-    * only the call order among calls sharing this `name` matters for
-    * disambiguating duplicates.
+    * Keying by `name` + occurrence (not call position) means identity survives
+    * inserting/reordering *other* `session(...)` calls between runs; only the
+    * order among calls sharing this `name` matters.
     *
-    * No LLM call and no commit — so it is callable outside a stage. (The id is
-    * a fresh UUID, so it is not referentially transparent.) The store write
-    * mints its [[WorkspaceWrite]] token via [[RuntimeInStage]] (the same door
-    * the `stage` runtime uses for setup-phase mutations) — this is the one call
-    * in the family that must remain outside-stage-callable, so it self-mints;
-    * [[FlowSession.run]]/[[FlowSessionCall]] instead take the token explicitly.
-    * Because that write isn't committed, a failure teardown's `git reset
-    * --hard` can erase it before the next stage commit carries the log — the
-    * retry then mints a fresh session and re-seeds (see
+    * No LLM call and no commit, so it is callable outside a stage (and, minting
+    * a fresh UUID, is not referentially transparent). This is the one call in
+    * the family that must remain outside-stage-callable, so its store write
+    * self-mints a [[WorkspaceWrite]] via [[RuntimeInStage]] rather than taking
+    * the token explicitly. Because that write isn't committed, a failure
+    * teardown's `git reset --hard` can erase it before the next stage commit
+    * carries the log — the retry then mints a fresh session and re-seeds (see
     * `ProgressStore.upsertSession`).
     */
   def session(name: String, seed: String)(using
       fc: FlowControl,
       outside: OutsideStage
   ): FlowSession[B] =
-    // An empty name would collide with legacy (pre-naming) records that
-    // decode to name="" — that's an authoring defect, so require rather than
-    // return an Either.
+    // An empty name decodes ambiguously; treat it as an authoring defect.
     require(name.nonEmpty, "session name must be non-empty")
-    // Sessions are keyed by (name, occurrence) at the flow-body top level; a
-    // session minted inside a stage that later gets skipped on resume would
-    // never re-mint, desyncing the occurrence counter. Rather than build a
-    // second, parent-scoped keying mechanism for a case real flows never hit
-    // (every call site mints outside stages), require it (ADR 0018 §2.6).
-    // [[OutsideStage]] already rejects the direct in-stage call at compile
-    // time; this runtime check catches the indirect path it can't see (a
+    // A session minted inside a stage that gets skipped on resume would never
+    // re-mint, desyncing the occurrence counter — so require the flow-body top
+    // level (ADR 0018 §2.6). [[OutsideStage]] rejects the direct in-stage call
+    // at compile time; this catches the indirect path it can't see (a
     // FlowControl-only helper invoked from within a stage).
     if fc.inStage then
       throw new OrcaFlowException(
@@ -221,15 +194,10 @@ extension [B <: BackendTag](agent: Agent[B])
         val currentTag = agent.backendTag.map(_.wireName)
         recorded.backend match
           case Some(recordedTag) if currentTag != Some(recordedTag) =>
-            // A lead-backend swap between runs: the wire id under `recorded.id`
-            // was minted (and is meaningful) only in the OLD backend's registry.
-            // Re-stamping it under the new tag would silently re-seed against
-            // the wrong agent forever (the write-side half of the bug class
-            // FlowLifecycle's targeted rehydration closed on the read side) — so
-            // mint fresh instead, exactly like the no-record case, rather than
-            // reuse the stale id. Checked BEFORE the seed-diff warning below —
-            // a tag mismatch always mints fresh, so it must be the ONLY warning
-            // surfaced here; a seed-diff warning in this branch would falsely
+            // Backend swapped between runs: `recorded.id` is meaningful only in
+            // the old backend's registry, so mint fresh rather than reuse it.
+            // Checked before the seed-diff warning below so a tag mismatch
+            // surfaces the ONLY warning — a seed-diff warning here would falsely
             // claim the (never-applied) edited seed is being reused.
             fc.emit(
               OrcaEvent.Step(
@@ -240,22 +208,18 @@ extension [B <: BackendTag](agent: Agent[B])
             )
             mintSession(agent, name, occ, seed)
           case _ =>
-            // No tag mismatch (tags match, or the record predates tagging): the
-            // recorded id is untrusted (log-sourced): parse rather than trust
-            // it verbatim. A record that fails to parse (hand-edited,
-            // truncated, or otherwise corrupted) is treated the same as a
-            // backend-tag mismatch — mint fresh rather than resume against a
-            // value that could carry a path/regex/URL injection downstream.
+            // Tags match (or the record predates tagging). The recorded id is
+            // log-sourced and untrusted: parse it rather than resume against a
+            // value that could carry a path/regex/URL injection downstream; a
+            // parse failure mints fresh like the tag-mismatch case.
             SessionId.parse[B](recorded.id) match
               case Some(validId) =>
-                // This is the only branch that genuinely reuses the recorded
-                // session, so it's the only branch where a seed-diff warning
-                // is honest. Sessions are keyed by name + occurrence (see the
-                // scaladoc), so a recorded seed differing from this call's
-                // means the seed was edited between runs. The recorded session
-                // is reused either way (re-seed is the safe fallback, ADR 0018
-                // §2.6) — surface the divergence rather than resume the wrong
-                // session silently.
+                // The only branch that genuinely reuses the recorded session,
+                // so the only one where a seed-diff warning is honest. A
+                // recorded seed differing from this call's means the seed was
+                // edited between runs; the session is reused either way (re-seed
+                // is the safe fallback, ADR 0018 §2.6) — surface the divergence
+                // rather than resume silently.
                 if recorded.seed != seed then
                   fc.emit(
                     OrcaEvent.Step(
@@ -274,19 +238,16 @@ extension [B <: BackendTag](agent: Agent[B])
                 )
                 mintSession(agent, name, occ, seed)
       case None =>
-        // First run: mint a fresh id, record it, and return it.
+        // First run.
         mintSession(agent, name, occ, seed)
     new FlowSession(agent, id)
 
 /** Mint a fresh session id, record `(name, occurrence, id, seed, backend)` in
   * the progress log (replacing any existing record at the same key — see
-  * `ProgressStore.upsertSession`), and return the minted id. Shared by every
-  * arm of `agent.session(name, seed)`'s reuse match that must NOT trust a
-  * stale/mismatched/corrupt recorded id: the no-record case (first run), a
-  * recorded-vs-current backend-tag mismatch, and a recorded id that fails
-  * [[SessionId.parse]]. Mints its own [[WorkspaceWrite]] via [[RuntimeInStage]]
-  * — see `session`'s scaladoc for why this one call must remain
-  * outside-stage-callable.
+  * `ProgressStore.upsertSession`), and return it. Shared by every arm of
+  * `agent.session(name, seed)`'s reuse match that must not trust a
+  * stale/mismatched/corrupt recorded id. Mints its own [[WorkspaceWrite]] via
+  * [[RuntimeInStage]] — see `session`'s scaladoc.
   */
 private def mintSession[B <: BackendTag](
     agent: Agent[B],
@@ -309,12 +270,10 @@ private def mintSession[B <: BackendTag](
 
 /** Probe → prime step shared by [[FlowSession.run]] and
   * [[FlowSessionCall.run]]: if the backend conversation for `session` is live,
-  * `text` is returned verbatim (continues the conversation); otherwise the
-  * recorded seed and progress preamble are looked up and prepended, per the
-  * class scaladoc's probe → seed/preamble → run → persist protocol. Persisting
-  * the learned wire id afterward is each caller's own last step (see
-  * [[persistResumeWireId]]) — only the probe/prime half is common, since the
-  * two doors run different underlying calls with the primed text.
+  * `text` is returned verbatim; otherwise the recorded seed and progress
+  * preamble are prepended. Persisting the learned wire id afterward is each
+  * caller's own last step (see [[persistResumeWireId]]), since the two doors
+  * run different underlying calls.
   */
 private def effectivePrompt[B <: BackendTag](
     agent: Agent[B],
@@ -326,10 +285,10 @@ private def effectivePrompt[B <: BackendTag](
     val log = fc.progressStore.load()
     val record = log.flatMap(_.sessions.find(_.id == session.value))
     // A recorded wire id proves a backend conversation once existed, so a
-    // failed probe here means it was LOST (pruned store, another machine) —
-    // the rebuilt conversation gets only seed + preamble, not the prior
-    // turns. Surface that: silently degraded context is hard to debug. A
-    // record without a wire id is a plain first use — no warning.
+    // failed probe here means it was lost (pruned store, another machine): the
+    // rebuilt conversation gets only seed + preamble, not the prior turns.
+    // Surface that — silently degraded context is hard to debug. A record
+    // without a wire id is a plain first use, no warning.
     if record.exists(_.resumeWireId.isDefined) then
       fc.emit(
         OrcaEvent.Step(
@@ -342,22 +301,15 @@ private def effectivePrompt[B <: BackendTag](
     val preamble = progressPreamble(log)
     composePrimedPrompt(preamble, seed, text)
 
-/** After a run, persist the wire id to resume against that the backend has now
-  * learned (durable backends only — pi returns `None`), so a resumed run can
-  * rehydrate the map and continue/probe the right session. Also SELF-HEALS
-  * [[SessionRecord.backend]] from `None` to `agent`'s current tag: the reuse
-  * arm in `session(...)` already refuses to reuse a mismatched-tag record
-  * (minting fresh instead), so the only backend value that ever reaches a
-  * genuinely-reused session unhealed is `None` — a record minted before the tag
-  * field existed (an untagged, pre-tagging log). This upgrades it here on the
-  * very run that just proved this `agent` owns it — so it doesn't have to wait
-  * for a second `session(...)` call to be re-labelled correctly. Upserts the
-  * matching [[SessionRecord]] only when the learned wire id OR the healed tag
-  * differs from what is already recorded (and a record for `session` exists),
-  * so a genuine no-op run writes nothing. Takes the [[WorkspaceWrite]] token
-  * explicitly — its callers ([[FlowSession.run]] / [[FlowSessionCall]]) run
-  * inside a stage where the token is ambient, and requiring it keeps these
-  * persisting writes flow-thread-only (ADR 0018 §6).
+/** After a run, persist the backend's now-learned resume wire id (durable
+  * backends only — pi returns `None`), so a resumed run can rehydrate the map
+  * and probe the right session. Also self-heals [[SessionRecord.backend]] from
+  * `None` (an untagged record) to `agent`'s current tag, on the very run that
+  * just proved this `agent` owns it, rather than waiting for a second
+  * `session(...)` call. Upserts only when the learned wire id or the healed tag
+  * differs from what is recorded, so a no-op run writes nothing. Takes the
+  * [[WorkspaceWrite]] token explicitly to keep these writes flow-thread-only
+  * (ADR 0018 §6).
   */
 private def persistResumeWireId[B <: BackendTag](
     agent: Agent[B],

--- a/flow/src/main/scala/orca/StageFrames.scala
+++ b/flow/src/main/scala/orca/StageFrames.scala
@@ -2,73 +2,59 @@ package orca
 
 /** Per-run stage-identity bookkeeping shared by every [[FlowControl]]
   * implementation (production [[orca.runner.DefaultFlowContext]] and the test
-  * doubles), so a test double can never drift from production semantics and
-  * silently greenwash a nesting/resume test. This is the canonical description
-  * of the frame-stack protocol — [[FlowControl]] and `stage` in Flow.scala
-  * point back here rather than repeating it; see ADR 0018 §2.1 for the design
-  * rationale.
+  * doubles), so a test double can't drift from production semantics and
+  * greenwash a nesting/resume test. Canonical description of the frame-stack
+  * protocol; see ADR 0018 §2.1 for the design rationale.
   *
   * '''Mechanism.''' A stack of frames — one per currently-open stage, plus a
   * root frame (path `""`) for the flow body — scopes occurrence counters
-  * hierarchically. Each frame stores its own full path id (denormalized, rather
-  * than just a parent pointer plus a segment) and a `name -> count` map for the
-  * stages nested directly under it, so [[enterStage]] builds a child's id by
-  * string-joining `name#occurrence` onto the already-materialized parent path —
-  * no walk up the stack needed. `enterStage` pushes the child frame;
-  * [[exitStage]] pops it; the stack's head is always the current scope.
+  * hierarchically. Each frame stores its own full path id and a `name -> count`
+  * map for the stages nested directly under it, so [[enterStage]] builds a
+  * child's id by joining `name#occurrence` onto the parent path. `enterStage`
+  * pushes the child frame, [[exitStage]] pops it, and the head is always the
+  * current scope.
   *
   * '''Invariants.'''
-  *   - '''Exactly-once bump.''' `enterStage` bumps the parent frame's
-  *     occurrence counter for `name` exactly once per stage attempt, before the
-  *     resume decision is made — so the slot is consumed whether the body is
-  *     skipped, runs to completion, or throws (`stage` pops the frame in a
-  *     `finally`, covering all three outcomes). Later same-named siblings
-  *     therefore see a stable occurrence index across resumes.
-  *   - '''Structural unreachability.''' A skipped (resumed) stage's body never
-  *     runs, so its nested `stage(...)` calls never fire and never call
-  *     `enterStage` — their frames are never opened and no counter desyncs. A
-  *     flat, un-nested id scheme could not offer this: a skipped parent's
-  *     vanished nested bumps would let a later same-named stage recompute the
-  *     nested stage's id and misattribute a stale or wrong-typed record.
+  *   - '''Exactly-once bump.''' `enterStage` bumps the parent's occurrence
+  *     counter for `name` exactly once per stage attempt, before the resume
+  *     decision — so the slot is consumed whether the body is skipped,
+  *     completes, or throws (`stage` pops in a `finally`). Later same-named
+  *     siblings then see a stable occurrence index across resumes.
+  *   - '''Structural unreachability.''' A skipped stage's body never runs, so
+  *     its nested `stage(...)` calls never `enterStage` and no counter desyncs.
+  *     A flat id scheme could not offer this: a skipped parent's vanished
+  *     nested bumps would let a later same-named stage recompute a nested id
+  *     and misattribute a stale or wrong-typed record.
   *   - '''Opaque paths.''' The `#`/`/`-joined path id is only ever compared for
-  *     exact equality, never parsed or reconstructed from its parts.
+  *     exact equality, never parsed or reconstructed.
   *
-  * Thread-affine: reached only through [[FlowControl]], which is
-  * single-threaded per top-level `flow(...)` (R12, ADR 0018 §2.2) — stages,
-  * `enterStage`, `exitStage` and `session(...)` calls never run concurrently,
-  * so plain vars state the real invariant where a concurrent map would falsely
-  * advertise cross-thread sharing. `ownerThread` (captured when the concrete
-  * class mixing this trait in is constructed) is asserted against
-  * `Thread.currentThread()` on [[enterStage]], [[exitStage]], and
-  * [[nextSessionOccurrence]], so a stray call from an `ox.fork` — always a
-  * fresh thread, verified for the pinned ox 1.0.5 — throws immediately instead
-  * of silently corrupting the frame stack / occurrence counters. Every
-  * `StageFrames` implementation (production `DefaultFlowContext`, every test
-  * double) gets this for free, per this trait's own purpose above. Note that Ox
-  * runs a `supervised:` block's own body on a fresh fork as well, so
-  * `stage(...)` from the direct body of a user-opened nested scope is rejected
-  * just like an explicit `fork` — the same boundary CC's separation checking
-  * draws (that body is a fork closure capturing the exclusive capability).
-  * Production is unaffected: `runFlow` constructs the context inside the same
-  * `supervised:` body that runs the flow, so owner and body thread coincide.
+  * Thread-affine: reached only through [[FlowControl]], single-threaded per
+  * top-level `flow(...)` (R12, ADR 0018 §2.2), so plain vars state the real
+  * invariant. `ownerThread` (captured at construction) is asserted on
+  * [[enterStage]], [[exitStage]], and [[nextSessionOccurrence]], so a stray
+  * call from an `ox.fork` — always a fresh thread on the pinned ox 1.0.5 —
+  * throws instead of silently corrupting the frame stack / counters. Ox runs a
+  * `supervised:` block's own body on a fresh fork too, so `stage(...)` from the
+  * direct body of a user-opened nested scope is rejected just like an explicit
+  * `fork`. Production is unaffected: `runFlow` constructs the context inside
+  * the same `supervised:` body that runs the flow, so owner and body thread
+  * coincide.
   *
   * '''This is the only enforcement of R12 for user flow scripts.''' The
-  * capture/separation checking enforcement (ADR 0018 §6) catches a fork
-  * boundary violation at compile time, but only in files that opt into the
-  * `captureChecking`/ `separationChecking` language imports — today that's
-  * exactly one internal call site (`orca.review.ReviewLoop`'s reviewer
-  * fan-out); no example or user `.sc` script carries them. It's also strictly
-  * stronger than CC regardless: a capture check can't see a leak via mutable
-  * storage (a fork reading a `FlowControl` out of a `var`/global a stage
-  * stashed it in), only this runtime assert can.
+  * capture/separation checking enforcement (ADR 0018 §6) catches a
+  * fork-boundary violation at compile time, but only in files opting into the
+  * `captureChecking`/`separationChecking` imports — today just
+  * `orca.review.ReviewLoop`, no user `.sc` script. It's also strictly stronger:
+  * a capture check can't see a leak via mutable storage (a fork reading a
+  * `FlowControl` out of a `var`/global a stage stashed it in); this runtime
+  * assert can.
   */
 private[orca] trait StageFrames:
   private val ownerThread: Thread = Thread.currentThread()
 
-  /** Throws with the R12 message when called off `ownerThread` — see the trait
-    * scaladoc's "only enforcement of R12 for user flow scripts" note. Also
-    * called by `FlowSession`'s run doors (via [[FlowControl]]), so durable runs
-    * — not just stage/session minting — refuse from a fork at runtime.
+  /** Throws when called off `ownerThread` (R12 — see the trait scaladoc). Also
+    * called by `FlowSession`'s run doors, so durable runs — not just
+    * stage/session minting — refuse from a fork at runtime.
     */
   private[orca] def assertOwnerThread(what: String): Unit =
     if Thread.currentThread() ne ownerThread then
@@ -87,14 +73,12 @@ private[orca] trait StageFrames:
       counts = counts.updated(name, n + 1)
       n
 
-  // The root frame (path "") is the flow body; it is never popped. `enterStage`
-  // pushes, `exitStage` pops, so the head is always the current scope.
+  // The root frame (path "") is the flow body; it is never popped.
   private var frames: List[Frame] = List(new Frame(""))
 
-  /** Bump the current frame's occurrence counter for `name`, push a child frame
-    * for the new stage, and return its full path id. See the class doc's
-    * "Exactly-once bump" and "Structural unreachability" invariants for why
-    * this must be called exactly once per stage attempt.
+  /** Bump the current frame's occurrence counter for `name`, push a child
+    * frame, and return its full path id. Must be called exactly once per stage
+    * attempt — see the class doc's "Exactly-once bump" invariant.
     */
   def enterStage(name: String): String =
     assertOwnerThread("stage(...)")
@@ -116,10 +100,9 @@ private[orca] trait StageFrames:
     */
   def inStage: Boolean = frames.tail.nonEmpty
 
-  // Session occurrences are counted flat, independent of the stage frames:
-  // `agent.session(...)` is required to be called outside any stage (see
-  // `FlowControl.inStage` / `Session.session`), so it always mints against the
-  // root scope. Keyed per-name, mirroring a frame's stage counter.
+  // Session occurrences are counted flat: `agent.session(...)` must be called
+  // outside any stage, so it always mints against the root scope. Keyed
+  // per-name, mirroring a frame's stage counter.
   private var sessionCounts: Map[String, Int] = Map.empty
   def nextSessionOccurrence(name: String): Int =
     assertOwnerThread("agent.session(...)")

--- a/flow/src/main/scala/orca/accessors.scala
+++ b/flow/src/main/scala/orca/accessors.scala
@@ -42,22 +42,17 @@ def planningAgent(using ctx: FlowContext): Agent[ctx.PlanB] = ctx.planningAgent
   * A session from `codingAgent.session` threads into `session.run` and the
   * reviewers because [[FlowContext.CodeB]] pins the backend.
   *
-  * Two ways to drive a model in a flow: a role accessor
+  * Two ways to drive a model: a role accessor
   * (`codingAgent`/`planningAgent`/`reviewAgent`) is backend-agnostic — settings
-  * choose the harness, and its session threads because the role type pins the
-  * backend. A concrete accessor + tier (`claude.opus`, `codex.mini`,
-  * `opencode.openaiLuna`) names a specific backend/tier — for interactive
-  * planning or a one-off cheap call. The tier accessors (`.opus`/`.sonnet`/…)
-  * live on the concrete types, not on the agnostic role accessors, so name the
-  * model/tier **first**, then any constraints (`claude.opus.withReadOnly`, not
-  * `claude.withReadOnly.opus`). Don't mix the two for one session: a
-  * `SessionId` is backend-typed, so a session minted from `claude` won't thread
-  * through `codingAgent` when settings name a different backend.
+  * choose the harness, and its session threads. A concrete accessor + tier
+  * (`claude.opus`, `codex.mini`) names a specific backend/tier for a one-off
+  * call; name the tier first, then constraints (`claude.opus.withReadOnly`).
+  * Don't mix the two for one session: a `SessionId` is backend-typed, so a
+  * session minted from `claude` won't thread through `codingAgent` when
+  * settings name a different backend.
   *
-  * See [[orca.FlowContext.CodeB]] for the helper-authoring caveat that the
-  * path-dependent `Agent[ctx.CodeB]` (and `ctx.PlanB` / `ctx.ReviewB`) carries
-  * once code is factored into a helper *function*, shared by all three role
-  * accessors.
+  * See [[orca.FlowContext.CodeB]] for the helper-authoring caveat shared by all
+  * three role accessors.
   */
 def codingAgent(using ctx: FlowContext): Agent[ctx.CodeB] = ctx.codingAgent
 

--- a/flow/src/main/scala/orca/events/CostTracker.scala
+++ b/flow/src/main/scala/orca/events/CostTracker.scala
@@ -5,22 +5,18 @@ import orca.agents.Model
 import java.util.concurrent.atomic.AtomicReference
 
 /** Listener that accumulates `TokensUsed` events along two independent axes —
-  * by `agent` (e.g. `claude`, `abstraction`, `performance`) and by `model`
-  * (e.g. `claude-opus-4-7`, `claude-haiku-4-5`). State is held in an
-  * `AtomicReference` so the tracker is safe to register across concurrent LLM
-  * calls.
+  * by `agent` and by `model`. State is held in an `AtomicReference` so the
+  * tracker is safe to register across concurrent LLM calls.
   *
-  * Cost: each event either carries a reported figure (Claude CLI returns
-  * `total_cost_usd`) or has its cost estimated from the supplied [[PriceList]].
-  * Estimated costs are flagged so the user can see when the number depends on a
-  * maintained price table rather than the backend's own figure; the legend
-  * shows the table's `lastUpdated` date so a stale snapshot is obvious. Pass a
-  * custom `pricing` to override the default rates.
+  * Cost per event is either a reported figure (Claude CLI returns
+  * `total_cost_usd`) or estimated from the supplied [[PriceList]]. Estimated
+  * costs are flagged, and the legend shows the table's `lastUpdated` date so a
+  * stale snapshot is obvious; pass a custom `pricing` to override the rates.
   *
-  * Both axes share the same set of underlying calls, so summing either map
-  * yields the grand total. The `model` axis stores `Option[Model]` because the
-  * response's reported model isn't always present; the by-model summary
-  * surfaces the missing case as `(unknown)`.
+  * Both axes share the same underlying calls, so summing either map yields the
+  * grand total. The `model` axis keys on `Option[Model]` because the reported
+  * model isn't always present; the summary surfaces the missing case as
+  * `(unknown)`.
   */
 class CostTracker(pricing: PriceList = Pricing.default) extends OrcaListener:
 
@@ -29,11 +25,9 @@ class CostTracker(pricing: PriceList = Pricing.default) extends OrcaListener:
       byModel: Map[Option[Model], Usage] = Map.empty,
       byAgentCost: Map[String, Cost] = Map.empty,
       byModelCost: Map[Option[Model], Cost] = Map.empty,
-      /** The role last recorded for a given agent — `TokensUsed.role` is
-        * constant per agent in practice (an agent's role is set once, at the
-        * emission edge, before any of its calls), so "last write" and "first
-        * write" agree; this is purely a display/subtotal lookup, not itself a
-        * source of truth for anything. See [[byRole]] for the subtotal axis.
+      /** The role last recorded for a given agent, for display/subtotal lookup.
+        * `TokensUsed.role` is constant per agent in practice, so last-write and
+        * first-write agree. See [[byRole]] for the subtotal axis.
         */
       agentRoles: Map[String, Option[String]] = Map.empty,
       byRole: Map[Option[String], Usage] = Map.empty,
@@ -122,14 +116,11 @@ class CostTracker(pricing: PriceList = Pricing.default) extends OrcaListener:
 
   /** Two or three sections — by-agent, by-model, and (only when at least one
     * call carried a [[orca.agents.Agent.role]] tag) by-role — each sorted
-    * alphabetically by its RENDERED label, so the ordering the reader sees is
-    * the ordering applied. Each by-agent line is prefixed with that agent's
-    * role when it has one (e.g. `reviewer: performance`), purely a display
-    * derivation from [[State.agentRoles]] — `agent` itself is never mutated to
-    * carry it. Cache hits and reasoning tokens are shown parenthetically when
-    * non-zero, and cost (when known) is appended as `$X.XXXX`. An asterisk
-    * after the dollar amount marks an estimated figure; a trailing legend line
-    * explains it when at least one estimate is present.
+    * alphabetically by its rendered label. Each by-agent line is prefixed with
+    * that agent's role when it has one (e.g. `reviewer: performance`). Cache
+    * hits and reasoning tokens are shown parenthetically when non-zero, and
+    * cost (when known) is appended as `$X.XXXX`; an asterisk marks an estimated
+    * figure, with a trailing legend line when any estimate is present.
     *
     * Empty string when no `TokensUsed` events have been observed.
     */

--- a/flow/src/main/scala/orca/events/EventDispatcher.scala
+++ b/flow/src/main/scala/orca/events/EventDispatcher.scala
@@ -5,37 +5,23 @@ import org.slf4j.LoggerFactory
 import scala.util.control.NonFatal
 
 /** Synchronously forwards every `OrcaEvent` to a fixed list of listeners in
-  * registration order.
+  * registration order. Implements `OrcaListener` itself, so it can be passed
+  * anywhere a single listener is expected.
   *
-  * Implements `OrcaListener` itself so it composes naturally: a tool that
-  * accepts an `OrcaListener` can take a dispatcher directly, and dispatchers
-  * could be nested if a future use case warranted it.
+  * Total: a throwing listener is logged at ERROR with its stack, announced once
+  * on stderr, then quarantined — permanently excluded from further dispatch for
+  * the rest of the run. The remaining listeners still see every event and the
+  * emitter is never disturbed, so observation never alters flow control.
   *
-  * Total: a listener that throws is a legitimate error, so on its first failure
-  * it is logged at ERROR with its full stack (lands in the trace file only,
-  * since `OrcaLog.start()` makes the `orca` logger non-additive/file-only) and
-  * ALSO announced on stderr as a single high-level line, then **quarantined** —
-  * permanently excluded from all further dispatch for the rest of the run. An
-  * errored observer's internal state is unrecoverable: re-delivering events to
-  * it would just yield repeated throws or misleading half-broken output, and
-  * quarantining after the first failure guarantees the announcement fires
-  * exactly once. The remaining listeners still see every event and the emitter
-  * is never disturbed. Observation must not alter flow control — stage
-  * bookkeeping used to depend on emit-placement relative to try blocks to
-  * defend against throwing listeners; making emit total retires that whole
-  * class of ordering constraints.
-  *
-  * Thread-safe: holds only an immutable list and delegates to each listener in
-  * turn. Concurrent `onEvent` calls fan out concurrently to each listener — the
-  * listeners must themselves be thread-safe (see [[OrcaListener]]).
+  * Thread-safe: holds only an immutable list. Concurrent `onEvent` calls fan
+  * out concurrently to each listener — the listeners must themselves be
+  * thread-safe (see [[OrcaListener]]).
   */
 class EventDispatcher(listeners: List[OrcaListener]) extends OrcaListener:
   private val log = LoggerFactory.getLogger(classOf[EventDispatcher])
 
-  // Listeners that threw are disabled for the rest of the run: an errored
-  // observer's state is unrecoverable, so re-delivering events yields repeated
-  // throws or misleading half-broken output. Genuinely cross-thread (emitters
-  // include reviewer forks) — a concurrent set is the honest primitive.
+  // Listeners that threw, disabled for the rest of the run. Cross-thread
+  // (emitters include reviewer forks), hence a concurrent set.
   private val quarantined =
     java.util.concurrent.ConcurrentHashMap.newKeySet[OrcaListener]()
 
@@ -45,25 +31,21 @@ class EventDispatcher(listeners: List[OrcaListener]) extends OrcaListener:
         try l.onEvent(event)
         catch
           case NonFatal(e) =>
-            // `add` returns false if another thread already quarantined this
-            // listener — gating the announcement on it means concurrent
-            // first-failures on the same listener still announce exactly once.
+            // `add` returns false if another thread already quarantined `l`;
+            // gating on it makes the announcement fire exactly once.
             if quarantined.add(l) then
               log.error(
                 s"listener ${l.getClass.getName} failed on ${event.getClass.getSimpleName}" +
                   " — listener disabled for the rest of the run",
                 e
               )
-              // The ERROR above (with its stack) lands in the trace file only (the
-              // `orca` logger is file-only once OrcaLog.start() runs), so ALSO
-              // write a direct stderr line — otherwise the pathological case (a
-              // broken terminal listener throwing on the very Error event that
-              // carries the user's failure) would leave nothing visible on the
-              // console. When the event is an Error, fold its message payload in
-              // so that underlying failure isn't lost. Raw stderr may tear the
-              // terminal's status row, but this path fires only when a listener —
-              // possibly the terminal itself — is broken; visibility beats tidiness
-              // here.
+              // The ERROR above lands in the trace file only (the `orca` logger
+              // is file-only once OrcaLog.start() runs), so also write a direct
+              // stderr line — otherwise a broken terminal listener throwing on
+              // the very Error event carrying the user's failure would leave
+              // nothing visible. Fold an Error event's message in so that
+              // failure isn't lost. Raw stderr may tear the status row, but this
+              // path fires only when a listener is broken.
               val payload = event match
                 case OrcaEvent.Error(message) => s" (event error: $message)"
                 case _                        => ""

--- a/flow/src/main/scala/orca/events/Pricing.scala
+++ b/flow/src/main/scala/orca/events/Pricing.scala
@@ -28,11 +28,9 @@ case class Cost(amount: BigDecimal, estimated: Boolean):
 /** Model id → per-million-token rates. */
 type PricingTable = Map[Model, ModelPricing]
 
-/** A pricing table paired with the date its numbers were last sanity-checked
-  * against provider pricing pages. The date is surfaced in the cost-summary
-  * legend so users can judge how stale an estimated figure might be — provider
-  * pricing changes silently, so an old snapshot can drift even though the
-  * estimate looks authoritative.
+/** A pricing table paired with the date its numbers were last checked against
+  * provider pricing pages. The date is surfaced in the cost-summary legend so
+  * users can judge how stale an estimate might be.
   *
   * Override by passing your own `PriceList` to `flow(pricing = …)`:
   *
@@ -51,12 +49,10 @@ case class PriceList(table: PricingTable, lastUpdated: LocalDate)
 
 object Pricing:
 
-  /** A dated-snapshot suffix, e.g. `-20251015` — the ONLY shape the prefix
-    * fallback in [[lookup]] is meant to bridge (a provider stamping a released
-    * model id with its pinned-snapshot date). Anything else after the matched
-    * prefix (`-lite`, `-mini`, `-pro`, …) is a genuinely different,
-    * differently-priced model tier, not a snapshot of the same one — see
-    * [[lookup]].
+  /** A dated-snapshot suffix, e.g. `-20251015` — the only shape [[lookup]]'s
+    * prefix fallback bridges. Other suffixes (`-lite`, `-mini`, `-pro`, …) are
+    * genuinely different, differently-priced tiers, not snapshots of the same
+    * model.
     */
   private val DateSuffix: Regex = """^-\d{8}$""".r
 
@@ -101,12 +97,9 @@ object Pricing:
           .flatMap(table.get)
 
   /** Default community-maintained pricing snapshot, in USD per million tokens.
-    * Override by passing your own [[PriceList]] (or one derived from this one)
-    * to `flow(pricing = …)`. Re-check against the provider's pricing pages
-    * before relying on the estimate — these numbers go stale whenever a
-    * provider repacks their tiers. [[PriceList.lastUpdated]] is the date the
-    * baked-in numbers were last verified, and is surfaced in the cost-summary
-    * legend so the user can tell at a glance whether the snapshot is fresh.
+    * Override by passing your own [[PriceList]] to `flow(pricing = …)`. These
+    * numbers go stale whenever a provider repacks its tiers, so re-check
+    * against the provider's pages before relying on the estimate.
     */
   val default: PriceList = PriceList(
     table = Map(
@@ -114,10 +107,9 @@ object Pricing:
       // Claude reports `total_cost_usd` from the CLI, so these are mostly
       // safety nets for sessions that didn't surface the field.
       Model("claude-fable-5") -> ModelPricing(10, 1.00, 50),
-      // The `[1m]` id is the claude CLI's 1M-context spelling of the same
-      // model (orca's default lead); Opus 4.8's 1M window carries no
-      // long-context premium, and the suffix isn't a date so the prefix
-      // fallback in `lookup` won't bridge it — hence its own row.
+      // `[1m]` is the CLI's 1M-context spelling of the same model at the same
+      // price; the suffix isn't a date, so `lookup` won't bridge it — hence its
+      // own row.
       Model("claude-opus-4-8") -> ModelPricing(5, 0.50, 25),
       Model("claude-opus-4-8[1m]") -> ModelPricing(5, 0.50, 25),
       Model("claude-opus-4-7") -> ModelPricing(5, 0.50, 25),

--- a/flow/src/main/scala/orca/plan/AssessedPlan.scala
+++ b/flow/src/main/scala/orca/plan/AssessedPlan.scala
@@ -48,12 +48,10 @@ private[plan] case class AssessedPlan(
       Left(s"assess-then-plan: unknown verdict '$other'")
 
 private[plan] object AssessedPlan:
-  /** Friendly summary surfaced via `StructuredResult` after the assess turn.
-    * Defers to [[Plan]]'s own `Announce` on proceed; on reject it surfaces the
-    * kind so the event log shows why no PR happened. Malformed payloads
-    * (`toVerdict` Left) silently fall through to `None` here —
-    * [[Plan.autonomous.assessThenPlan]] throws the structured error at the call
-    * site, so the log just stays quiet about the rendering.
+  /** Summary surfaced after the assess turn: defers to [[Plan]]'s `Announce` on
+    * proceed, surfaces the rejection kind otherwise. Malformed payloads fall
+    * through to `None` — [[Plan.autonomous.assessThenPlan]] throws the
+    * structured error at the call site.
     */
   given Announce[AssessedPlan] = Announce.fromOption: a =>
     a.toVerdict.toOption.flatMap:

--- a/flow/src/main/scala/orca/plan/Plan.scala
+++ b/flow/src/main/scala/orca/plan/Plan.scala
@@ -5,44 +5,35 @@ import orca.agents.{Announce, BackendTag, JsonData, Agent, given}
 
 import scala.annotation.unused
 
-/** A development plan: an ordered list of [[Task]]s the agent will work
-  * through, all on a single branch, plus a `brief` — a concise codebase
-  * briefing the implementing agents rely on so they don't have to rediscover
-  * the layout.
+/** A development plan: an ordered list of [[Task]]s the agent works through on
+  * a single branch, plus a `brief` — a concise codebase briefing the
+  * implementing agents rely on. The brief is always present: it is part of the
+  * planner's structured output, and feeds the implementer session seed (ADR
+  * 0018 §2.6).
   *
   * `epicId` is a kebab-case identifier for the plan itself (it heads the
-  * markdown render). It is NOT the git branch name: the flow derives and
-  * announces its own branch at setup via [[orca.BranchNamingStrategy]], so the
-  * two can differ.
-  *
-  * The brief is always present: it is produced as part of the planner's
-  * structured output, not a separate turn, and feeds the implementer session
-  * seed (ADR 0018 §2.6).
+  * markdown render), NOT the git branch name: the flow derives and announces
+  * its own branch at setup via [[orca.BranchNamingStrategy]], so the two can
+  * differ.
   *
   * ==Planning grid==
   *
-  * The planning entry points form a `mode × operation` grid. Mode and operation
-  * are orthogonal — every combination is valid:
+  * The entry points form an orthogonal `mode × operation` grid:
   *
   *   - **mode** — [[autonomous]] (single agentic turn, read-only, no human) or
   *     [[interactive]] (a conversation the agent can drive via `ask_user`).
-  *     Chosen by the nested object so it's visible at the call site, mirroring
-  *     `claude.autonomous.run` / `claude.resultAs[O].interactive.run`.
   *   - **operation** — `from` (produce a [[Plan]] directly), `assessThenPlan`
   *     (skeptically assess first, returning a [[Verdict]] that either proceeds
   *     with a plan or rejects), or `triage` (classify a bug report into a
   *     [[Triage]] verdict).
   *
   * Every cell returns a [[Sessioned]] — the result plus the agent session that
-  * produced it. From a `Sessioned[B, Plan]` the same session can be continued
-  * read-only into [[Sessioned.reviewed]] (self-critique), or discarded for a
-  * fresh implementer session.
+  * produced it. A `Sessioned[B, Plan]` can be continued read-only into
+  * [[Sessioned.reviewed]] (self-critique), or discarded for a fresh implementer
+  * session.
   *
-  * `derives JsonData` so the structured-output path works directly: the helper
-  * methods consume Orca's auto-generated JSON schema; no caller-side
-  * serialization is needed. As a single case class it is also a valid stage
-  * result (ADR 0018 §2.3) — the stage log, not a plan file, is what resume
-  * reads.
+  * As a single case class it is a valid stage result (ADR 0018 §2.3) — the
+  * stage log, not a plan file, is what resume reads.
   */
 case class Plan(
     epicId: String,
@@ -52,8 +43,7 @@ case class Plan(
 ) derives JsonData:
 
   /** Prompt for `task`: its description, with the shared brief prepended when
-    * present. An empty brief yields the description verbatim — no stray
-    * separator.
+    * present (an empty brief yields the description verbatim).
     */
   def taskPrompt(task: Task): String =
     if brief.isEmpty then task.description
@@ -62,16 +52,13 @@ case class Plan(
 object Plan:
 
   /** Autonomous planning — a single agentic turn, no human in the loop. The
-    * agent runs `NetworkOnly` (`.withNetworkOnly`): it can verify claims via
-    * Read/Grep and read-only network (issues/PRs/web) but can't edit during the
-    * planning turn (see [[autonomousResult]] for the per-backend guarantee).
-    * Sibling of [[interactive]]; the choice between the two is visible at the
-    * call site (`Plan.autonomous.from(...)` vs `Plan.interactive.from(...)`),
-    * mirroring `Agent`'s own `autonomous` / `interactive` split.
+    * agent runs `NetworkOnly`: it can verify claims via Read/Grep and read-only
+    * network (issues/PRs/web) but can't edit during the planning turn (see
+    * [[autonomousResult]] for the per-backend guarantee).
     *
-    * Each operation returns a [[Sessioned]]: the read-only planning turn's
-    * session is still resumable by a later writable call, so the caller can
-    * continue it into implementation or discard it for a fresh session.
+    * Each operation returns a [[Sessioned]]: the read-only planning session is
+    * still resumable by a later writable call, so the caller can continue it
+    * into implementation or discard it for a fresh session.
     */
   object autonomous:
     /** Produce a [[Plan]] directly from `userPrompt`. */
@@ -109,15 +96,15 @@ object Plan:
         getOrFail(b.toTriage)
       )
 
-  /** Interactive planning — the LLM call opens a conversation the user can
-    * drive (clarifying questions, refinements) before the agent produces the
-    * result. Not read-only: claude's plan mode would disable the `ask_user` MCP
-    * tool, so the agent runs with normal permissions; the prompt asks it not to
-    * edit, and the user sees any violation. Use [[autonomous]] when no
-    * mid-session questions are needed.
+  /** Interactive planning — opens a conversation the user can drive (clarifying
+    * questions, refinements) before the agent produces the result. Not
+    * read-only: plan mode would disable the `ask_user` MCP tool, so the agent
+    * runs with normal permissions; the prompt asks it not to edit, and the user
+    * sees any violation. Use [[autonomous]] when no mid-session questions are
+    * needed.
     *
     * Each operation returns a [[Sessioned]] so the conversation can carry into
-    * implementation (e.g. a triage agent's exploration informs the fix).
+    * implementation.
     */
   object interactive:
     /** Produce a [[Plan]] directly from `userPrompt`. */
@@ -170,14 +157,13 @@ object Plan:
 
   /** Run one autonomous turn producing wire type `O`, convert it to the public
     * result `A`, and pair it with the session. Shared by every `autonomous.*`
-    * operation (`from`, `assessThenPlan`, `triage`).
+    * operation.
     *
     * Runs `NetworkOnly`: reads plus read-only network, so the planner can fetch
-    * an issue/PR it was pointed at and verify external claims. Edits stay
-    * blocked (hard on claude/gemini/opencode; prompt-only on pi/codex — the
-    * planning prompts forbid edits). Reviewers and the post-planning `reviewed`
-    * turn use plain `withReadOnly` instead — no network, hard no-edit
-    * everywhere.
+    * an issue/PR and verify external claims. Edits stay blocked (hard on
+    * claude/gemini/opencode; prompt-only on pi/codex). Reviewers and the
+    * post-planning `reviewed` turn use plain `withReadOnly` instead — no
+    * network, hard no-edit everywhere.
     */
   private def autonomousResult[B <: BackendTag, O: JsonData: Announce, A](
       agent: Agent[B],
@@ -188,9 +174,8 @@ object Plan:
       ev: InStage
   ): Sessioned[B, A] =
     // The planning turn runs on the restricted (NetworkOnly) sibling, but the
-    // chat handed out is bound to the BASE agent: a continuation must get the
-    // caller's full capability back (a NetworkOnly chat couldn't edit files),
-    // so the restriction stays per-turn, never on the thread.
+    // chat handed out is bound to the BASE agent, so a continuation regains the
+    // caller's full capability — the restriction stays per-turn.
     val planningChat = agent.withNetworkOnly.chat()
     val raw = planningChat
       .resultAs[O]
@@ -221,11 +206,9 @@ object Plan:
       .run(withInstructions(input, instructions))
     Sessioned(chat, convert(raw))
 
-  // == Post-planning step on a produced plan ==
-  //
   // `reviewed` resumes the planning session read-only, reusing the planner's
-  // exploration. Defined here so it's in the implicit scope of
-  // `Sessioned[B, Plan]` — no extra import needed.
+  // exploration. Defined here to keep it in the implicit scope of
+  // `Sessioned[B, Plan]`.
 
   extension [B <: BackendTag](sp: Sessioned[B, Plan])
     /** Resume the planning conversation for a critical self-review, returning
@@ -253,17 +236,15 @@ object Plan:
     else
       val plural = if plan.tasks.size == 1 then "" else "s"
       // No branch name here: `epicId` is the plan's own identifier, not the git
-      // branch (which the flow derives and announces separately at setup). The
-      // two can differ, so naming a branch here would be misleading on resume.
+      // branch (derived and announced separately at setup).
       val header = s"Planned ${plan.tasks.size} task$plural:"
       val body = plan.tasks.map(t => s"  - ${t.title}").mkString("\n")
       s"$header\n$body"
 
   /** Render a plan to markdown (tasks as plain bullets, the brief as a trailing
     * `## Brief` section). Used by [[Sessioned.reviewed]] to feed the plan back
-    * into the self-review prompt, and equally usable as a human-readable
-    * summary. It is **never parsed back**: the stage log is the sole resume
-    * mechanism (ADR 0018 §2.8), so there is no inverse parser to keep in sync.
+    * into the self-review prompt, and usable as a human-readable summary. Never
+    * parsed back — the stage log is the sole resume mechanism (ADR 0018 §2.8).
     */
   def render(plan: Plan): String =
     val base = renderPlan(plan)

--- a/flow/src/main/scala/orca/plan/PlanPrompts.scala
+++ b/flow/src/main/scala/orca/plan/PlanPrompts.scala
@@ -16,11 +16,10 @@ import orca.util.PromptResource
   */
 object PlanPrompts:
 
-  /** Used by `Plan.interactive.*` and `Plan.autonomous.*` to brief the planner
-    * agent. Without the opening clause agents tend to start editing files
-    * during the planning turn — the implementation is the implementer's job.
-    * Also asks the planner to fill the `brief` field of its structured output
-    * with a codebase briefing for the implementing agents.
+  /** Briefs the planner agent for `Plan.{autonomous,interactive}.from`. The
+    * opening clause keeps agents from editing files during the planning turn;
+    * also asks the planner to fill the `brief` field with a codebase briefing
+    * for the implementing agents.
     */
   val Planning: String =
     PromptResource.load("/orca/plan/prompts/planning.md")

--- a/flow/src/main/scala/orca/plan/Sessioned.scala
+++ b/flow/src/main/scala/orca/plan/Sessioned.scala
@@ -5,18 +5,15 @@ import orca.agents.{BackendTag, Chat}
 /** A planning-phase result paired with the (ephemeral) [[Chat]] that produced
   * it.
   *
-  * Every `Plan.autonomous.*` / `Plan.interactive.*` operation returns one of
-  * these so the caller can choose to continue the same conversation for the
-  * downstream implementation phase (the agent keeps the context it built up
-  * while planning / assessing / triaging) or discard it — `.value` — and mint a
-  * durable session via `agent.session(name, seed)`. The chat is in-run only, so
-  * a continuation this way does not survive a crash/resume; every shipped
-  * example takes `.value`.
+  * Every `Plan.{autonomous,interactive}.*` operation returns one of these, so
+  * the caller can continue the same conversation into the implementation phase
+  * (the agent keeps the context it built while planning) or discard it —
+  * `.value` — and mint a durable session via `agent.session(name, seed)`. The
+  * chat is in-run only, so a continuation does not survive a crash/resume.
   *
-  * Autonomous planning runs the planning TURN restricted (`NetworkOnly`), but
-  * the returned chat is bound to the base agent, so a later `chat.run(task)`
-  * continues the same conversation with write access restored — the restriction
-  * applied only to the planning turn, not to the thread.
+  * Autonomous planning restricts the planning TURN (`NetworkOnly`), but the
+  * returned chat is bound to the base agent, so a later `chat.run(task)`
+  * continues with write access restored.
   *
   * Destructure at the call site:
   *

--- a/flow/src/main/scala/orca/plan/Title.scala
+++ b/flow/src/main/scala/orca/plan/Title.scala
@@ -19,8 +19,6 @@ object Title:
   def apply(s: String): Title = s
   extension (t: Title) def value: String = t
 
-  // Title is `String` at runtime, so jsoniter's existing String codec semantics
-  // apply directly — we just retype them.
   given JsonValueCodec[Title] with
     def decodeValue(in: JsonReader, default: Title): Title =
       in.readString(default)

--- a/flow/src/main/scala/orca/plan/Triage.scala
+++ b/flow/src/main/scala/orca/plan/Triage.scala
@@ -17,24 +17,18 @@ import orca.agents.{Announce, JsonData}
   * pattern-match instead of guarding the wide-record [[BugTriage]] wire format
   * with runtime `Option#get` / empty-string checks.
   *
-  * Produced by [[Plan.autonomous.triage]] / [[Plan.interactive.triage]], both
-  * wrapped in a [[Sessioned]] that carries the triage session id. Flows
-  * typically discard the triage session (calling `.value`) and start a FRESH
-  * implementer session seeded with the issue body
-  * (`agent.session("implementer", seed = issue.body)`) rather than continuing
-  * the triage session — so the `Sessioned` wrapper is available but no
-  * carry-over is guaranteed.
+  * Produced by [[Plan.autonomous.triage]] / [[Plan.interactive.triage]],
+  * wrapped in a [[Sessioned]]. Flows typically discard the triage session
+  * (`.value`) and seed a fresh implementer session from the issue body.
   *
-  * `derives JsonData` so a `stage` can record and replay a `Triage` result —
-  * the triage stage is a checkpoint before the failing-test / fix pipeline (ADR
-  * 0018 §3.2).
+  * A `stage` can record and replay a `Triage` result — the triage stage is a
+  * checkpoint before the failing-test / fix pipeline (ADR 0018 §3.2).
   */
 enum Triage derives JsonData:
   case NotABug(explanation: String)
   case Untestable(summary: String, reproductionSteps: String)
-  // `branchName` is the LLM-suggested name from the wire format. The actual
-  // feature branch is created by the flow runtime (via BranchNamingStrategy),
-  // not from this field — flows should wildcard it in pattern matches.
+  // `branchName` is only the LLM's suggestion; the actual feature branch comes
+  // from the runtime (BranchNamingStrategy), so flows should wildcard it.
   case Testable(summary: String, branchName: String, failingTestPath: String)
 
 object Triage:

--- a/flow/src/main/scala/orca/plan/Verdict.scala
+++ b/flow/src/main/scala/orca/plan/Verdict.scala
@@ -1,13 +1,12 @@
 package orca.plan
 
 /** Outcome of an assess-before-act stage (e.g.
-  * [[Plan.autonomous.assessThenPlan]]). Either the agent endorses the input and
-  * supplies a value to act on (`Proceed`), or it rejects the input with a body
-  * the caller surfaces to whoever filed the report — a follow-up question, a
-  * constructive critique, or an outright rebuff. The `kind` lets the caller
-  * pick framing (e.g. a GH comment template) without re-reading the body.
+  * [[Plan.autonomous.assessThenPlan]]): either the agent endorses the input and
+  * supplies a value to act on (`Proceed`), or it rejects it with a body the
+  * caller surfaces to the reporter. `kind` lets the caller pick framing (e.g. a
+  * GH comment template) without re-reading the body.
   *
-  * Generic so the same type works for plan-or-critique, design-doc-or-pushback,
+  * Generic, so the same type serves plan-or-critique, design-doc-or-pushback,
   * triage-or-defer, etc.
   */
 sealed trait Verdict[+A]

--- a/flow/src/main/scala/orca/pr/PrPrompts.scala
+++ b/flow/src/main/scala/orca/pr/PrPrompts.scala
@@ -2,11 +2,9 @@ package orca.pr
 
 import orca.util.PromptResource
 
-/** Default prompt fragment for the helpers in this package. Override by passing
-  * a different string to the helper's `instructions` parameter — wrap the
-  * default if you only want to extend it.
-  *
-  * Source text lives in `src/main/resources/orca/pr/prompts/`.
+/** Default prompt fragments for the helpers in this package, overridable via
+  * each helper's `instructions` parameter. Source text lives in
+  * `src/main/resources/orca/pr/prompts/`.
   */
 object PrPrompts:
 

--- a/flow/src/main/scala/orca/pr/openPrFromBranch.scala
+++ b/flow/src/main/scala/orca/pr/openPrFromBranch.scala
@@ -6,26 +6,19 @@ import orca.tools.PrHandle
 
 import ox.either.orThrow
 
-/** Push the current feature branch and open a PR for it, as the three separate
-  * stages the resume protocol needs: push → summarise → create. Bundles the
-  * hand-rolled tail every "land the work and open a PR" flow otherwise repeats.
+/** Push the current feature branch and open a PR for it, as three separate
+  * [[stage]]s: push → summarise → create. Split because a stage commits only on
+  * completion, so pushing in the same stage as the summarise (or the preceding
+  * edits) would be fragile on resume.
   *
-  * The split into three [[stage]]s is deliberate and resume-critical: a stage
-  * commits only on completion, so pushing in the same stage as the summarise
-  * (or the edits that preceded it) would be fragile on resume. Each stage keeps
-  * the name the examples used ("Push branch", "Generate PR title and
-  * description", "Open PR") so an existing flow's recorded progress still
-  * matches.
-  *
-  * The diff handed to the summariser is `git.diffVsBase(git.defaultBase())` —
-  * the branch-vs-base diff, NOT `git.diff()` (vs HEAD), which is empty once
-  * every task is already committed.
+  * The diff handed to the summariser is the branch-vs-base diff
+  * (`git.diffVsBase(git.defaultBase())`), NOT `git.diff()` (vs HEAD), which is
+  * empty once every task is already committed.
   *
   * Customise the PR text with `title`/`body`, both given the generated
-  * [[PrSummary]]: `body` defaults to the summary body verbatim, but a flow that
-  * closes an issue passes e.g. `body = s => s"${s.body}\n\nCloses #42."`. Point
-  * `summarisingAgent` at a cheap model (the summary is a small fold) and pass
-  * `context` to anchor it to the originating issue/prompt.
+  * [[PrSummary]]; a flow that closes an issue passes e.g. `body = s =>
+  * s"${s.body}\n\nCloses #42."`. Point `summarisingAgent` at a cheap model and
+  * pass `context` to anchor it to the originating issue/prompt.
   *
   * `gh.createPr` is idempotent by head branch: a re-run that already opened the
   * PR gets the existing handle back rather than failing. Returns that handle.

--- a/flow/src/main/scala/orca/pr/orcaCommentMarker.scala
+++ b/flow/src/main/scala/orca/pr/orcaCommentMarker.scala
@@ -3,16 +3,14 @@ package orca.pr
 import orca.progress.ProgressStore
 
 /** Build a stable, per-run HTML comment marker for use with
-  * [[orca.tools.GitHubTool.upsertComment]]. The marker is an HTML comment
-  * invisible in the rendered GitHub UI but detectable in the raw body, enabling
-  * a re-run to find and update its own prior comment instead of duplicating it.
+  * [[orca.tools.GitHubTool.upsertComment]]. Invisible in GitHub's rendered UI
+  * but detectable in the raw body, so a re-run finds and updates its own prior
+  * comment instead of duplicating it.
   *
-  * `userPrompt` is hashed so two different flow runs for different prompts
-  * produce distinct markers even with the same `purpose`. `purpose` further
-  * namespaces the marker within a single run (e.g. `"reject"`, `"triage"`).
-  *
-  * Example: `orcaCommentMarker(userPrompt, "reject")` produces a single-line
-  * marker: `<!-- orca:a1b2c3d4e5f6:reject -->`
+  * `userPrompt` is hashed so runs for different prompts produce distinct
+  * markers even with the same `purpose`; `purpose` further namespaces the
+  * marker within a run (e.g. `"reject"`, `"triage"`). Produces e.g. `<!--
+  * orca:a1b2c3d4e5f6:reject -->`.
   */
 def orcaCommentMarker(userPrompt: String, purpose: String): String =
   s"<!-- orca:${ProgressStore.hashPrompt(userPrompt)}:$purpose -->"

--- a/flow/src/main/scala/orca/pr/summarisePr.scala
+++ b/flow/src/main/scala/orca/pr/summarisePr.scala
@@ -6,27 +6,21 @@ import orca.agents.{Announce, JsonData, Agent}
 import scala.annotation.unused
 
 /** What [[summarisePr]] produces: a one-line PR title and a multi-paragraph
-  * body. `gh.createPr(title = …, body = …)` accepts the two fields directly, so
-  * call sites typically destructure or pass them positionally.
+  * body, consumed directly by `gh.createPr(title = …, body = …)`.
   */
 case class PrSummary(title: String, body: String) derives JsonData
 
 object PrSummary:
-  /** Silent — the calling stage already names the PR; an `Announce` summary
-    * here would just repeat the title.
-    */
+  /** Silent — the calling stage already names the PR. */
   given Announce[PrSummary] = Announce.from(_ => "")
 
-/** Ask `agent` to fold `diff` (and optionally `context`) into a [[PrSummary]] —
-  * the one-line title and multi-paragraph body that `gh.createPr` consumes.
+/** Ask `agent` to fold `diff` (and optionally `context`) into a [[PrSummary]].
   *
-  * `context` is rendered above the diff as a preamble; typical contents are the
-  * originating issue link and title, the user prompt that drove the work, or
-  * whatever the flow author wants the model to anchor the description to. Omit
-  * for diff-only summarisation.
+  * `context` is rendered above the diff as a preamble — typically the
+  * originating issue link and title, or the user prompt that drove the work.
+  * Omit for diff-only summarisation.
   *
-  * Use a cheap model — summarisation is a small fold and doesn't benefit from a
-  * frontier model. The autonomous call runs `emitPrompt = false` because the
+  * Use a cheap model. The autonomous call runs `emitPrompt = false` because the
   * diff dominates the prompt and would dwarf the event log.
   */
 def summarisePr(

--- a/flow/src/main/scala/orca/progress/FeatureBranch.scala
+++ b/flow/src/main/scala/orca/progress/FeatureBranch.scala
@@ -3,50 +3,36 @@ package orca.progress
 /** A branch name orca itself may create, commit to, or delete during its own
   * lifecycle bookkeeping (ADR 0018 §2.4/§2.5) — as opposed to any bare `String`
   * git happens to accept. Every [[FeatureBranch]] is guaranteed non-protected
-  * AND ref-shape-safe: it is NOT a protected branch, where "protected" means
-  * the always-protected floor ([[RecoveryCheck.alwaysProtected]] — `main`/
-  * `master`) unioned with whatever the caller additionally supplies — in
-  * practice the repo's detected default branch (`git.defaultBranch()`), so a
-  * repo whose default is e.g. `trunk` is covered too — AND it is a safe git ref
-  * ([[RecoveryCheck.isSafeBranchRef]]), so the guarantee holds regardless of
-  * whether the caller already slugged `name`.
+  * (not in the always-protected floor [[RecoveryCheck.alwaysProtected]] unioned
+  * with the caller-supplied set, in practice the repo's detected default) AND a
+  * safe git ref ([[RecoveryCheck.isSafeBranchRef]]), so the guarantee holds
+  * regardless of whether the caller already slugged `name`.
   *
   * Both places orca binds itself to a feature branch mint one through
-  * [[FeatureBranch.resolve]]: `FlowLifecycle`'s fresh-run arm (a
-  * strategy/LLM-resolved name that might collide with a protected branch —
-  * previously UNCHECKED, the hole this type closes) and its resume arm
-  * ([[RecoveryCheck.validateHeader]], checking an untrusted persisted header).
-  * One constructor, one policy, one home for the protected-branch check — a
-  * protected name can never reach `FlowSetup.featureBranch` from either arm.
+  * [[FeatureBranch.resolve]]: `FlowLifecycle`'s fresh-run arm and its resume
+  * arm ([[RecoveryCheck.validateHeader]], checking an untrusted persisted
+  * header). One constructor, one home for the protected-branch check.
   *
-  * Deliberately takes `protectedBranches: Set[String]` rather than a `GitTool`,
-  * mirroring [[RecoveryCheck.validateHeader]]'s existing shape: it stays pure
-  * and unit-testable without a repo fixture, and `tools` (below `flow` in the
-  * module graph) never learns this type exists — the git layer stays
+  * Takes `protectedBranches: Set[String]` rather than a `GitTool` so it stays
+  * pure and unit-testable without a repo fixture, and the git layer stays
   * `String`-typed and flow-oblivious. Callers unwrap via `.value` only at the
-  * actual git call site.
+  * git call site.
   */
 opaque type FeatureBranch = String
 
 object FeatureBranch:
 
-  /** Attempt to mint a [[FeatureBranch]] from `name`. Refuses `name` (case-
-    * insensitively, matching [[RecoveryCheck]]'s existing normalization — case
-    * folded with `Locale.ROOT` so the comparison is locale-independent, e.g.
-    * immune to the Turkish-I dotless-i bug) when it is in `protectedBranches`
-    * or the always-protected floor ([[RecoveryCheck.alwaysProtected]]); the
-    * union mirrors [[RecoveryCheck.validateHeader]]'s protected-branch check
-    * exactly, so a name refused for a resumed header is refused for a fresh run
-    * too, and vice versa.
+  /** Attempt to mint a [[FeatureBranch]] from `name`. Refuses `name`
+    * (case-insensitively, folded with `Locale.ROOT`) when it is in
+    * `protectedBranches` or the always-protected floor
+    * ([[RecoveryCheck.alwaysProtected]]); the union mirrors
+    * [[RecoveryCheck.validateHeader]]'s check so fresh and resumed runs agree.
     *
     * ALSO refuses `name` when it is not a safe ref shape
-    * ([[RecoveryCheck.isSafeBranchRef]]) — this is what makes the type's
-    * guarantee unconditional rather than resting on every caller having slugged
-    * `name` first. `FlowLifecycle`'s fresh arm always passes an already-slugged
-    * name ([[orca.BranchNamingStrategy]] guarantees shape by construction), so
-    * this is a no-op there; [[RecoveryCheck.validateHeader]] already
-    * shape-checks the untrusted header BEFORE calling `resolve`, so this is a
-    * no-op (redundant, defensive) there too.
+    * ([[RecoveryCheck.isSafeBranchRef]]) — this makes the guarantee
+    * unconditional rather than resting on callers having slugged `name`. Both
+    * call sites already pass a shape-safe name, so it is a defensive no-op
+    * there.
     */
   def resolve(
       name: String,
@@ -62,29 +48,23 @@ object FeatureBranch:
     else Right(name)
 
   extension (fb: FeatureBranch)
-    /** Unwrap for the git layer. The only sanctioned way out of the opaque type
-      * — call this at the `GitTool` call site, not earlier.
+    /** Unwrap for the git layer — call at the `GitTool` call site, not earlier.
       */
     def value: String = fb
 
 /** Common parent for [[FeatureBranch.resolve]] refusal reasons — lets a caller
-  * pattern-match "protected branch" apart from "unsafe ref shape" instead of
-  * inspecting a message string.
+  * distinguish "protected branch" from "unsafe ref shape" without inspecting a
+  * message string.
   */
 sealed trait FeatureBranchRefused:
   def name: String
 
-/** `name` was refused by [[FeatureBranch.resolve]] because it is a protected
-  * branch (case-insensitive match against the always-protected floor or the
-  * caller-supplied protected set).
-  */
+/** `name` was refused because it is a protected branch. */
 final case class ProtectedBranchRefused(name: String)
     extends FeatureBranchRefused
 
-/** `name` was refused by [[FeatureBranch.resolve]] because it is not a safe git
-  * ref ([[RecoveryCheck.isSafeBranchRef]]) — not the slug shape
-  * [[orca.BranchNamingStrategy.slug]] produces, e.g. not `/`-segmented
-  * lowercase-alphanumeric-with-hyphens, or otherwise unsafe as a raw ref.
+/** `name` was refused because it is not a safe git ref
+  * ([[RecoveryCheck.isSafeBranchRef]]).
   */
 final case class UnsafeBranchRefRefused(name: String)
     extends FeatureBranchRefused

--- a/flow/src/main/scala/orca/progress/ProgressLog.scala
+++ b/flow/src/main/scala/orca/progress/ProgressLog.scala
@@ -18,16 +18,14 @@ case class ProgressHeader(
 /** A single stage's outcome, stored as an already-serialised JSON subtree.
   *
   * `id` is the stage's hierarchical path id — `name#occurrence` segments joined
-  * by `/` (e.g. `outer#0/inner#0`), where a nested stage carries its enclosing
-  * stages' segments as a prefix (ADR 0018 §2.1). It is opaque: only ever
-  * compared for exact equality (resume lookup, upsert), never parsed. A per-run
-  * artifact, so the format is not a cross-version contract.
+  * by `/` (e.g. `outer#0/inner#0`), a nested stage prefixed by its enclosing
+  * stages' segments (ADR 0018 §2.1). Opaque: only compared for exact equality,
+  * never parsed.
   *
   * `resultJson` is type-erased at rest — the log is heterogeneous across stage
-  * types. Deserialisation back to a typed value happens at the stage call site
-  * (C3), not here. It is a [[orca.util.RawJson]], embedded verbatim in the log
-  * file rather than as a string-escaped blob, so the persisted file stays
-  * directly readable when debugging.
+  * types; deserialisation to a typed value happens at the stage call site. A
+  * [[orca.util.RawJson]], embedded verbatim rather than string-escaped so the
+  * persisted file stays directly readable when debugging.
   */
 case class StageEntry(id: String, name: String, resultJson: RawJson)
     derives JsonData
@@ -35,41 +33,32 @@ case class StageEntry(id: String, name: String, resultJson: RawJson)
 /** A persisted session: the name + occurrence that key it (stage-style — see
   * [[orca.FlowControl.nextSessionOccurrence]]), a minted UUID, the seed string
   * the author supplied, and — when the session is durably resumable — the wire
-  * id to resume against. Like [[StageEntry]], a per-run artifact: cross-version
-  * resume of an in-flight run is not supported.
+  * id to resume against.
   *
   * `id` is the stable client id the framework hands across calls;
   * [[SessionRecord.resumeWireId]] is the id to put on the wire when resuming
-  * the live backend conversation (the same `wireId` notion as
-  * [[orca.backend.Dispatch]]). Its value depends on the backend, but its
-  * meaning is uniform:
+  * the live backend conversation (same `wireId` notion as
+  * [[orca.backend.Dispatch]]). Its value depends on the backend:
   *   - codex/gemini/opencode: a backend-minted server-thread id (≠ `id`);
-  *   - claude: equal to `id` itself — claude's sessions are durable on disk and
-  *     its client id IS the wire id, so recording it re-claims the session
-  *     (`--resume`) on a resumed run rather than re-creating it;
-  *   - pi: `None` — pi's sessions live in a `deleteOnExit` temp dir, so nothing
-  *     survives a restart and a resumed run always re-seeds.
+  *   - claude: equal to `id` itself — claude's sessions are durable on disk, so
+  *     recording it re-claims the session (`--resume`) on a resumed run;
+  *   - pi: `None` — pi's sessions live in a `deleteOnExit` temp dir, so a
+  *     resumed run always re-seeds.
   *
-  * It is persisted so a resumed run can rehydrate the in-memory map and (a)
-  * resume against the right wire id and (b) probe it for existence.
-  *
-  * `resumeWireId` is `None` until a run learns it (see `persistResumeWireId` in
-  * `orca.Session`). Stored in [[ProgressLog.sessions]] so that a resumed run
-  * reuses the same [[orca.agents.SessionId]] rather than minting a second one.
+  * Persisted so a resumed run can rehydrate the in-memory map, resume against
+  * the right wire id, and reuse the same [[orca.agents.SessionId]] rather than
+  * minting a second one. `resumeWireId` is `None` until a run learns it (see
+  * `persistResumeWireId` in `orca.Session`).
   *
   * `backend` records the minting agent's [[orca.agents.BackendTag]] via its
-  * stable [[orca.agents.BackendTag.wireName]] (e.g. `"Codex"` — frozen
-  * independently of the case name, so a future case rename can't strand this
-  * field), so a resumed run's targeted rehydration
-  * (`FlowLifecycle.rehydrateSessions`) knows which agent to replay this
-  * record's `resumeWireId` into rather than always assuming the lead. `None`
-  * when the minting agent carries no backend tag (a stub agent built directly
-  * on `Agent`) — such records fall back to the lead on rehydration. A value
-  * that matches no known [[orca.agents.BackendTag.wireName]] (an edited log) is
-  * skipped with a warning rather than guessed — see
-  * `FlowLifecycle.targetAgent`. `agent.session(name, seed)`'s reuse arm also
-  * self-heals a stale tag (a lead-backend swap between runs) rather than
-  * silently re-seeding under the wrong tag forever.
+  * stable [[orca.agents.BackendTag.wireName]] (frozen independently of the case
+  * name), so targeted rehydration (`FlowLifecycle.rehydrateSessions`) knows
+  * which agent to replay `resumeWireId` into rather than assuming the lead.
+  * `None` when the minting agent carries no backend tag (a stub agent) — falls
+  * back to the lead. A value matching no known `wireName` (an edited log) is
+  * skipped with a warning rather than guessed (`FlowLifecycle.targetAgent`);
+  * `agent.session(name, seed)`'s reuse arm self-heals a stale tag from a
+  * lead-backend swap.
   */
 case class SessionRecord(
     name: String,
@@ -81,11 +70,8 @@ case class SessionRecord(
 ) derives JsonData
 
 /** An append-only log of stage outcomes and session records for one flow run,
-  * keyed by its header.
-  *
-  * `sessions` defaults to `Nil` so that existing log files written before this
-  * field was introduced continue to decode. The custom [[JsonData]] instance
-  * below uses a lenient codec config that tolerates missing collection fields.
+  * keyed by its header. The custom [[JsonData]] instance below tolerates
+  * missing collection fields so logs round-trip across software versions.
   */
 case class ProgressLog(
     header: ProgressHeader,
@@ -94,16 +80,11 @@ case class ProgressLog(
 )
 
 object ProgressLog:
-  /** Custom `JsonData` instance for `ProgressLog` that does **not** require the
-    * `sessions` collection field to be present in the JSON. All other
-    * collection fields (`entries`) are similarly lenient here — `entries` is
-    * never absent in practice, but a uniform config keeps the rule simple.
-    *
-    * This intentionally diverges from `JsonData.strictCodecConfig`, which sets
-    * `withRequireCollectionFields(true)`. That strictness is appropriate for
-    * LLM-reply DTOs (where a missing list is almost certainly a model error),
-    * but wrong for the progress log, which must round-trip across software
-    * versions where new optional fields are added over time.
+  /** Does not require collection fields to be present, diverging from
+    * `JsonData.strictCodecConfig` (`withRequireCollectionFields(true)`). Strict
+    * is right for LLM-reply DTOs where a missing list signals a model error,
+    * but wrong for the progress log, which must round-trip across versions that
+    * add optional fields over time.
     */
   given JsonData[ProgressLog] = JsonData(
     Schema.derived[ProgressLog],

--- a/flow/src/main/scala/orca/progress/ProgressStore.scala
+++ b/flow/src/main/scala/orca/progress/ProgressStore.scala
@@ -20,19 +20,15 @@ trait ProgressStore:
     */
   def path: os.Path
 
-  /** Lenient load for the runtime's frequent reads (rehydration, `appendEntry`
-    * / `upsertSession`'s read-modify-write): absent and corrupt both collapse
-    * to `None`, since those call sites don't need to tell the two apart.
-    * `loadDetailed()` is the one call site that does — the lifecycle's resume
-    * decision.
+  /** Lenient load for the runtime's frequent reads: absent and corrupt both
+    * collapse to `None`. Use [[loadDetailed]] where the difference matters.
     */
   def load(): Option[ProgressLog]
 
-  /** Detailed load for the lifecycle's resume decision: distinguishes an absent
-    * log (normal fresh run) from a present-but-unparseable one (a corrupt or
-    * truncated file — the caller starts fresh but WARNS, because the user may
-    * have expected a resume). `load()` keeps its lenient Option shape for the
-    * runtime's frequent reads.
+  /** Distinguishes an absent log (normal fresh run) from a present-but-
+    * unparseable one (corrupt or truncated — the caller starts fresh but WARNS,
+    * since the user may have expected a resume). Used by the lifecycle's resume
+    * decision.
     */
   def loadDetailed(): ProgressStore.LoadResult
 
@@ -50,24 +46,17 @@ trait ProgressStore:
     * [[SessionRecord.occurrence]]: replaces an existing record with that key,
     * or appends if none exists. Last write wins.
     *
-    * Requires [[writeHeader]] to have been called first; otherwise it throws.
-    * Does NOT commit — the session is recorded in the log file only; the next
-    * stage commit will force-add the log and carry it. Consequence: on failure
-    * teardown (`git reset --hard`) any session record written since the last
-    * stage commit is erased — the retry then mints a fresh session and
-    * re-seeds. This is the intended fail-safe; `session(name, seed)`'s
-    * get-or-create contract is therefore best-effort until a stage commit has
-    * carried the log.
+    * Requires [[writeHeader]] first; otherwise it throws. Does NOT commit — the
+    * next stage commit force-adds the log and carries it. So on failure
+    * teardown (`git reset --hard`) any record written since the last stage
+    * commit is erased and the retry re-seeds; `session(name, seed)`'s
+    * get-or-create is best-effort until a stage commit has carried the log.
     */
   def upsertSession(record: SessionRecord)(using WorkspaceWrite): Unit
 
 object ProgressStore:
 
-  /** Outcome of [[ProgressStore.loadDetailed]]. Nested here (rather than a
-    * top-level type) so it reads as `ProgressStore.LoadResult` at import sites
-    * — it's meaningless without the store it came from, same call as
-    * `Verdict.RejectionKind`.
-    */
+  /** Outcome of [[ProgressStore.loadDetailed]]. */
   enum LoadResult:
     case Absent
     case Corrupt(reason: String)
@@ -118,14 +107,9 @@ private class OsProgressStore(workDir: os.Path, val path: os.Path)
     writeLog(upsertSessionRecord(currentLogOrThrow("upsertSession"), record))
 
   /** Read-modify-write precondition for [[appendEntry]] / [[upsertSession]]:
-    * both require a log to already exist (`writeHeader` must have run first).
-    * Routed through [[loadDetailed]] (not the lenient [[load]]) so the two ways
-    * "no usable log" can happen get distinct, honest messages: a log that was
-    * genuinely never written (`Absent` — the real protocol violation the
-    * original message described) vs. one that exists but is corrupted
-    * (`Corrupt` — a torn write, an external edit — mid-run, which `load()`'s
-    * collapsing to `None` used to misreport as "before writeHeader" even though
-    * writeHeader plainly *did* run).
+    * both require a log to already exist. Routed through [[loadDetailed]] so an
+    * `Absent` log (writeHeader never ran) and a `Corrupt` one (a torn write or
+    * external edit mid-run) get distinct messages.
     */
   private def currentLogOrThrow(callerName: String): ProgressLog =
     loadDetailed() match
@@ -158,20 +142,15 @@ private class OsProgressStore(workDir: os.Path, val path: os.Path)
       else log.sessions :+ record
     log.copy(sessions = updated)
 
-  // We rewrite the whole file each time rather than append JSONL: the log is a
-  // single structured *document* (a header + entries + sessions object), not a
-  // flat event stream — `upsertEntry`/`upsertSession` mutate existing elements,
-  // which an append-only log can't express. It's also small and bounded (a
-  // handful of stages + sessions per run), so a full rewrite is negligible.
+  // Rewrite the whole file each time rather than append JSONL: the log is a
+  // single structured document whose elements `upsertEntry`/`upsertSession`
+  // mutate in place, which an append-only log can't express, and it's small and
+  // bounded so a full rewrite is negligible.
   //
-  // Written atomically: a plain `os.write.over` can tear the file if the
-  // process dies mid-write (a killed run, an OOM), leaving `loadDetailed()`
-  // reading `Corrupt` where a resume was expected. Writing to a sibling temp
-  // file (same directory, so the same filesystem) then `os.move` with
-  // `atomicMove = true` makes the visible file always either the old complete
-  // content or the new complete content, never a partial write.
+  // Written atomically via a sibling temp file + `os.move(atomicMove = true)`:
+  // a plain `os.write.over` can tear the file if the process dies mid-write,
+  // leaving `loadDetailed()` reading `Corrupt` where a resume was expected.
   private def writeLog(log: ProgressLog): Unit =
-    // `.orca` creation routes through OrcaDir like every other writer's.
     val dir = OrcaDir.ensureRoot(workDir)
     val tmp = os.temp(
       contents = writeToString(log)(using codec),
@@ -180,20 +159,16 @@ private class OsProgressStore(workDir: os.Path, val path: os.Path)
       suffix = ".tmp",
       deleteOnExit = false
     )
-    // The whole move sequence (including the fallback) is wrapped so that ANY
-    // failure — not just the handled AtomicMoveNotSupportedException — cleans
-    // up the temp file instead of leaking it. The target itself is untouched
-    // on failure; only the orphaned `tmp` is removed here.
+    // Wrapped so ANY failure cleans up the temp file rather than leaking it;
+    // the target is untouched on failure.
     try
       try os.move(tmp, path, replaceExisting = true, atomicMove = true)
       catch
-        // Some filesystems (network mounts, certain container overlay/bind
-        // mounts) reject ATOMIC_MOVE even for a same-directory rename,
-        // throwing this checked exception. Torn writes are impossible on
-        // those anyway (rename semantics still apply — only the *atomicity
-        // guarantee against concurrent readers* is unavailable) so a plain
-        // move is a safe fallback, not a silent downgrade of the actual
-        // protection we need.
+        // Some filesystems (network mounts, some container overlay/bind mounts)
+        // reject ATOMIC_MOVE even for a same-directory rename. Torn writes are
+        // impossible there anyway (only the atomicity guarantee against
+        // concurrent readers is unavailable), so a plain move is a safe
+        // fallback.
         case _: java.nio.file.AtomicMoveNotSupportedException =>
           os.move(tmp, path, replaceExisting = true)
     catch

--- a/flow/src/main/scala/orca/progress/RecoveryCheck.scala
+++ b/flow/src/main/scala/orca/progress/RecoveryCheck.scala
@@ -16,15 +16,13 @@ object RecoveryCheck:
     * same charset [[orca.BranchNamingStrategy.slug]] produces). Issue branches
     * like `fix/issue-42` pass; ``, `-x`, `a/..`, `a b`, `Feat` are rejected.
     *
-    * Forcing a leading alphanumeric blocks a name that begins with `-` (which
-    * `git`/`gh` would read as a CLI flag) and bans path-traversal/whitespace
-    * segments.
+    * The leading-alphanumeric requirement blocks a name beginning with `-`
+    * (which `git`/`gh` would read as a CLI flag) and bans
+    * path-traversal/whitespace segments. Referencing
+    * `BranchNamingStrategy.isSlugSegment` keeps producer and validator from
+    * drifting.
     */
   def isSafeBranchRef(s: String): Boolean =
-    // A safe ref is a `/`-separated path of slug segments — the exact shape
-    // `BranchNamingStrategy.slug` produces. Referencing its predicate (rather
-    // than re-deriving the charset here) keeps the producer and this validator
-    // from drifting apart.
     s.nonEmpty && s
       .split("/", -1)
       .forall(orca.BranchNamingStrategy.isSlugSegment)
@@ -65,12 +63,8 @@ object RecoveryCheck:
         case Left(ProtectedBranchRefused(name)) =>
           Left(s"branch '$name' is a protected branch")
         case Left(UnsafeBranchRefRefused(name)) =>
-          // Unreachable in practice: `header.branch` already passed
-          // `isSafeBranchRef` above, before `resolve` was even called.
-          // `resolve`'s own shape check is redundant here — this arm exists
-          // only so the match stays exhaustive — but the message matches the
-          // existing shape-check message above for consistency if it were
-          // ever hit.
+          // Unreachable: `header.branch` already passed `isSafeBranchRef` above.
+          // This arm exists only for exhaustiveness.
           Left(s"branch '$name' is not a safe ref")
         case Right(featureBranch) =>
           if header.promptHash != ProgressStore.hashPrompt(userPrompt) then

--- a/flow/src/main/scala/orca/review/FixRequest.scala
+++ b/flow/src/main/scala/orca/review/FixRequest.scala
@@ -5,11 +5,9 @@ import orca.agents.{AgentInput, JsonData, given}
 /** The fix instruction plus the issues handed to the coding agent each round.
   *
   * Lives in its own compilation unit (not `ReviewLoop.scala`) because its
-  * `derives JsonData` expands the tapir `Schema` derivation macro, whose
-  * generated code does not type-check under `ReviewLoop.scala`'s
-  * `captureChecking` mode (the reviewer fan-out needs that mode — ADR 0018 §6).
-  * Keeping the derivation in a plain, non-capture-checked file sidesteps the
-  * macro/CC interaction; the capability check on the fan-out is unaffected.
+  * `derives JsonData` expands the tapir `Schema` macro, whose generated code
+  * does not type-check under `ReviewLoop.scala`'s `captureChecking` mode
+  * (needed for the reviewer fan-out — ADR 0018 §6).
   */
 private[review] case class FixRequest(
     instructions: String,

--- a/flow/src/main/scala/orca/review/Lint.scala
+++ b/flow/src/main/scala/orca/review/Lint.scala
@@ -1,23 +1,18 @@
 package orca.review
 
-// Compiled under capture checking (the two language imports below) to match
-// `ReviewLoop.scala`, where `lint` is fanned out alongside the reviewers
-// through the CheckedPar funnel (ADR 0018 §6).
+// Capture-checked to match `ReviewLoop.scala`, where `lint` is fanned out
+// alongside the reviewers through the CheckedPar funnel (ADR 0018).
 import language.experimental.captureChecking
 import language.experimental.separationChecking
 
 import orca.{FlowContext, InStage, OrcaDir}
 import orca.agents.Agent
 
-/** The lint gate `reviewAndFixLoop` runs alongside the reviewers each round:
-  * `commands` (each run via `bash -c`, in file/declaration order — e.g. one per
-  * stack half of a multi-stack repo, per ADR 0019's `lint` list) and the
-  * `agent` that summarises their labelled, concatenated output into a
-  * `ReviewResult` (a cheap model — `claude.haiku`, `codex.mini` — since the
-  * summary is a small fold). Bundling the pair into one value (rather than
-  * `reviewAndFixLoop` taking a separate command-list and agent parameter) makes
-  * "commands with no summariser" unrepresentable, so the loop no longer needs a
-  * runtime `require` to reject that half-set state.
+/** The lint gate run alongside the reviewers each round: `commands` (each run
+  * via `bash -c`, in order) and the `agent` that summarises their concatenated
+  * output into a `ReviewResult` (a cheap model suffices — the summary is a
+  * small fold). Bundling the pair makes "commands with no summariser"
+  * unrepresentable.
   */
 case class Lint(commands: List[String], agent: Agent[?])
 
@@ -26,46 +21,31 @@ case class Lint(commands: List[String], agent: Agent[?])
   * {{{
   * $ <command>   (exit <status>)
   * }}}
-  * with the trimmed output on the following lines. An empty output keeps the
-  * label line alone, so the summariser still sees "ran, produced nothing,
-  * exited N".
+  * with the trimmed output following. Empty output keeps the label line alone,
+  * so the summariser still sees "ran, produced nothing, exited N".
   */
 private case class LintRun(command: String, exitCode: Int, output: String):
   def labelled: String =
     val label = s"$$ $command   (exit $exitCode)"
     if output.isEmpty then label else s"$label\n$output"
 
-/** Run each of `commands` via `bash -c`, in order, in the flow's working tree
-  * (`ctx.workDir`), capturing each command's combined stdout+stderr; then ask
-  * `agent` — in a single pass — to summarise the concatenation as a
-  * `ReviewResult`. Every command runs even when an earlier one fails, so a
-  * broken first linter doesn't hide the second's diagnostics from the same
-  * review round; each block carries its own command and exit status. When every
-  * command exits 0 with empty output — including `commands = Nil`, a disabled
-  * gate — the call short-circuits to `ReviewResult.empty` and skips the LLM
-  * round-trip entirely (a silent nonzero exit still reaches the summariser: a
-  * linter can fail with no stdout). Override `instructions` when the lint
-  * produces unusual shapes the default phrasing doesn't fit.
+/** Run each of `commands` via `bash -c`, in order, in `ctx.workDir`, capturing
+  * each command's combined stdout+stderr; then ask `agent` to summarise the
+  * concatenation as a `ReviewResult`. Every command runs even when an earlier
+  * one fails, so a broken first linter doesn't hide the second's diagnostics.
+  * When every command exits 0 with empty output (including `commands = Nil`)
+  * the call short-circuits to `ReviewResult.empty`, skipping the LLM; a silent
+  * nonzero exit still reaches the summariser. Override `instructions` for lint
+  * output the default phrasing doesn't fit.
   *
-  * How the combined text reaches the agent depends on its size:
+  * Combined text ≤ [[Lint.InlineLintThreshold]] chars is inlined into the
+  * prompt (the common case), which is what makes lint work under a sandboxed
+  * autonomous agent that denies file reads outside its worktree. Larger output
+  * is spilled to a file under `<workDir>/.orca/cache/` (NOT `/tmp`, so an
+  * in-sandbox worktree can still reach it), avoiding a context-window overflow.
   *
-  *   - **Small (≤ [[Lint.InlineLintThreshold]] chars):** inlined directly into
-  *     the prompt. This is the common case (a `cargo check` with a handful of
-  *     errors), and inlining is what makes lint work under a sandboxed
-  *     autonomous agent — opencode's autonomous mode denies file reads outside
-  *     its worktree, so a `/tmp` file reference was silently unreadable and the
-  *     lint gate became a no-op ("lint: 0 issues" every round).
-  *   - **Large (> threshold):** spilled to a file the agent reads with its
-  *     read-only tools (in chunks if needed), because an unbounded build/test
-  *     run (hundreds of KB) would overflow the model's context window. The file
-  *     holds the same labelled blocks the inline path embeds, and lives under
-  *     `<workDir>/.orca/cache/` — NOT `/tmp` — so a sandboxed agent whose
-  *     worktree is in-sandbox can still reach it. It's removed in the `finally`
-  *     before this call returns.
-  *
-  * The LLM is invoked read-only: the task is text-in / JSON-out, and the agent
-  * may verify a lint claim against the sources it references but should never
-  * edit during the summarisation step.
+  * The LLM is invoked read-only: the agent may verify a lint claim against the
+  * sources it references but must not edit.
   */
 def lint(
     commands: List[String],
@@ -77,9 +57,7 @@ def lint(
       .proc("bash", "-c", command)
       .call(cwd = ctx.workDir, check = false, mergeErrIntoOut = true)
     LintRun(command, proc.exitCode, proc.out.text().trim)
-  // Vacuously true for `commands = Nil`, so an empty list no-ops. The
-  // exit-status guard matters: a clean run must be silent AND successful
-  // everywhere before the summariser is skipped.
+  // The summariser is skipped only when every run is both silent AND successful.
   val allClean = runs.forall(r => r.exitCode == 0 && r.output.isEmpty)
   if allClean then ReviewResult.empty
   else
@@ -107,19 +85,12 @@ def lint(
            |```""".stripMargin
       )
     else
-      // Too large to inline without risking the model's context window, so
-      // spill it to a file the agent reads with its read-only tools. The file
-      // lives under the flow's working tree (NOT `/tmp`) so sandboxed
-      // autonomous agents — e.g. opencode, which denies reads outside its
-      // worktree — can still reach it.
-      //
-      // Commit-safety: `.orca/cache/` self-ignores via the `.gitignore` that
-      // `ensureCache` writes before anything else can land in the dir, so a
-      // stage's `git add -A` can never sweep the spill file — even after a
-      // crash mid-lint. The `finally` still removes the file before this call
-      // returns. `deleteOnExit = false`: the `finally` owns cleanup, so we
-      // skip the JVM-exit hook (one per lint call would otherwise accumulate
-      // over a long run).
+      // Spill to a file under the working tree (NOT `/tmp`, so a sandboxed
+      // agent that denies reads outside its worktree can reach it).
+      // `.orca/cache/` self-ignores via the `.gitignore` `ensureCache` writes
+      // first, so a stage's `git add -A` can never sweep the spill file, even
+      // after a crash mid-lint. `deleteOnExit = false`: the `finally` owns
+      // cleanup, avoiding a JVM-exit hook per lint call.
       val cacheDir = OrcaDir.ensureCache(ctx.workDir)
       val outputFile =
         os.temp(
@@ -141,19 +112,15 @@ def lint(
       finally
         val _ = os.remove(outputFile)
 
-// Public (not `private[review]`): it's the case class's companion, and the
-// case class is exported for its `apply` — a `private[review]` object here
-// would carry the synthesized `apply`/`unapply` down with it, making
-// `Lint(commands, agent)` inaccessible from outside the package despite the
-// class itself being public. `InlineLintThreshold` stays package-private on
-// its own member, below.
+// Public (not `private[review]`): as the case class's companion it carries the
+// synthesized `apply`/`unapply`, so restricting it would make `Lint(...)`
+// inaccessible outside the package despite the class being public.
+// `InlineLintThreshold` stays package-private on its own member below.
 object Lint:
-  /** Max combined lint-output length (in chars) inlined straight into the
-    * summariser prompt; larger output is spilled to a file instead (see
-    * [[lint]]). Sized so a typical lint/`cargo check` failure (a handful of
-    * diagnostics) inlines — which is what keeps the lint gate working under
-    * sandboxed autonomous agents that can't read files outside their worktree —
-    * while a full build/test dump still goes to a file rather than flooding the
-    * context.
+  /** Max combined lint-output length (chars) inlined into the summariser
+    * prompt; larger output spills to a file (see [[lint]]). Sized so a typical
+    * lint failure inlines — keeping the gate working under sandboxed agents
+    * that can't read outside their worktree — while a full build/test dump goes
+    * to a file rather than flooding the context.
     */
   private[review] val InlineLintThreshold: Int = 8 * 1024

--- a/flow/src/main/scala/orca/review/ReviewFormatting.scala
+++ b/flow/src/main/scala/orca/review/ReviewFormatting.scala
@@ -2,20 +2,17 @@ package orca.review
 
 import orca.util.{TextUtil, TextWrap}
 
-// Rendering of review outcomes into `Step`-body text for the event log — split
-// out of `ReviewLoop` so the loop file carries only the loop control flow.
-// Plain (non-capture-checked): these are pure string helpers with no fork
-// boundary to guard, so they don't need `ReviewLoop.scala`'s CC imports.
+// Rendering of review outcomes into `Step`-body text for the event log.
 
 /** Format a single review comment as the body lines of a `Step`.
   *
-  * Shape: `- [Severity] title ...wrapped to ~76 cols...`, optionally followed
-  * by ` at file:line` and a ` suggestion: …` line. The leading `- ` makes the
-  * issue a bullet within a multi-issue body; outer indentation is added by the
-  * caller (typically [[formatReviewerOutcome]]).
+  * Shape: `- [Severity] title ...wrapped...`, optionally followed by ` at
+  * file:line` and a ` suggestion: …` line. The leading `- ` makes the issue a
+  * bullet within a multi-issue body; outer indentation is added by the caller
+  * (typically [[formatReviewerOutcome]]).
   *
-  * The `description` field is intentionally not rendered — it's the longer form
-  * fed back to the fixing agent; the user sees the short form on screen.
+  * `description` is deliberately not rendered — it's the longer form fed back
+  * to the fixing agent; the user sees the short form on screen.
   */
 private[review] def formatIssue(issue: ReviewIssue): String =
   val header = TextWrap.wrap(

--- a/flow/src/main/scala/orca/review/ReviewIssue.scala
+++ b/flow/src/main/scala/orca/review/ReviewIssue.scala
@@ -5,9 +5,8 @@ import orca.plan.Title
 
 /** A single review finding. `title` is the one-line user-facing label (rendered
   * in the event log under `▶`); `description` is the longer form fed back to
-  * the fixing agent and includes whatever context the reviewer gave. The split
-  * mirrors `Plan.Task`'s title/description pair so flow scripts that handle
-  * issues and tasks can use the same field names.
+  * the fixing agent. The split mirrors `Plan.Task`'s title/description pair so
+  * flow scripts handling issues and tasks share field names.
   */
 case class ReviewIssue(
     severity: Severity,

--- a/flow/src/main/scala/orca/review/ReviewLoop.scala
+++ b/flow/src/main/scala/orca/review/ReviewLoop.scala
@@ -1,10 +1,9 @@
 package orca.review
 
-// This file compiles under capture checking (the two language imports below)
-// so that the CheckedPar fan-out enforcement (ADR 0018 §6) actually fires at
-// its call site further down. Keep tapir `derives`/macro-expanding types out
-// of here — they don't type-check under CC — and put them in a sibling
-// non-CC file instead, as FixRequest.scala already does.
+// Compiled under capture checking (imports below) so CheckedPar's fan-out
+// enforcement (ADR 0018 §6) fires at its call site. Tapir `derives`/macro types
+// don't type-check under CC — keep them in a sibling non-CC file (see
+// FixRequest.scala).
 import language.experimental.captureChecking
 import language.experimental.separationChecking
 
@@ -26,9 +25,6 @@ import orca.util.TextUtil
 
 /** The decision the fix-loop stop policy ([[stopPolicy]]) reaches for one
   * round, given that round's evaluated issues — before `fix` is (maybe) called.
-  * Shared by [[fixLoop]]'s state-free loop and [[ReviewFixLoop.run]]'s
-  * state-threading loop, which otherwise differ only in what they thread across
-  * iterations.
   */
 private[review] enum LoopStep:
   /** No issues found this round — the loop is done; nothing to accumulate. */
@@ -43,19 +39,12 @@ private[review] enum LoopStep:
   case NeedsFix
 
 /** The fix-loop stop policy, shared by [[fixLoop]] and [[ReviewFixLoop.run]]:
-  * stop with nothing accumulated when `issues` is empty; stop and fold `issues`
-  * into [[IgnoredIssues]] (reason: `"max iterations (N) reached"`) once
-  * `iteration >= maxIterations`; otherwise signal that `fix` should run.
+  * done when `issues` is empty; fold `issues` into [[IgnoredIssues]] (reason
+  * `"max iterations (N) reached"`) once `iteration >= maxIterations`; otherwise
+  * signal that `fix` should run.
   *
-  * `maxIterations` counts FIX attempts, not evaluations: the cap check only
-  * fires once `iteration >= maxIterations`, so a loop built on this policy
-  * performs up to `maxIterations + 1` evaluations (the extra one is the final
-  * round that discovers the cap was reached).
-  *
-  * The halt-on-zero-fixed half of the policy — stop once `fix` reports nothing
-  * fixed, since re-evaluating would just rediscover the same issues — is a
-  * single `outcome.fixed.isEmpty` check with no cap-style arithmetic to share,
-  * so both loops inline it directly after their `fix` call.
+  * `maxIterations` counts FIX attempts, not evaluations, so a loop built on
+  * this policy performs up to `maxIterations + 1` evaluations.
   */
 private[review] def stopPolicy(
     issues: List[ReviewIssue],
@@ -74,18 +63,13 @@ private[review] def stopPolicy(
   else LoopStep.NeedsFix
 
 /** Evaluate, fix, re-evaluate until the reviewer reports no issues, the fixer
-  * reports zero fixes (so re-evaluating would just rediscover the same things),
-  * or `maxIterations` fix attempts have been made. Issues that remain when the
-  * cap is hit are folded into the returned `IgnoredIssues` with a `max
-  * iterations reached` reason so callers can surface them. See [[stopPolicy]]
-  * for the shared decision.
+  * reports zero fixes, or `maxIterations` fix attempts have been made. Issues
+  * remaining when the cap is hit are folded into the returned `IgnoredIssues`
+  * with a `max iterations reached` reason. See [[stopPolicy]] for the decision.
   *
-  * Each round emits an `Iteration N` progress marker (a `display`, not a
-  * committing stage — it runs under the caller's task stage, ADR 0018 §2.2).
-  *
-  * This is the state-free entry point: it has no cross-iteration data to
-  * thread, so it recurses directly. [[ReviewFixLoop.run]], which backs
-  * [[reviewAndFixLoop]], additionally threads a [[ReviewLoopState]].
+  * The state-free entry point: no cross-iteration data to thread, so it
+  * recurses directly. [[ReviewFixLoop.run]] (backing [[reviewAndFixLoop]])
+  * additionally threads a [[ReviewLoopState]].
   */
 def fixLoop(
     evaluate: () => ReviewResult,
@@ -94,8 +78,8 @@ def fixLoop(
 )(using ctx: FlowContext): IgnoredIssues =
   @scala.annotation.tailrec
   def loop(accumulated: IgnoredIssues, iteration: Int): IgnoredIssues =
-    // A progress marker, not a committing stage: this runs under the caller's
-    // task stage (ADR 0018 §2.2), so it must not open its own stage.
+    // A progress marker, not a committing stage: runs under the caller's task
+    // stage (ADR 0018 §2.2).
     orca.display(s"Iteration ${iteration + 1}")
     val issues = evaluate().issues
     stopPolicy(issues, iteration, maxIterations) match
@@ -118,26 +102,17 @@ def fixLoop(
 
 /** An opaque handle to one reviewer in `reviewAndFixLoop`'s configured roster.
   *
-  * A [[ReviewerSelector]] is handed the roster as `RosterEntry` values and can
-  * only return a subset/permutation of them: the constructor is
-  * `private[review]`, so a selector cannot fabricate an entry for an agent the
-  * roster never contained. This makes "a foreign reviewer" unrepresentable at
-  * the type level, so the loop needs no runtime roster-membership defences (no
-  * foreign-drop warning, no silent full-roster fallback).
+  * The `private[review]` constructor means a [[ReviewerSelector]] can only
+  * return a subset/permutation of the entries it was handed — a foreign
+  * reviewer is unrepresentable, so the loop needs no runtime roster-membership
+  * defences.
   *
-  * Identity is reference identity (the default for a plain class): the loop
-  * keys its per-reviewer session map on the entry instance, and each roster
-  * agent is wrapped exactly once ([[RosterEntry.wrap]]), so `eq` on entries is
-  * the reviewer's identity.
-  *
-  * Two call sites depend on this being a plain class, not a case class:
-  * `runReviewersAndLint`'s session lookup (`currentState.sessions.find(_.entry
-  * eq e)`) and `evaluate`'s `selectRound(state.history).distinct`, which
-  * de-duplicates a selector's accidental repeats. A case class would generate
-  * structural `equals`/`hashCode`, and `List.distinct` uses `equals`, not `eq`
-  * — so `.distinct` would start collapsing by structural equality (every
-  * `RosterEntry[B]` wrapping the same `agent` looks alike) while the session
-  * lookup kept using `eq`, splitting the two "same entry" notions apart.
+  * Identity is reference identity: the loop keys its per-reviewer session map
+  * on the entry instance, and each roster agent is wrapped exactly once
+  * ([[RosterEntry.wrap]]). Must stay a plain class, not a case class:
+  * `runReviewersAndLint`'s session lookup uses `eq` while `evaluate`'s
+  * `.distinct` uses `equals`, so a generated structural `equals` would collapse
+  * distinct entries wrapping the same agent and split the two identity notions.
   */
 final class RosterEntry[B <: BackendTag] private[review] (
     private[review] val agent: Agent[B]
@@ -149,18 +124,17 @@ final class RosterEntry[B <: BackendTag] private[review] (
   def name: String = agent.name
 
 private[review] object RosterEntry:
-  /** Wrap a roster agent, binding its existential backend tag so the entry's
-    * `agent` and any session paired with it in [[ReviewLoopState.sessions]]
-    * share one `B` by construction (no cast needed to recover it later).
+  /** Wrap a roster agent, binding its backend tag so the entry's `agent` and
+    * any session paired with it in [[ReviewLoopState.sessions]] share one `B`
+    * by construction.
     */
   def wrap(a: Agent[?]): RosterEntry[?] =
     a match
       case a: Agent[b] => new RosterEntry[b](a)
 
-/** One round of reviews, with each reviewer's individual outcome preserved. The
-  * list keeps the order callers configured (so positions match
-  * `allReviewers(claude)` etc.), and lets the loop decide which reviewers to
-  * re-run on the next iteration based on which ones found issues this time.
+/** One round of reviews, with each reviewer's individual outcome preserved and
+  * kept in configured order, so the loop can decide which reviewers to re-run
+  * next iteration based on which ones found issues.
   */
 case class ReviewBatch(outcomes: List[(RosterEntry[?], ReviewResult)]):
   def reviewersWithIssues: List[RosterEntry[?]] =
@@ -168,10 +142,9 @@ case class ReviewBatch(outcomes: List[(RosterEntry[?], ReviewResult)]):
   def allIssues: List[ReviewIssue] =
     outcomes.flatMap(_._2.issues)
 
-/** One reviewer's live [[Chat]], paired with the entry it belongs to under a
-  * single existential backend tag `B`. The chat already bundles the role-tagged
-  * agent with its conversation id, so a resume just calls the chat again — no
-  * `SessionId.Untyped`/`.as[RB]` round-trip.
+/** One reviewer's live [[Chat]], paired with its entry under a single backend
+  * tag `B`. The chat bundles the role-tagged agent with its conversation id, so
+  * a resume just calls the chat again.
   */
 private case class SessionEntry[B <: BackendTag](
     entry: RosterEntry[B],
@@ -181,8 +154,7 @@ private case class SessionEntry[B <: BackendTag](
 /** All cross-iteration state for `reviewAndFixLoop`, in one immutable record.
   * `history` is consulted by [[ReviewerSelector]]; `sessions` holds one
   * [[SessionEntry]] per reviewer that has run at least once, looked up by entry
-  * identity (`eq`). See [[reviewWithSession]] for how the existential pairing
-  * keeps the recovered session id typed to the reviewer's backend.
+  * identity (`eq`).
   */
 private case class ReviewLoopState(
     history: List[ReviewBatch],
@@ -192,76 +164,63 @@ private object ReviewLoopState:
   val empty: ReviewLoopState = ReviewLoopState(Nil, Nil)
 
 /** Run reviewers in parallel against `task`, gather per-reviewer outcomes, hand
-  * any issues above `confidenceThreshold` to the coder — through
-  * `coderSession`'s seeded, structured door — and loop. `reviewerSelection`
-  * decides which reviewers run each iteration; the default
-  * ([[ReviewerSelector.agentDriven]]) runs a picker LLM on the review-role
-  * agent's cheap tier. Pass `ReviewerSelector.allEveryRound` to skip selection,
-  * or `ReviewerSelector.agentDriven(...)` to point the picker at a specific
-  * model.
+  * any issues above `confidenceThreshold` to the coder through `coderSession`'s
+  * seeded, structured door, and loop. `reviewerSelection` decides which
+  * reviewers run each iteration; the default ([[ReviewerSelector.agentDriven]])
+  * runs a picker LLM on the review-role agent's cheap tier. Pass
+  * `ReviewerSelector.allEveryRound` to skip selection, or
+  * `ReviewerSelector.agentDriven(...)` to point the picker at a specific model.
   *
-  * The default picker resolves `reviewAgent`'s cheap variant: four backends
-  * have a distinct cheap tier (claude→haiku, codex→mini,
-  * opencode→anthropicHaiku, gemini→flash); pi has no separate tier, so
-  * `pi.cheap` is `pi` itself (pi selects the model via its own CLI config) and
-  * the picker simply runs on the review-role pi agent — correct, just not a
-  * cheaper model. A hypothetical backend without a cheap tier behaves the same
-  * (`.cheap` returns `this`).
+  * The default picker resolves `reviewAgent`'s cheap variant; a backend with no
+  * separate cheap tier (`.cheap` returns `this`, e.g. pi) simply runs the
+  * picker on the full review-role agent — correct, just not cheaper.
   *
   * `coderSession` is the coder's durable [[FlowSession]] (obtain it once with
-  * `agent.session(name, seed)` and pass the handle here). Each fix turn goes
-  * through [[FlowSession.resultAs]]`.autonomous.run`, so a coder whose backend
+  * `agent.session(name, seed)`). Each fix turn goes through
+  * [[FlowSession.resultAs]]`.autonomous.run`, so a coder whose backend
   * conversation is fresh or lost-on-resume is re-primed with the recorded seed
-  * and progress preamble, and its learned wire id is persisted — the durable
-  * protocol the pre-2C raw-door fix turn silently skipped.
+  * and progress preamble, and its learned wire id is persisted.
   *
-  * The fix step instructs the agent to report a `FixOutcome`: list the titles
-  * of issues actually fixed in code under `fixed`, and anything not addressed
-  * (environmental, out-of-scope, false positive) under `ignored` with a reason.
-  * The loop only re-evaluates when something was fixed — if `fixed` is empty
-  * there's nothing new for the reviewers to find, so the loop halts.
+  * The fix step instructs the agent to report a `FixOutcome`: titles of issues
+  * actually fixed under `fixed`, anything not addressed under `ignored` with a
+  * reason. The loop only re-evaluates when something was fixed — an empty
+  * `fixed` means nothing new for the reviewers to find, so the loop halts.
   */
 def reviewAndFixLoop[B <: BackendTag](
     coderSession: FlowSession[B],
     reviewers: List[Agent[?]],
     task: String,
-    /** Which reviewers run each iteration. The default runs a picker LLM on the
-      * review-role agent's cheap tier; pass [[ReviewerSelector.allEveryRound]]
-      * to skip selection, or [[ReviewerSelector.agentDriven]]`(...)` to point
-      * the picker at a specific model.
+    /** Which reviewers run each iteration. Default runs a picker LLM on the
+      * review-role agent's cheap tier; [[ReviewerSelector.allEveryRound]] skips
+      * selection, [[ReviewerSelector.agentDriven]]`(...)` picks a specific
+      * model.
       */
     reviewerSelection: ReviewerSelector = ReviewerSelector.agentDriven,
-    /** Shell commands run in order before each review round — after the
-      * implementation and after every fix — so reviewers and the lint see
-      * formatted code and the committed tree stays formatted. Each runs via
-      * `bash -c` in `ctx.workDir`, exit status ignored (a formatter that fails
-      * shouldn't abort the review). E.g. `"sbt scalafmtAll"`, `"cargo fmt"`,
-      * `"prettier -w ."`. The default resolves the project's
-      * `ctx.stackSettings.format` (ADR 0019); pass `Configured.Off` to skip
-      * formatting, or `Configured.Use(...)` to override the settings.
+    /** Shell commands run in order before each review round so reviewers and
+      * the lint see formatted code and the committed tree stays formatted. Each
+      * runs via `bash -c` in `ctx.workDir`, exit status ignored. The default
+      * resolves the project's `ctx.stackSettings.format` (ADR 0019);
+      * `Configured.Off` skips formatting, `Configured.Use(...)` overrides the
+      * settings.
       */
     formatCommands: Configured[List[String]] = Configured.FromSettings,
     /** Commands + summariser agent for the lint gate run alongside the
-      * reviewers each round (see [[Lint]] for why the pair is bundled into one
-      * value). The default builds the gate from the project's
-      * `ctx.stackSettings.lint` with the review-role agent's cheap tier
-      * (`reviewAgent.cheap`) as the summariser; empty settings build no gate.
-      * Pass `Configured.Off` to skip linting entirely, or
-      * `Configured.Use(Lint(...))` to override the settings.
+      * reviewers each round (see [[Lint]]). The default builds the gate from
+      * the project's `ctx.stackSettings.lint` with `reviewAgent.cheap` as the
+      * summariser; empty settings build no gate. `Configured.Off` skips
+      * linting, `Configured.Use(Lint(...))` overrides the settings.
       */
     lint: Configured[Lint] = Configured.FromSettings,
     confidenceThreshold: Double = 0.7,
     maxIterations: Int = 10,
     fixInstructions: String = ReviewLoopPrompts.Fix,
     /** Override the diff handed to each reviewer in its initial prompt.
-      * Defaults to `ctx.git.diff()` re-sampled at the start of every iteration:
-      * a reviewer that joins the active set on iteration N (e.g. picked up by
-      * an `onlyPreviouslyReporting` selector after N-1 silent rounds) sees the
-      * working tree as it stands then, including the fixes from earlier
-      * iterations. Reviewers that already have a session resume it and don't
-      * get the diff again — their session has the original framing. Pass
-      * `Some(...)` to pin the diff (tests, or when the change set has already
-      * been committed and `git.diff()` would be empty).
+      * Defaults to `ctx.git.diff()` re-sampled at the start of every iteration,
+      * so a reviewer joining the active set on iteration N sees the working
+      * tree including earlier fixes. Reviewers with an existing session resume
+      * it and don't get the diff again. Pass `Some(...)` to pin the diff
+      * (tests, or when the change set is already committed and `git.diff()`
+      * would be empty).
       */
     initialDiff: Option[String] = None
 )(using
@@ -270,10 +229,9 @@ def reviewAndFixLoop[B <: BackendTag](
     fc: FlowControl,
     ws: WorkspaceWrite
 ): IgnoredIssues =
-  // `Configured` resolution happens here, on the collecting thread at loop
-  // entry (ADR 0019): the config then carries plain data, so the
-  // capture-checked fan-out below never reads `ctx.stackSettings` (or touches
-  // `ctx.reviewAgent`) from a fork.
+  // `Configured` resolution happens here at loop entry (ADR 0019): the config
+  // then carries plain data, so the capture-checked fan-out below never reads
+  // `ctx.stackSettings` (or touches `ctx.reviewAgent`) from a fork.
   val resolvedFormat: List[String] = formatCommands match
     case Configured.FromSettings => ctx.stackSettings.format
     case Configured.Off          => Nil
@@ -287,12 +245,12 @@ def reviewAndFixLoop[B <: BackendTag](
       )
     case Configured.Off    => None
     case Configured.Use(l) => Some(l)
-  // `ctx` (the pure [[FlowContext]]) is what the loop's fan-out closures may
-  // capture; `fc`/`ws` (exclusive capabilities) are handed only to `run()`, so
-  // the durable fix turn reaches the [[FlowSession]] door without those tokens
-  // ever landing in the fan-out (ADR 0018 §6). Passed explicitly rather than by
-  // implicit search: the more-specific `fc: FlowControl` would otherwise be
-  // picked for the constructor's `FlowContext` and its root capability rejected.
+  // `ctx` (pure [[FlowContext]]) is what the fan-out closures may capture;
+  // `fc`/`ws` (exclusive capabilities) are handed only to `run()`, so the durable
+  // fix turn reaches the [[FlowSession]] door without those tokens landing in the
+  // fan-out (ADR 0018 §6). Passed explicitly, not by implicit search: the
+  // more-specific `fc: FlowControl` would otherwise be picked for the
+  // constructor's `FlowContext` and its root capability rejected.
   new ReviewFixLoop(
     ReviewLoopConfig(
       coderSession = coderSession,
@@ -308,22 +266,17 @@ def reviewAndFixLoop[B <: BackendTag](
     )
   )(using ctx, ev).run()(using fc, ws)
 
-/** [[reviewAndFixLoop]]'s 10 parameters, bundled into one value so
-  * [[ReviewFixLoop]]'s constructor doesn't mirror them field-for-field (the
-  * `FlowWiring`/`flow(...)` shape — `runner/.../FlowWiring.scala` — collects a
-  * public function's named arguments into one internal record the same way).
-  * `reviewAndFixLoop` itself keeps its own 10 named, documented parameters as
-  * the public surface; this bundling is internal-only. See `reviewAndFixLoop`'s
-  * parameter docs for the full description of each field.
+/** [[reviewAndFixLoop]]'s parameters bundled into one value so
+  * [[ReviewFixLoop]]'s constructor doesn't mirror them field-for-field. See
+  * `reviewAndFixLoop`'s parameter docs for each field.
   *
   * `fc`/`ws` deliberately stay out: they're exclusive capabilities threaded to
-  * [[ReviewFixLoop.run]] as method parameters, not loop configuration, so they
-  * never land in the reviewer fan-out closures that capture the config-holding
-  * instance (ADR 0018 §6).
+  * [[ReviewFixLoop.run]] as method parameters, so they never land in the
+  * reviewer fan-out closures that capture the config-holding instance (ADR 0018
+  * §6).
   *
-  * `formatCommands`/`lint` hold the RESOLVED values — `Configured` resolution
-  * against `ctx.stackSettings` happens once at loop entry (in
-  * [[reviewAndFixLoop]]), so the fan-out only ever sees plain data.
+  * `formatCommands`/`lint` hold RESOLVED values — `Configured` resolution
+  * happens once at loop entry, so the fan-out only ever sees plain data.
   */
 private[review] case class ReviewLoopConfig[B <: BackendTag](
     coderSession: FlowSession[B],
@@ -339,20 +292,13 @@ private[review] case class ReviewLoopConfig[B <: BackendTag](
 )
 
 /** Implementation of [[reviewAndFixLoop]]: one instance per invocation holds
-  * the loop-constant configuration ([[ReviewLoopConfig]]) plus its individual
-  * fields (imported below) as if they were constructor params, so the
-  * per-iteration logic reads top-down as plain methods rather than a stack of
-  * nested closures. Construct and call [[run]].
+  * the loop-constant [[ReviewLoopConfig]] (fields imported below), so the
+  * per-iteration logic reads as plain methods. Construct and call [[run]].
   *
   * All cross-iteration state lives in one immutable [[ReviewLoopState]]
-  * threaded explicitly through [[run]] (no captured `var`): within an iteration
-  * the reviewers fan out via `Flow.mapParUnordered`, but each fork reads the
-  * snapshot it was handed and the next state is computed once after they all
-  * return — so no concurrent mutation, no `mutable.Map`, no
-  * `ConcurrentHashMap`.
-  *
-  * See [[reviewAndFixLoop]]'s parameter docs for the full description of each
-  * [[ReviewLoopConfig]] field.
+  * threaded explicitly through [[run]] (no captured `var`): reviewers fan out
+  * within an iteration but each fork reads the snapshot it was handed and the
+  * next state is computed once after they all return — no concurrent mutation.
   */
 private[review] class ReviewFixLoop[B <: BackendTag](
     config: ReviewLoopConfig[B]
@@ -360,27 +306,22 @@ private[review] class ReviewFixLoop[B <: BackendTag](
     ctx: FlowContext,
     ev: InStage
 ):
-  // `lint` excluded from the wildcard: the config field of that name would
-  // otherwise shadow the package-level `lint(command, agent)` summariser
-  // function this class calls below — `config.lint` stays the qualified way
-  // to reach the field.
+  // `lint` excluded from the wildcard: the config field would otherwise shadow
+  // the package-level `lint(command, agent)` summariser function this class calls
+  // below — `config.lint` stays the qualified way to reach the field.
   import config.{lint as _, *}
 
-  // The roster, wrapped once as identity-keyed handles. A selector receives
-  // these and may only return a subset/permutation of them (foreign agents are
-  // unrepresentable), and the session map keys on these instances by `eq` — so
-  // duplicate reviewer names cannot break session threading and no
-  // name-uniqueness `require` is needed.
+  // The roster, wrapped once as identity-keyed handles (see [[RosterEntry]]).
   private val roster: List[RosterEntry[?]] = reviewers.map(RosterEntry.wrap)
 
-  // Sampled per iteration in `runReviewersAndLint`. A constant override skips
-  // the git call; the default thunk shells out fresh each iteration so a newly-
-  // active reviewer sees the latest diff rather than the loop-start one.
+  // A constant override skips the git call; the default samples the diff fresh
+  // each iteration so a newly-active reviewer sees the latest, not the
+  // loop-start one.
   private def sampleDiff(): String = initialDiff.getOrElse(ctx.git.diff())
 
-  // Loop-constant context handed to the selector on every iteration: the
-  // task's title, plus the file paths derived from the diff at loop entry.
-  // Sampled here so each iteration's selector call doesn't re-shell-out.
+  // Loop-constant context handed to the selector on every iteration: the task's
+  // title plus the file paths from the diff at loop entry. Sampled here so each
+  // iteration's selector call doesn't re-shell-out.
   private val taskTitle: Title = Title(task)
   private val changedFiles: List[String] =
     ReviewLoop.extractChangedFiles(sampleDiff())
@@ -390,21 +331,13 @@ private[review] class ReviewFixLoop[B <: BackendTag](
       result.issues.filter(_.confidence >= confidenceThreshold)
     )
 
-  /** Run one reviewer iteration against an immutable sessions snapshot. Returns
-    * the review result plus, on a reviewer's first call, the new
-    * [[SessionEntry]] the caller should fold into the next state. Pure with
-    * respect to its inputs — no side effects on shared state — which lets the
-    * caller run many of these in parallel.
+  /** Run one reviewer against an immutable sessions snapshot. Returns the
+    * review result plus, on a reviewer's first call, the new [[SessionEntry]]
+    * the caller folds into the next state. Pure with respect to its inputs — no
+    * shared-state side effects — so the caller can run many in parallel.
     *
     * `stored` is the reviewer's existing [[SessionEntry]] (found by entry
-    * identity), if any; `currentDiff` is the working-tree diff the caller
-    * sampled at the start of this iteration, consumed only on the first call.
-    *
-    * No cast is involved: a resume runs `stored`'s own paired entry+chat
-    * ([[resumeReview]]), whose backend tag `B` the wrapper carries by
-    * construction; a first call binds the entry's `B` ([[firstReview]]) and
-    * pairs the fresh `Chat[B]` back with it. The pairing is a compile-time
-    * invariant, not a claim recovered at runtime.
+    * identity), if any; `currentDiff` is consumed only on the first call.
     */
   private def reviewWithSession(
       e: RosterEntry[?],
@@ -415,11 +348,9 @@ private[review] class ReviewFixLoop[B <: BackendTag](
       case Some(se) => (resumeReview(se), None)
       case None     => firstReview(e, currentDiff)
 
-  /** Resume a reviewer's existing session. `se` pairs the entry with a session
-    * id under one `B`, so `se.session` is already typed to `se.entry.agent`'s
-    * backend — no recovery cast. The LLM run is tagged with the `reviewer` cost
-    * role ([[ReviewerPrompts.Role]]) so the `TokensUsed` breakdown can
-    * group/subtotal reviewer spend, without renaming the entry's identity.
+  /** Resume a reviewer's existing session. The run carries the `reviewer` cost
+    * role ([[ReviewerPrompts.Role]]) so the `TokensUsed` breakdown can subtotal
+    * reviewer spend, without renaming the entry's identity.
     */
   private def resumeReview[B <: BackendTag](se: SessionEntry[B]): ReviewResult =
     se.chat
@@ -427,9 +358,9 @@ private[review] class ReviewFixLoop[B <: BackendTag](
       .autonomous
       .run(ReviewLoopPrompts.ReReview, emitPrompt = false)
 
-  /** A reviewer's first call: bind the entry's backend tag `B`, mint a fresh
-    * [[Chat]] on the role-tagged agent, and pair it back with the entry so a
-    * later resume recovers it typed. `currentDiff` seeds the initial framing.
+  /** A reviewer's first call: mint a fresh [[Chat]] on the role-tagged agent
+    * and pair it back with the entry so a later resume recovers it typed.
+    * `currentDiff` seeds the initial framing.
     */
   private def firstReview[B <: BackendTag](
       e: RosterEntry[B],
@@ -458,15 +389,14 @@ private[review] class ReviewFixLoop[B <: BackendTag](
     )
     case Lint(result: ReviewResult)
 
-  /** Run every active reviewer plus the optional lint summariser concurrently
-    * via `Flow.mapParUnordered`, emitting one Step per agent as it finishes.
-    * State is a parameter, not a closure capture — the parallel block never
-    * reads a moving var. LLM-internal events (`TokensUsed`, `StructuredResult`)
-    * emit from fork threads; [[OrcaListener]] requires implementations to be
-    * thread-safe.
+  /** Run every active reviewer plus the optional lint summariser concurrently,
+    * emitting one Step per agent as it finishes. State is a parameter, not a
+    * closure capture, so the parallel block never reads a moving var.
+    * LLM-internal events emit from fork threads; [[OrcaListener]]
+    * implementations must be thread-safe.
     *
     * The diff is sampled once per call so all first-time reviewers see the same
-    * payload — pre-sampling also avoids redundant shell-outs.
+    * payload.
     */
   private def runReviewersAndLint(
       active: List[RosterEntry[?]],
@@ -491,29 +421,29 @@ private[review] class ReviewFixLoop[B <: BackendTag](
       config.lint.map: l =>
         () =>
           // Group lint tokens under the same `reviewer` cost role as the
-          // dimension reviewers, under the bare identity "lint"; the
-          // renamed/tagged copy stays local to this call.
+          // reviewers, under the bare identity "lint"; the tagged copy stays
+          // local to this call.
           val labelled =
             l.agent.withName("lint").withRole(ReviewerPrompts.Role)
           AgentOutcome.Lint(filterByConfidence(lint(l.commands, labelled)))
 
-    // The explicit type application is CC-forced: it widens both lists'
-    // element type to the impure function type `() => AgentOutcome` so their
-    // capture sets unify into the single `C^` CheckedPar.mapParUnordered
-    // binds below. Deleting it breaks the CC compile.
+    // The explicit type application is CC-forced: it widens both lists' element
+    // type to `() => AgentOutcome` so their capture sets unify into the single
+    // `C^` CheckedPar.mapParUnordered binds below. Deleting it breaks the CC
+    // compile.
     val tasks = reviewerTasks.++[() => AgentOutcome](lintTaskOpt.toList)
     if tasks.isEmpty then (Nil, None, currentState)
     else
       val outcomes: List[AgentOutcome] =
-        // Fan out through the capture-checked funnel (CheckedPar) rather than
-        // Ox's Flow directly, so separation checking guards the fork boundary:
-        // the shared `InStage` these thunks capture is admitted (load-bearing —
-        // each reviewer reaches a gated LLM `run`), while an exclusive
-        // `WorkspaceWrite`/`FlowControl` capture would be a compile error here
-        // (ADR 0018 §6). Enforcement needs this file's two language imports.
+        // Fan out through the capture-checked funnel (CheckedPar), so separation
+        // checking guards the fork boundary: the shared `InStage` these thunks
+        // capture is admitted (load-bearing — each reviewer reaches a gated LLM
+        // `run`), while an exclusive `WorkspaceWrite`/`FlowControl` capture would
+        // be a compile error here (ADR 0018 §6). Needs this file's two language
+        // imports.
         CheckedPar.mapParUnordered(tasks.size)(tasks):
           // Display the bare slug — the `reviewer` role tag is a cost-report
-          // grouping detail, not part of what the user sees per reviewer.
+          // grouping detail, not part of what the user sees.
           case AgentOutcome.Reviewer(e, res, _) =>
             ctx.emit(OrcaEvent.Step(formatReviewerOutcome(e.name, res)))
           case AgentOutcome.Lint(res) =>
@@ -536,24 +466,21 @@ private[review] class ReviewFixLoop[B <: BackendTag](
       state: ReviewLoopState,
       selectRound: List[ReviewBatch] -> List[RosterEntry[?]]
   ): (ReviewResult, ReviewLoopState) =
-    // Format before reviewing so the implementation's (and each prior fix's)
-    // edits are cleaned up before reviewers and the lint see them, and the
-    // committed tree stays formatted. Commands run sequentially in the flow's
-    // working tree, mirroring [[lint]]'s execution contract. Exit status
-    // ignored — a formatter failure shouldn't abort the review.
-    // `mergeErrIntoOut` folds stderr into the captured stdout so neither
-    // stream reaches the terminal and tears the status row (previously stdout
-    // was captured but stderr leaked through).
+    // Format before reviewing so the implementation's and each fix's edits are
+    // cleaned up before reviewers and the lint see them, and the committed tree
+    // stays formatted. Exit status ignored — a formatter failure shouldn't abort
+    // the review. `mergeErrIntoOut` folds stderr into captured stdout so neither
+    // stream reaches the terminal and tears the status row.
     formatCommands.foreach: cmd =>
       val _ = os
         .proc("bash", "-c", cmd)
         .call(cwd = ctx.workDir, check = false, mergeErrIntoOut = true)
-    // The selector returns roster entries only, so there is no membership
-    // defence to apply — just collapse an accidental duplicate (`.distinct` on
-    // entry identity) so a reviewer runs at most once per round. An empty
-    // selection stays empty: no reviewers run, the round finds no issues, and
-    // the shared stop policy converges — the loop never silently resurrects the
-    // roster behind the selector's back.
+    // The selector returns roster entries only, so no membership defence is
+    // needed — just collapse an accidental duplicate (`.distinct` on entry
+    // identity) so a reviewer runs at most once per round. An empty selection
+    // stays empty: no reviewers run, the round finds no issues, and the stop
+    // policy converges — the loop never resurrects the roster behind the
+    // selector's back.
     val active = selectRound(state.history).distinct
     val totalAgents = active.size + (if config.lint.isDefined then 1 else 0)
     if totalAgents > 0 then
@@ -562,8 +489,8 @@ private[review] class ReviewFixLoop[B <: BackendTag](
           s"Running ${TextUtil.pluralize(totalAgents, "review agent")}"
         )
       )
-    // Apply the confidence filter before display so what's shown matches
-    // what the fixer receives — otherwise low-confidence issues are listed
+    // The confidence filter is applied before display so what's shown matches
+    // what the fixer receives — otherwise low-confidence issues would be listed
     // per-reviewer but silently dropped from the fix payload.
     val (results, lintResult, nextState) = runReviewersAndLint(active, state)
     val result = ReviewResult(issues =
@@ -571,12 +498,11 @@ private[review] class ReviewFixLoop[B <: BackendTag](
     )
     (result, nextState)
 
-  // Routed through the durable [[FlowSession]] door (not the raw structured
-  // door it used pre-2C): a coder whose backend conversation is fresh or lost
-  // gets the seed + progress preamble re-applied and its learned wire id
-  // persisted. Runs on the collecting thread (outside the reviewer fan-out), so
-  // the FlowControl/WorkspaceWrite tokens it needs stay method-scoped and are
-  // never captured into the `CheckedPar` closures (ADR 0018 §6).
+  // Routed through the durable [[FlowSession]] door: a coder whose backend
+  // conversation is fresh or lost gets the seed + progress preamble re-applied
+  // and its learned wire id persisted. Runs on the collecting thread (outside the
+  // reviewer fan-out), so its FlowControl/WorkspaceWrite tokens stay
+  // method-scoped and never land in the `CheckedPar` closures (ADR 0018 §6).
   private def fix(issues: List[ReviewIssue])(using
       fc: FlowControl,
       ws: WorkspaceWrite
@@ -586,10 +512,9 @@ private[review] class ReviewFixLoop[B <: BackendTag](
       .run(FixRequest(fixInstructions, issues), emitPrompt = false)
 
   /** Run the evaluate/fix loop to convergence and return the accumulated
-    * [[IgnoredIssues]], applying the shared [[stopPolicy]] each round — see
-    * there for what it decides — but additionally threading the immutable
-    * [[ReviewLoopState]] (reviewer history + sessions) through each round so
-    * the cross-iteration data flow stays explicit.
+    * [[IgnoredIssues]], applying the shared [[stopPolicy]] each round and
+    * threading the immutable [[ReviewLoopState]] (reviewer history + sessions)
+    * through each round.
     *
     * Takes [[FlowControl]] + [[WorkspaceWrite]] as method parameters (not
     * constructor fields) so the durable fix turn ([[fix]]) can reach the
@@ -601,14 +526,12 @@ private[review] class ReviewFixLoop[B <: BackendTag](
     // A progress marker, not a committing stage: the enclosing implement-task
     // stage already names the work and owns the commit (ADR 0018 §2.2).
     orca.display("Review & fix")
-    // Two-phase selection: run the selector's gated effects (e.g. the
-    // agentDriven picker LLM call) ONCE here, at loop start, inside this stage.
-    // `selectRound` is the resulting pure per-iteration narrowing — passed down
-    // to `evaluate` so it stays a function of its inputs.
-    // Pass `ctx`/`ev` explicitly: under capture checking the more-specific
-    // `fc: FlowControl` in scope would otherwise be picked for `prepare`'s
-    // `using FlowContext` and its root capability rejected (same reason the
-    // `reviewAndFixLoop` constructor call passes them positionally).
+    // Two-phase selection: run the selector's gated effects (e.g. the agentDriven
+    // picker LLM call) ONCE here, at loop start, inside this stage. `selectRound`
+    // is the resulting pure per-iteration narrowing, passed to `evaluate` so it
+    // stays a function of its inputs. Pass `ctx`/`ev` explicitly: the
+    // more-specific `fc: FlowControl` in scope would otherwise be picked for
+    // `prepare`'s `using FlowContext` and its root capability rejected.
     val selectRound: List[ReviewBatch] -> List[RosterEntry[?]] =
       reviewerSelection.prepare(roster, taskTitle, changedFiles)(using ctx, ev)
     @scala.annotation.tailrec

--- a/flow/src/main/scala/orca/review/ReviewLoopPrompts.scala
+++ b/flow/src/main/scala/orca/review/ReviewLoopPrompts.scala
@@ -3,10 +3,9 @@ package orca.review
 import orca.util.PromptResource
 
 /** Default prompt fragments for the helpers in this package. Each `val` is a
-  * complete instruction block that the helper sends as part of its LLM call.
-  * Override by passing a different string to the helper's `instructions`
-  * parameter — wrap one of these defaults if you only want to extend the
-  * boilerplate:
+  * complete instruction block the helper sends as part of its LLM call;
+  * override via the helper's `instructions` parameter, wrapping a default to
+  * extend it:
   *
   * {{{
   * reviewAndFixLoop(
@@ -24,9 +23,9 @@ import orca.util.PromptResource
 object ReviewLoopPrompts:
 
   /** Used by [[reviewAndFixLoop]]'s fix step. Tells the agent to classify every
-    * input issue as either `fixed` (title listed) or `ignored` (title +
-    * reason). The loop relies on `fixed` being non-empty to justify
-    * re-evaluating, so any override should preserve that contract.
+    * input issue as `fixed` (title) or `ignored` (title + reason). The loop
+    * relies on `fixed` being non-empty to justify re-evaluating, so any
+    * override should preserve that contract.
     */
   val Fix: String =
     PromptResource.load("/orca/review/prompts/fix.md")

--- a/flow/src/main/scala/orca/review/ReviewerSelectionRequest.scala
+++ b/flow/src/main/scala/orca/review/ReviewerSelectionRequest.scala
@@ -5,12 +5,10 @@ import orca.plan.Title
 
 /** The `(name, description)` pair the picker LLM sees for one reviewer.
   *
-  * Lives in its own compilation unit (not `ReviewerSelector.scala`) because its
-  * `derives JsonData` expands the tapir `Schema` derivation macro, whose
-  * generated code does not type-check under `ReviewerSelector.scala`'s
-  * `captureChecking` mode (needed there so `prepare` can declare a pure `->`
-  * arrow). Keeping the derivation in a plain, non-capture-checked file
-  * sidesteps the macro/CC interaction — the same split `FixRequest.scala` uses.
+  * In its own compilation unit because `derives JsonData` expands the tapir
+  * `Schema` macro, whose generated code doesn't type-check under
+  * `ReviewerSelector.scala`'s `captureChecking` mode (same split as
+  * `FixRequest.scala`).
   */
 private[review] case class ReviewerInfo(name: String, description: String)
     derives JsonData

--- a/flow/src/main/scala/orca/review/ReviewerSelector.scala
+++ b/flow/src/main/scala/orca/review/ReviewerSelector.scala
@@ -1,11 +1,9 @@
 package orca.review
 
-// Compiled under capture checking so `prepare`'s returned narrowing can be
-// declared as a PURE `->` arrow — enforcing at compile time that the
-// selector's per-round function does not capture `InStage`. Keep
-// tapir `derives`/macro-expanding types out of here (they don't type-check
-// under CC); [[ReviewerInfo]]/[[ReviewerSelectionRequest]] live in a sibling
-// non-CC file, as `FixRequest.scala` does.
+// Compiled under capture checking so `prepare`'s returned narrowing can be a
+// PURE `->` arrow — enforced at compile time not to capture `InStage`. Tapir
+// `derives`/macro-expanding types don't type-check under CC, so
+// [[ReviewerInfo]]/[[ReviewerSelectionRequest]] live in a sibling non-CC file.
 import language.experimental.captureChecking
 import language.experimental.separationChecking
 
@@ -20,21 +18,16 @@ import scala.util.matching.Regex
   *
   * Two-phase: [[prepare]] is called ONCE at loop start with the loop-constant
   * context (the roster as opaque [[RosterEntry]] handles, task title, changed
-  * files) and the loop's own capabilities — any gated effect (e.g.
-  * [[ReviewerSelector.agentDriven]]'s picker LLM call) happens there, inside
-  * the loop's stage. It returns the pure per-iteration narrowing: given the
-  * review history (most recent batch first), which reviewers run this round.
+  * files); any gated effect (e.g. [[ReviewerSelector.agentDriven]]'s picker LLM
+  * call) happens there, inside the loop's stage. It returns the pure
+  * per-iteration narrowing: given the review history (most recent batch first),
+  * which reviewers run this round.
   *
   * A selector can only ever return a subset/permutation of the [[RosterEntry]]
-  * handles it was handed — a foreign agent is unrepresentable (the ctor is
-  * `private[review]`), so the loop needs no runtime roster-membership defence.
-  * The returned narrowing is a pure arrow (`->`): it captures nothing gated, so
-  * selector values are freely reusable across loops.
-  *
-  * Implementers: any per-round effect (an LLM call, a shell-out, anything
-  * needing `FlowContext`/`InStage`) must be hoisted into [[prepare]] itself —
-  * the arrow it returns is capture-checked pure and may only narrow over the
-  * `history` it's given each round.
+  * handles it was handed (the ctor is `private[review]`), so the loop needs no
+  * runtime roster-membership defence. The returned arrow captures nothing
+  * gated, so selector values are freely reusable across loops. Implementers:
+  * hoist any per-round effect into [[prepare]] itself.
   */
 trait ReviewerSelector:
   def prepare(
@@ -48,8 +41,7 @@ object ReviewerSelector:
   /** First iteration runs every reviewer; subsequent rounds re-run only those
     * that found something last round. Saves API spend on consistently-quiet
     * reviewers; the trade-off is that a reviewer who'd catch a regression
-    * introduced by a fix won't see the fix. Was the default before LLM-driven
-    * selection landed; pass explicitly when you want this behaviour back.
+    * introduced by a fix won't see the fix.
     */
   val onlyPreviouslyReporting: ReviewerSelector = new ReviewerSelector:
     def prepare(
@@ -76,31 +68,22 @@ object ReviewerSelector:
 
   /** Asks a picker LLM which reviewers are worth running for a given task. The
     * parameterless form — `reviewAndFixLoop`'s default — resolves the picker at
-    * loop start as the flow's review-role agent's cheap tier
-    * ([[orca.FlowContext.reviewAgent]]`.cheap`); the overload below takes the
-    * picker (and optionally retuned prompts/descriptions) explicitly. The
-    * selection is computed once, in [[ReviewerSelector.prepare]] at loop start
-    * — task context doesn't change mid-loop, so a single query answers every
-    * round; the returned per-round function is pure (it just replays the pick,
-    * ignoring history).
+    * loop start as [[orca.FlowContext.reviewAgent]]`.cheap`; the overload below
+    * takes the picker (and optionally retuned prompts/descriptions) explicitly.
+    * The selection is computed once, at loop start — task context doesn't
+    * change mid-loop — and the returned per-round function replays it, ignoring
+    * history.
     *
-    * `taskTitle` and `changedFiles` arrive at `prepare` from
-    * `reviewAndFixLoop`; the call site supplies at most the picker LLM.
-    *
-    * The picker sees each reviewer as a `(name, description)` pair. By default
-    * `descriptions` is [[ReviewerPrompts.descriptionsBySlug]], so users who
-    * pass `allReviewers(...)` get rich purpose-aware selection without extra
-    * wiring; supply a custom map (keyed by the reviewer's bare slug, e.g.
-    * `"my-thing"`) when overriding the default set. If the picker would see
-    * all-empty descriptions, a one-time `Step` warning fires so the
-    * silent-name-only-selection failure mode is visible.
+    * The picker sees each reviewer as a `(name, description)` pair.
+    * `descriptions` defaults to [[ReviewerPrompts.descriptionsBySlug]]; supply
+    * a custom map (keyed by bare slug) when overriding the default set. If the
+    * picker would see all-empty descriptions, a one-time `Step` warning fires.
     *
     * `filePatterns` is a code-side pre-filter applied before the LLM call:
     * reviewers whose pattern doesn't match any of the iteration's
     * `changedFiles` are dropped, so the picker can't pick them. The default
-    * uses [[ReviewerPrompts.filePatternsBySlug]] — only reviewers that declared
-    * a `files:` frontmatter entry are constrained; everything else is offered
-    * to the picker as-is.
+    * ([[ReviewerPrompts.filePatternsBySlug]]) constrains only reviewers that
+    * declared a `files:` frontmatter entry.
     *
     * Pick a cheap model (e.g. `claude.haiku`); the request is small. Override
     * `instructions` to retune the selection brief.
@@ -136,9 +119,6 @@ object ReviewerSelector:
           case None     => true
           case Some(rx) => changedFiles.exists(f => rx.findFirstIn(f).isDefined)
       val infos = eligible.map: r =>
-        // Names are bare slugs; the cost-attribution prefix never reaches the
-        // picker (it's applied only at the loop's emission edge), so there's
-        // nothing to strip and no ambiguity in the `name: description` line.
         ReviewerInfo(
           name = r.name,
           description = descriptions.getOrElse(r.name, "")
@@ -154,10 +134,8 @@ object ReviewerSelector:
       val names =
         if eligible.isEmpty then Nil
         else
-          // Read-only: the picker only needs to decide which reviewers
-          // to run; it should never edit files during the selection
-          // turn. If the model reads context (Cargo.toml, etc.) to
-          // make a better choice, that's fine.
+          // Read-only: the picker decides which reviewers to run and must not
+          // edit files during selection (reading context is fine).
           agent.withReadOnly
             .resultAs[SelectedReviewers]
             .autonomous
@@ -174,11 +152,9 @@ object ReviewerSelector:
       // Post-filter against `eligible`, not `all`, so a picker that hallucinates
       // a name pre-filtered out can't resurrect it.
       val selected = SelectedReviewers(names).pick(eligible)
-      // Safety floor: the picker is an optimisation that *narrows* the set, not
-      // a gate that can skip review entirely. If it picks nothing (a refusal, a
-      // hallucinated set that matches nothing) while reviewers are eligible,
-      // fall back to all eligible so a real change is never silently unreviewed
-      // — orca's contract is that AI-written code gets reviewed.
+      // Safety floor: the picker narrows the set, it can't skip review. If it
+      // picks nothing while reviewers are eligible, fall back to all eligible
+      // so a real change is never silently unreviewed.
       val active =
         if selected.isEmpty && eligible.nonEmpty then
           ctx.emit(

--- a/flow/src/main/scala/orca/review/Reviewers.scala
+++ b/flow/src/main/scala/orca/review/Reviewers.scala
@@ -12,11 +12,10 @@ import scala.util.matching.Regex
   * the selector drops the reviewer before the picker LLM sees it.
   *
   * Public so a flow can define its own reviewers alongside the shipped
-  * [[ReviewerPrompts]] set: build a `List[Reviewer]` (shipped entries, a
-  * subset, and/or your own), turn it into agents with [[buildReviewers]], and
-  * hand that to [[reviewAndFixLoop]]. To make [[ReviewerSelector.agentDriven]]
-  * purpose- aware of custom reviewers, pass matching
-  * `descriptions`/`filePatterns` maps keyed by `name`.
+  * [[ReviewerPrompts]] set: build a `List[Reviewer]`, turn it into agents with
+  * [[buildReviewers]], and hand that to [[reviewAndFixLoop]]. To make
+  * [[ReviewerSelector.agentDriven]] purpose-aware of custom reviewers, pass
+  * matching `descriptions`/`filePatterns` maps keyed by `name`.
   */
 case class Reviewer(
     name: String,
@@ -37,19 +36,17 @@ case class Reviewer(
   * Public as the customization surface: reference individual reviewers
   * ([[CodeFunctionality]], [[Security]], …), the preset lists ([[all]],
   * [[minimal]]), or the selector-feeding maps ([[descriptionsBySlug]],
-  * [[filePatternsBySlug]]) when composing your own reviewer list to swap or
-  * extend what [[allReviewers]] builds. Pair with [[buildReviewers]].
+  * [[filePatternsBySlug]]) when composing your own reviewer list. Pair with
+  * [[buildReviewers]].
   */
 object ReviewerPrompts:
 
-  /** Role tag applied to a reviewer's agent ONLY at the loop's emission edge,
-    * via `Agent.withRole`, right before the actual LLM run — never baked into
-    * the agent's `name`/identity, so the roster, the session map, the selection
-    * picker, and the on-screen outcomes all keep using the bare slug. Its sole
-    * job is cost attribution: `CostTracker` groups/subtotals every `TokensUsed`
-    * event carrying this role, and derives the human-readable `"reviewer:
-    * <slug>"` display line from it — a display derivation, not a stringly
-    * identity convention (12.7).
+  /** Role tag applied to a reviewer's agent via `Agent.withRole` only at the
+    * loop's emission edge, never baked into the agent's `name`/identity — the
+    * roster, session map, picker, and outcomes all keep using the bare slug.
+    * Its sole job is cost attribution: `CostTracker` groups every `TokensUsed`
+    * event carrying this role and derives the `"reviewer: <slug>"` display line
+    * from it.
     */
   val Role: String = "reviewer"
 
@@ -90,10 +87,8 @@ object ReviewerPrompts:
   )
 
   /** A small universally-applicable subset: correctness, test quality, clarity.
-    * Useful as a starting point when the full set is overkill — e.g. a flow
-    * that touches small diffs where performance/architecture concerns are
-    * rarely actionable. Pair with [[ReviewerSelector.agentDriven]] (the default
-    * in [[reviewAndFixLoop]]) to let the picker narrow further.
+    * Useful when the full set is overkill — e.g. a flow that touches small
+    * diffs where performance/architecture concerns are rarely actionable.
     */
   val minimal: List[Reviewer] = List(
     CodeFunctionality,
@@ -101,11 +96,10 @@ object ReviewerPrompts:
     Test
   )
 
-  /** Descriptions keyed by the bare reviewer slug (a reviewer's identity).
+  /** Descriptions keyed by the bare reviewer slug.
     * [[ReviewerSelector.agentDriven]] consults this by default so the picker
-    * LLM gets each reviewer's purpose alongside its name. Covers every shipped
-    * reviewer, regardless of which preset list was used to build the actual
-    * tools.
+    * gets each reviewer's purpose alongside its name. Covers every shipped
+    * reviewer.
     */
   val descriptionsBySlug: Map[String, String] =
     all.map(r => r.name -> r.description).toMap
@@ -118,9 +112,9 @@ object ReviewerPrompts:
   val filePatternsBySlug: Map[String, Regex] =
     all.flatMap(r => r.filePattern.map(p => r.name -> p)).toMap
 
-/** Build Agents for every reviewer the library ships with. The picker in
-  * [[ReviewerSelector.agentDriven]] (the default in [[reviewAndFixLoop]])
-  * narrows the active set per task, so passing the full list isn't wasteful.
+/** Build Agents for every reviewer the library ships with. The default picker
+  * ([[ReviewerSelector.agentDriven]]) narrows the active set per task, so
+  * passing the full list isn't wasteful.
   */
 def allReviewers[B <: BackendTag](base: Agent[B]): List[Agent[B]] =
   buildReviewers(base, ReviewerPrompts.all)
@@ -133,19 +127,14 @@ def minimalReviewers[B <: BackendTag](base: Agent[B]): List[Agent[B]] =
   buildReviewers(base, ReviewerPrompts.minimal)
 
 /** Layer each reviewer's system prompt onto the base tool, name it with the
-  * bare reviewer slug (its identity — the cost-attribution `reviewer` role tag
-  * is applied only later, when the loop labels the actual LLM run for the
-  * `OrcaEvent.TokensUsed` breakdown), and gate every reviewer to read-only
-  * access. A reviewer's job is to *report* issues, not fix them; without
-  * `withReadOnly` the agent inherits the base tool's permissions (typically
-  * `AutoApprove.All`) and could edit files mid-review. Reads (Read/Glob/Grep on
-  * claude, `--sandbox read-only` on codex) stay available so the agent can
-  * verify claims beyond the diff. The non-reviewer driver agent keeps its
-  * default name (`main`) and write permissions.
+  * bare reviewer slug, and gate every reviewer to read-only access. A
+  * reviewer's job is to *report* issues, not fix them; without `withReadOnly`
+  * the agent inherits the base tool's permissions (typically `AutoApprove.All`)
+  * and could edit files mid-review. Reads stay available so the agent can
+  * verify claims beyond the diff.
   *
-  * Public so a flow can build agents from a custom [[Reviewer]] list —
-  * `buildReviewers(base, ReviewerPrompts.minimal :+ myReviewer)` — rather than
-  * being limited to the [[allReviewers]] / [[minimalReviewers]] presets.
+  * Public so a flow can build agents from a custom [[Reviewer]] list rather
+  * than being limited to the [[allReviewers]] / [[minimalReviewers]] presets.
   */
 def buildReviewers[B <: BackendTag](
     base: Agent[B],

--- a/flow/src/main/scala/orca/review/SelectedReviewers.scala
+++ b/flow/src/main/scala/orca/review/SelectedReviewers.scala
@@ -3,12 +3,10 @@ package orca.review
 import orca.agents.{Announce, JsonData}
 
 case class SelectedReviewers(names: List[String]) derives JsonData:
-  /** Resolve the picker's reply to roster entries by matching the bare slug — a
-    * reviewer's identity, and exactly what the picker is shown and asked to
-    * echo. Matching against the handed [[RosterEntry]] list (not raw names) is
-    * the hallucinated-picker floor: a name the picker invents that no entry
-    * carries simply matches nothing. The `reviewer` cost-attribution role tag
-    * never reaches the picker, so it plays no part in selection.
+  /** Resolve the picker's reply to roster entries by matching the bare slug.
+    * Matching against the handed [[RosterEntry]] list (not raw names) is the
+    * hallucinated-picker floor: an invented name that no entry carries matches
+    * nothing.
     */
   def pick(all: List[RosterEntry[?]]): List[RosterEntry[?]] =
     all.filter(r => names.contains(r.name))

--- a/flow/src/main/scala/orca/settings/SettingsEntry.scala
+++ b/flow/src/main/scala/orca/settings/SettingsEntry.scala
@@ -7,11 +7,10 @@ private[orca] enum SettingsEntry:
   /** `key = command`, with an optional comment carrying the discovery evidence,
     * rendered as `# ` line(s) directly above the command line.
     *
-    * `command` is non-blank and does not start with `#` (even after render's
-    * newline collapse): discovery's mechanical checks demote blank and
-    * unresolvable commands to [[Demoted]] before render sees them, so render
-    * does not re-validate. A violating command would render as a line the
-    * parser drops (blank value) or rejects (`#`-leading `CommentedValue`).
+    * Invariant: `command` is non-blank and does not start with `#` (even after
+    * render's newline collapse) — discovery demotes blank and unresolvable
+    * commands to [[Demoted]] before render sees them, so render does not
+    * re-validate.
     */
   case Command(key: String, command: String, comment: Option[String])
 
@@ -24,9 +23,8 @@ private[orca] enum SettingsEntry:
   case Unset(key: String, reason: String)
 
   /** A discovered command that failed a mechanical check (ADR 0019), rendered
-    * commented-out with the failure reason — invisible to the parser like any
-    * `#` line, but the command stays visible for the user to fix and
-    * un-comment:
+    * commented-out with the failure reason — invisible to the parser, but the
+    * command stays visible for the user to fix and un-comment:
     * {{{
     * # key = command   (reason)
     * }}}

--- a/flow/src/main/scala/orca/settings/SettingsFile.scala
+++ b/flow/src/main/scala/orca/settings/SettingsFile.scala
@@ -39,10 +39,9 @@ private[settings] enum SettingsError:
 
 /** The closed set of settings-file keys; `raw` is the exact on-disk spelling
   * (keys are case-sensitive). Split into [[StackKey]] and [[AgentKey]] so
-  * `append` and the agent-key handling each match only their own cases —
-  * exhaustively, with no wildcard arm over the full six-case set — a key added
-  * to either enum without matching code added everywhere fails to compile
-  * instead of silently falling through.
+  * `append` and the agent-key handling each match exhaustively over their own
+  * cases — a key added without matching code fails to compile rather than
+  * silently falling through.
   */
 private[settings] sealed trait SettingKey:
   def raw: String
@@ -78,13 +77,13 @@ private[orca] case class ParsedSettings(
     agents: AgentSettings
 )
 
-/** Strict line format for `.orca/settings.properties`: `#` comments (a line
-  * whose first non-space char is `#`), `key = value` with the value taken
-  * verbatim (trimmed) after the first `=` — always, with no comment stripping,
-  * so a `#` inside the value is command text — repeated stack keys append in
-  * file order, repeated agent keys are rejected, an empty value is equivalent
-  * to omitting the key. Hand-rolled rather than `java.util.Properties`, whose
-  * backslash/unicode escape handling would mangle shell commands (ADR 0019).
+/** Strict line format for `.orca/settings.properties`: `#` comments (first
+  * non-space char is `#`), `key = value` with the value taken verbatim
+  * (trimmed) after the first `=` — no comment stripping, so a `#` inside the
+  * value is command text. Repeated stack keys append in file order, repeated
+  * agent keys are rejected, an empty value is equivalent to omitting the key.
+  * Hand-rolled rather than `java.util.Properties`, whose backslash/unicode
+  * escape handling would mangle shell commands (ADR 0019).
   */
 private[orca] object SettingsFile:
 
@@ -121,9 +120,8 @@ private[orca] object SettingsFile:
             case None      => Left(SettingsError.UnknownKey(number, rawKey))
             case Some(key) =>
               // A value starting with `#` (e.g. `lint = # disabled`) runs
-              // nothing under `bash -c` and exits 0, silently turning the
-              // gate off — rejected so the whole line is commented out
-              // instead.
+              // nothing under `bash -c` and exits 0, silently turning the gate
+              // off — rejected so the whole line is commented out instead.
               if value.startsWith("#") then
                 Left(SettingsError.CommentedValue(number, rawKey))
               else if value.isEmpty then Right(acc)
@@ -172,9 +170,9 @@ private[orca] object SettingsFile:
       "re-run auto-discovery."
 
   /** The full settings-file text for `entries` under [[Header]],
-    * newline-terminated. A [[SettingsEntry.Command]]'s comment renders as its
-    * own `# ` line(s) directly above the `key = command` line — one `# ` line
-    * per line of comment text, so a multi-line comment stays parseable.
+    * newline-terminated. A [[SettingsEntry.Command]]'s comment renders as one
+    * `# ` line per line of comment text, directly above the `key = command`
+    * line, so a multi-line comment stays parseable.
     */
   def render(entries: List[SettingsEntry]): String =
     (Header :: entries.map(renderEntry)).mkString("", "\n", "\n")
@@ -183,8 +181,7 @@ private[orca] object SettingsFile:
     * newline-terminated. The append shape for a file that already exists but
     * carries no stack lines (an agents-only hand-written file): discovery
     * appends its stack entries below the user's untouched agent lines instead
-    * of overwriting the whole file. Shares [[renderEntry]] with [[render]] so
-    * the entry formatting lives in one place.
+    * of overwriting the whole file.
     */
   def renderAppend(entries: List[SettingsEntry]): String =
     entries.map(renderEntry).mkString("", "\n", "\n")
@@ -192,12 +189,9 @@ private[orca] object SettingsFile:
   private def renderEntry(entry: SettingsEntry): String =
     entry match
       case SettingsEntry.Command(key, command, comment) =>
-        // Newlines in the command collapse to single spaces so the entry stays
-        // one physical line (an LLM-sourced multi-line string would otherwise
-        // wedge the next parse).
+        // Collapse newlines so the entry stays one physical line — an
+        // LLM-sourced multi-line command would otherwise wedge the next parse.
         val commandLine = s"$key = ${collapseNewlines(command)}"
-        // A blank comment renders as absent — a lone `# ` line above the
-        // command would carry no information.
         comment.filter(!_.isBlank) match
           case Some(text) =>
             text.linesIterator
@@ -205,12 +199,10 @@ private[orca] object SettingsFile:
               .mkString("", "\n", "\n") + commandLine
           case None => commandLine
       case SettingsEntry.Unset(key, reason) =>
-        // Whitespace runs in the reason collapse to single spaces — the same
-        // one-physical-line guarantee as the command above.
         s"# $key =   (${collapseWhitespace(reason)})"
       case SettingsEntry.Demoted(key, command, reason) =>
-        // Both parts collapse like Unset's reason: the whole entry must stay
-        // one physical `#` line or the tail would parse as live commands.
+        // Collapse both parts: the whole entry must stay one physical `#` line
+        // or the tail would parse as live commands.
         s"# $key = ${collapseWhitespace(command)}   " +
           s"(${collapseWhitespace(reason)})"
 
@@ -231,13 +223,11 @@ private[orca] object SettingsFile:
       case StackKey.Test   => acc.copy(test = acc.test :+ command)
 
   /** Split a `key = value` line at the FIRST `=`: the trimmed key and the
-    * verbatim-but-trimmed value (everything after the first `=` belongs to the
-    * value, so commands containing `=` — e.g. `FOO=bar cargo check` — survive
-    * intact). `None` when the line has no `=`. The single definition of "which
-    * key does this line name", shared by [[parseLine]] and [[hasStackLines]] so
-    * a control byte `String.trim` strips (but a `\s` regex would not match) can
-    * never make the discovery gate and the parser disagree about whether a line
-    * is a live stack key.
+    * verbatim-but-trimmed value (so commands containing `=` — e.g. `FOO=bar
+    * cargo check` — survive intact). `None` when the line has no `=`. The
+    * single definition of "which key does this line name", shared by
+    * [[parseLine]] and [[hasStackLines]] so the discovery gate and the parser
+    * can't disagree about whether a line is a live stack key.
     */
   private def splitAssignment(line: String): Option[(String, String)] =
     line.indexOf('=') match
@@ -247,14 +237,9 @@ private[orca] object SettingsFile:
   /** True when any line of `content` names a stack key — live or commented. The
     * discovery trigger (ADR 0020): a discovery-written file always carries at
     * least commented stack lines, so only a hand-written file with no stack
-    * content at all re-triggers discovery.
-    *
-    * Uses the parser's own [[splitAssignment]] key extraction (after stripping
-    * a leading `#` comment marker so a commented stack line still counts),
-    * rather than a second regex: the two must agree on what a stack key is, and
-    * `String.trim`'s control-byte stripping is a strict superset of a regex
-    * `\s`, so a divergent second definition could report "no stack line" for a
-    * line the parser reads as a live stack key.
+    * content re-triggers discovery. Reuses [[splitAssignment]] (after stripping
+    * a leading `#`) rather than a second regex, so it can't disagree with the
+    * parser about what a stack key is.
     */
   def hasStackLines(content: String): Boolean =
     content.linesIterator.exists(namesStackKey)

--- a/flow/src/test/scala/orca/AccessorsTest.scala
+++ b/flow/src/test/scala/orca/AccessorsTest.scala
@@ -32,9 +32,8 @@ class AccessorsTest extends munit.FunSuite:
 
   /** Compile-only: a session minted from `codingAgent` must type as
     * `FlowSession[ctx.CodeB]`, matching the coding role's pinned backend — a
-    * regression here would silently erase the type and stop sessions from
-    * threading through `session.run`. Never invoked; typechecking alone is the
-    * assertion (see `flowtests.FlowCompilesTest` for the sibling canary style).
+    * regression here would erase the type and stop sessions from threading
+    * through `session.run`. Typechecking alone is the assertion.
     */
   def codingAgentSessionThreads(using
       ctx: FlowContext,

--- a/flow/src/test/scala/orca/BranchNamingTest.scala
+++ b/flow/src/test/scala/orca/BranchNamingTest.scala
@@ -282,7 +282,7 @@ class BranchNamingTest extends munit.FunSuite:
     "producer == validator: slug output always passes RecoveryCheck.isSafeBranchRef"
   ):
     // Pins that the producer (slug) and the untrusted-header validator agree by
-    // construction — they now share one predicate (BranchNamingStrategy.isSlugSegment).
+    // construction — they share one predicate (BranchNamingStrategy.isSlugSegment).
     val inputs = List(
       "Add a Multiply Function!",
       "  -rf dangerous  ",

--- a/flow/src/test/scala/orca/CapabilitiesTest.scala
+++ b/flow/src/test/scala/orca/CapabilitiesTest.scala
@@ -2,9 +2,8 @@ package orca
 
 import orca.events.EventDispatcher
 
-/** Tests for the FlowControl capability type (ADR 0018 §2.2).
-  *
-  * Verifies that FlowControl <: FlowContext (subtyping satisfaction).
+/** Tests for the FlowControl capability type (ADR 0018 §2.2): FlowControl
+  * satisfies a `using FlowContext` requirement.
   */
 class CapabilitiesTest extends munit.FunSuite:
 

--- a/flow/src/test/scala/orca/CcNegativeCompileTest.scala
+++ b/flow/src/test/scala/orca/CcNegativeCompileTest.scala
@@ -9,30 +9,26 @@ import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.interfaces.Diagnostic as IDiagnostic
 import dotty.tools.dotc.reporting.{Diagnostic, Reporter}
 
-/** Capture-checking enforcement, pinned as automated negative-compile tests. A
-  * manual spike first proved that the checked fan-out shape — an impure-typed
-  * thunk list (`Seq[() => Int]`) routed through [[orca.CheckedPar]] — rejects
-  * an exclusive-capability capture; this suite pins that proof so a compiler
-  * upgrade or a wrapper edit can't silently drop the enforcement. Note the
+/** Capture-checking enforcement pinned as automated negative-compile tests, so
+  * a compiler upgrade or a wrapper edit can't silently drop it. The checked
+  * fan-out shape — an impure-typed thunk list (`Seq[() => Int]`) routed through
+  * [[orca.CheckedPar]] — must reject an exclusive-capability capture. The
   * rejection fires at the fixture's impure `Seq[() => Int]` ascription (the
-  * widening that "hides" the exclusive token), not at the wrapper boundary
-  * itself — see [[orca.CheckedPar]]'s object doc.
+  * widening that "hides" the exclusive token), not at the wrapper boundary —
+  * see [[orca.CheckedPar]]'s object doc.
   *
-  * Why an in-process compiler, not munit's `compileErrors`: that macro runs
-  * only the typer, but capture/separation checking runs post-typer — so a
+  * An in-process `dotc` is used, not munit's `compileErrors`: that macro runs
+  * only the typer, but capture/separation checking runs post-typer, so a
   * `compileErrors` version of the exclusive-capture cases would report ZERO
-  * errors and pass vacuously. (`orcacaps.InStageNegativeTest` legitimately
-  * stays on `compileErrors`: its negatives ARE typer errors.) Here we invoke
-  * the real `dotc` ([[dotty.tools.dotc.Main]]) on fixture sources, against this
-  * module's own Test classpath, so the full checked-compilation pipeline runs.
+  * errors and pass vacuously. Invoking the real `dotc`
+  * ([[dotty.tools.dotc.Main]]) against this module's own Test classpath runs
+  * the full checked-compilation pipeline.
   *
   * Fixtures declare `package orca` because [[orca.CheckedPar]] is
-  * `private[orca]` — an internal funnel, not meant on the `import orca.*` user
-  * namespace. They still pass the capability token in as a method parameter
+  * `private[orca]`. They pass the capability token in as a method parameter
   * rather than minting it via `InStage.unsafe`: passing an exclusive parameter
   * into the parallel closures is exactly the smuggling separation checking must
-  * reject, and it keeps each fixture to one token, one wrapper call, two
-  * closures — no `.unsafe` door, no Ox scope.
+  * reject, and keeps each fixture to one token, one wrapper call, two closures.
   */
 class CcNegativeCompileTest extends munit.FunSuite:
 
@@ -81,7 +77,6 @@ class CcNegativeCompileTest extends munit.FunSuite:
       deleteRecursively(srcDir)
       deleteRecursively(outDir)
 
-  /** Recursively removes a directory tree created for one fixture compile. */
   private def deleteRecursively(dir: java.nio.file.Path): Unit =
     if Files.exists(dir) then
       Files
@@ -156,12 +151,12 @@ class CcNegativeCompileTest extends munit.FunSuite:
       s"expected a separation-checking error rejecting the $token capture, got: $errors"
     )
 
-  /** Fixture implementing [[orca.review.ReviewerSelector]] (ADR 0011's
-    * 2026-07-08 amendment: `prepare` returns a pure `->` arrow that may only
-    * narrow over `history`). `body` is that returned lambda; the surrounding
-    * shape — imports, `prepare`'s signature, the `using ctx: FlowContext, ev:
-    * InStage` capabilities in scope — is identical for the (d)/(e) pair below,
-    * so purity of the returned lambda is the only axis under test.
+  /** Fixture implementing [[orca.review.ReviewerSelector]] (ADR 0011: `prepare`
+    * returns a pure `->` arrow that may only narrow over `history`). `body` is
+    * that returned lambda; the surrounding shape — imports, `prepare`'s
+    * signature, the `using ctx: FlowContext, ev: InStage` capabilities in scope
+    * — is identical for the (d)/(e) pair below, so purity of the returned
+    * lambda is the only axis under test.
     */
   private def selectorFixture(body: String): String =
     s"""package orca.review
@@ -200,7 +195,7 @@ class CcNegativeCompileTest extends munit.FunSuite:
 
   /** Assert `prepare`'s returned arrow was rejected for capturing a `using`
     * capability into a pure `->` type — the compile-time form of the
-    * ReviewerSelector contract (ADR 0011, 2026-07-08 amendment; see also
+    * ReviewerSelector contract (ADR 0011; see also
     * [[orca.review.ReviewerSelector]]'s trait doc): the returned narrowing may
     * only close over `history`, not the loop's capabilities.
     *

--- a/flow/src/test/scala/orca/CommitMessageTest.scala
+++ b/flow/src/test/scala/orca/CommitMessageTest.scala
@@ -16,10 +16,9 @@ import orca.progress.ProgressStore
 import orca.testkit.GitRepo
 import orca.tools.{GitTool, OsGitTool}
 
-/** Tests for the agent-generated commit-message path in `recordAndCommit`.
-  *
-  * Strategy: build a `TestFlowControlWithAgent` that wires a real temp repo and
-  * a stubbed LLM, then assert the message in `git log` after a stage runs.
+/** Tests for the agent-generated commit-message path in `recordAndCommit`: wire
+  * a real temp repo and a stubbed LLM, then assert the message in `git log`
+  * after a stage runs.
   */
 class CommitMessageTest extends munit.FunSuite:
 
@@ -121,7 +120,6 @@ class CommitMessageTest extends munit.FunSuite:
     lazy val gh: orca.tools.GitHubTool = stub("gh")
     lazy val fs: orca.tools.FsTool = stub("fs")
     def emit(event: OrcaEvent): Unit = ()
-    // Stage-identity bookkeeping inherited from the shared `StageFrames` mixin.
 
   private def withCtx(
       agentStub: Agent[BackendTag.ClaudeCode.type]
@@ -159,11 +157,8 @@ class CommitMessageTest extends munit.FunSuite:
     // force-added) triggers the `s"stage: $name"` fallback.
     withCtx(stubbedAgent("should not appear")): (ctx, dir) =>
       given FlowControl = ctx
-      // Run a stage that produces no code changes — only the progress file changes.
       val _ = stage("no-op"):
         "done"
-      // The commit message must be the fallback, not the LLM reply, because the
-      // diff was empty (no code files modified in the body).
       assertEquals(lastCommitMessage(dir), "stage: no-op")
 
   test(

--- a/flow/src/test/scala/orca/CostTrackerTest.scala
+++ b/flow/src/test/scala/orca/CostTrackerTest.scala
@@ -140,7 +140,7 @@ class CostTrackerTest extends munit.FunSuite:
   test(
     "price-table lookup does NOT fall back across a non-date model-tier suffix"
   ):
-    // 12.5: "opus-mini" is a different (and differently-priced) model tier
+    // "opus-mini" is a different (and differently-priced) model tier
     // from "opus", not a dated snapshot of it — unlike "opus-20251015" above,
     // the prefix fallback must not cross tiers just because one name prefixes
     // the other. Mirrors the real-world gemini-2.5-flash / -flash-lite risk.
@@ -271,9 +271,8 @@ class CostTrackerTest extends munit.FunSuite:
   test(
     "summary derives a display-only role prefix per agent and adds a By role subtotal section"
   ):
-    // 12.7: the old "reviewer: <slug>" string was baked into the agent's
-    // identity/name; now `agent` stays bare and the summary derives the same
-    // display text purely from `role`, plus a "By role:" subtotal section.
+    // `agent` stays bare; the summary derives the "reviewer: <slug>" display
+    // text purely from `role`, and adds a "By role:" subtotal section.
     val tracker = new CostTracker(pricing = testTable)
     tracker.onEvent(
       tokens(

--- a/flow/src/test/scala/orca/FlowSessionTest.scala
+++ b/flow/src/test/scala/orca/FlowSessionTest.scala
@@ -24,8 +24,7 @@ import orca.testkit.TempDirs
 import orca.util.RawJson
 
 /** Tests for [[FlowSession]] — the durable-session handle that owns the probe →
-  * seed/preamble → run → persist protocol (ADR 0018 §2.6, absorbs the former
-  * `agent.runSeeded` extension).
+  * seed/preamble → run → persist protocol (ADR 0018 §2.6).
   *
   * Each scenario constructs a [[FlowSession]] directly over a
   * [[StubAgentForSeeded]] (whose `willContinue` and `run` behaviours are
@@ -93,9 +92,9 @@ class FlowSessionTest extends FunSuite:
   ) extends Agent[BackendTag.ClaudeCode.type]:
     val name: String = "stub-seeded"
 
-    /** [[Agent.backendTag]] override — `None` by default (matching every
-      * pre-6B.2 test's expectation), settable so a self-heal test can drive
-      * `persistResumeWireId`'s tag-healing write with a concrete tag.
+    /** [[Agent.backendTag]] override — `None` by default, settable so a
+      * self-heal test can drive `persistResumeWireId`'s tag-healing write with
+      * a concrete tag.
       */
     override private[orca] def backendTag: Option[BackendTag] = tag
 
@@ -224,7 +223,7 @@ class FlowSessionTest extends FunSuite:
   ): FlowSession[BackendTag.ClaudeCode.type] =
     new FlowSession(agent, testSession)
 
-  // ── tests: free-text run protocol (ported from the former runSeeded) ────────
+  // ── tests: free-text run protocol ───────────────────────────────────────────
 
   test("live session: prompt forwarded verbatim, no preamble, no seed"):
     val seed = "You are a planning agent."
@@ -596,9 +595,6 @@ class FlowSessionTest extends FunSuite:
   ):
     // The guard in persistResumeWireId calls agent.resumeWireId(session).foreach { … }
     // so a None result short-circuits and the record's resumeWireId is left intact.
-    // Pre-seed the log with a SessionRecord whose resumeWireId is already
-    // Some("server-1"), then run with a stub whose resumeWireId returns None, and
-    // confirm the stored resumeWireId is still Some("server-1") (not cleared).
     val fc = makeControl(
       sessions = List(
         SessionRecord(
@@ -626,8 +622,8 @@ class FlowSessionTest extends FunSuite:
   test(
     "resultAs.run primes seed + preamble and persists wire id on a lost session"
   ):
-    // The structured door had NO seed/probe/persist path before FlowSession
-    // (it went through the raw door); assert it now follows the same protocol.
+    // The structured door must follow the same seed/probe/persist protocol as
+    // the free-text door.
     val seed = "You are a fixer."
     val fc = makeControl(
       sessions = List(

--- a/flow/src/test/scala/orca/NoTaintCanaryTest.scala
+++ b/flow/src/test/scala/orca/NoTaintCanaryTest.scala
@@ -1,7 +1,7 @@
 package orca
 
-/** Consumer-taint canary — pins the research's no-taint verdict against future
-  * compiler upgrades.
+/** Consumer-taint canary — pins the no-taint property against future compiler
+  * upgrades.
   *
   * [[InStage]] extends `caps.SharedCapability` (non-experimental), while
   * [[WorkspaceWrite]] and [[FlowControl]] extend `caps.ExclusiveCapability` —
@@ -10,12 +10,10 @@ package orca
   * `@experimental`, yet it freely mints, summons, and passes all three tokens.
   *
   * If a future compiler propagated `@experimental` from the capture-checking
-  * parents into these definitions, merely referencing them from this plain,
-  * non-CC compilation unit would fail with "... is marked @experimental",
-  * turning this green test RED. That is exactly the taint the research showed
-  * cannot happen on stable 3.8.4 (the `sbt compile` of every non-CC module that
-  * already references `FlowControl`/`InStage` is the implicit canary; this is
-  * the explicit, named insurance).
+  * parents into these definitions, referencing them from this plain, non-CC
+  * compilation unit would fail with "... is marked @experimental", turning this
+  * test RED. That taint cannot happen on stable 3.8.4; this is the explicit,
+  * named insurance for it.
   */
 class NoTaintCanaryTest extends munit.FunSuite:
 

--- a/flow/src/test/scala/orca/SessionTest.scala
+++ b/flow/src/test/scala/orca/SessionTest.scala
@@ -203,9 +203,8 @@ class SessionTest extends FunSuite:
     assertEquals(store.load().get.sessions.head.backend, Some("Codex"))
 
     // Second run over the SAME (name, occurrence): a differently-tagged
-    // agent — a lead-backend swap between runs. Today (pre-6B.2) this
-    // silently reuses the Codex-minted id under the new tag; the fix must
-    // mint fresh and warn instead.
+    // agent — a lead-backend swap between runs. A backend-tag mismatch must
+    // mint a fresh id and warn, not silently reuse the Codex-minted id.
     val claudeAgent = new StubAgent:
       override private[orca] def backendTag: Option[BackendTag] =
         Some(BackendTag.ClaudeCode)

--- a/flow/src/test/scala/orca/TestFlowContext.scala
+++ b/flow/src/test/scala/orca/TestFlowContext.scala
@@ -103,8 +103,8 @@ class TestFlowControl(
 
   // Stage-identity bookkeeping (enterStage/exitStage/inStage and
   // nextSessionOccurrence) is inherited from the shared `StageFrames` mixin — the
-  // SAME implementation production uses, so this double cannot silently keep the
-  // old flat-counter semantics and greenwash a nesting/resume test.
+  // SAME implementation production uses, so this double can't diverge from
+  // production nesting/resume semantics and greenwash a test.
 
 object TestFlowControl:
   /** Build a `TestFlowControl` over a fresh temp git repo (with one seed commit

--- a/flow/src/test/scala/orca/plan/AssessThenPlanTest.scala
+++ b/flow/src/test/scala/orca/plan/AssessThenPlanTest.scala
@@ -5,7 +5,7 @@ import orca.agents.ToolSet
 
 class AssessThenPlanTest extends munit.FunSuite:
 
-  // Planning helpers are now gated on `InStage`; mint the token for the suite.
+  // Planning helpers are gated on `InStage`; mint the token for the suite.
   private given orca.InStage = orca.InStage.unsafe
 
   private val samplePlan = Plan(

--- a/flow/src/test/scala/orca/plan/PlanGridTest.scala
+++ b/flow/src/test/scala/orca/plan/PlanGridTest.scala
@@ -15,7 +15,7 @@ class PlanGridTest extends munit.FunSuite:
   private given orca.FlowContext =
     new orca.TestFlowContext(new EventDispatcher(Nil))
 
-  // Planning helpers are now gated on `InStage`; mint the token for the suite.
+  // Planning helpers are gated on `InStage`; mint the token for the suite.
   private given orca.InStage = orca.InStage.unsafe
 
   private val samplePlan = Plan(

--- a/flow/src/test/scala/orca/pr/OpenPrFromBranchTest.scala
+++ b/flow/src/test/scala/orca/pr/OpenPrFromBranchTest.scala
@@ -24,14 +24,12 @@ import orca.events.{EventDispatcher, OrcaEvent, OrcaListener}
 import scala.concurrent.duration.FiniteDuration
 import java.util.concurrent.ConcurrentLinkedQueue
 
-/** Tests for [[openPrFromBranch]] — the push → summarise → create tail bundled
-  * as three resume-safe stages.
-  *
-  * The helper is thin orchestration, so the honest thing to pin is its
-  * STRUCTURE: three stages in the fixed order, and — the resume-critical
-  * property — `git.push` happening in an earlier stage than `gh.createPr`.
-  * Recording `git`/`gh` doubles capture call order; a real [[TestFlowControl]]
-  * runs the actual `stage` machinery so the emitted stage boundaries are real.
+/** Tests for [[openPrFromBranch]] — push → summarise → create as three
+  * resume-safe stages. Pins the structure: three stages in fixed order, with
+  * the resume-critical property that `git.push` runs in an earlier stage than
+  * `gh.createPr`. Recording `git`/`gh` doubles capture call order; a real
+  * [[TestFlowControl]] runs the actual `stage` machinery so the emitted stage
+  * boundaries are real.
   */
 class OpenPrFromBranchTest extends FunSuite:
 

--- a/flow/src/test/scala/orca/progress/ProgressStoreTest.scala
+++ b/flow/src/test/scala/orca/progress/ProgressStoreTest.scala
@@ -81,15 +81,10 @@ class ProgressStoreTest extends FunSuite:
   test("load returns None for a corrupt file (no throw)"):
     val workDir = TempDirs.dir()
     val store = ProgressStore.default(workDir, "my prompt")
-    // Manually write garbage to the expected path location
     val path = workDir / ".orca"
     os.makeDir.all(path)
-    // Write garbage to every possible progress file via direct os.write
-    // The store's path is deterministic for a given prompt, so we can
-    // reconstruct it by writing to any file there — but we need the exact path.
-    // Instead, call writeHeader so the file exists, then overwrite with garbage.
+    // writeHeader creates the store file; overwrite it with garbage.
     store.writeHeader(header)
-    // Overwrite with non-JSON content
     val files = os.list(path).filter(_.last.startsWith("progress-"))
     assert(files.nonEmpty, "expected at least one progress file")
     os.write.over(files.head, "not json {{{")
@@ -166,9 +161,9 @@ class ProgressStoreTest extends FunSuite:
   test(
     "appendEntry against a corrupted-but-present log surfaces a corruption-specific message, not the before-writeHeader lie"
   ):
-    // 12.4: a log that exists but is torn/corrupted mid-run must not be
-    // misreported as "appendEntry called before writeHeader" — that message
-    // is a lie when writeHeader plainly did run (the file exists).
+    // A log that exists but is torn/corrupted mid-run must not be misreported
+    // as "appendEntry called before writeHeader" — that message is wrong when
+    // writeHeader plainly did run (the file exists).
     val workDir = TempDirs.dir()
     val store = ProgressStore.default(workDir, "my prompt")
     val path = workDir / ".orca"
@@ -229,7 +224,6 @@ class ProgressStoreTest extends FunSuite:
     val files = os.list(orcaDir).filter(_.last.startsWith("progress-"))
     assert(files.size == 1, s"expected exactly one progress file, got $files")
     val filename = files.head.last
-    // filename must match progress-<12 hex chars>.json
     assert(
       filename.matches("progress-[0-9a-f]{12}\\.json"),
       s"unexpected filename: $filename"
@@ -330,9 +324,8 @@ class ProgressStoreTest extends FunSuite:
   test(
     "writeHeader writes atomically: no leftover .tmp files"
   ):
-    // The AtomicMoveNotSupportedException fallback path has no injectable
-    // seam in this test harness — verified by code review, mirroring
-    // FlowLifecycleTest's convention for the corrupt-log WARN.
+    // The AtomicMoveNotSupportedException fallback path has no injectable seam
+    // in this harness; it is verified by code review only.
     val workDir = TempDirs.dir()
     val store = ProgressStore.default(workDir, "my prompt")
     store.writeHeader(header)

--- a/flow/src/test/scala/orca/review/FixLoopTest.scala
+++ b/flow/src/test/scala/orca/review/FixLoopTest.scala
@@ -82,9 +82,8 @@ class FixLoopTest extends munit.FunSuite:
       result.issues,
       List(IgnoredIssue(Title("b"), "out of scope"))
     )
-    // Iterations are progress markers (`display`) now, not committing stages —
-    // they run under the caller's task stage (ADR 0018 §2.2), so they surface
-    // as Step events rather than StageStarted.
+    // Iterations run under the caller's task stage (ADR 0018 §2.2), so they
+    // surface as Step events rather than StageStarted.
     assertEquals(
       rec.steps.filter(_.startsWith("Iteration ")),
       List("Iteration 1", "Iteration 2", "Iteration 3")

--- a/flow/src/test/scala/orca/review/LintTest.scala
+++ b/flow/src/test/scala/orca/review/LintTest.scala
@@ -21,22 +21,21 @@ import orca.{TestFlowContext}
 
 class LintTest extends munit.FunSuite:
 
-  // `lint` is now gated on `InStage`; mint the token for the suite.
+  // `lint` is gated on `InStage`; mint the token for the suite.
   private given orca.InStage = orca.InStage.unsafe
 
   private def ctx: FlowContext =
     new TestFlowContext(new EventDispatcher(Nil))
 
   /** Agent that records the serialized prompt passed to
-    * `resultAs.autonomous.run` and returns a canned ReviewResult. Method-scope
-    * mutable var holds the captured string.
+    * `resultAs.autonomous.run` and returns a canned ReviewResult.
     */
   private class CapturingAgent(canned: ReviewResult)
       extends Agent[BackendTag.ClaudeCode.type]:
     var captured: String = ""
-    // Contents of the `*.txt` file the prompt references, if any, read inside
-    // `run` while it still exists — `lint` deletes it once `run` returns. Empty
-    // when the output was inlined (small) rather than spilled to a file.
+    // Contents of the `*.txt` file the prompt references, read inside `run`
+    // while it still exists — `lint` deletes it once `run` returns. Empty when
+    // the output was inlined rather than spilled to a file.
     var capturedFileContent: String = ""
     val name = "mock"
     def autonomous: AutonomousTextCall[BackendTag.ClaudeCode.type] = ???
@@ -86,10 +85,9 @@ class LintTest extends munit.FunSuite:
     val mock = new CapturingAgent(expected)
     val result = lint(List("echo LINT-BODY-MARKER"), mock)
     assertEquals(result, expected)
-    // Small output is inlined directly — the sandbox-safe path (a read-only
-    // autonomous agent that can't reach files outside its worktree still sees
-    // it). So no `.txt` file is referenced and the output is in the prompt;
-    // the exact block format is pinned by the block-labelling test below.
+    // Small output is inlined directly, so a read-only autonomous agent that
+    // can't reach files outside its worktree still sees it: no `.txt` file is
+    // referenced.
     assert(
       mock.captured.contains("LINT-BODY-MARKER"),
       s"prompt should inline the lint output, got: ${mock.captured}"
@@ -105,9 +103,8 @@ class LintTest extends munit.FunSuite:
     val result = lint(List("echo ONE-OUT; exit 2", "echo TWO-OUT"), mock)
     assertEquals(result, expected)
     // The FIRST command fails, and the second's block still follows — an
-    // earlier failure never hides later diagnostics. The summariser sees one
-    // concatenation, in command order, each block labelled with its own
-    // command and exit status.
+    // earlier failure never hides later diagnostics. Blocks are concatenated in
+    // command order, each labelled with its command and exit status.
     assert(
       mock.captured.contains(
         "$ echo ONE-OUT; exit 2   (exit 2)\nONE-OUT\n\n" +
@@ -122,8 +119,8 @@ class LintTest extends munit.FunSuite:
     val result = lint(List("exit 3"), mock)
     assertEquals(result, expected)
     // A linter can fail with no stdout — the nonzero exit must not be
-    // swallowed by the empty-output short-circuit. The block is the label
-    // line alone, telling the summariser "ran, empty output, exit 3".
+    // swallowed by the empty-output short-circuit. The block is the label line
+    // alone.
     assert(
       mock.captured.contains("```\n$ exit 3   (exit 3)\n```"),
       s"prompt should hold the label-only block, got: ${mock.captured}"

--- a/flow/src/test/scala/orca/review/ReviewAndFixTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewAndFixTest.scala
@@ -23,10 +23,8 @@ import orca.events.{EventDispatcher, OrcaEvent, OrcaListener, Usage}
 import orca.testkit.TempDirs
 
 /** Fake AgentCall whose `autonomous.run` drains a scripted sequence of outputs
-  * in order — cast through `Any` because the trait is generic over output type.
-  * The session id from the call site is echoed back so tests can verify the
-  * loop threaded a consistent id; `seenSessions` records each call's session id
-  * so tests can assert "fresh on first, same id thereafter."
+  * in order. `seenSessions` records each call's session id so tests can assert
+  * "fresh on first, same id thereafter."
   */
 class FakeAgentCall[O](outputs: Iterator[Any])
     extends AgentCall[BackendTag.ClaudeCode.type, O]:
@@ -73,10 +71,8 @@ class FakeAgent(
   def withTools(tools: ToolSet): Agent[BackendTag.ClaudeCode.type] = this
 
 /** A reviewer stub that emits a `TokensUsed` event carrying the name + role
-  * captured at `resultAs` time — mirroring `BaseAgent`, whose `resultAs`
-  * snapshots `name`/`role` for the cost axes. `withRole` returns a role-tagged
-  * copy (identity/`name` unchanged), so the copy the loop makes at its emission
-  * edge reports the tagged role without renaming.
+  * captured at `resultAs` time, mirroring `BaseAgent`. `withRole` returns a
+  * role-tagged copy with `name` unchanged.
   */
 private class TokenEmittingReviewer(
     override val name: String,
@@ -114,9 +110,8 @@ private class TokenEmittingReviewer(
         ???
 
 /** A coder stub for the fix-turn seeding test: captures the prompt its
-  * structured `run` receives (after the [[orca.FlowSession]] door composes
-  * seed/preamble) and drives `willContinue` via a real durable
-  * [[SessionSupport]] so a test can exercise both the fresh (re-seed) and live
+  * structured `run` receives and drives `willContinue` via a real durable
+  * [[SessionSupport]], so a test can exercise both the fresh (re-seed) and live
   * (no re-seed) branches of the fix turn. Always returns `fixOutcome`.
   */
 private class SeedProbingCoder(
@@ -127,9 +122,8 @@ private class SeedProbingCoder(
 
   @volatile var capturedFixPrompt: Option[String] = None
 
-  // A fresh support per access, registered (only when `existsResult`) so the
-  // mapping-gated probe returns `existsResult`; mirrors the durability wiring
-  // `Agent.willContinue` / `resumeWireId` route through.
+  // A fresh support per access, registered only when `existsResult` so the
+  // mapping-gated probe returns `existsResult`.
   override private[orca] def sessionSupport
       : Option[SessionSupport[BackendTag.ClaudeCode.type]] =
     val support = SessionSupport.durable[BackendTag.ClaudeCode.type](
@@ -166,8 +160,8 @@ private class SeedProbingCoder(
 
 class ReviewAndFixTest extends munit.FunSuite:
 
-  // `reviewAndFixLoop` is gated on `InStage` + `WorkspaceWrite` (the durable
-  // fix turn's tokens, ADR 0018 §6); mint both for the suite.
+  // `reviewAndFixLoop` is gated on `InStage` + `WorkspaceWrite` (ADR 0018 §6);
+  // mint both for the suite.
   private given orca.InStage = orca.InStage.unsafe
   private given orca.WorkspaceWrite = orca.WorkspaceWrite.unsafe
 
@@ -266,10 +260,8 @@ class ReviewAndFixTest extends munit.FunSuite:
   test(
     "reviewer is called with the same session id on every iteration"
   ):
-    // Pins the cross-iteration session-threading contract: a reviewer's
-    // first call mints its own chat (`agent.chat()`), and every subsequent
-    // call resumes the SAME conversation. Without this the loop could lose
-    // context across iterations.
+    // Cross-iteration session-threading contract: a reviewer's first call mints
+    // its own chat, and every subsequent call resumes the SAME conversation.
     given FlowControl = control
     val stubborn = issue("never ends")
     val reviewer = new FakeAgent(
@@ -767,11 +759,10 @@ class ReviewAndFixTest extends munit.FunSuite:
     assertEquals(events.map(_.role), List(Some("reviewer")))
 
   test("a selector runs exactly the roster entries it returns"):
-    // The new roster-bound contract: `prepare` is handed the roster as opaque
+    // Roster-bound contract: `prepare` is handed the roster as opaque
     // `RosterEntry` handles and can only return a subset/permutation of them —
-    // a foreign agent is unrepresentable (the ctor is `private[review]`). Here
-    // the selector keeps only "x", so "y" (an empty-output stub that would
-    // throw if run) must never run.
+    // a foreign agent is unrepresentable. Here the selector keeps only "x", so
+    // "y" (an empty-output stub that would throw if run) must never run.
     given FlowControl = control
     val rosterX = new FakeAgent(
       name = "x",
@@ -804,11 +795,10 @@ class ReviewAndFixTest extends munit.FunSuite:
     )
 
   test("an empty selection runs no reviewers and stops the round honestly"):
-    // The old silent full-roster fallback is gone. An empty selection now means
-    // exactly what it says: no reviewers run this round. With no issues found,
-    // the shared stop policy converges — the loop never resurrects the roster
-    // behind the selector's back, and the (empty-output) coder is never asked
-    // to fix anything.
+    // An empty selection means exactly what it says: no reviewers run this
+    // round. With no issues found, the shared stop policy converges — the loop
+    // never resurrects the roster behind the selector's back, and the
+    // (empty-output) coder is never asked to fix anything.
     given FlowControl = control
     val rosterA = new FakeAgent(name = "a") // no outputs: throws if run
     val emptySelector = new ReviewerSelector:
@@ -870,10 +860,9 @@ class ReviewAndFixTest extends munit.FunSuite:
   test(
     "fix turn seeds a fresh coder session but not a live one"
   ):
-    // The fix turn now routes through the durable FlowSession door (task 2C):
-    // on a coder whose backend conversation is fresh/lost it re-applies the
-    // recorded seed; on a live one it forwards the fix request verbatim. This
-    // is the gap the pre-2C raw-door fix turn silently skipped.
+    // The fix turn routes through the durable FlowSession door: on a coder
+    // whose backend conversation is fresh/lost it re-applies the recorded seed;
+    // on a live one it forwards the fix request verbatim.
     val seed = "SEED-MARKER: you are the fixer for this repo."
 
     def fixPromptWhen(existsResult: Boolean): String =

--- a/flow/src/test/scala/orca/review/ReviewFixFlowTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewFixFlowTest.scala
@@ -13,8 +13,8 @@ import java.util.concurrent.atomic.AtomicReference
   */
 class ReviewFixFlowTest extends munit.FunSuite:
 
-  // `reviewAndFixLoop` is gated on `InStage` + `WorkspaceWrite` (the durable
-  // fix turn's tokens, ADR 0018 §6); mint both for the suite.
+  // `reviewAndFixLoop` is gated on `InStage` + `WorkspaceWrite` (ADR 0018 §6);
+  // mint both for the suite.
   private given orca.InStage = orca.InStage.unsafe
   private given orca.WorkspaceWrite = orca.WorkspaceWrite.unsafe
 
@@ -60,8 +60,8 @@ class ReviewFixFlowTest extends munit.FunSuite:
       initialDiff = Some("")
     )
 
-    // The loop now runs under the caller's task stage (ADR 0018 §2.2), so it
-    // emits a progress line rather than opening its own committing stage.
+    // The loop runs under the caller's task stage (ADR 0018 §2.2), so it emits
+    // a progress line rather than opening its own committing stage.
     val events = listener.events
     assert(
       events.exists {
@@ -78,7 +78,6 @@ class ReviewFixFlowTest extends munit.FunSuite:
     // Reviewer keeps reporting the same issue every round; coder claims it
     // fixed it every round (so the loop sees progress) but the next eval
     // still finds it. The cap is the only thing that can stop this.
-    // Reviewer keeps reporting the same issue across all iterations.
     val stubborn = issue("never ends")
     val reviewer = new FakeAgent(
       name = "loud",

--- a/flow/src/test/scala/orca/review/ReviewLoopFixture.scala
+++ b/flow/src/test/scala/orca/review/ReviewLoopFixture.scala
@@ -6,18 +6,14 @@ import orca.events.EventDispatcher
 
 /** Shared fixture construction for the `reviewAndFixLoop` tests.
   *
-  * The loop now takes ONE [[FlowSession]] (coder + session bundle) and drives
-  * its fix turn through the durable [[FlowSession]] door, which needs a
+  * The loop takes one [[FlowSession]] (coder + session bundle) and drives its
+  * fix turn through the durable [[FlowSession]] door, which needs a
   * [[orca.FlowControl]] (progress store) and [[orca.WorkspaceWrite]] in scope.
-  * Rather than have every call site hand-build a [[FlowSession]] via its
-  * `private[orca]` constructor and a [[TestFlowControl]], both suites route
-  * through here.
   */
 object ReviewLoopFixture:
 
-  /** A coder [[FlowSession]] over `agent` and a fixed session id. Constructed
-    * via the `private[orca]` [[FlowSession]] ctor — legal because the tests
-    * live under `orca.*` — so no production factory is widened for tests.
+  /** A coder [[FlowSession]] over `agent` and a fixed session id, built via the
+    * `private[orca]` ctor so no production factory is widened for tests.
     */
   def coderSession(
       agent: Agent[BackendTag.ClaudeCode.type],

--- a/flow/src/test/scala/orca/review/ReviewerSelectorTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewerSelectorTest.scala
@@ -99,8 +99,8 @@ class ReviewerSelectorTest extends munit.FunSuite:
     // Even though the picker tried to include scala-fp, it was never offered
     // and the post-filter drops it from the result.
     assertEquals(picked.map(_.name), List("generic"))
-    // The picker is shown bare slugs (which are now the reviewers' identity —
-    // no `reviewer: ` cost-attribution prefix reaches it).
+    // The picker is shown bare slugs — no `reviewer: ` cost-attribution prefix
+    // reaches it.
     assertEquals(
       captured.get().map(_.availableReviewers.map(_.name)),
       Some(List("generic"))

--- a/flow/src/test/scala/orca/settings/SettingsFileTest.scala
+++ b/flow/src/test/scala/orca/settings/SettingsFileTest.scala
@@ -262,9 +262,9 @@ class SettingsFileTest extends FunSuite:
     "hasStackLines and the parser agree on a key with a trailing control byte"
   ):
     // `\u001f` is stripped by String.trim (the parser's key trim) but is not
-    // matched by a regex `\s`: the old regex-based gate reported "no stack
-    // line" for this line while the parser read a live `format` key, so the
-    // line survived the discovery append and self-activated on a later run.
+    // matched by a regex `\s`: `hasStackLines` and the parser must agree that
+    // this is a live `format` key, or the line survives a discovery append and
+    // self-activates on a later run.
     val line = "format\u001f= cargo fmt"
     assert(
       SettingsFile.hasStackLines(line),

--- a/gemini/src/main/scala/orca/tools/gemini/DefaultGeminiAgent.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/DefaultGeminiAgent.scala
@@ -26,10 +26,8 @@ private[orca] class DefaultGeminiAgent(
     )
     with GeminiAgent:
 
-  /** Pin the cheap-and-fast model variant. The literal id matches what's
-    * available in the installed `gemini` CLI; newer versions may rename, in
-    * which case callers override via `withConfig(AgentConfig(model =
-    * Some(Model("..."))))`.
+  /** Pin the cheap-and-fast model variant. Newer `gemini` CLI versions may
+    * rename the id — callers override via `withConfig`.
     */
   def flash: GeminiAgent = withModel(Model("gemini-2.5-flash"))
 
@@ -50,9 +48,7 @@ private[orca] class DefaultGeminiAgent(
 
 private[orca] object DefaultGeminiAgent:
 
-  /** The strong default model. Bare `gemini` pins this (in the runtime wiring,
-    * mirroring claude's Opus default for the long-lived implementer); `flash`
-    * opts down. Newer `gemini` CLI versions may rename the id — override via
-    * `withConfig` if so.
+  /** The strong default model that bare `gemini` pins; `flash` opts down. Newer
+    * `gemini` CLI versions may rename the id — override via `withConfig` if so.
     */
   val Pro: Model = Model("gemini-2.5-pro")

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiAgents.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiAgents.scala
@@ -10,9 +10,8 @@ import orca.subprocess.OsProcCliRunner
   */
 object GeminiAgents:
 
-  /** The default gemini agent for a run: Gemini Pro pinned (the strong model,
-    * like claude defaults to Opus for the long-lived implementer); `.flash`
-    * opts down for cheap one-shots.
+  /** The default gemini agent for a run: Gemini Pro pinned (the strong model);
+    * `.flash` opts down for cheap one-shots.
     */
   def default(wiring: AgentWiring): GeminiAgent =
     new DefaultGeminiAgent(

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
@@ -11,17 +11,15 @@ import orca.agents.{
 }
 
 /** Maps `AgentConfig` fields to `gemini` headless CLI flags. `systemPrompt` is
-  * not handled here — gemini has no `--append-system-prompt` equivalent (it
-  * picks up `GEMINI.md` files for static instructions), so the backend folds it
-  * into the user prompt before this method runs. The `ask_user` MCP server is
-  * registered via a project-local `.gemini/settings.json` merge in the backend
-  * rather than an argv flag (gemini has no inline MCP override like codex's
-  * `-c`).
+  * not handled here — gemini has no `--append-system-prompt` equivalent, so the
+  * backend folds it into the user prompt first. The `ask_user` MCP server is
+  * registered via a project-local `.gemini/settings.json` merge in the backend,
+  * not an argv flag.
   *
   * gemini headless is one-shot: each `-p` invocation processes one prompt and
-  * exits. Multi-turn happens via `--resume <session-id>`, where the id is the
-  * one surfaced on the `init` event of a prior `stream-json` run. We expose
-  * both shapes via [[headless]] / [[resume]].
+  * exits. Multi-turn happens via `--resume <session-id>`, where the id comes
+  * from the `init` event of a prior `stream-json` run — see [[headless]] /
+  * [[resume]].
   */
 private[gemini] object GeminiArgs:
 
@@ -52,38 +50,28 @@ private[gemini] object GeminiArgs:
       Seq("--output-format", "stream-json", "-p", prompt)
 
   /** gemini refuses to run headless in a folder it doesn't consider "trusted"
-    * (exit 55) and, worse, silently overrides `--approval-mode` back to
-    * `default` before failing. orca always drives a working directory the agent
-    * is meant to operate in, so trust is unconditional — the direct analog of
-    * codex's `--skip-git-repo-check`. (Equivalent to setting
-    * `GEMINI_CLI_TRUST_WORKSPACE=true`; the flag keeps it visible at the call
-    * site.)
+    * (exit 55) and silently overrides `--approval-mode` back to `default`
+    * before failing. orca always drives a working directory the agent is meant
+    * to operate in, so trust is unconditional.
     */
   private val trustArgs: Seq[String] = Seq("--skip-trust")
 
   /** Web tools pre-approved on [[ToolSet.NetworkOnly]] turns. Plan mode gates
     * `web_fetch` behind an approval no autonomous turn can answer; listing it
-    * in `--allowed-tools` pre-approves it (verified), so the planner gets web
-    * reads while plan mode still blocks edits and shell — a hard no-edit
-    * guarantee like claude's. `--allowed-tools` is deprecated (gemini 1.0
-    * removes it for a `settings.json` Policy Engine); migrate then.
+    * in `--allowed-tools` pre-approves it, so the planner gets web reads while
+    * plan mode still blocks edits and shell. (`--allowed-tools` is deprecated
+    * for a `settings.json` Policy Engine in gemini 1.0.)
     */
   private val NetworkTools: Seq[String] = Seq("web_fetch")
 
-  /** Maps [[AgentConfig.tools]] to gemini's approval mode. The read-only tiers
-    * use `--approval-mode plan` (no writes, no shelling out), matching claude's
-    * `--permission-mode plan` and codex's `--sandbox read-only`. `Full` has no
+  /** Maps [[AgentConfig.tools]] to gemini's approval mode. `Full` has no
     * per-tool CLI allowlist, and in headless mode `auto_edit` blocks on shell
     * approvals no one can answer, so both [[AutoApprove.All]] and
-    * [[AutoApprove.Only]] map to `yolo`. The `Only` widening is in ADR 0015.
+    * [[AutoApprove.Only]] map to `yolo` (the `Only` widening: ADR 0015).
     *
     *   - `ReadOnly` → `--approval-mode plan`
     *   - `NetworkOnly` → `--approval-mode plan --allowed-tools <web tools>`
     *   - `Full` + `AutoApprove.All` / `Only(_)` → `--approval-mode yolo`
-    *
-    * `NetworkOnly` stays in plan mode (hard no-edit) and adds [[NetworkTools]]
-    * so the planner can fetch issue/PR/web content — no shell `gh`, so no
-    * authed GitHub, but web reads work.
     */
   private def approvalArgs(config: AgentConfig): Seq[String] =
     config.tools match
@@ -103,16 +91,13 @@ private[gemini] object GeminiArgs:
   /** How strongly gemini enforces each `(tools, autoApprove)` combination — see
     * [[approvalArgs]] for the flags this classifies.
     *
-    *   - `ReadOnly` / `NetworkOnly` → `Hard`: `--approval-mode plan` makes
-    *     writes and shell mechanically unavailable; `NetworkOnly` only layers a
-    *     scoped `--allowed-tools` web allowlist, so the no-edit gate stays
-    *     hard.
-    *   - `Full` + `AutoApprove.All` → `Hard`: `yolo` is exactly "approve
-    *     everything" — the requested policy is honoured verbatim.
-    *   - `Full` + `AutoApprove.Only(_)` → `Ignored`: gemini has no per-tool CLI
-    *     allowlist and `auto_edit` blocks on unanswerable shell approvals in
-    *     headless mode, so any `Only` set is widened to `yolo` (ADR 0015) — the
-    *     requested subset is not encoded at all.
+    *   - `ReadOnly` / `NetworkOnly` → `Hard`: `plan` makes writes and shell
+    *     mechanically unavailable.
+    *   - `Full` + `AutoApprove.All` → `Hard`: `yolo` honours "approve
+    *     everything" verbatim.
+    *   - `Full` + `AutoApprove.Only(_)` → `Ignored`: no per-tool allowlist, so
+    *     any `Only` set is widened to `yolo` (ADR 0015) — the requested subset
+    *     is not encoded.
     */
   def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
     tools match

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
@@ -32,45 +32,37 @@ import ox.Ox
   * into [[orca.tools.gemini.jsonl.InboundEvent]]s, and the accumulated
   * assistant message content becomes the result at the terminal `result` event.
   * See [[../../../adr/0015-gemini-stream-json-driver.md ADR 0015]] for the
-  * protocol shape and the rationale.
+  * protocol shape and rationale.
   *
   * Both modes wrap the subprocess in a [[GeminiConversation]]; the autonomous
-  * path drains it internally via [[orca.backend.Conversations.drainAutonomous]]
-  * while the interactive path returns the conversation for an `Interaction` to
-  * drive. Multi-turn: subsequent calls with the same session id route through
-  * `gemini --resume <session-id>` via [[sessions]] (backed by a
-  * [[IdScheme.ServerMinted]]), where the id was learned from the `init` event
-  * of the prior run.
+  * path drains it internally, the interactive path returns it for an
+  * `Interaction` to drive. Multi-turn calls with the same session id route
+  * through `gemini --resume <session-id>` via [[sessions]] (an
+  * [[IdScheme.ServerMinted]] id learned from the prior run's `init` event).
   *
   * Interactive calls additionally stand up an `ask_user` MCP host bridge
-  * ([[AskUserMcpServer]]) on an ephemeral port and register it with gemini by
-  * merging an `mcpServers.orca` entry into a project-local
-  * `.gemini/settings.json` ([[GeminiSettings]]) — gemini has no inline `-c` MCP
-  * override like codex. The merge is restored when the conversation finalises
-  * (the restore rides as an `extras` `AutoCloseable` on the
-  * [[AskUserSession]]). Autonomous calls skip the bridge entirely.
+  * ([[AskUserMcpServer]]) and register it by merging an `mcpServers.orca` entry
+  * into a project-local `.gemini/settings.json` ([[GeminiSettings]]) — gemini
+  * has no inline `-c` MCP override. The merge is restored when the conversation
+  * finalises. Autonomous calls skip the bridge.
   */
 private[orca] class GeminiBackend(
     cli: CliRunner,
-    /** Fixed at construction; every spawn (`openConversation`) runs in this
-      * directory. The `os.pwd` default serves bare/test construction; the
-      * runtime (`GeminiAgents.default`) passes the flow's real `workDir`.
+    /** Fixed at construction; every spawn runs in this directory. The `os.pwd`
+      * default serves bare/test construction; the runtime passes the flow's
+      * real `workDir`.
       */
     override val workDir: os.Path = os.pwd
 ) extends AgentBackend[BackendTag.Gemini.type]:
 
   /** Gemini's sessions are server-side and durable: the client→server map is
-    * persisted to the progress log and rehydrated on resume. Existence probes
-    * the SERVER id resolved for a client (gemini mints its own id; the caller's
-    * stable id never appears in `--list-sessions`): it runs `gemini
-    * --list-sessions` and scans the output for that server id (substring).
-    *
-    * Because [[SessionSupport.willContinue]] resolves the recorded mapping
-    * first, `false` results when no server id is mapped — which includes a
-    * server id that failed the [[orca.agents.SessionId.isSafe]] guard at commit
-    * time (kept for uniformity with the other backends' probes; the substring
-    * scan itself is not injection-susceptible): `register`/`commitAfterDrain`
-    * refuse to record it — as well as on non-zero exit or any exception.
+    * persisted to the progress log and rehydrated on resume. The existence
+    * probe runs `gemini --list-sessions` and scans for the resolved SERVER id
+    * (substring) — gemini mints its own id; the caller's stable id never
+    * appears there. [[SessionSupport.willContinue]] resolves the mapping first,
+    * so it returns `false` when no server id is mapped (including an id
+    * rejected by the [[orca.agents.SessionId.isSafe]] guard at commit time), on
+    * non-zero exit, or on any exception.
     */
   val tag: BackendTag.Gemini.type = BackendTag.Gemini
 
@@ -87,11 +79,8 @@ private[orca] class GeminiBackend(
     StructuredOutputMode.RawText
 
   /** The sole session handle. [[IdScheme.ServerMinted]]: the client-allocated
-    * id maps to gemini's `init`-reported session id (`gemini -p` mints its
-    * own), so subsequent calls dispatch through `gemini --resume <server-id>`.
-    * The bookkeeping is encapsulated; the spawn/commit paths go through
-    * `sessions.dispatchFor` / `Conversations.runAutonomous(session, sessions,
-    * …)`.
+    * id maps to gemini's `init`-reported session id, so subsequent calls
+    * dispatch through `gemini --resume <server-id>`.
     */
   val sessions: SessionSupport[BackendTag.Gemini.type] =
     SessionSupport.durable(
@@ -120,8 +109,7 @@ private[orca] class GeminiBackend(
         session = session,
         config = config,
         // Forwarded so `conv.outputSchema` signals structured mode to the drain
-        // (suppressing the raw JSON payload from the user log). gemini has no
-        // `--output-schema` flag, so enforcement is prompt-only.
+        // (suppressing the raw JSON payload from the user log).
         outputSchema = outputSchema
       )
 
@@ -141,15 +129,12 @@ private[orca] class GeminiBackend(
     )
 
   /** Spawn `gemini -p` (fresh) or `gemini --resume <server-id> -p`
-    * (continuation), and wrap the process in a live [[GeminiConversation]].
+    * (continuation) and wrap the process in a live [[GeminiConversation]].
     * Stdin is closed immediately — gemini consumes the prompt argv-side.
     *
-    * `Interactive` mode wires the MCP `ask_user` tool: stand up the bridge +
-    * Netty server, merge the server URL into `.gemini/settings.json` (the
-    * restore rides as an `extras` `AutoCloseable`), fold the system-prompt hint
-    * into the user prompt (gemini has no `--append-system-prompt`), and hand
-    * the bundle to `GeminiConversation` so it can surface `UserQuestion` events
-    * and restore the settings file on finalize. `Autonomous` skips all of it.
+    * `Interactive` mode additionally wires the MCP `ask_user` tool: stand up
+    * the bridge, merge the server URL into `.gemini/settings.json`, and fold
+    * the system-prompt hint into the user prompt. `Autonomous` skips all of it.
     */
   private def openConversation(
       prompt: String,
@@ -166,9 +151,8 @@ private[orca] class GeminiBackend(
     // On a spawn/build failure the ask_user bundle is closed, which also
     // restores the settings.json via its `extras`, so nothing leaks.
     SubprocessSpawn.open("gemini", askUser.toList) {
-      // gemini has no `--append-system-prompt` flag (it picks up `GEMINI.md`
-      // files for static instructions), so fold the composed system prompt into
-      // the user prompt — same approach as codex.
+      // gemini has no `--append-system-prompt` flag, so fold the composed
+      // system prompt into the user prompt.
       val finalPrompt = SystemPromptComposer.foldIntoPrompt(
         config,
         prompt,
@@ -181,8 +165,7 @@ private[orca] class GeminiBackend(
           GeminiArgs.headless(finalPrompt, config)
       cli.spawnPiped(args, cwd = workDir, pipeStderr = true)
     } { process =>
-      // Close stdin so the child stops waiting on EOF (gemini reads the prompt
-      // argv-side).
+      // Close stdin so the child stops waiting on EOF.
       process.closeStdin()
       new GeminiConversation(
         process,

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiConversation.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiConversation.scala
@@ -15,20 +15,17 @@ import orca.tools.gemini.jsonl.{InboundEvent, Role}
 
 /** Drives a `gemini -p <prompt> --output-format stream-json` session to
   * completion. Boilerplate lives in [[orca.backend.ForkedConversation]]; this
-  * class supplies the gemini-specific protocol translation: JSONL →
-  * [[InboundEvent]] → `ConversationEvent`s.
+  * class supplies the gemini-specific translation: JSONL → [[InboundEvent]] →
+  * `ConversationEvent`s.
   *
-  * Notable parity gaps vs. claude (deliberate — see ADR 0015):
-  *   - gemini emits whole `message` chunks, not negotiated tool approvals;
-  *     `approval-mode` is pre-baked into spawn args, so `ApproveTool` is never
-  *     emitted here.
-  *   - gemini headless is one-shot; multi-turn happens via `--resume` on a
-  *     fresh spawn, so `sendUserMessage` is a no-op.
-  *   - **`AgentResult.output` is synthesised**: gemini has no single terminal
+  * Gemini specifics (see ADR 0015):
+  *   - `approval-mode` is pre-baked into spawn args, so `ApproveTool` is never
+  *     emitted.
+  *   - headless is one-shot; multi-turn happens via `--resume` on a fresh
+  *     spawn, so `sendUserMessage` is a no-op.
+  *   - `AgentResult.output` is synthesised: gemini has no single terminal
   *     message carrying the answer, so assistant-role `message` content is
-  *     accumulated as it streams and the result builder reads it at the
-  *     `result` event. The prompt template makes the closing content JSON in
-  *     structured mode.
+  *     accumulated as it streams and read at the `result` event.
   */
 private[gemini] class GeminiConversation(
     process: PipedCliProcess,
@@ -42,10 +39,8 @@ private[gemini] class GeminiConversation(
     )
     with StderrPipeline[BackendTag.Gemini.type]:
 
-  // Reader-thread-confined: written and read only from the JSONL reader
-  // thread (`handle`/`handleResult`, called from `handleLine`); `awaitResult`'s
-  // `readerFork.join()` publishes the final values to the caller. Same
-  // single-threaded-reader reasoning as `answer` and `toolNames` below.
+  // Reader-thread-confined: written and read only from the JSONL reader thread;
+  // `awaitResult`'s `readerFork.join()` publishes the final values to the caller.
   private var sessionId: String = ""
   private var model: Option[String] = None
 
@@ -56,8 +51,7 @@ private[gemini] class GeminiConversation(
 
   /** Maps a tool_use `tool_id` to the `tool_name` it announced, so the matching
     * `tool_result` (which only carries the id) can be keyed by name in the
-    * emitted [[ConversationEvent.ToolResult]]. Single-threaded reader (the
-    * JSONL reader thread is the sole writer), so a plain `var` is enough.
+    * emitted [[ConversationEvent.ToolResult]].
     */
   private var toolNames: Map[String, String] = Map.empty
 
@@ -79,9 +73,7 @@ private[gemini] class GeminiConversation(
 
   /** Known-benign chatter gemini prints on every successful run (see
     * [[GeminiConversation.isKnownStderrNoise]]) is dropped so it doesn't render
-    * as a spurious `✖` on each call; anything else passes through
-    * [[StderrPipeline]]'s hoisted `handleStderr` (strip → trim → filter → Error
-    * event → recorded diagnostic).
+    * as a spurious `✖`; anything else passes through [[StderrPipeline]].
     */
   override protected def isStderrNoise(line: String): Boolean =
     GeminiConversation.isKnownStderrNoise(line)
@@ -102,10 +94,9 @@ private[gemini] class GeminiConversation(
     case InboundEvent.Error(message) =>
       eventQueue.enqueue(ConversationEvent.Error(s"gemini: $message"))
     case InboundEvent.Result(usage, status) =>
-      // `result` is terminal (one turn per conversation): the base funnel
-      // auto-closes any open turn when `handleResult` settles, and drops the
-      // turn end entirely when the turn was empty (e.g. an immediate failure
-      // with no streamed content) — so nothing is emitted here.
+      // `result` is terminal: the base funnel auto-closes any open turn when
+      // `handleResult` settles (and drops the turn end when the turn was empty),
+      // so nothing is emitted here.
       handleResult(usage, status)
     case InboundEvent.Unknown(_) =>
       // Forward-compat: gemini may add new top-level event types; drop them
@@ -113,17 +104,15 @@ private[gemini] class GeminiConversation(
       ()
 
   /** Settle the conversation outcome at the terminal `result` event.
-    * `"success"` is the documented good status (headless stream-json); an
-    * empty/absent status is also treated as success for robustness. Any other
-    * non-empty status is a failed turn that must NOT be reported as success
-    * even though gemini exited 0 — tagged `AgentTurnFailed` so the autonomous
-    * retry loop doesn't reopen the now-registered session id.
+    * `"success"` (and an empty/absent status) is success; any other non-empty
+    * status is a failed turn that must NOT be reported as success even though
+    * gemini exited 0 — tagged `AgentTurnFailed` so the autonomous retry loop
+    * doesn't reopen the now-registered session id.
     */
   private def handleResult(usage: Usage, status: String): Unit =
     if status.nonEmpty && status != "success" then
       // Fold in the buffered stderr (the real reason — quota, auth, …) so the
-      // exception carries it even for a noop listener, matching the
-      // non-zero-exit and missing-result failure paths.
+      // exception carries it even for a noop listener.
       failWith(
         new AgentTurnFailed(
           appendContext(s"gemini turn ended with status '$status'")
@@ -137,14 +126,10 @@ private[gemini] class GeminiConversation(
         modelId = model
       )
 
-  /** A `user`-role message is the prompt echo (the base already surfaced the
-    * opening prompt as a `UserMessage`), so it's dropped from both the event
-    * stream and the answer. [[Role.Assistant]] (any present role other than
-    * `"user"` — gemini spells the assistant side `model`/`assistant` across
-    * versions) is agent output. [[Role.Unknown]] (a `role` key missing from the
-    * wire message) is DROPPED — never treated as assistant prose, unlike the
-    * pre-fix behavior where a missing role's `""` default failed the `!=
-    * "user"` check and silently passed through.
+  /** A `user`-role message is the prompt echo, so it's dropped.
+    * [[Role.Assistant]] (any present role other than `"user"`) is agent output.
+    * [[Role.Unknown]] (a missing `role` key) is dropped — never treated as
+    * assistant prose.
     */
   private def handleMessage(role: Role, content: String): Unit = role match
     case Role.User => ()
@@ -183,26 +168,23 @@ private[gemini] class GeminiConversation(
 
 private[gemini] object GeminiConversation:
 
-  /** The `ask_user` MCP tool as gemini names it in `tool_use` events: gemini
-    * qualifies an MCP tool as `<server>__<tool>` (e.g. `orca__ask_user`). Match
+  /** The `ask_user` MCP tool as gemini names it in `tool_use` events. gemini
+    * qualifies an MCP tool as `<server>__<tool>` (e.g. `orca__ask_user`); match
     * that exact name (or the bare slug) rather than any name *containing*
-    * `ask_user`, so an unrelated tool whose name merely includes the slug isn't
-    * suppressed.
+    * `ask_user`, so an unrelated tool isn't suppressed.
     */
   private def isAskUserTool(name: String): Boolean =
     name == AskUserMcpServer.ToolSlug ||
       name == s"${AskUserMcpServer.ServerName}__${AskUserMcpServer.ToolSlug}"
 
-  /** Stderr lines gemini prints on every (successful) headless run that carry
-    * no diagnostic value — filtered before they reach the event queue so they
-    * don't render as spurious `✖` errors. Observed on gemini 0.45.2:
+  /** Stderr lines gemini prints on every successful headless run that carry no
+    * diagnostic value — filtered so they don't render as spurious `✖` errors.
+    * Observed on gemini 0.45.2:
     *
     *   - a 256-color terminal-capability warning,
-    *   - `YOLO mode is enabled. …` notices (we always pass `--approval-mode
-    *     yolo` for non-read-only turns),
+    *   - `YOLO mode is enabled. …` notices,
     *   - `Shell cwd was reset to …` after a tool run,
-    *   - `[IDEClient]` companion-extension chatter (gemini probes for a VS Code
-    *     companion that an orca-driven subprocess never has).
+    *   - `[IDEClient]` companion-extension probe chatter.
     */
   private[gemini] def isKnownStderrNoise(line: String): Boolean =
     line.contains("256-color support not detected") ||

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiSettings.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiSettings.scala
@@ -11,22 +11,20 @@ import com.github.plokhotnyuk.jsoniter_scala.core.{
 import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 
 /** Registers the ephemeral `ask_user` MCP server with gemini for the lifetime
-  * of one interactive conversation. Unlike codex (which takes an inline `-c
-  * mcp_servers.orca.url=…` override), gemini only reads MCP server config from
+  * of one interactive conversation. gemini only reads MCP server config from
   * `settings.json`, so we merge an entry into the project-local
   * `<workDir>/.gemini/settings.json` and restore the prior state when the
   * conversation finalises.
   *
-  * Merge strategy preserves the user's file: unknown top-level keys and other
-  * configured `mcpServers` ride through verbatim (held as [[RawJson]]). The
-  * `allowedMcpServerNames` allowlist is only touched when it already exists —
-  * introducing one where there was none would restrict gemini to ONLY orca and
-  * hide the user's other servers.
+  * The merge preserves the user's file: unknown top-level keys and other
+  * configured `mcpServers` ride through verbatim. The `allowedMcpServerNames`
+  * allowlist is only touched when it already exists — introducing one where
+  * there was none would restrict gemini to ONLY orca and hide the user's other
+  * servers.
   *
-  * Two sharp edges (documented in ADR 0015): two interactive runs in the same
+  * Restore is best-effort, not transactional: two interactive runs in the same
   * `workDir` race on this file, and a hard crash skips the restore, leaving a
-  * stale `orca` entry behind. Restore is therefore best-effort, not
-  * transactional.
+  * stale `orca` entry behind (ADR 0015).
   */
 private[gemini] object GeminiSettings:
 
@@ -70,12 +68,10 @@ private[gemini] object GeminiSettings:
     // Serialize through a typed codec rather than interpolating into a raw JSON
     // string, so a URL containing `"` or `\` stays valid JSON.
     //
-    // `timeout` (ms) is one of three renderings of
-    // [[orca.backend.mcp.AskUserMcpServer.ToolTimeout]] — claude JSON ms /
-    // codex TOML sec / gemini settings.json ms; keep in sync. Without it,
-    // gemini falls back to its own per-server default (shorter than our 1h
-    // ToolTimeout), giving up on `ask_user` mid-answer and firing a duplicate
-    // question.
+    // `timeout` (ms) mirrors [[orca.backend.mcp.AskUserMcpServer.ToolTimeout]]
+    // (rendered as ms/sec across backends; keep in sync). Without it gemini
+    // falls back to a shorter per-server default, giving up on `ask_user`
+    // mid-answer and firing a duplicate question.
     val orcaEntry = RawJson(
       writeToString(
         OrcaServerEntry(mcpUrl, AskUserMcpServer.ToolTimeout.toMillis)

--- a/gemini/src/main/scala/orca/tools/gemini/jsonl/InboundEvent.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/jsonl/InboundEvent.scala
@@ -6,37 +6,29 @@ import orca.util.RawJson
 import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
 import com.github.plokhotnyuk.jsoniter_scala.macros.ConfiguredJsonValueCodec
 
-/** Typed classification of a `message` event's `role` field — see
-  * [[InboundEvent.Message]]. gemini spells the assistant side `model`/
-  * `assistant` across versions, so any *present* value that isn't literally
-  * `"user"` counts as [[Role.Assistant]] (matching the pre-existing "not user"
-  * match). A *missing* `role` key is [[Role.Unknown]] — identity-critical, so
-  * it's typed and dropped by the conversation rather than defaulting to `""`
-  * and silently passing gemini's `!= "user"` check as agent output.
+/** Typed classification of a `message` event's `role` field. gemini spells the
+  * assistant side `model`/`assistant` across versions, so any *present* value
+  * that isn't `"user"` counts as [[Role.Assistant]]. A *missing* `role` key is
+  * [[Role.Unknown]] — dropped by the conversation rather than treated as agent
+  * output.
   */
 private[gemini] enum Role:
   case User, Assistant, Unknown
 
-/** One event parsed off gemini's stdout when it runs with `-p <prompt>
-  * --output-format stream-json`.
-  *
-  * The shape is documented in
-  * [[../../../adr/0015-gemini-stream-json-driver.md ADR 0015]]; each variant
-  * carries only the fields the driver actually inspects. Unknown top-level
-  * types collapse to [[Unknown]] so protocol drift doesn't crash the pipeline.
-  * Most wire fields are optional with a default so a renamed/missing key
-  * degrades gracefully rather than throwing — the two identity-critical
-  * exceptions are `init`'s `session_id` (required; a missing key throws so the
-  * reader's generic parse-error handling surfaces it as a visible `Error` event
-  * near the cause, instead of silently becoming `Init("")`) and `message`'s
-  * `role` (typed via [[Role]] rather than defaulted to `""`).
+/** One event parsed off gemini's stdout under `-p <prompt> --output-format
+  * stream-json` (shape in
+  * [[../../../adr/0015-gemini-stream-json-driver.md ADR 0015]]). Each variant
+  * carries only the fields the driver inspects. Unknown top-level types
+  * collapse to [[Unknown]] so protocol drift doesn't crash the pipeline. Most
+  * wire fields default so a renamed/missing key degrades gracefully; the two
+  * identity-critical exceptions are `init`'s `session_id` (required — a missing
+  * key throws rather than becoming `Init("")`) and `message`'s `role` (typed
+  * via [[Role]]).
   */
 private[gemini] enum InboundEvent:
-  /** First event in a session — carries the session id (used to drive
-    * `--resume`) and, when present, the resolved model id. `sessionId` is never
-    * empty: [[InitWire.session_id]] is a required wire field, so a missing key
-    * fails parsing rather than producing an `Init` with an empty id (see
-    * [[InboundEvent.parse]]/[[InboundEvent.parseInit]]).
+  /** First event in a session — the session id (drives `--resume`) and, when
+    * present, the resolved model id. `sessionId` is never empty: a missing
+    * `session_id` fails parsing rather than producing an `Init("")`.
     */
   case Init(sessionId: String, model: Option[String])
 
@@ -58,9 +50,7 @@ private[gemini] object InboundEvent:
 
   /** Parse one JSONL line. Malformed JSON, and — for `init` — a missing
     * `session_id`, propagate `JsonReaderException`; callers decide whether to
-    * skip or fail (`ForkedConversation.runReader`'s generic per-line catch
-    * skips this one line and surfaces a visible `Error` event, see its
-    * scaladoc).
+    * skip or fail.
     */
   def parse(line: String): InboundEvent =
     val envelope = readFromString[TopEnvelope](line)
@@ -81,9 +71,8 @@ private[gemini] object InboundEvent:
     val w = readFromString[MessageWire](line)
     Message(roleOf(w.role), w.content.getOrElse(""))
 
-  /** Classify the wire `role` — see [[Role]]. Operates on the `Option` (not the
-    * `.getOrElse("")`-collapsed string) so a genuinely missing key ([[None]])
-    * is distinguishable from a present-but-empty one.
+  /** Classify the wire `role` — see [[Role]]. Operates on the `Option` so a
+    * missing key ([[None]]) is distinguishable from a present-but-empty value.
     */
   private def roleOf(role: Option[String]): Role = role match
     case Some("user") => Role.User
@@ -131,9 +120,7 @@ private[gemini] object InboundEvent:
       derives ConfiguredJsonValueCodec
 
   /** `session_id` is required (no default): missing it throws
-    * `JsonReaderException` from `readFromString`, rather than silently becoming
-    * `Init("")` — see [[InboundEvent.parseInit]]. Mirrors codex's
-    * `ThreadStartedWire.thread_id`.
+    * `JsonReaderException` rather than silently becoming `Init("")`.
     */
   private case class InitWire(
       session_id: String,

--- a/gemini/src/test/scala/orca/tools/gemini/DefaultGeminiToolTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/DefaultGeminiToolTest.scala
@@ -7,7 +7,7 @@ import orca.subprocess.{FakePipedCliProcess, SpawnStubCliRunner}
 
 class DefaultGeminiAgentTest extends munit.FunSuite:
 
-  // LLM `run` is now gated on `InStage`; mint the token for the suite.
+  // LLM `run` is gated on `InStage`; mint the token for the suite.
   private given orca.InStage = orca.InStage.unsafe
 
   private val stubInteraction: Interaction = new Interaction:

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiArgsTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiArgsTest.scala
@@ -22,9 +22,7 @@ class GeminiArgsTest extends munit.FunSuite:
 
   test("headless passes --skip-trust so headless runs in an untrusted dir"):
     // Without it gemini refuses to run in a non-trusted folder (exit 55) and
-    // silently overrides --approval-mode back to "default". orca always drives
-    // a working dir the agent is meant to operate in, so trust is unconditional
-    // — the analog of codex's --skip-git-repo-check.
+    // silently overrides --approval-mode back to "default".
     val args = GeminiArgs.headless("x", AgentConfig())
     assert(args.contains("--skip-trust"), args.toString)
 
@@ -43,9 +41,9 @@ class GeminiArgsTest extends munit.FunSuite:
     assert(args.containsSlice(Seq("--approval-mode", "yolo")), args.toString)
 
   test("AutoApprove.Only widens to --approval-mode yolo"):
-    // Gemini has no per-tool CLI allowlist; Only(_) widens to yolo so
-    // autonomous (headless) turns actually progress instead of blocking on
-    // an approval prompt no one can answer. See ADR 0015.
+    // Gemini has no per-tool CLI allowlist; Only(_) widens to yolo so headless
+    // turns progress instead of blocking on an approval no one can answer (ADR
+    // 0015).
     val args = GeminiArgs.headless(
       "x",
       AgentConfig().copy(autoApprove = AutoApprove.Only(Set("Bash")))

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiConversationTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiConversationTest.scala
@@ -247,10 +247,6 @@ class GeminiConversationTest extends munit.FunSuite:
     val _ = conv.awaitResult()
 
   convTest("stderr strips terminal controls before surfacing as an Error"):
-    // Pinning Task 8.4's hoist: pre-hoist, only pi's handleStderr stripped
-    // ANSI/terminal control sequences before surfacing stderr as an Error
-    // event — codex and gemini did not. StderrPipeline now strips
-    // for all three uniformly.
     val process = new FakePipedCliProcess()
     val conv = new GeminiConversation(process)
 
@@ -333,14 +329,10 @@ class GeminiConversationTest extends munit.FunSuite:
   convTest(
     "missing session_id on init surfaces a visible Error and the turn fails loudly"
   ):
-    // Task 8.5: session_id is identity-critical. Pre-fix, a missing key
-    // silently became Init("") with no exception and no Error event — the
-    // wrong session id would only surface indirectly, retries later, at
-    // commitAfterDrain's guard. Post-fix, InitWire.session_id is a required
-    // wire field, so the malformed init line throws JsonReaderException;
-    // ForkedConversation's generic per-line catch turns that into a visible
-    // Error event near the cause. With no other line ever settling the turn,
-    // it still fails loudly via the existing clean-exit-without-result path.
+    // session_id is identity-critical: a missing key makes InitWire parsing
+    // throw JsonReaderException, which ForkedConversation's per-line catch turns
+    // into a visible Error event. With no line settling the turn, it then fails
+    // loudly via the clean-exit-without-result path.
     val process = new FakePipedCliProcess(initiallyAlive = false)
     val conv = new GeminiConversation(process)
 
@@ -361,9 +353,8 @@ class GeminiConversationTest extends munit.FunSuite:
       ex.getMessage.contains("result"),
       s"expected the missing-result message; got: ${ex.getMessage}"
     )
-    // 12.1: ForkedConversation.awaitResult's generic Outcome.Failed(e) arm
-    // must thread `e` through as the cause, not just fold its message into
-    // text and drop it.
+    // ForkedConversation.awaitResult's generic Outcome.Failed(e) arm must thread
+    // `e` through as the cause, not just fold its message into text.
     assert(
       ex.getCause != null,
       "AgentTurnFailed from the generic clean-exit-without-result path must " +
@@ -373,9 +364,8 @@ class GeminiConversationTest extends munit.FunSuite:
   convTest(
     "a message with a missing role is dropped, never treated as assistant prose"
   ):
-    // Task 8.5: pre-fix, a missing role's "" default failed the `!= "user"`
-    // check and silently landed in the answer as agent output. Post-fix it's
-    // typed Role.Unknown and dropped.
+    // A missing role is typed Role.Unknown and dropped, never landing in the
+    // answer as agent output.
     val process = new FakePipedCliProcess()
     val conv = new GeminiConversation(process)
 

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiSettingsTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiSettingsTest.scala
@@ -42,11 +42,9 @@ class GeminiSettingsTest extends munit.FunSuite:
     assertEquals(httpUrl, """http://h/"x\y""")
 
   test("merge sets the orca server's timeout to the shared ToolTimeout"):
-    // 3 600 000 ms == 1h == AskUserMcpServer.ToolTimeout, the same value
-    // claude (ms) and codex (sec) render for the same tool. Without this,
-    // gemini's own MCP client default (10 min) undercuts the shared budget —
-    // the same answer-twice bug class as claude/codex's 60s defaults, just
-    // with a longer fuse.
+    // 3 600 000 ms == 1h == AskUserMcpServer.ToolTimeout. Without it gemini's
+    // own MCP client default undercuts the shared budget and fires a duplicate
+    // question mid-answer.
     val merged = GeminiSettings.merge("{}", "http://x/mcp")
     val servers = topLevel(topLevel(merged)("mcpServers").value)
     assertEquals(

--- a/gemini/src/test/scala/orca/tools/gemini/jsonl/InboundEventTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/jsonl/InboundEventTest.scala
@@ -20,10 +20,9 @@ class InboundEventTest extends munit.FunSuite:
       case other => fail(s"expected Init, got $other")
 
   test("init with a missing session_id throws rather than defaulting to \"\""):
-    // Identity-critical field (see Task 8.5): a missing session_id must not
-    // silently become Init(""); it propagates JsonReaderException so the
-    // reader's generic catch turns it into a visible Error event near the
-    // cause, instead of a session id that's wrong three retries later.
+    // Identity-critical: a missing session_id must not silently become Init("");
+    // it propagates JsonReaderException so the reader's generic catch surfaces a
+    // visible Error event near the cause.
     val line = """{"type":"init","model":"gemini-2.5-pro"}"""
     intercept[com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException]:
       InboundEvent.parse(line)

--- a/opencode/src/main/scala/orca/tools/opencode/DefaultOpencodeAgent.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/DefaultOpencodeAgent.scala
@@ -11,8 +11,7 @@ import orca.agents.{
   Prompts
 }
 
-/** Default [[OpencodeAgent]]. Inherits the autonomous-text + `resultAs[O]`
-  * plumbing from [[BaseAgent]] and adds OpenCode's provider-prefixed model
+/** Default [[OpencodeAgent]]. Adds OpenCode's provider-prefixed model
   * accessors. The pinned ids are convenience defaults — any id from `opencode
   * models` is valid; bump them as the catalog moves.
   */
@@ -43,20 +42,19 @@ private[orca] class DefaultOpencodeAgent(
 
   // Cheap is provider-matched so incidental work doesn't pull in a second
   // provider's auth: an openai-led tool's cheap is an openai model, otherwise
-  // anthropic haiku (also the default when no model is pinned). Reads the
-  // provider prefix directly (not OpencodeModel.split, which throws on a bare
-  // id) so resolving the cheap model can never break a flow.
+  // anthropic haiku. Reads the provider prefix directly (not
+  // OpencodeModel.split, which throws on a bare id) so resolving cheap can
+  // never break a flow.
   override protected def defaultCheap: OpencodeAgent =
     config.model.map(m => Model.name(m).takeWhile(_ != '/')) match
       case Some("openai") => openaiLuna
       case _              => anthropicHaiku
 
-  // Two-arg form validates and joins via OpencodeModel (one place); the
-  // accessors above share it. `withModel(String)` takes an already-joined id.
+  // Validates and joins via OpencodeModel (one place); the accessors share it.
   override def withModel(provider: String, modelId: String): OpencodeAgent =
     super[BaseAgent].withModel(OpencodeModel(provider, modelId))
 
-  // `super` disambiguates from BaseAgent's protected `withModel(Model)`.
+  // Takes an already-joined `provider/model` id.
   def withModel(providerModel: String): OpencodeAgent =
     super[BaseAgent].withModel(Model(providerModel))
 

--- a/opencode/src/main/scala/orca/tools/opencode/JavaNetOpencodeHttp.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/JavaNetOpencodeHttp.scala
@@ -64,10 +64,10 @@ private[opencode] class JavaNetOpencodeHttp(baseUrl: String, password: String)
 
   def events(): StreamSource =
     val req = request("/event").GET().build()
-    // `ofInputStream` returns once headers arrive; we read lines off the raw body
-    // ourselves. Closing the InputStream reliably unblocks a thread parked in
-    // `readLine()` (the SSE stream is otherwise open-ended) — `ofLines().close()`
-    // does not, which deadlocks the reader at turn end.
+    // `ofInputStream` returns once headers arrive; we read lines off the raw
+    // body ourselves. Closing the InputStream reliably unblocks a thread parked
+    // in `readLine()` on the open-ended SSE stream — `ofLines().close()` does
+    // not, which deadlocks the reader at turn end.
     val body =
       client.send(req, HttpResponse.BodyHandlers.ofInputStream()).body()
     val reader =

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
@@ -21,12 +21,10 @@ import orca.util.RawJson
   */
 private[opencode] object OpencodeArgs:
 
-  /** `opencode serve` launch args. The `launcher` prefix (default: the bare
-    * `opencode` binary, resolved from `PATH`) is followed by `serve …`; an
-    * alternative like [[OpencodeLauncher.ollama]] wraps the binary to inject
-    * provider config. Port 0 = an OS-assigned free port (read back from the
-    * server's "listening on …" line). `--pure` is deliberately omitted so the
-    * spawned server inherits the user's configured providers.
+  /** `opencode serve` launch args: the `launcher` prefix followed by `serve …`.
+    * Port 0 = an OS-assigned free port (read back from the server's "listening
+    * on …" line). `--pure` is deliberately omitted so the spawned server
+    * inherits the user's configured providers.
     */
   def serve(
       launcher: OpencodeLauncher = OpencodeLauncher.default,
@@ -63,13 +61,9 @@ private[opencode] object OpencodeArgs:
     * `question` tool on an autonomous turn. Returns `None` when nothing is
     * gated so the body omits `tools` and the server's defaults apply.
     *
-    * Both read-only tiers disable the same write tools, so `NetworkOnly`
-    * behaves like `ReadOnly` here — opencode gets no dedicated network
-    * handling. opencode's web tool isn't in the disabled set, so web reads may
-    * remain available (server-dependent; not verified here); shell `gh` stays
-    * off (`bash` disabled). Scoped network would require enabling `bash`
-    * (dropping the hard no-edit guarantee) — out of scope; opencode flows
-    * pre-fetch issue/PR context instead.
+    * `NetworkOnly` gets no dedicated handling and behaves like `ReadOnly`:
+    * scoped network would need `bash` enabled, dropping the hard no-edit
+    * guarantee, so opencode flows pre-fetch issue/PR context instead.
     */
   private def toolFlags(
       config: AgentConfig,
@@ -95,14 +89,11 @@ private[opencode] object OpencodeArgs:
   /** How strongly opencode enforces each `(tools, autoApprove)` combination —
     * see [[toolFlags]] for the gate this classifies.
     *
-    *   - `ReadOnly` / `NetworkOnly` → `Hard`: both tiers disable the write
-    *     tools (`write`/`edit`/`bash`/`patch`) on the message body, a
-    *     mechanical no-edit gate. (`NetworkOnly` gets no dedicated handling —
-    *     it behaves like `ReadOnly`.)
-    *   - `Full` + `AutoApprove.All` / `Only(_)` → `Ignored`: `autoApprove` is
-    *     never encoded here — the approval policy is whatever the user's
-    *     `opencode` server config says via the `permission.asked` reply, which
-    *     is outside orca's control (ADR 0014 risk).
+    *   - `ReadOnly` / `NetworkOnly` → `Hard`: the write tools are disabled on
+    *     the message body, a mechanical no-edit gate.
+    *   - `Full` → `Ignored`: `autoApprove` is never encoded here — the approval
+    *     policy is whatever the user's `opencode` server config says via the
+    *     `permission.asked` reply, outside orca's control (ADR 0014 risk).
     */
   def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
     tools match

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeBackend.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeBackend.scala
@@ -45,23 +45,18 @@ private[opencode] trait OpencodeServerHandle:
   * Each turn opens its own `GET /event` SSE stream, starts the turn with
   * `prompt_async`, and reads the result off the stream via
   * [[OpencodeConversation]]. The single [[OpencodeServerHandle]] is built once
-  * at construction ([[OpencodeBackend.apply]]) and shared across turns; the
-  * process spawn behind it stays lazy.
-  *
-  * OpenCode mints `ses_…` ids, so — like Codex — a [[IdScheme.ServerMinted]]
-  * bookkeeping maps the caller's stable id to the server id; [[runAutonomous]]
-  * returns the caller's id so it stays the handle.
+  * at construction and shared across turns; the process spawn behind it stays
+  * lazy.
   *
   * A turn relies on the server emitting a terminal
   * `session.idle`/`session.error` (or closing the SSE stream); there is no
-  * per-turn timeout at this layer, so an orchestrator-level deadline (the
-  * flow's own timeout) is the backstop for a server that wedges mid-turn.
+  * per-turn timeout at this layer, so the flow's own timeout is the backstop
+  * for a server that wedges mid-turn.
   */
 private[orca] object OpencodeBackend:
-  /** Build the backend with its server fixed at construction. Per-turn working
-    * directories are assumed constant (orca flows run in one repo), so the
-    * server's `workDir` is pinned here — and is the SAME value
-    * [[AgentBackend.workDir]] exposes, by construction.
+  /** Build the backend with its server fixed at construction. orca flows run in
+    * one repo, so the server's `workDir` is pinned here — the same value
+    * [[AgentBackend.workDir]] exposes.
     */
   def apply(
       cli: CliRunner,
@@ -79,9 +74,8 @@ private[orca] class OpencodeBackend(
 ) extends AgentBackend[BackendTag.Opencode.type]:
 
   /** Tear down the shared `opencode serve` process and its drain forks. A no-op
-    * if the server was never started (opencode wired but unused). Called by the
-    * runtime in the flow body's `finally`, before the flow scope joins forks
-    * (see [[orca.backend.AgentBackend.close]]).
+    * if the server was never started. Called in the flow body's `finally`,
+    * before the flow scope joins forks.
     */
   override def close(): Unit = server.close()
 
@@ -123,44 +117,13 @@ private[orca] class OpencodeBackend(
     )
 
   /** Probe `http` for the given session id via `GET /session/<id>` → status
-    * 200. Callable directly in tests without going through the lazy-init guard.
-    * Returns `false` on any transport error. The
-    * [[orca.agents.SessionId.isSafe]] guard must have passed before this method
-    * is called — it is not re-checked here.
+    * 200; `false` on any transport error. The [[orca.agents.SessionId.isSafe]]
+    * guard must have passed before this is called — it is not re-checked here.
     */
   private[opencode] def probeSession(id: String, http: OpencodeHttp): Boolean =
     try http.getStatus(s"/session/$id") == 200
     catch case NonFatal(_) => false
 
-  /** OpenCode's `ses_…` sessions are server-side and durable: the client→server
-    * map is persisted to the progress log and rehydrated on resume. Existence
-    * probes the SERVER id resolved for a client (opencode mints server-side
-    * ids; the caller's stable id never matches one) via `GET
-    * /session/<serverId>` → 200.
-    *
-    * Because [[SessionSupport.willContinue]] resolves the recorded mapping
-    * first, `false` results when no server id is mapped — which includes a
-    * server id that failed the [[orca.agents.SessionId.isSafe]] guard at commit
-    * time (blocks URL injection such as `a/b` routing to a different endpoint):
-    * `register`/`commitAfterDrain` refuse to record it — as well as the map not
-    * having been rehydrated yet (⇒ no known live session), or the request
-    * failing for any reason.
-    *
-    * Sessions genuinely outlive the process: opencode persists them to a global
-    * on-disk store shared by every `opencode serve` on the machine
-    * (cwd-independent), so a fresh server spawned after a kill/restart resumes
-    * a prior run's `resumeWireId` — `GET /session/<id>` returns 200 with full
-    * message history (live-verified 2026-07-08). The probe therefore forces
-    * `server.http` (the lazy spawn) rather than gating on whether the server
-    * has already started: on resume the registry has a mapped id but no turn
-    * has necessarily touched the server yet, so gating on "already spawned"
-    * would answer "absent" before ever asking the (perfectly capable) fresh
-    * server. This is safe because [[SessionSupport.willContinue]]
-    * short-circuits on no mapped id, so the forced spawn only fires when there
-    * is a wire id to resume — i.e. precisely when the server is about to be
-    * needed for a turn anyway. The per-run server process is an implementation
-    * detail, not a durability boundary.
-    */
   val tag: BackendTag.Opencode.type = BackendTag.Opencode
 
   override def enforcement(
@@ -185,14 +148,12 @@ private[orca] class OpencodeBackend(
   val sessions: SessionSupport[BackendTag.Opencode.type] =
     SessionSupport.durable(
       IdScheme.ServerMinted,
-      // No `server.started &&` guard: opencode persists sessions in its
-      // global on-disk DB, and a freshly (lazily) spawned server resumes
-      // them, so the probe must be allowed to force the spawn — gating on
-      // "already started" would short-circuit the very first resume probe
-      // of a run, before anything had forced `server.http` yet. Safe because
-      // `SessionSupport.willContinue` short-circuits on no mapped wire id,
-      // so the forced spawn only fires on a genuine resume, when the server
-      // is about to be needed for a turn anyway.
+      // No `server.started &&` guard: opencode persists sessions in a global
+      // on-disk DB that a freshly (lazily) spawned server resumes, so the probe
+      // must be allowed to force the spawn. Safe because
+      // `SessionSupport.willContinue` short-circuits on no mapped wire id, so
+      // the forced spawn only fires on a genuine resume — when the server is
+      // about to be needed anyway.
       id => probeSession(id, server.http)
     )
 
@@ -209,17 +170,12 @@ private[orca] class OpencodeBackend(
         val resp = http.postJson("/session", writeToString(SessionCreateBody()))
         readFromString[SessionCreated](resp).id
 
-  /** Resolve the server session, THEN open the SSE stream —
-    * [[serverSessionFor]] can throw (a fresh `POST /session`, or a bad resume
-    * id), and Scala evaluates call arguments left-to-right, so putting
-    * `http.events()` in argument position ahead of it used to open a live `GET
-    * /event` connection that a subsequent `serverSessionFor` failure then
-    * discarded uninterrupted (leaking the connection/socket). Resolving the
-    * session first means that failure never gets near the stream at all. The
+  /** Resolve the server session, THEN open the SSE stream: [[serverSessionFor]]
+    * can throw (fresh `POST /session`, or a bad resume id), and opening the
+    * stream first would leak the `GET /event` connection on that failure. The
     * `try`/`catch` is defense-in-depth for any throw between the stream opening
-    * and [[openConversation]] handing it to the [[OpencodeConversation]] that
-    * owns it (that method's own `catch` only covers the later `prompt_async`
-    * POST).
+    * and [[openConversation]] handing it to the owning [[OpencodeConversation]]
+    * (whose own `catch` only covers the later `prompt_async` POST).
     */
   private def startTurn(
       http: OpencodeHttp,
@@ -246,10 +202,9 @@ private[orca] class OpencodeBackend(
         source.interrupt()
         throw e
 
-  /** Open the SSE stream (reader running) **then** fire `prompt_async`, so no
-    * turn events are missed. The conversation derives the result from the
-    * stream. Callers ([[startTurn]]) are responsible for resolving the server
-    * session and opening `source` in the leak-safe order.
+  /** Start the reader on the SSE stream **then** fire `prompt_async`, so no
+    * turn events are missed. Callers ([[startTurn]]) resolve the server session
+    * and open `source` in the leak-safe order.
     */
   private def openConversation(
       http: OpencodeHttp,

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeConversation.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeConversation.scala
@@ -49,14 +49,11 @@ private[opencode] class OpencodeConversation(
       nativeAskUser = canAsk
     ):
 
-  /** Best-effort `POST /session/{id}/abort`, so a GENUINELY cancelled turn
+  /** Best-effort `POST /session/{id}/abort`, so a genuinely cancelled turn
     * (mid-flight, never settled) stops running (and writing) on the shared
-    * server instead of continuing headless after the user has moved on. The
-    * base [[ForkedConversation.cancel]] only calls this hook when the turn
-    * hasn't already settled via `succeedWith`/`failWith` — a turn that finished
-    * normally and is merely being torn down in a `finally` never reaches here,
-    * so a just-idle session (which may be resumed next turn) doesn't get a
-    * spurious abort.
+    * server. The base [[ForkedConversation.cancel]] only calls this hook when
+    * the turn hasn't already settled, so a just-idle session that may be
+    * resumed next turn doesn't get a spurious abort.
     */
   override protected def onCancelRequested(): Unit =
     try
@@ -64,9 +61,8 @@ private[opencode] class OpencodeConversation(
     catch case NonFatal(_) => ()
 
   /** Turn state, accumulated as the reader thread processes frames.
-    * `handleLine` (and the `settleResult` it drives at `session.idle`) run only
-    * on that single thread, so a plain `var` over an immutable snapshot is safe
-    * and avoids cross-thread machinery; `awaitResult` reads the outcome only
+    * `handleLine` (and the `settleResult` it drives) run only on that single
+    * thread, so a plain `var` is safe; `awaitResult` reads the outcome only
     * after joining the reader, which publishes these writes.
     */
   private var turnState: TurnState = TurnState()
@@ -129,11 +125,8 @@ private[opencode] class OpencodeConversation(
 
   /** Terminal (`session.idle`): a turn whose assistant message carries
     * `info.error`, or that went idle without producing anything, is a failure;
-    * otherwise settle with the built result. The base funnel auto-closes any
-    * still-open turn at settle (and drops an empty one), so no turn end is
-    * emitted here — a `session.idle` is a single turn per conversation, hence
-    * always settle-adjacent. Both paths close the otherwise open-ended SSE
-    * stream (via [[succeedWith]]/[[failWith]]).
+    * otherwise settle with the built result. Both paths close the otherwise
+    * open-ended SSE stream (via [[succeedWith]]/[[failWith]]).
     */
   private def finishTurn(): Unit =
     turnState.info.flatMap(_.error) match

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeHttp.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeHttp.scala
@@ -18,9 +18,8 @@ private[opencode] trait OpencodeHttp:
   def postJson(path: String, body: String): String
 
   /** Open `GET /event` as a source of raw SSE lines. This is the whole server's
-    * firehose; the conversation filters it to its own session id. (OpenCode's
-    * `?directory=` scoping is the only narrowing the endpoint offers and isn't
-    * session-precise, so it's not used.)
+    * firehose; the conversation filters it to its own session id (the endpoint
+    * offers no session-precise narrowing).
     */
   def events(): StreamSource
 

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeLauncher.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeLauncher.scala
@@ -1,13 +1,11 @@
 package orca.tools.opencode
 
-/** How orca launches the shared `opencode serve` process. orca always appends
-  * `serve --port <n> --log-level WARN` to the prefix below.
+/** The launch prefix for the shared `opencode serve` process; orca appends
+  * `serve --port <n> --log-level WARN`.
   *
   *   - [[default]] runs the `opencode` binary directly.
-  *   - [[ollama]] wraps it in `ollama launch opencode --model <model> --`, so
-  *     the spawned server inherits Ollama's generated provider config (injected
-  *     via `OPENCODE_CONFIG_CONTENT`) — the zero-config path for local Ollama
-  *     models, instead of hand-writing that config into `opencode.json`.
+  *   - [[ollama]] wraps it to inject Ollama's generated provider config — the
+  *     zero-config path for local Ollama models.
   *
   * Select it per flow via the `opencode` agent-override factory: `flow(
   * OrcaArgs(args), opencode = Some(w => OpencodeAgents.default(w,
@@ -22,13 +20,12 @@ object OpencodeLauncher:
   /** `ollama launch opencode --model <model> --` — injects Ollama's provider
     * config for `model` and makes it the server's **default**, so a bare
     * `opencode` turn routes to it with no `withModel` call. The model must
-    * already be pulled (`ollama pull <model>`) and the `ollama` CLI on PATH.
-    * `--model` is required: `ollama launch` otherwise falls back to interactive
-    * model selection, which fails in orca's headless server context.
+    * already be pulled and the `ollama` CLI on PATH. `--model` is required:
+    * `ollama launch` otherwise falls back to interactive selection, which fails
+    * in orca's headless context.
     *
-    * The launcher pins exactly this one model — the spawned server declares
-    * only it and rejects any other Ollama model id — so switching models means
-    * relaunching with a different `ollama(...)`, not `withModel`.
+    * The launcher pins exactly this one model — the server rejects any other
+    * Ollama id — so switching models means relaunching, not `withModel`.
     */
   def ollama(model: String): OpencodeLauncher =
     Seq("ollama", "launch", "opencode", "--model", model, "--")

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeServer.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeServer.scala
@@ -11,44 +11,33 @@ import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import scala.util.control.NonFatal
 
-/** Lifecycle owner for a shared `opencode serve` process (ADR 0014): it spawns
-  * the server, reads its base URL, and tears the process down via [[shutdown]].
-  * The HTTP/SSE client to talk to it is exposed via [[http]] — this class
-  * *owns* a client rather than *being* one, keeping process lifecycle separate
-  * from the request surface ([[OpencodeHttp]]).
+/** Lifecycle owner for a shared `opencode serve` process (ADR 0014): spawns the
+  * server, reads its base URL, and tears it down via [[shutdown]]. Owns the
+  * HTTP/SSE client ([[OpencodeHttp]]) rather than being one.
   *
   * The process is spawned the first time [[http]] is forced (so a backend wired
-  * but never used starts nothing). Its stdout/stderr are drained by Ox forks
-  * bound to the enclosing (flow) scope; [[shutdown]] destroys the process —
-  * which unblocks those forks' non-interruptible reads — so the scope can then
-  * join them cleanly. `shutdown` MUST be called from the flow body's `finally`
-  * (before the scope joins its forks): Ox runs `releaseAfterScope` finalizers
-  * *after* the join, so a `releaseAfterScope`-based kill would deadlock on a
-  * fork blocked in `readLine`. The runner wires this via
-  * `DefaultFlowContext.close`.
+  * but never used starts nothing). Its stdout/stderr are drained by Ox forks in
+  * the enclosing flow scope; [[shutdown]] destroys the process to unblock those
+  * forks' non-interruptible reads so the scope can join them. `shutdown` MUST
+  * run in the flow body's `finally`, before the scope joins its forks: Ox runs
+  * `releaseAfterScope` finalizers *after* the join, so a `releaseAfterScope`
+  * kill would deadlock on a fork blocked in `readLine`.
   *
   * A random `OPENCODE_SERVER_PASSWORD` keeps the bound localhost port closed to
-  * other processes; `--pure` is *not* passed (`OpencodeArgs.serve`) so the
-  * server inherits the user's configured providers.
+  * other processes; `--pure` is not passed so the server inherits the user's
+  * configured providers.
   *
-  * The internal `processRef`/`clientRef`/`stopped` atomics are deliberately not
-  * a single monitor: [[shutdown]] must be able to run while [[start]] is
-  * blocked in a non-interruptible native read, and destroying the process is
-  * precisely what unblocks that read — a shared lock would deadlock there.
+  * The `processRef`/`clientRef`/`stopped` atomics are deliberately not a single
+  * monitor: [[shutdown]] must run while [[start]] is blocked in a
+  * non-interruptible native read, and destroying the process is what unblocks
+  * that read — a shared lock would deadlock.
   *
-  * This server *process* is per-run and ephemeral: each run (including a
-  * resumed run after a kill/restart) spawns its own on `--port 0`. But the
-  * *storage* it reads from is not — opencode persists sessions to a global
-  * on-disk store shared by every `opencode serve` on the machine, independent
-  * of cwd, so a freshly spawned process resumes a session minted by a prior
-  * (now-dead) process: `GET /session/<id>` returns 200 with full message
-  * history (live-verified 2026-07-08). So although this class's process is
-  * ephemeral, opencode sessions genuinely are durable
-  * ([[orca.backend.SessionSupport.durable]]) across a restart —
-  * [[OpencodeBackend.probeSession]] just needs to force a fresh spawn to see it
-  * (see that method's scaladoc). This per-run process is an implementation
-  * detail of how orca talks to opencode, not a durability boundary on the
-  * sessions themselves.
+  * The process is per-run and ephemeral, but opencode's session storage is not:
+  * it persists sessions to a global on-disk store shared by every `opencode
+  * serve` on the machine, so a fresh process resumes a session minted by a
+  * prior one. Sessions are thus durable
+  * ([[orca.backend.SessionSupport.durable]]) across a restart;
+  * [[OpencodeBackend.probeSession]] just forces a fresh spawn to see it.
   */
 private[opencode] class OpencodeServer(
     cli: CliRunner,
@@ -60,42 +49,33 @@ private[opencode] class OpencodeServer(
 
   private val log = LoggerFactory.getLogger(classOf[OpencodeServer])
 
-  // Set during start() so shutdown() can tear them down. The reader forks block
-  // on a non-interruptible read, so destroying the process is the only way to
-  // unblock them — see the class scaladoc.
+  // Set during start() so shutdown() can tear them down.
   private val processRef = new AtomicReference[PipedCliProcess]()
   private val clientRef = new AtomicReference[OpencodeHttp]()
   private val stopped = new AtomicBoolean(false)
 
   /** The HTTP/SSE client against this server. Forcing it spawns `opencode
-    * serve` exactly once: a `lazy val` gives one spawn under concurrent first
-    * use and does not cache a failed start (Scala re-runs the initializer if it
-    * threw). This is the load-bearing once-init — `OpencodeBackend` holds a
-    * single server *instance* (built eagerly at construction); this `lazy val`
-    * guarantees a single *spawn* of it.
+    * serve` exactly once; a failed start is not cached (the initializer re-runs
+    * on the next force).
     */
   lazy val http: OpencodeHttp = start()
 
   /** Tear down the server: tree-destroy the process (unblocking the drain
-    * forks' reads so the enclosing scope can join them) and close the HTTP
-    * client. Idempotent and a no-op if the server was never started. Must run
-    * in the flow body's `finally`, before the scope joins the drain forks (see
-    * class scaladoc).
+    * forks' reads so the scope can join them) and close the HTTP client.
+    * Idempotent and a no-op if the server was never started. Must run in the
+    * flow body's `finally`, before the scope joins the drain forks.
     *
-    * In the runner's normal flow `http` is forced during the body and
-    * `shutdown` runs in the same scope's `finally` afterwards, so the process
-    * is already recorded here. Should a background fork ever force `http`
-    * concurrently with this call and lose the `processRef` write/read race,
+    * If a fork forces `http` concurrently and loses the `processRef` race,
     * `start` re-checks `stopped` after spawning and tree-destroys the process
-    * itself — so the kill is never silently missed.
+    * itself, so the kill is never missed.
     */
   def shutdown(): Unit =
     if stopped.compareAndSet(false, true) then
       val proc = Option(processRef.get())
       if proc.isDefined then log.debug("opencode server stopping")
-      // Tree-destroy (not SIGINT, not PID-only) so EVERY pipe holder dies and
-      // the drains' native reads hit EOF before the enclosing scope joins them —
-      // a launch wrapper (ollama) forks the real serve, which inherits the pipes.
+      // Tree-destroy (not PID-only) so EVERY pipe holder dies and the drains'
+      // reads hit EOF: a launch wrapper (ollama) forks the real serve, which
+      // inherits the pipes.
       proc.foreach(_.destroyForciblyTree())
       Option(clientRef.get()).foreach(_.close())
 
@@ -106,9 +86,9 @@ private[opencode] class OpencodeServer(
 
   private def start(): OpencodeHttp =
     val password = UUID.randomUUID.toString
-    // Pipe stderr (don't inherit it): a failed launch — e.g. `ollama launch`
-    // reporting a missing model — writes the reason here, so we can put it in
-    // the start-failure error below instead of losing it to the console.
+    // Pipe stderr (don't inherit): a failed launch (e.g. `ollama launch`
+    // reporting a missing model) writes the reason here for the start-failure
+    // error below.
     val process = cli.spawnPiped(
       OpencodeArgs.serve(launcher),
       env = Map("OPENCODE_SERVER_PASSWORD" -> password),
@@ -118,10 +98,8 @@ private[opencode] class OpencodeServer(
     processRef.set(process)
     process.closeStdin()
     // Drain stderr in a fork (a chatty launcher mustn't fill the pipe and stall
-    // startup), tracing each line and keeping a bounded tail to report if the
-    // server never binds. A joinable `fork` (not `forkDiscard`) so the bind-
-    // failure path can wait for the tail; the body swallows NonFatal so a stray
-    // read error never tears down the flow scope.
+    // startup), keeping a bounded tail to report if the server never binds. A
+    // joinable `fork` so the bind-failure path can wait for the tail.
     val errTail = new ConcurrentLinkedDeque[String]()
     val errFork = fork:
       try
@@ -139,9 +117,8 @@ private[opencode] class OpencodeServer(
       .nextOption()
       .getOrElse:
         // stdout closed with no listening line — the launcher/serve exited.
-        // Tree-destroy first so the stderr fork's read EOFs (even if a wrapper
-        // forked a pipe-holding child) and the join below can't hang, then
-        // surface its stderr (e.g. ollama's "model not found").
+        // Tree-destroy first so the stderr fork's read EOFs and the join can't
+        // hang, then surface its stderr (e.g. ollama's "model not found").
         process.destroyForciblyTree()
         errFork.join()
         val tail = String.join("\n", errTail)
@@ -151,16 +128,14 @@ private[opencode] class OpencodeServer(
              else " and produced no error output")
         )
     log.debug("opencode server started, listening on {}", baseUrl)
-    // Keep draining stdout — resuming the *same* lazy iterator past the bind
-    // line — so the server's log output can't back-fill the pipe and stall it.
-    // A `forkDiscard` in the flow scope; `shutdown`'s destroy unblocks its read
-    // before the scope joins it (the read is native and interrupt-immune).
+    // Keep draining stdout (resuming the same iterator past the bind line) so
+    // the server's log output can't back-fill the pipe and stall it.
+    // `shutdown`'s destroy unblocks this fork's interrupt-immune read.
     forkDiscard:
       try out.foreach(_ => ())
       catch case NonFatal(e) => log.debug("opencode stdout drain ended", e)
-    // Close the shutdown-before-processRef window structurally: if `shutdown`
-    // latched `stopped` before `processRef` was set, it destroyed nothing — do
-    // it here so the drains we just forked don't outlive that shutdown.
+    // If `shutdown` latched `stopped` before `processRef` was set, it destroyed
+    // nothing — do it here so the drains just forked don't outlive it.
     if stopped.get() then process.destroyForciblyTree()
     val client = httpFor(baseUrl, password)
     clientRef.set(client)

--- a/opencode/src/test/scala/orca/tools/opencode/DefaultOpencodeToolTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/DefaultOpencodeToolTest.scala
@@ -23,7 +23,7 @@ import orca.agents.{
 
 class DefaultOpencodeAgentTest extends munit.FunSuite:
 
-  // LLM `run` is now gated on `InStage`; mint the token for the suite.
+  // LLM `run` is gated on `InStage`; mint the token for the suite.
   private given orca.InStage = orca.InStage.unsafe
 
   /** Captures the config the tool resolves for an autonomous call. */

--- a/opencode/src/test/scala/orca/tools/opencode/OpencodeBackendTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/OpencodeBackendTest.scala
@@ -93,7 +93,6 @@ class OpencodeBackendTest extends munit.FunSuite:
           "/session/ses_server1/prompt_async"
         )
       )
-      // The backend forwards the prompt into the prompt_async body.
       val (_, body) = http.posts.find(_._1.endsWith("/prompt_async")).get
       assert(body.contains(""""text":"hi""""), body)
 
@@ -161,13 +160,11 @@ class OpencodeBackendTest extends munit.FunSuite:
     "interactive shell: finally-cancel after a successful turn posts no /abort " +
       "(settledOutcome race regression)"
   ):
-    // Mirrors the real driving loop (`AgentCall.runInteractiveOnce`:
-    // `try interaction.drive(conversation) finally conversation.cancel()`):
-    // the reader settles on its own fork/thread while `cancel()` runs here, on
-    // the test's thread — a genuine cross-thread race on `isSettled`, not just
-    // a same-thread call sequence. Before `settledOutcome` was `@volatile`,
-    // `cancel()` could observe a stale `isSettled == false` on this path and
-    // fire the real `/abort` on a turn that already succeeded.
+    // Mirrors the real driving loop (`try interaction.drive(conversation)
+    // finally conversation.cancel()`): the reader settles on its own fork while
+    // `cancel()` runs on the test's thread — a genuine cross-thread race on
+    // `isSettled`. A stale `isSettled == false` here would fire a real `/abort`
+    // on a turn that already succeeded.
     supervised:
       val http = new FakeHttp(
         turn(
@@ -223,12 +220,10 @@ class OpencodeBackendTest extends munit.FunSuite:
   ):
     supervised:
       // Mirrors resume: FlowLifecycle.rehydrateSessions registers the
-      // client→server mapping before any turn has touched the server, so
-      // `http` has never been forced yet when `exists` is called. The probe
-      // must still force the (lazy) spawn and contact the fresh server rather
-      // than short-circuiting on whether it was already running — that
-      // short-circuit was the cross-restart-resume bug this pins against a
-      // regression of.
+      // client→server mapping before any turn has touched the server, so `http`
+      // has never been forced when `exists` is called. The probe must still
+      // force the lazy spawn and contact the fresh server rather than
+      // short-circuiting on whether it was already running.
       val http = new FakeHttp(
         Nil,
         path => if path == "/session/ses_server1" then 200 else 404

--- a/opencode/src/test/scala/orca/tools/opencode/OpencodeServerTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/OpencodeServerTest.scala
@@ -161,8 +161,7 @@ class OpencodeServerTest extends munit.FunSuite:
       server.shutdown() // idempotent: no exception, no double effect
     // The scope then joins the drain forks. (The fake's queue read is
     // interruptible, unlike a real native readLine, so this can't reproduce the
-    // production hang — the destroy/close assertions above are the real teeth;
-    // OpencodeServerTest's value is shutdown's effects + idempotency.)
+    // production hang; the destroy/close assertions above are the real teeth.)
 
   test("shutdown is a no-op when the server was never started"):
     supervised:

--- a/pi/src/main/scala/orca/tools/pi/PiAgents.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiAgents.scala
@@ -10,10 +10,7 @@ import orca.subprocess.OsProcCliRunner
   */
 object PiAgents:
 
-  /** The default pi agent for a run: standard config. Pi model selection is
-    * left to generic [[AgentConfig.model]] values since Pi supports many
-    * providers and fuzzy model patterns through its own CLI.
-    */
+  /** The default pi agent for a run: standard config. */
   def default(wiring: AgentWiring): PiAgent =
     new DefaultPiAgent(
       backend = new PiBackend(OsProcCliRunner, workDir = wiring.workDir),

--- a/pi/src/main/scala/orca/tools/pi/PiArgs.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiArgs.scala
@@ -3,15 +3,13 @@ package orca.tools.pi
 import orca.backend.CliArgs
 import orca.agents.{AgentConfig, AutoApprove, Enforcement, ToolSet}
 
-/** Maps Orca backend configuration to Pi CLI arguments. The backend drives Pi
-  * through RPC mode and sends prompts over stdin, so the argv carries only
-  * process/session/configuration flags.
+/** Maps Orca backend configuration to Pi CLI arguments; the argv carries only
+  * process/session/configuration flags, since prompts go over stdin.
   *
   * Session continuity uses Pi's on-disk sessions: `--session-dir` points at a
-  * directory Pi creates a fresh session in on the first turn; `resume` adds
-  * `--continue` so a later turn picks up the prior session in that dir. (Pi's
-  * `--session <id>` only *resumes* an existing id, so it can't seed a
-  * caller-chosen id for a new session.)
+  * directory Pi seeds a fresh session in; `resume` adds `--continue` to pick up
+  * the prior session there. (`--session <id>` only resumes an existing id, so
+  * it can't seed a caller-chosen id for a new session.)
   */
 private[pi] object PiArgs:
 
@@ -41,10 +39,9 @@ private[pi] object PiArgs:
   private def systemPromptArgs(file: Option[os.Path]): Seq[String] =
     CliArgs.flag("--append-system-prompt", file)(_.toString)
 
-  /** Maps [[AgentConfig.tools]] to pi's `--tools` allowlist. `Full` omits the
-    * flag (all built-in tools enabled); `ReadOnly` restricts to
-    * [[ReadOnlyTools]]; `NetworkOnly` adds [[NetworkTool]] (`bash`) for network
-    * access. The ask-user extension tool is appended when present.
+  /** Maps [[AgentConfig.tools]] to pi's `--tools` allowlist (`Full` omits the
+    * flag for all built-ins); the ask-user extension tool is appended when
+    * present.
     */
   private def toolsArgs(
       config: AgentConfig,
@@ -67,17 +64,14 @@ private[pi] object PiArgs:
   private def extensionArgs(file: Option[os.Path]): Seq[String] =
     CliArgs.flag("--extension", file)(_.toString)
 
-  /** How strongly pi enforces each `(tools, autoApprove)` combination — see
-    * [[toolsArgs]] for the `--tools` allowlist this classifies.
-    *
-    *   - `ReadOnly` → `Hard`: `--tools read,grep,find,ls` mechanically excludes
+  /** How strongly pi enforces each `(tools, autoApprove)` combination:
+    *   - `ReadOnly` → `Hard`: the `--tools` allowlist mechanically excludes
     *     every writable tool.
-    *   - `NetworkOnly` → `PromptOnly`: pi has no web tool, so network arrives
-    *     only via the general `bash` tool, which also permits writes — the
-    *     no-edit guarantee then rests only on the planner prompt.
+    *   - `NetworkOnly` → `PromptOnly`: network arrives only via the general
+    *     `bash` tool, which also permits writes, so the no-edit guarantee rests
+    *     on the planner prompt.
     *   - `Full` + `AutoApprove.All` / `Only(_)` → `Ignored`: pi RPC never
-    *     prompts and the argv encodes no approval policy, so `autoApprove` is
-    *     not represented at all.
+    *     prompts and the argv encodes no approval policy.
     */
   def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
     tools match

--- a/pi/src/main/scala/orca/tools/pi/PiAskUserExtension.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiAskUserExtension.scala
@@ -2,13 +2,11 @@ package orca.tools.pi
 
 import scala.util.control.NonFatal
 
-/** Temporary Pi extension that exposes Orca's backend-agnostic `ask_user`
-  * conversation event through Pi's native extension UI protocol.
+/** Temporary Pi extension exposing Orca's `ask_user` conversation event through
+  * Pi's native extension UI protocol.
   *
-  * The extension intentionally has no imports so it can be written to a temp
-  * directory and loaded by Pi without relying on Node module resolution from
-  * that directory. The `parameters` value is plain JSON Schema / TypeBox shape,
-  * which Pi accepts for tool schemas.
+  * The extension deliberately has no imports, so it can be written to a temp
+  * directory and loaded without Node module resolution from there.
   */
 private[pi] final class PiAskUserExtension private (
     val dir: os.Path,

--- a/pi/src/main/scala/orca/tools/pi/PiBackend.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiBackend.scala
@@ -28,43 +28,33 @@ import ox.Ox
 
 /** Pi backend driven through `pi --mode rpc` JSONL over stdio.
   *
-  * Pi exposes no HTTP server and its in-process SDK is Node-only, so a
-  * subprocess is the only way to embed it from the JVM; `--mode rpc` is the
-  * bidirectional channel (needed within a turn for `ask_user` extension-UI
-  * replies).
+  * Pi exposes no HTTP server and its SDK is Node-only, so a subprocess is the
+  * only way to embed it; `--mode rpc` gives the bidirectional channel needed
+  * for `ask_user` extension-UI replies within a turn.
   *
-  * Lifecycle is deliberately per-call: each Orca call spawns its own `pi --mode
-  * rpc` process, sends one `prompt`, reads to `agent_end`, then lets the
-  * process exit. Context carries across calls through a per-session
-  * `--session-dir` (one dir per Orca session id) that Pi creates on the first
-  * turn and `--continue` resumes on later turns — rather than a long-lived
-  * process.
+  * Lifecycle is per-call: each call spawns its own process, sends one `prompt`,
+  * reads to `agent_end`, then exits. Context carries across calls through a
+  * per-session `--session-dir` that Pi seeds on the first turn and `--continue`
+  * resumes on later ones.
   */
 private[orca] class PiBackend(
     cli: CliRunner,
-    /** Fixed at construction; every spawn (`openConversation`) runs in this
-      * directory. The `os.pwd` default serves bare/test construction; the
-      * runtime (`PiAgents.default`) passes the flow's real `workDir`.
+    /** Working directory every spawn runs in. The `os.pwd` default serves test
+      * construction; the runtime passes the flow's real `workDir`.
       */
     override val workDir: os.Path = os.pwd
 ) extends AgentBackend[BackendTag.Pi.type]:
 
-  // Pi persists each session in a directory; one dir per Orca session id gives
-  // caller-stable continuity. The registry tracks fresh-vs-resume and is
-  // committed only *after* a successful turn, so a retried open-failure starts
-  // fresh rather than `--continue`-ing a dir Pi never created.
+  // One session dir per Orca session id gives caller-stable continuity.
+  // Fresh-vs-resume is committed only after a successful turn, so a retried
+  // open-failure starts fresh rather than `--continue`-ing a dir Pi never made.
   private val sessionsBase: os.Path =
     os.temp.dir(prefix = "orca-pi-sessions-", deleteOnExit = true)
 
-  /** Pi's sessions live in a `deleteOnExit` temp dir (gone across runs), so it
-    * is ephemeral: fresh-vs-resume is tracked within a live process
-    * ([[IdScheme.ClientClaimed]] — the CLI takes the caller's id), but there is
-    * nothing durable to persist, rehydrate, or probe — pi always re-seeds
-    * across runs (ADR 0018 §2.6). `SessionSupport.ephemeral` says this
-    * structurally, so `persistableWireId` reports absence without a per-backend
-    * override. The bookkeeping is encapsulated; the spawn/commit paths go
-    * through `sessions.dispatchFor` / `Conversations.runAutonomous(session,
-    * sessions, …)`.
+  /** Ephemeral: Pi's sessions live in a `deleteOnExit` temp dir, so
+    * fresh-vs-resume is tracked only within a live process
+    * ([[IdScheme.ClientClaimed]]) with nothing durable to persist or probe — pi
+    * always re-seeds across runs (ADR 0018 §2.6).
     */
   val sessions: SessionSupport[BackendTag.Pi.type] =
     SessionSupport.ephemeral(IdScheme.ClientClaimed)
@@ -122,21 +112,16 @@ private[orca] class PiBackend(
       outputSchema: Option[String]
   ): PiConversation =
     // Temp files (ask-user extension, system prompt) Pi reads for the whole
-    // turn. Ownership passes to the conversation once it's constructed — it
-    // closes them in `onFinalize` when the turn ends; `SubprocessSpawn.open`'s
-    // failure path is the backstop for a failure before that point. Closes are
-    // idempotent (`closeQuietly` + `os.remove.all`); the temp dirs are also
-    // `deleteOnExit`, so a hard JVM kill mid-turn still reclaims them. Both
-    // files are allocated up front (before `open`) so `resources` is a plain
-    // immutable list.
+    // turn. Ownership passes to the conversation, which closes them in
+    // `onFinalize`; `SubprocessSpawn.open`'s failure path is the backstop for a
+    // failure before construction. Closes are idempotent and the dirs are
+    // `deleteOnExit`, so a hard kill mid-turn still reclaims them.
     val displayPrompt = mode.displayPrompt
     val extraHint = Option.when(mode.isInteractive)(PiAskUserExtension.Hint)
 
-    // Write the system prompt file FIRST — before ANY resource is allocated —
-    // so a temp-write failure (e.g. disk full) can't leak the ask-user
-    // extension resource that `PiAskUserExtension.allocate()` would spin up:
-    // with nothing allocated yet, there's nothing to tear down. `Hint` is a
-    // static constant, so knowing it doesn't require the allocation.
+    // Write the system prompt file before allocating any resource, so a
+    // temp-write failure can't leak the ask-user extension: with nothing
+    // allocated yet, there's nothing to tear down.
     val systemPromptFile = writeSystemPromptIfPresent(config, extraHint)
 
     val askUserExtension =

--- a/pi/src/main/scala/orca/tools/pi/PiConversation.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiConversation.scala
@@ -15,14 +15,13 @@ import orca.tools.pi.rpc.{
 
 import scala.util.control.NonFatal
 
-/** Drives one `pi --mode rpc` process for a single Orca LLM call. The backend
-  * sends one `prompt` command, this conversation translates Pi RPC events into
-  * Orca conversation events, and `agent_end` becomes the terminal
+/** Drives one `pi --mode rpc` process for a single Orca LLM call: translates Pi
+  * RPC events into Orca conversation events, with `agent_end` as the terminal
   * [[AgentResult]].
   *
-  * Pi has no native structured-output / JSON-schema flag, so `outputSchema` is
-  * carried only for the framework's parsing: the schema is enforced through the
-  * prompt (`DefaultAgentCall` injects the rules), not the Pi CLI.
+  * Pi has no native structured-output flag, so `outputSchema` is carried only
+  * for the framework's parsing; the schema is enforced through the prompt, not
+  * the Pi CLI.
   */
 private[pi] class PiConversation(
     process: PipedCliProcess,
@@ -41,13 +40,12 @@ private[pi] class PiConversation(
 
   import PiConversation.*
 
-  /** Turn state, accrued by the single reader thread — `handleLine` and the
-    * handlers it drives all run there, so a plain `var` over an immutable
-    * snapshot is safe and avoids cross-thread machinery; `awaitResult` reads
-    * the outcome only after joining the reader, which publishes these writes.
+  /** Turn state, accrued only by the single reader thread, so a plain `var` is
+    * safe; `awaitResult` reads the outcome after joining the reader, which
+    * publishes these writes.
     *
-    * `textStreamedThisMessage` lets `message_end` emit the completed text as a
-    * fallback only when no `text_delta` already streamed it.
+    * `textStreamedThisMessage` lets `message_end` emit its text as a fallback
+    * only when no `text_delta` already streamed it.
     */
   private case class TurnState(
       lastAssistantMessage: String = "",
@@ -57,15 +55,14 @@ private[pi] class PiConversation(
   )
   private var turnState: TurnState = TurnState()
 
-  // All stdin writes funnel through this lock: `sendPrompt` runs on the caller's
-  // thread, the ask-user reply on the event consumer's, and the reader fork may
-  // write an extension cancel. `writeLine` is an unsynchronised write+flush, so
-  // concurrent callers would otherwise interleave JSONL frames.
+  // All stdin writes funnel through this lock: `sendPrompt` (caller thread), the
+  // ask-user reply (event consumer), and the reader fork's extension cancel can
+  // race. `writeLine` is an unsynchronised write+flush, so concurrent callers
+  // would otherwise interleave JSONL frames.
   private val stdinLock = new AnyRef
 
-  // No `start()`: the base spawns its reader / stderr forks lazily on first
-  // touch of the conversation surface, after this subclass's fields (incl.
-  // `stdinLock`) are initialised.
+  // The base spawns its reader/stderr forks lazily on first touch, after this
+  // subclass's fields (incl. `stdinLock`) are initialised.
 
   def sendPrompt(prompt: String): Unit =
     sendLine(OutboundMessage.prompt(prompt))
@@ -150,14 +147,12 @@ private[pi] class PiConversation(
       if fallbackText then
         eventQueue.enqueue(ConversationEvent.AssistantTextDelta(message.text))
 
-  // A turn can span several assistant messages (each ends with `message_end`),
-  // so the single turn boundary is `agent_end`, not per-message. `agent_end` is
-  // terminal (one turn per conversation), so the base funnel auto-closes the
-  // open turn when `succeedWith` settles — no explicit `AssistantTurnEnd` here.
+  // A turn can span several assistant messages, so the turn boundary is
+  // `agent_end`, not per-message. It's terminal, so the base funnel auto-closes
+  // the open turn on `succeedWith` — no explicit `AssistantTurnEnd` here.
   private def handleAgentEnd(): Unit =
-    // Closing stdin tells Pi no more commands are coming; `settleSuccess` (via
-    // `succeedWith`) then sets the outcome and interrupts the source (SIGINTs
-    // the process), so stdin must close first.
+    // Close stdin first: `settleSuccess` then interrupts the source (SIGINTs the
+    // process), so no more commands can be sent afterward.
     closeStdin()
     settleSuccess(
       wireId = clientSession.value,
@@ -177,16 +172,15 @@ private[pi] class PiConversation(
           ConversationEvent.UserQuestion(
             question,
             answer =>
-              // The turn may have already reached agent_end (stdin closed) by
-              // the time a human answers; a late reply is moot, so don't let the
-              // write blow up the consumer thread.
+              // Stdin may already be closed (agent_end reached) by the time a
+              // human answers; a late reply is moot, so don't let the write
+              // blow up the consumer thread.
               try sendLine(OutboundMessage.extensionUiValue(id, answer))
               catch case NonFatal(_) => ()
           )
         )
       case method if FireAndForgetUiMethods.contains(method) =>
-        // Pi extensions use these for TUI decoration/status. In RPC mode they
-        // are explicitly fire-and-forget, so Orca can safely ignore them.
+        // TUI decoration/status; fire-and-forget in RPC mode, so ignore them.
         ()
       case other =>
         eventQueue.enqueue(
@@ -207,8 +201,7 @@ private[pi] object PiConversation:
   )
 
   private def isKnownStderrNoise(line: String): Boolean =
-    // Pi's terminal notifier can write iTerm2-style notifications to stderr as
-    // OSC 777 (`ESC ] 777 ; ... BEL`). We strip well-formed controls before
-    // trimming, but keep this guard for environments that have already removed
-    // the leading ESC byte before the line reaches us.
+    // Pi's terminal notifier writes iTerm2 OSC 777 notifications to stderr
+    // (`ESC ] 777 ; ... BEL`). Well-formed controls are stripped before
+    // trimming; this guard catches lines that already lost the leading ESC.
     line.startsWith("]777;notify;")

--- a/runner/src/main/scala/orca/OrcaArgs.scala
+++ b/runner/src/main/scala/orca/OrcaArgs.scala
@@ -17,22 +17,11 @@ object OrcaArgs:
   def parse(args: Seq[String]): Either[String, OrcaArgs] =
     summon[ParserForClass[OrcaArgs]].constructEither(args.toList)
 
-  /** Convenience overload for scala-cli flow scripts, where the top-level
-    * `args` is `Array[String]`:
-    *
-    * ```
-    * flow(OrcaArgs(args)):
-    *   // userPrompt resolves against the positional CLI arg
-    * ```
-    *
-    * Throws `OrcaFlowException` on a parse failure — flow scripts should either
-    * surface the message to the user or catch and handle it.
+  /** Overload for scala-cli flow scripts, whose top-level `args` is
+    * `Array[String]`. Throws `OrcaFlowException` on a parse failure.
     */
   def apply(args: Array[String]): OrcaArgs = from(args.toSeq)
 
-  /** `Seq[String]` companion to the array-taking `apply` above — useful for
-    * tests and callers that already have a parsed list.
-    */
   def from(args: Seq[String]): OrcaArgs =
     parse(args) match
       case Right(parsed)  => parsed

--- a/runner/src/main/scala/orca/exports.scala
+++ b/runner/src/main/scala/orca/exports.scala
@@ -1,23 +1,14 @@
 package orca
 
-// Re-exports the user-facing surface from each sub-package so flow scripts
-// can pull everything in with a single `import orca.{*, given}`. The list
-// mirrors what the README documents as the public API; deliberately omits
-// customisation-only knobs (e.g. `orca.plan.PlanPrompts.Planning`) so they
-// stay self-documenting at the call site rather than fading into the
-// wildcard.
+// Re-exports the user-facing surface from each sub-package so flow scripts can
+// pull everything in with a single `import orca.{*, given}`. Mirrors the public
+// API the README documents; deliberately omits customisation-only knobs (e.g.
+// `orca.plan.PlanPrompts.Planning`) so they stay self-documenting at the call
+// site. The flow DSL, StackSettings and Configured live at top-level `orca`
+// already, so they need no re-export.
 
-// flow DSL (flow, stage, fail, accessors, OrcaArgs, FlowContext),
-// StackSettings, and Configured live at top-level `orca` so their symbols sit
-// at the heart of the user surface; no re-export needed (re-exporting a
-// top-level `orca` symbol from this `package orca` file would be
-// self-referential).
-
-// Usage/Cost/CostTracker: OrcaEvent.TokensUsed carries a Usage, so any
-// listener pattern-matching it needs Usage in scope; CostTracker is the type
-// flow's own scaladoc invites callers to instantiate directly (`new
-// CostTracker(pricing)`, passed via `extraListeners`), and its accessors
-// report in Cost.
+// Usage is carried by OrcaEvent.TokensUsed, so listeners matching it need it in
+// scope; CostTracker is instantiable directly by callers via `extraListeners`.
 export orca.events.{
   OrcaEvent,
   OrcaListener,
@@ -52,20 +43,13 @@ export orca.agents.{
   codecFromJsonData
 }
 export orca.plan.{BugReportMatch, Plan, Sessioned, Task, Title, Triage, Verdict}
-// openPrFromBranch bundles the push→summarise→createPr tail every PR flow
-// otherwise hand-rolls; PrSummary is its (and summarisePr's) result type.
-// orcaCommentMarker builds the idempotency marker gh.upsertComment keys on.
+// PrSummary is the result type of openPrFromBranch and summarisePr;
+// orcaCommentMarker is the idempotency marker gh.upsertComment keys on.
 export orca.pr.{openPrFromBranch, orcaCommentMarker, summarisePr, PrSummary}
-// IgnoredIssue(s): the return type of both fixLoop and reviewAndFixLoop above
-// — a caller binding the result to a typed val, or inspecting `.issues`,
-// needs it in scope.
-// Reviewer + ReviewerPrompts + buildReviewers: the reviewer-customisation
-// surface — compose your own `List[Reviewer]` (shipped `ReviewerPrompts`
-// entries, a subset, and/or your own) and `buildReviewers` it into the agents
-// `reviewAndFixLoop` takes, to swap or extend what `allReviewers` builds.
-// Lint: `reviewAndFixLoop`'s `lint: Configured[Lint]` parameter is a public
-// type — a caller constructs `Lint(command, agent)` at the call site, so it
-// must resolve through the same wildcard import as the loop itself.
+// Reviewer-customisation surface: compose your own `List[Reviewer]` and
+// `buildReviewers` it into the agents `reviewAndFixLoop` takes. IgnoredIssue(s)
+// is the result type of fixLoop/reviewAndFixLoop; Lint is constructed at the
+// call site for reviewAndFixLoop's `lint` parameter.
 export orca.review.{
   allReviewers,
   buildReviewers,
@@ -85,9 +69,8 @@ export orca.review.{
   ReviewResult,
   RosterEntry
 }
-// PushFailure: the Left of GitTool.push's Either — pattern-matching its
-// NonFastForward/RemoteDeclined cases needs it in scope. BuildWaitFailed is
-// the same shape for GitHubTool.waitForBuild's Either.
+// PushFailure is the Left of GitTool.push's Either; BuildWaitFailed the same
+// for GitHubTool.waitForBuild.
 export orca.tools.{
   BuildOutcome,
   BuildStatus,
@@ -100,7 +83,7 @@ export orca.tools.{
 }
 export orca.tools.opencode.OpencodeLauncher
 // Agent-override surface: the wiring an override factory receives, plus each
-// backend's public default-agent factory (`ClaudeAgents.default(w).opus`, …).
+// backend's default-agent factory (`ClaudeAgents.default(w).opus`, …).
 export orca.backend.AgentWiring
 export orca.tools.claude.ClaudeAgents
 export orca.tools.codex.CodexAgents

--- a/runner/src/main/scala/orca/flow.scala
+++ b/runner/src/main/scala/orca/flow.scala
@@ -68,12 +68,12 @@ import scala.util.control.NonFatal
   * ```
   *
   * Agent overrides are `AgentWiring => Ox ?=> Agent` factories, not prebuilt
-  * agents — see [[orca.runner.FlowWiring]] for why and for the shared `Ox ?=>`
-  * shape. Start from a per-backend factory and tune it, `claude = Some(w =>
+  * agents — see [[orca.runner.FlowWiring]] for the shared shape. Start from a
+  * per-backend factory and tune it, `claude = Some(w =>
   * ClaudeAgents.default(w).opus)`, or wrap a prebuilt agent `claude = Some(_ =>
-  * myAgent)`. There's no separate `opencodeLauncher` parameter — select a
-  * non-default launcher through the factory itself: `opencode = Some(w =>
-  * OpencodeAgents.default(w, OpencodeLauncher.ollama("qwen3-coder")))`.
+  * myAgent)`. Select a non-default opencode launcher through the factory
+  * itself: `opencode = Some(w => OpencodeAgents.default(w,
+  * OpencodeLauncher.ollama("qwen3-coder")))`.
   *
   * '''Role agents (ADR 0020).''' A run has three role agents —
   * [[orca.planningAgent]], [[orca.codingAgent]], [[orca.reviewAgent]] —
@@ -82,40 +82,28 @@ import scala.util.control.NonFatal
   * `{workDir}/.orca/settings.properties` > the user-global file
   * `$XDG_CONFIG_HOME/orca/settings.properties` > the built-in default (claude,
   * default model). Each file carries `planningAgent`/`codingAgent`/
-  * `reviewAgent = harness[:model]` lines (`codingAgent = codex`, `planningAgent
-  * \= claude:opus`, …); a malformed value in either file — or an unreadable one
-  * — aborts the run before any tree mutation. Both files are read once, before
-  * setup; setup then emits one `Step` naming each resolved role and its source
-  * (default/project/global/override), the debugging handle for "why did codex
-  * run here?".
+  * `reviewAgent = harness[:model]` lines; a malformed or unreadable value in
+  * either file aborts the run before any tree mutation. Setup emits one `Step`
+  * naming each resolved role and its source, the handle for "why did codex run
+  * here?".
   *
-  * The three `planningAgent`/`codingAgent`/`reviewAgent` overrides are the
-  * programmatic top of that precedence — selector-shaped
-  * (`Some(_.claude.opus)`) so a `copyTool`-derived sibling of a wired agent
-  * stays expressible, and the seam the tests use in place of a real user-global
-  * file. Each must resolve to one of the five wired agents (`_.claude`, …) or a
-  * sibling of one — anything sharing their backend is safe. An override that
-  * instead returns an agent built from a SEPARATE `AgentWiring`/backend (e.g.
-  * `_ => myPrebuiltAgent`) compiles but is event-blind — it never reaches this
-  * run's dispatcher, so its cost/steps never reach the terminal or cost tracker
-  * — and gets a loud resolution-time warning; the runtime still closes its
-  * backend at flow end to avoid a resource leak, but nothing can retrofit it
-  * onto this run's event stream after the fact.
+  * The three overrides are the programmatic top of that precedence — selector-
+  * shaped (`Some(_.claude.opus)`) so a `copyTool`-derived sibling stays
+  * expressible, and the seam tests use in place of a global file. Each must
+  * resolve to one of the wired agents or a sibling — anything sharing their
+  * backend. An override returning an agent built from a SEPARATE
+  * `AgentWiring`/backend (e.g. `_ => myPrebuiltAgent`) compiles but is
+  * event-blind: it never reaches this run's dispatcher, so its cost/steps never
+  * surface, and it gets a loud resolution-time warning. Its backend is still
+  * closed at flow end to avoid a leak.
   *
-  * The runtime resolves the three roles BEFORE the `FlowContext` is constructed
-  * (the context receives them as constructor vals); `FlowContext` extends
-  * `AgentSet`, so the same accessors keep working inside the body. Each role's
-  * backend tag is captured into `FlowContext.PlanB`/`CodeB`/`ReviewB` so the
-  * role accessors are concretely typed and sessions thread.
-  *
-  * `stackSettings` still wins outright for the stack commands (ADR 0019): when
-  * passed, the project file's stack keys are ignored and discovery is skipped —
-  * but the file's agent keys are STILL honoured (a malformed file still
-  * aborts).
+  * `stackSettings` wins outright for the stack commands (ADR 0019): when
+  * passed, the project file's stack keys are ignored and discovery is skipped,
+  * but its agent keys are still honoured (a malformed file still aborts).
   *
   * Overrides default to `None` so the runtime can build the default lazily —
-  * `TerminalInteraction`, in particular, takes the resolved `workDir` which
-  * can't be threaded through a Scala 3 default-arg expression.
+  * `TerminalInteraction` in particular takes the resolved `workDir`, which
+  * can't be threaded through a default-arg expression.
   */
 def flow(
     args: OrcaArgs,
@@ -123,22 +111,14 @@ def flow(
     interaction: Option[Interaction] = None,
     extraListeners: List[OrcaListener] = Nil,
     branchNaming: Option[BranchNamingStrategy] = None,
-    // Explicit stack settings win outright for the stack commands (ADR 0019):
-    // when passed, the project file's stack keys are neither read nor written —
-    // the escape hatch for language-specific flows that own their tooling. The
-    // file's agent keys are still honoured.
     stackSettings: Option[StackSettings] = None,
-    // Per-role programmatic overrides — win over both settings files. Selector-
-    // shaped so a derived sibling of a wired agent stays expressible
-    // (`Some(_.claude.opus)`); also the seam tests use in place of the global
-    // file.
     planningAgent: Option[AgentSet => Agent[?]] = None,
     codingAgent: Option[AgentSet => Agent[?]] = None,
     reviewAgent: Option[AgentSet => Agent[?]] = None,
     returnToStartBranch: Boolean = false,
     progressStore: Option[ProgressStore] = None,
-    // Every field shares the `AgentWiring => Ox ?=> Agent` shape — see
-    // FlowWiring's scaladoc for why.
+    // Agent factories share the `AgentWiring => Ox ?=> Agent` shape — see
+    // FlowWiring's scaladoc.
     claude: Option[AgentWiring => Ox ?=> ClaudeAgent] = None,
     codex: Option[AgentWiring => Ox ?=> CodexAgent] = None,
     opencode: Option[AgentWiring => Ox ?=> OpencodeAgent] = None,
@@ -150,26 +130,20 @@ def flow(
     prompts: Prompts = DefaultPrompts,
     pricing: PriceList = Pricing.default
 )(body: FlowControl ?=> Unit): Unit =
-  // Per-run trace file: captures every stage, prompt, tool/subprocess call and
-  // result at DEBUG. Started before anything logs so the whole run is caught;
-  // the path is printed by the banner and the detail stays in the file.
+  // Per-run trace file capturing every stage, prompt and tool/subprocess call
+  // at DEBUG. Started before anything logs so the whole run is caught.
   val orcaLog = OrcaLog.start()
   OrcaBanner.print(System.err, orcaLog.file)
   val flowLog = LoggerFactory.getLogger("orca.flow")
   flowLog.info("orca {} starting (workDir={})", OrcaBanner.version, workDir)
   flowLog.info("user prompt: {}", args.userPrompt)
-  // A daemon thread or unsupervised fork that throws would otherwise
-  // disappear with no diagnostic. Log the message to the console and the
-  // stack to the trace file so a silent exit always leaves a trail.
+  // A daemon thread or unsupervised fork that throws would otherwise disappear
+  // with no diagnostic; this leaves a trail on the console and in the trace.
   installUncaughtExceptionHandler()
-  // Always tally token usage; print the summary on exit (success or failure)
-  // so the user sees what was spent before the process terminates. Callers
-  // can still pass their own CostTracker via `extraListeners` for other uses
-  // — it'll observe the same events independently.
+  // Tally token usage and print the summary on exit (success or failure).
   val costTracker = new CostTracker(pricing)
   // `try/finally` so the cost summary always lands — even when a fatal
   // throwable (OOM, StackOverflow) escapes the NonFatal catch below.
-  // Tokens may have already been spent; the user deserves to see what.
   var failed = false
   try
     try
@@ -198,55 +172,40 @@ def flow(
         )
       )(body)
     catch
-      // Every phase that can fail — lead resolution and setup (bracketed in
-      // `runFlow`), rehydration and the body (bracketed in
-      // `FlowLifecycle.run`) — is wrapped so a failure is reported to the
-      // user's event surface BEFORE it escapes, then rethrown as
-      // `SurfacedFlowFailure`. Seeing that marker means the message already
-      // reached the user — only the exit code remains to decide (after the
-      // finally below prints the summary and detaches the trace).
+      // A `SurfacedFlowFailure` marks a failure already reported to the user's
+      // event surface by the phase that raised it; only the exit code remains.
       case _: SurfacedFlowFailure => failed = true
-      // Backstop: any other NonFatal escaped a code path that was never
-      // bracketed — a pre-dispatcher failure (agent factory,
-      // TerminalInteraction start) has no event surface to report to, and a
-      // future unsurfaced path would otherwise exit 1 in silence. Print it
-      // loudly to stderr so no failure is ever swallowed.
+      // Backstop for any other NonFatal — a pre-dispatcher failure (agent
+      // factory, TerminalInteraction start) has no event surface, so print it
+      // to stderr rather than exit 1 in silence.
       case NonFatal(e) =>
         failed = true
         System.err.println(s"[orca] ${TextUtil.throwableMessage(e)}")
   finally
     costTracker.printSummary()
     orcaLog.finish()
-  // Residual: for a NESTED `flow()` call (the outer flow's body invoking
-  // `flow()` again), this `System.exit` tears down the JVM before the OUTER
-  // flow's own `finally` (branch restore, workdir-lock release) ever runs —
-  // the outer branch is left checked out and `.orca/flow.lock` stays behind
-  // (self-heals: the next run steals the dead-PID lock with a warning).
-  // Known, not fixed — an accepted residual of the exit-based CLI contract.
+  // Known residual: in a NESTED `flow()` call this `System.exit` tears down the
+  // JVM before the OUTER flow's `finally` (branch restore, lock release) runs,
+  // leaving the outer branch checked out and `.orca/flow.lock` behind (the next
+  // run self-heals by stealing the dead-PID lock). Accepted cost of the
+  // exit-based CLI contract.
   if failed then System.exit(1)
 
-/** Exit-free flow lifecycle: builds the interaction and the wired agents,
-  * resolves the three role agents from settings, runs setup, constructs the
-  * context, then runs the body as a top-level stage with disjoint
-  * success/failure teardown. Unlike [[flow]], a failure in any phase is
-  * **propagated** (after any body-failure teardown), not turned into a
-  * `System.exit` — so the crash→`resetHard`→resume wiring is directly testable
-  * end-to-end. Every phase that can fail — settings read + role resolution and
-  * setup (pre-context, bracketed below), then rehydration and the body
-  * (bracketed inside `FlowLifecycle.run`) — reports to the event surface first,
-  * so a `NonFatal` failure from one of those escapes here wrapped in
-  * [[orca.runner.SurfacedFlowFailure]]`(cause)`; tests inspect its `cause`. A
-  * failure from BEFORE the dispatcher and agents exist (e.g. an agent-override
-  * factory, applied just after the dispatcher is built) has no event surface to
-  * report to and so escapes unwrapped instead. [[flow]] wraps this to keep the
-  * observable CLI behaviour (cost summary, OrcaLog, `System.exit(1)`).
+/** Exit-free flow lifecycle: builds the interaction and wired agents, resolves
+  * the three role agents from settings, runs setup, constructs the context,
+  * then runs the body as a top-level stage with disjoint success/failure
+  * teardown. Unlike [[flow]], a failure in any phase is **propagated** (after
+  * body-failure teardown), not turned into a `System.exit`, so the
+  * crash→`resetHard`→resume wiring is directly testable. A phase that reports
+  * to the event surface first escapes wrapped in
+  * [[orca.runner.SurfacedFlowFailure]]`(cause)`; a failure from BEFORE the
+  * dispatcher and agents exist (e.g. an agent-override factory) has no event
+  * surface and escapes unwrapped.
   *
-  * `extraListeners` is the full listener set this run should observe beyond the
-  * interaction's own (the CLI wrapper adds its [[CostTracker]] here); a
-  * [[LoggingListener]] is always appended. `globalSettingsPath` is the
-  * user-global settings file location — defaulted to
-  * [[orca.settings.GlobalSettings.default]] and overridden only by tests, which
-  * must never read the developer's real `~/.config`.
+  * `extraListeners` is the listener set beyond the interaction's own (the CLI
+  * wrapper adds its [[CostTracker]] here); a [[LoggingListener]] is always
+  * appended. `globalSettingsPath` is overridden only by tests, which must never
+  * read the developer's real `~/.config`.
   */
 private[orca] def runFlow(
     args: OrcaArgs,
@@ -264,17 +223,16 @@ private[orca] def runFlow(
     wiring: FlowWiring = FlowWiring()
 )(body: FlowControl ?=> Unit): Unit =
   val debug = OrcaDebug.enabled || args.verbose.value
-  // Acquire both reentrancy/concurrency guards before anything else
-  // — including before `supervised:`, since neither needs an `Ox` scope — so
-  // a violation is caught before any git mutation. See [[FlowLock]] for the
-  // two-layer rationale and the release-ordering symmetry.
+  // Acquire both guards before `supervised:` (neither needs an `Ox` scope) so a
+  // violation is caught before any git mutation. See [[FlowLock]] for the
+  // two-layer rationale and release-ordering symmetry.
   FlowLock.acquireProcess()
   try
     val lockPath = FlowLock.acquireWorkdir(workDir)
     try
       // Default TerminalInteraction is built inside `supervised:` because its
       // worker is a `forkUser` bound to that scope; close() in the body's
-      // `finally` lets the worker drain and exit before the scope joins it.
+      // `finally` lets it drain before the scope joins it.
       supervised:
         val effectiveInteraction = interaction.getOrElse(
           TerminalInteraction.start(workDir = Some(workDir))
@@ -289,13 +247,11 @@ private[orca] def runFlow(
             progressStore.getOrElse(
               ProgressStore.default(workDir, args.userPrompt)
             )
-          // One wiring bundle handed to every agent factory — overrides and
-          // defaults build against the SAME event sink (dispatcher),
-          // interaction, workDir and prompts, so a user agent is wired into the
-          // run exactly like the default ones. Agent construction is pure —
-          // backends are created but no subprocess spawns until the first gated
-          // `run` — and runs BEFORE the reporting bracket below, so a factory
-          // failure escapes unwrapped (there are no agents to close yet).
+          // One wiring bundle handed to every agent factory, so overrides and
+          // defaults build against the SAME dispatcher, interaction, workDir and
+          // prompts. Agent construction is pure (no subprocess spawns until the
+          // first gated `run`) and runs BEFORE the reporting bracket below, so a
+          // factory failure escapes unwrapped (no agents to close yet).
           val agentWiring = AgentWiring(
             events = dispatcher,
             interaction = effectiveInteraction,
@@ -309,26 +265,21 @@ private[orca] def runFlow(
           )
           val fsTool = wiring.fs.getOrElse(new OsFsTool(workDir))
           val log = LoggerFactory.getLogger("orca.flow")
-          // Ownership-transfer guard: between here and the context taking
-          // ownership at construction, the wired agents (and the resolved role
-          // agents) have no owner whose close() runs on failure. If an
-          // exception escapes before the transfer, close them best-effort — the
-          // five wired agents, then any FOREIGN role (an override built from a
-          // separate backend). A settings-resolved or `copyTool`-sibling role
-          // shares a wired backend, already closed via `agents.all`, so it's
-          // filtered out here to avoid closing the same backend twice (post
-          // transfer `ctx.close()` stays unconditional, leaning on backend
-          // idempotence, but the pre-transfer guard can be precise). git/gh/fs
-          // hold no closeable resources, so the agents are all it must cover.
+          // Ownership-transfer guard: until the context takes ownership at
+          // construction, the wired and role agents have no owner whose close()
+          // runs on failure. If an exception escapes before the transfer, close
+          // them best-effort — the wired agents, then any FOREIGN role (an
+          // override from a separate backend). A settings-resolved or
+          // `copyTool`-sibling role shares a wired backend already covered by
+          // `agents.all`, so it's filtered out to avoid a double close. git/gh/fs
+          // hold no closeable resources.
           var roles: List[Agent[?]] = Nil
           var transferred = false
           try
             // Pre-context equivalent of `FlowLifecycle.run`'s `surfaced`
             // bracket: report the failure to the event surface, log, print the
-            // stack under `--verbose`/debug, and rethrow as
-            // `SurfacedFlowFailure` so `flow()` exits without re-printing. No
-            // `reportOnce` here — pre-context there is no second reporter that
-            // could double-report the same throwable.
+            // stack under debug, and rethrow as `SurfacedFlowFailure` so
+            // `flow()` exits without re-printing.
             def surfaced[T](op: => T): T =
               try op
               catch
@@ -339,25 +290,21 @@ private[orca] def runFlow(
                   log.debug("flow aborted", e)
                   if debug then e.printStackTrace(System.err)
                   throw SurfacedFlowFailure(e)
-            // Read both settings files, then resolve the three roles (override
-            // > project > global > default) and everything derived from that
-            // resolution — the announcement text and any foreign-agent warnings
-            // — in one place (`RoleAgents.resolveAll`, ADR 0020 §10). Inside
-            // `surfaced` so a malformed file, a bad model pin, or a throwing
-            // override reaches the event surface before aborting — and BEFORE
-            // any tree mutation, since setup (and its `ensureClean`) runs after.
+            // Read both settings files, then resolve the three roles and
+            // derived announcement/warnings in one place (`RoleAgents.resolveAll`,
+            // ADR 0020 §10). Inside `surfaced` so a malformed file, bad model pin
+            // or throwing override reaches the event surface before aborting, and
+            // BEFORE any tree mutation (setup runs after).
             val (resolvedRoles, settingsRead) = surfaced:
               val read = FlowLifecycle.readSettings(
                 workDir,
                 globalSettingsPath,
                 stackSettings
               )
-              // Cover each resolved role in the pre-transfer close guard AS it
-              // resolves — the wired backends are already covered via
-              // `agents.all`, so only a foreign override adds anything (filtered
-              // below). Appended incrementally (not from the returned
-              // `RoleResolution`) so an earlier foreign role is still closed when
-              // a LATER override throws and `resolveAll` never returns.
+              // Cover each resolved role in the close guard AS it resolves,
+              // appended incrementally (not from the returned `RoleResolution`)
+              // so an earlier foreign role is still closed when a LATER override
+              // throws and `resolveAll` never returns.
               val resolution = RoleAgents.resolveAll(
                 read.projectAgents,
                 read.globalAgents,
@@ -370,8 +317,8 @@ private[orca] def runFlow(
               dispatcher.onEvent(OrcaEvent.Step(resolution.announcement))
               (resolution.roles, read)
             // Setup (branch + log binding, stack discovery) runs BEFORE the
-            // context is constructed, so its outcome is a constructor input
-            // rather than late-bound state; it drives the CODING role.
+            // context so its outcome is a constructor input; it drives the
+            // CODING role.
             val flowSetup = surfaced(
               FlowLifecycle.setup(
                 args,
@@ -387,9 +334,7 @@ private[orca] def runFlow(
             )
             // Open the three runtime `Agent[?]` roles into their own backend
             // tags so `DefaultFlowContext` is concretely typed and each role's
-            // sessions thread. The single case matches every tuple of the three
-            // `Agent[?]` values — the type-variable patterns just bind each
-            // existential's tag.
+            // sessions thread.
             val ctx = (
               resolvedRoles.planning,
               resolvedRoles.coding,
@@ -411,10 +356,10 @@ private[orca] def runFlow(
                   stackSettings = flowSetup.stackSettings
                 )
             transferred = true
-            // From here on, `ctx.close()` runs in this `finally`, BEFORE the
-            // `supervised` scope joins its forks: it destroys the opencode
-            // `serve` process so its drain forks' reads EOF and the join can't
-            // hang (Ox runs `releaseAfterScope` only after the join).
+            // `ctx.close()` runs here, BEFORE the `supervised` scope joins its
+            // forks: it destroys the opencode `serve` process so its drain
+            // forks' reads EOF and the join can't hang (Ox runs
+            // `releaseAfterScope` only after the join).
             try
               FlowLifecycle.run(ctx, flowSetup, returnToStartBranch, debug)(
                 body
@@ -430,10 +375,9 @@ private[orca] def runFlow(
   finally FlowLock.releaseProcess()
 
 private def installUncaughtExceptionHandler(): Unit =
-  // Idempotent across nested or repeated `flow(...)` calls — we only install
-  // our handler if no app-specific one is already in place. The `orca` logger
-  // is routed to the trace file only (see `OrcaLog`), so the message goes
-  // straight to the console via stderr; the stack follows it into the trace.
+  // Idempotent across nested or repeated `flow(...)` calls: install only if no
+  // handler is already in place. The `orca` logger routes to the trace file
+  // only, so the message goes to stderr and the stack into the trace.
   if Thread.getDefaultUncaughtExceptionHandler == null then
     val log = LoggerFactory.getLogger("orca")
     Thread.setDefaultUncaughtExceptionHandler: (thread, throwable) =>

--- a/runner/src/main/scala/orca/runner/DefaultFlowContext.scala
+++ b/runner/src/main/scala/orca/runner/DefaultFlowContext.scala
@@ -11,8 +11,8 @@ import ox.discard
 /** Production FlowContext wiring. Constructed by `runFlow` AFTER the three role
   * agents are resolved and lifecycle setup has run, so the role agents and
   * `stackSettings` are plain constructor facts. Ownership of the wired agents
-  * transfers here at construction: from that point `close()` is the sole
-  * disposal path (before it, `runFlow`'s ownership guard covers them).
+  * transfers here at construction; from that point `close()` is the sole
+  * disposal path.
   */
 private[orca] class DefaultFlowContext[
     PB <: BackendTag,
@@ -22,11 +22,9 @@ private[orca] class DefaultFlowContext[
     val userPrompt: String,
     val workDir: os.Path,
     dispatcher: EventDispatcher,
-    // The three role agents (ADR 0020), resolved by `runFlow` from settings
-    // against the wired agent set (with per-role programmatic overrides on
-    // top). Each is concretely typed via its own tag parameter — opened from
-    // the runtime `Agent[?]` values with type-variable patterns — so the role
-    // type members pin them and sessions thread.
+    // The three role agents (ADR 0020), resolved by `runFlow`. Each is
+    // concretely typed via its own tag parameter so the role type members pin
+    // them and sessions thread.
     val planningAgent: Agent[PB],
     val codingAgent: Agent[CB],
     val reviewAgent: Agent[RB],
@@ -43,32 +41,22 @@ private[orca] class DefaultFlowContext[
 ) extends FlowControl,
       orca.StageFrames:
 
-  // Each role's backend tag, pinned from its type parameter. Concrete here, so
-  // the role accessors are concretely typed and sessions thread; abstract when
-  // the context is seen as `FlowContext` in a body, where the path-dependent
-  // `ctx.PlanB` / `ctx.CodeB` / `ctx.ReviewB` are still stable.
+  // Each role's backend tag, pinned from its type parameter — concrete here so
+  // the role accessors are concretely typed and sessions thread.
   type PlanB = PB
   type CodeB = CB
   type ReviewB = RB
 
   export wired.{claude, codex, opencode, pi, gemini}
 
-  /** Tear down context-owned background resources by closing every wired agent
-    * plus the three resolved role agents. Runs in the flow body's `finally`,
-    * before the flow scope joins its forks (see
-    * [[orca.backend.AgentBackend.close]]).
+  /** Tear down context-owned resources by closing every wired agent plus the
+    * three resolved role agents. Runs in the flow body's `finally`, before the
+    * flow scope joins its forks (see [[orca.backend.AgentBackend.close]]).
     *
-    * The role agents are UNCONDITIONALLY appended to the fan-out rather than
-    * filtered by [[WiredAgents.isWiredBackend]] first: a foreign role agent (a
-    * programmatic override like `_ => myPrebuiltAgent`, built from a separate
-    * `AgentWiring`/backend) is otherwise unreachable from the wired set and
-    * would leak past flow end, and a role that DOES share a wired backend (the
-    * common settings-resolved and `_.claude.opus` cases) just gets `close()`
-    * called on it a second time — provably harmless, since every backend's
-    * `close()` is idempotent (the shared `closedFlag` latches via a plain
-    * `set`, opencode's teardown is CAS-guarded, and every other backend's
-    * `close()` is a no-op). Skipping the check here trades a handful of
-    * redundant `close()` calls for one less thing this method has to get right.
+    * The role agents are appended UNCONDITIONALLY rather than filtered by
+    * [[WiredAgents.isWiredBackend]]: a foreign role agent (an override built
+    * from a separate backend) is otherwise unreachable and would leak, while a
+    * role sharing a wired backend just gets a second, idempotent `close()`.
     */
   def close(): Unit =
     WiredAgents.closeBestEffort(
@@ -78,8 +66,8 @@ private[orca] class DefaultFlowContext[
   def emit(event: OrcaEvent): Unit = dispatcher.onEvent(event)
 
   // Written possibly from fork threads (`fail` inside a parallel block), read on
-  // the stage thread during unwind — pure atomic state, per the concurrency
-  // conventions. Identity comparison: the mark belongs to the object instance.
+  // the stage thread during unwind. Identity comparison: the mark belongs to the
+  // object instance.
   private val reportedErrors =
     new java.util.concurrent.atomic.AtomicReference[List[Throwable]](Nil)
   private[orca] def markErrorReported(e: Throwable): Unit =
@@ -87,7 +75,6 @@ private[orca] class DefaultFlowContext[
   private[orca] def errorAlreadyReported(e: Throwable): Boolean =
     reportedErrors.get().exists(_ eq e)
 
-  // Stage-identity bookkeeping (enterStage/exitStage/inStage and
-  // nextSessionOccurrence) comes from the shared `StageFrames` mixin — the
-  // single source of truth for the hierarchical frame-stack semantics, so the
-  // test doubles cannot drift from production.
+  // Stage-identity bookkeeping (enterStage/exitStage/inStage,
+  // nextSessionOccurrence) comes from the shared `StageFrames` mixin, so test
+  // doubles cannot drift from production.

--- a/runner/src/main/scala/orca/runner/FlowLifecycle.scala
+++ b/runner/src/main/scala/orca/runner/FlowLifecycle.scala
@@ -32,52 +32,34 @@ import ox.either.orThrow
 import scala.util.control.NonFatal
 
 /** Marker that a flow failure has ALREADY been reported to the user's event
-  * surface (an `OrcaEvent.Error` was emitted, the stack logged, and — under
-  * `--verbose`/debug — printed). Thrown by the `surfaced` brackets —
-  * `runFlow`'s pre-context one (lead resolution + setup) and
-  * [[FlowLifecycle.run]]'s (rehydration + body) — after they report `cause`, so
-  * `flow()` may discard it without re-reporting: the user has already seen the
-  * message.
-  *
-  * The contract is the whole point of the type: ANY other `NonFatal` exception
-  * escaping `runFlow` unwrapped means a code path that was NOT bracketed, i.e.
-  * an UNSURFACED failure — `flow()` treats that as the backstop and prints it
-  * to stderr rather than exiting silently. A `case class` so tests can
-  * pattern-match `case SurfacedFlowFailure(cause) => ...` and inspect the
-  * original directly.
+  * surface. Thrown by the `surfaced` brackets after they report `cause`, so
+  * `flow()` may discard it without re-reporting. The contract is the whole
+  * point of the type: any other `NonFatal` exception escaping `runFlow`
+  * unwrapped means a code path that was NOT bracketed — an unsurfaced failure
+  * `flow()` prints to stderr as a backstop rather than exiting silently.
   */
 private[orca] final case class SurfacedFlowFailure(cause: Throwable)
     extends RuntimeException(cause)
 
-/** Flow setup/teardown/recovery lifecycle (ADR 0018 §2.4/§2.5). Extracted from
-  * the `flow` entry point so `flow.scala` holds only the entry point and
-  * orchestration: this object owns the privileged, outside-any-user-stage git
-  * and progress-store mutations that bracket the body.
+/** Flow setup/teardown/recovery lifecycle (ADR 0018 §2.4/§2.5). Owns the
+  * privileged, outside-any-user-stage git and progress-store mutations that
+  * bracket the body.
   */
 object FlowLifecycle:
 
-  /** The context-bound phases of one run, in their mandated order: session
-    * rehydration → body → disjoint success/failure teardown. Extracted here so
-    * the ordering invariants that used to live as comments in the runner's
-    * entry point have one executable owner (ADR 0018 §2.4/§2.5). [[setup]]
-    * (branch + log binding) is NOT a phase here — `runFlow` runs it BEFORE
-    * constructing the context, so `flowSetup`'s outcome (the resolved stack
-    * settings) arrives as a constructor input.
+  /** The context-bound phases of one run, in mandated order: session
+    * rehydration → body → disjoint success/failure teardown (ADR 0018
+    * §2.4/§2.5). [[setup]] (branch + log binding) is not a phase here —
+    * `runFlow` runs it before constructing the context, so `flowSetup`'s
+    * resolved stack settings arrive as a constructor input.
     *
-    * Failure path: the two phases — rehydration and the body — run inside the
-    * `surfaced` bracket, which reports the error (unless the exception already
-    * reported itself), logs, and rethrows a [[SurfacedFlowFailure]] so `flow()`
-    * never exits without an explanation. The body phase additionally runs
-    * `teardownFailure` on the way out.
-    *
-    * Success path runs `teardownSuccess` OUTSIDE `surfaced`, deliberately: it
-    * is already internally best-effort (every leg is wrapped in `bestEffort`,
-    * so nothing `NonFatal` can escape it), and wrapping a phase that can't fail
-    * with a bracket meant for reporting failures would be directionally wrong —
-    * it would convert a future non-`bestEffort` leg into a *reported, failed*
-    * successful run instead of the silent cosmetic failure `teardownSuccess`'s
-    * own contract promises. So the phase protocol is two bracketed phases plus
-    * one best-effort phase, not three bracketed ones.
+    * Rehydration and the body run inside the `surfaced` bracket, which reports
+    * the error, logs, and rethrows a [[SurfacedFlowFailure]] so `flow()` never
+    * exits without an explanation; the body phase additionally runs
+    * `teardownFailure` on the way out. `teardownSuccess` runs OUTSIDE
+    * `surfaced` deliberately: it is already internally best-effort, and a
+    * bracket meant for reporting failures would convert a cosmetic teardown
+    * failure into a reported, failed successful run.
     *
     * The failure and success teardowns are structurally disjoint — the body
     * catch rethrows, so success teardown is unreachable on a body failure.
@@ -89,15 +71,11 @@ object FlowLifecycle:
       debug: Boolean
   )(body: FlowControl ?=> Unit): Unit =
     val log = LoggerFactory.getLogger("orca.flow")
-    // Report/log/wrap bracket applied to every phase that CAN fail —
-    // rehydration and the body — so none of them can reach `flow()` unreported
-    // and exit 1 in silence. Phase-agnostic by design: it reports once
+    // Report/log/wrap bracket for every phase that can fail. Reports once
     // (reusing the context's reported-set so it never double-prints a failure
     // a nested stage already surfaced), logs, prints the stack under
-    // `--verbose`/debug, then throws `SurfacedFlowFailure`. It carries NO
-    // teardown side effect — `teardownFailure` (git reset) is the body phase's
-    // job alone (below). Success teardown is NOT wrapped here — see its own
-    // scaladoc for why.
+    // `--verbose`/debug, then throws `SurfacedFlowFailure`. Carries no teardown
+    // side effect — `teardownFailure` is the body phase's job alone (below).
     def surfaced[T](op: => T): T =
       try op
       catch
@@ -109,36 +87,19 @@ object FlowLifecycle:
           if debug then e.printStackTrace(System.err)
           throw SurfacedFlowFailure(e)
     surfaced(rehydrateSessions(ctx, ctx.codingAgent, ctx.progressStore))
-    // The whole flow body runs as a top-level stage: an otherwise
-    // unhandled exception surfaces as a single Error event (the same
-    // message a stage failure shows). A nested stage / `fail` marks the
-    // throwable reported on the context once it has surfaced it, so
-    // `surfaced`'s `reportOnce` above doesn't re-report it. The stack goes to
-    // the trace file only (DEBUG, below the console's WARN threshold);
-    // `--verbose` also prints it to stderr.
-    //
-    // Teardown separation: body-failure and body-success teardowns are
-    // completely disjoint — structurally, not flag-guarded: the catch below
-    // rethrows, so success teardown is unreachable on failure. A
-    // success-teardown error (e.g. a cosmetic cleanup-commit failure) must
-    // NOT trigger the failure teardown (`resetHard`), and must NOT strand
-    // the user on the feature branch. `teardownFailure` runs OUTSIDE
-    // `surfaced` (which is side-effect-free) and only here, in the body phase.
+    // The whole flow body runs as a top-level stage: an otherwise unhandled
+    // exception surfaces as a single Error event. `teardownFailure` runs only
+    // here in the body phase, so a success-teardown error can never trigger
+    // `resetHard` or strand the user on the feature branch.
     try surfaced(body(using ctx))
     catch
       case f @ SurfacedFlowFailure(e) =>
         // `e` was already reported by `surfaced`. Discard the failed stage's
-        // partial edits; if the reset ITSELF fails, attach it as suppressed so
-        // it travels with `e` rather than masking the original body failure
-        // the user needs to see. `e` was reported (and its stack printed
-        // under `--verbose`) BEFORE this reset ran, so the suppressed
-        // teardown failure would otherwise never reach the console/trace —
-        // log and (under the same `--verbose`/debug flag) print it here. Also
-        // emit a user-visible `Step` (in ADDITION to, not instead of, the
-        // suppressed exception + debug log): `emit` is total (the dispatcher
-        // quarantines a misbehaving listener), so it's safe to call from this
-        // catch, and the user needs to know the working tree may still hold
-        // the failed run's partial edits.
+        // partial edits; if the reset itself fails, attach it as suppressed so
+        // it travels with `e` rather than masking the original failure. Since
+        // `e` was already reported before this reset ran, log and print the
+        // suppressed failure here too, and emit a user-visible `Step` so the
+        // user knows the tree may still hold the failed run's partial edits.
         try teardownFailure(ctx.git)
         catch
           case NonFatal(t) =>
@@ -155,18 +116,13 @@ object FlowLifecycle:
     teardownSuccess(ctx.git, flowSetup, returnToStartBranch)
 
   /** Replay the persisted resume-wire-id map (ADR 0018 §2.6) into each
-    * session's OWN agent's in-memory registry, so a resumed run resumes against
-    * the right wire id and the existence probes target the right id. Reads
-    * every [[orca.progress.SessionRecord]] that carries a `resumeWireId` and
-    * registers it — via [[orca.agents.Agent.registerResumeWireId]] — into the
-    * agent [[targetAgent]] resolves for the record's `backend` tag: untagged
-    * (older) records go to `lead`, a tag matching one of `ctx`'s per-backend
-    * accessors goes there, and a tag matching none of them (an edited log, or a
-    * renamed [[BackendTag]] case) is skipped rather than guessed — LOUDLY, via
-    * an `OrcaEvent.Step` (`ctx.emit`), not a silent for-comprehension drop.
-    * `record.id`/`wireId` are equally untrusted (log-sourced): a value that
-    * fails [[SessionId.parse]]/[[WireSessionId.parse]] is skipped the same loud
-    * way rather than rehydrated raw.
+    * session's own agent's in-memory registry, so a resumed run resumes against
+    * the right wire id. For each [[orca.progress.SessionRecord]] carrying a
+    * `resumeWireId`, registers it into the agent [[targetAgent]] resolves for
+    * the record's `backend` tag. A tag matching no known backend (edited log or
+    * renamed [[BackendTag]] case) is skipped loudly via an `OrcaEvent.Step`
+    * rather than guessed. `record.id`/`wireId` are equally untrusted
+    * (log-sourced): a value that fails to parse is skipped the same loud way.
     */
   private[orca] def rehydrateSessions(
       ctx: FlowContext,
@@ -190,13 +146,8 @@ object FlowLifecycle:
         case Some(agent) =>
           register(ctx, agent, record, wireId)
 
-  /** Untagged records (older logs) go to the lead — the pre-tagging behaviour.
-    * A tag that matches no accessor (edited log, or a renamed [[BackendTag]]
-    * case whose [[BackendTag.wireName]] no longer matches) is skipped, not
-    * guessed. `DefaultFlowContext` holds all five per-backend agents as eager
-    * constructor vals, so resolving an accessor here just reads the
-    * already-constructed agent — touching it is safe even for backends the flow
-    * body never otherwise uses.
+  /** Untagged records go to the lead; a tag matching no accessor (edited log,
+    * or a renamed [[BackendTag]] case) is skipped, not guessed.
     */
   private def targetAgent(
       ctx: FlowContext,
@@ -209,8 +160,7 @@ object FlowLifecycle:
 
   /** Parse `record.id`/`wire` (both log-sourced, untrusted) and register the
     * mapping into `agent`; a value that fails to parse is skipped with a
-    * visible warning rather than rehydrated raw — mirrors `session(...)`'s
-    * reuse arm treatment of a corrupt recorded id.
+    * visible warning rather than rehydrated raw.
     */
   private def register[B <: BackendTag](
       ctx: FlowContext,
@@ -229,12 +179,10 @@ object FlowLifecycle:
         )
 
   /** ADR 0019 migration warning: a repo that gitignores `.orca/` keeps the
-    * committed stack settings at `.orca/settings.properties` out of version
-    * control, so every run names the likely `.orca/` line to remove. Skipped
-    * when a programmatic override is in force — such a run neither reads nor
-    * writes the file, so the warning would be noise. The probe is best-effort
-    * ([[GitTool.isIgnored]] answers `false` when it cannot tell) and never
-    * fails the flow.
+    * committed stack settings out of version control, so every run names the
+    * likely `.orca/` line to remove. Skipped under a programmatic override
+    * (which neither reads nor writes the file). Best-effort and never fails the
+    * flow.
     */
   private def warnIfSettingsIgnored(
       git: GitTool,
@@ -255,12 +203,9 @@ object FlowLifecycle:
     * resolved stack settings (ADR 0019).
     *
     * `featureBranch` is a [[FeatureBranch]], not a bare `String`: both arms of
-    * `setup` only ever construct one via [[FeatureBranch.resolve]] (the fresh
-    * arm directly, the resume arm via [[RecoveryCheck.validateHeader]]), so
-    * "delete/checkout an unvalidated name" is unrepresentable here — a
-    * protected name can never reach this field, not just "doesn't today because
-    * nothing upstream produces one." `finishBranch` unwraps `.value` only at
-    * the actual `GitTool` call sites.
+    * `setup` construct one via [[FeatureBranch.resolve]], so a protected name
+    * can never reach this field — "delete/checkout an unvalidated name" is
+    * unrepresentable here.
     */
   private[orca] case class FlowSetup(
       store: ProgressStore,
@@ -274,47 +219,39 @@ object FlowLifecycle:
     * dirty tree, then either resumes an existing log or starts fresh (resolve a
     * branch name, create it, write + commit the header). All git/store
     * mutations run with a runtime-minted `WorkspaceWrite`, and branch-name
-    * resolution (which may call the cheap model) with a runtime-minted
-    * `InStage` — setup is privileged, predating any user stage.
+    * resolution with a runtime-minted `InStage` — setup is privileged,
+    * predating any user stage.
     *
-    * The progress header is **untrusted input** on load (the log is
-    * human-visible and pushable), so a resumed run:
-    *   - Snapshots the log file BEFORE `ensureClean` and restores it if the
+    * The progress header is untrusted input on load (the log is human-visible
+    * and pushable), so a resumed run:
+    *   - Snapshots the log file before `ensureClean` and restores it if the
     *     stash removed it, so the header is always readable.
     *   - Validates the header before any destructive action (safe refs,
     *     prompt-hash match, no protected feature branch). A
-    *     parseable-but-invalid header is a HARD abort (`OrcaFlowException`),
-    *     not a silent fresh start — it signals tampering or a mismatch. (An
-    *     *unparseable* log is `loadDetailed() == Corrupt(reason)` → fresh run,
-    *     but WARNED (logger + `emit(Step)`) since it's distinguishable from a
-    *     genuinely absent log; that path is separate below.)
-    *   - Cross-checks that the current branch is the one the header records
-    *     (the in-place invariant): a log that surfaced on a branch it does not
-    *     name (e.g. its feature branch was merged, carrying the log along)
-    *     aborts rather than resuming against the wrong branch.
+    *     parseable-but-invalid header is a hard abort (`OrcaFlowException`),
+    *     not a silent fresh start. (An unparseable log → fresh run, but warned
+    *     since it's distinguishable from a genuinely absent log.)
+    *   - Cross-checks that the current branch is the one the header records: a
+    *     log that surfaced on a branch it does not name (e.g. carried along by
+    *     a merge) aborts rather than resuming against the wrong branch.
     *
     * On resume `startBranch` is the header's recorded `startingBranch` (the
-    * ORIGINAL branch at first run), so when a run does return to start (a PR
-    * flow via `returnToStartBranch`, or a throwaway) it goes to that original
-    * branch — exactly like a fresh run — not the re-run's current (feature)
-    * branch.
+    * original branch at first run), so a return-to-start goes to that original
+    * branch, not the re-run's current feature branch.
     */
   private[orca] def setup(
       args: OrcaArgs,
-      // The resolved CODING-role agent (ADR 0020): branch-name resolution and
+      // The resolved coding-role agent (ADR 0020): branch-name resolution and
       // stack discovery — the run's privileged pre-body model calls — run here.
       agent: Agent[?],
       git: GitTool,
       workDir: os.Path,
       branchNaming: Option[BranchNamingStrategy],
-      // The stack resolution, parsed by `runFlow` upstream inside the
-      // dispatcher-surfaced bracket (ADR 0020 §6). Setup does not touch the
-      // settings file itself, so a malformed file has already aborted before
-      // this point.
+      // The stack resolution, parsed by `runFlow` upstream (ADR 0020 §6); a
+      // malformed file has already aborted before this point.
       resolution: SettingsResolution,
       // True when `flow(stackSettings = Some(...))` governs the stack commands,
-      // gating the gitignored-settings migration warning (the run neither reads
-      // nor writes the file's stack portion, so the warning would be noise).
+      // gating the gitignored-settings migration warning.
       stackOverridden: Boolean,
       store: ProgressStore,
       emit: OrcaEvent => Unit
@@ -331,24 +268,19 @@ object FlowLifecycle:
     restoreLogIfMissing(store.path, snapshot)
     // Discovery (ADR 0019) is sequenced after `ensureClean` (whose `stash -u`
     // would stash a just-written untracked file straight back out of the
-    // tree). When it runs, the written file gets its OWN commit
-    // (`commitDiscoveredSettings`, below) on both arms — after branch creation
-    // on the fresh arm, right after this write on the resume arm — so no later
-    // `add -A` sweep silently carries it under an unrelated message.
-    // `discovered` flags that the write happened, gating those commits; the
-    // override/file-present paths leave it `false` and are untouched.
-    // Catch-free: a discovery failure aborts setup as a surfaced failure — see
-    // [[StackDiscovery.discover]] for the ADR rationale (no
-    // degrade-to-empty-file).
+    // tree). When it runs, the written file gets its own commit
+    // (`commitDiscoveredSettings`, below), so no later `add -A` sweep carries
+    // it under an unrelated message. `discovered` flags that the write
+    // happened, gating those commits. A discovery failure aborts setup as a
+    // surfaced failure (no degrade-to-empty-file — see [[StackDiscovery]]).
     val (stackSettings, discovered) = resolution match
       case SettingsResolution.Resolved(settings) => (settings, false)
       case SettingsResolution.NeedsDiscovery(existingContent) =>
         val (settings, entries) = StackDiscovery.discover(agent, workDir, emit)
-        // Absent file → write the whole rendered file (header + entries). A
-        // present-but-stack-silent file (an agents-only hand-written file, its
-        // content captured pre-stash) → APPEND the rendered stack entries below
-        // the user's untouched agent lines, so discovery never clobbers agent
-        // keys (ADR 0020 §7). `os.write.over` because the stash may have
+        // Absent file → write the whole rendered file. An agents-only
+        // hand-written file (content captured pre-stash) → append the stack
+        // entries below the untouched agent lines, so discovery never clobbers
+        // agent keys (ADR 0020 §7). `os.write.over` because the stash may have
         // already swept an untracked file out of the tree.
         val fileText = existingContent match
           case None => SettingsFile.render(entries)
@@ -365,33 +297,21 @@ object FlowLifecycle:
           )
         )
         (settings, true)
-    // The protected set BOTH arms enforce: the always-protected floor
-    // (`main`/`master`) plus the repo's ACTUAL detected default branch
-    // (best-effort — `git.defaultBranch()` is read-only/cheap and already
-    // collapses "no remote"/detection failure to `None` internally, so a
-    // failed detection silently falls back to just the floor here, exactly
-    // as it already does for the resume arm). Computed ONCE so the fresh arm
-    // (via `FeatureBranch.resolve`) and the resume arm (via
-    // `RecoveryCheck.validateHeader`) apply the identical policy from the
-    // identical set — this is what makes "a protected name can never reach
-    // `FlowSetup.featureBranch`" true from either arm.
+    // The protected set both arms enforce: the always-protected floor
+    // (`main`/`master`) plus the repo's detected default branch (best-effort;
+    // failed detection falls back to just the floor). Computed once so the
+    // fresh and resume arms apply the identical policy from the identical set.
     val protectedBranches =
       RecoveryCheck.alwaysProtected ++ git
         .defaultBranch()
         .map(_.toLowerCase(java.util.Locale.ROOT))
     val (featureBranch, effectiveStartBranch) = store.loadDetailed() match
       case ProgressStore.LoadResult.Corrupt(reason) =>
-        // The log file exists but didn't parse — a truncated/corrupted write,
-        // not the normal "no log yet" case. We still start fresh (there's no
-        // sane way to resume from unparseable data), but the user may have
-        // expected a resume, so this must be LOUD, not silently
-        // indistinguishable from a first run. The dispatcher is live by the
-        // time `setup` runs, so its `emit` is threaded in: an `OrcaEvent.Step`
-        // (there's no Warning case — Step matches `GitTool`'s convention for a
-        // non-fatal note) reaches BOTH the terminal renderer and any custom
-        // Interaction's listeners (e.g. Slack), which a raw stderr line never
-        // would. The logger keeps the DEBUG trace; we emit the Step INSTEAD of
-        // a stderr line so a terminal user doesn't see it twice.
+        // The log file exists but didn't parse. Start fresh (no sane way to
+        // resume from unparseable data), but loudly — the user may have
+        // expected a resume, so this must be distinguishable from a first run.
+        // The `emit(Step)` reaches both the terminal renderer and custom
+        // Interaction listeners (e.g. Slack); the logger keeps the DEBUG trace.
         log.warn(
           s"progress log at ${store.path} is corrupt ($reason); starting fresh"
         )
@@ -430,9 +350,8 @@ object FlowLifecycle:
         (branch, startBranch)
       case ProgressStore.LoadResult.Loaded(progressLog) =>
         val header = progressLog.header
-        // Validate the untrusted header before any destructive action. The
-        // protected set is the main/master floor plus the repo's ACTUAL default
-        // branch (best-effort), so a tampered header naming e.g. `trunk` as a
+        // Validate the untrusted header before any destructive action, against
+        // the same protected set — a tampered header naming e.g. `trunk` as a
         // feature branch is refused too.
         val featureBranch =
           RecoveryCheck.validateHeader(
@@ -445,7 +364,7 @@ object FlowLifecycle:
                 s"refusing to resume: progress log header failed validation ($reason)"
               )
             case Right(featureBranch) => featureBranch
-        // Only resume IN PLACE. If the log surfaced on a branch it does not
+        // Only resume in place. If the log surfaced on a branch it does not
         // name, it was likely carried here by a merge — abort, don't replay.
         val current = git.currentBranch()
         if current != header.branch then
@@ -454,24 +373,21 @@ object FlowLifecycle:
               s"'$current' — was it merged? aborting rather than resuming " +
               "against the wrong branch"
           )
-        // Resume in place: already on header.branch. The recorded start branch
-        // (where a PR flow / throwaway returns to) is the ORIGINAL one, not this
-        // feature branch. The branch already exists, so a just-discovered
-        // settings file gets its dedicated commit right here (ADR 0019) — this
-        // arm has no header commit that would otherwise sweep it in.
+        // The recorded start branch (where a return-to-start goes) is the
+        // original one, not this feature branch. The branch already exists, so
+        // a just-discovered settings file gets its dedicated commit right here
+        // (ADR 0019) — this arm has no header commit that would sweep it in.
         if discovered then commitDiscoveredSettings(git, workDir)
         (featureBranch, header.startingBranch)
     FlowSetup(store, featureBranch, effectiveStartBranch, stackSettings)
 
   /** Outcome of the pre-`ensureClean` stack read: either the resolved values,
     * or the marker that auto-discovery must run. `NeedsDiscovery` carries the
-    * existing file content (ADR 0020 §7): `None` when the file is absent OR
-    * present-but-blank (write the whole file — a blank file has no agent lines
-    * to preserve), `Some(content)` when the file exists, is non-blank, and
-    * names no stack line (an agents-only hand-written file — append the stack
-    * entries, leaving the agent lines untouched). Its content is captured
-    * pre-stash so a hand-written file the stash sweeps out of a dirty tree is
-    * not lost.
+    * existing file content (ADR 0020 §7): `None` when the file is absent or
+    * blank (write the whole file), `Some(content)` for an agents-only
+    * hand-written file (append the stack entries, leaving agent lines
+    * untouched). Content is captured pre-stash so a hand-written file the stash
+    * sweeps out of a dirty tree is not lost.
     */
   private[runner] enum SettingsResolution:
     case Resolved(settings: StackSettings)
@@ -479,8 +395,7 @@ object FlowLifecycle:
 
   /** The parsed outcome of both settings files (ADR 0020 §6): the stack
     * resolution, plus the project- and user-global agent keys kept separate so
-    * `runFlow` can track each role's source (project/global/default) for the
-    * announcement `Step`.
+    * `runFlow` can track each role's source for the announcement `Step`.
     */
   private[runner] case class SettingsRead(
       stack: SettingsResolution,
@@ -488,24 +403,20 @@ object FlowLifecycle:
       globalAgents: AgentSettings
   )
 
-  /** Read + parse both settings files once, before any tree mutation (design
-    * decision 6). The project file (`{workDir}/.orca/settings.properties`)
-    * carries both families; the user-global file (`globalSettingsPath`) carries
-    * agent keys only. An unreadable or malformed file — project OR global — is
+  /** Read + parse both settings files once, before any tree mutation (ADR 0020
+    * §6). The project file carries both families; the user-global file carries
+    * agent keys only. An unreadable or malformed file — project or global — is
     * a hard abort ([[OrcaFlowException]]); the caller sequences this ahead of
     * `ensureClean`, so a malformed file aborts with no stash and no branch
     * mutation, and its content is captured before the stash can sweep it away.
-    * An absent global file yields no agent keys.
     *
     * A stack override (`flow(stackSettings = Some(...))`) fixes the stack
-    * resolution to [[SettingsResolution.Resolved]] and skips discovery, but the
-    * project file is STILL read and parsed — its agent keys are honoured and a
-    * malformed file still aborts (stricter than ADR 0019's stack-only override;
-    * ADR 0020 §6). Absent that override, the stack resolution follows the
-    * stack-aware discovery trigger (ADR 0020 §7): a present file whose content
-    * names a stack line (live or commented, per [[SettingsFile.hasStackLines]])
-    * resolves; an absent file, a blank file, or a present non-blank file with
-    * no stack line, needs discovery.
+    * resolution and skips discovery, but the project file is still read and
+    * parsed — its agent keys are honoured and a malformed file still aborts.
+    * Absent that override, the stack resolution follows the stack-aware
+    * discovery trigger (ADR 0020 §7): a present file naming a stack line (per
+    * [[SettingsFile.hasStackLines]]) resolves; an absent, blank, or
+    * stack-silent file needs discovery.
     */
   private[orca] def readSettings(
       workDir: os.Path,
@@ -513,22 +424,15 @@ object FlowLifecycle:
       stackOverride: Option[StackSettings]
   ): SettingsRead =
     val projectPath = OrcaDir.settingsPath(workDir)
-    // A repo can commit `.orca/settings.properties` — or `.orca` ITSELF — as a
-    // symlink (git mode 120000) pointing outside the tree. `os.exists`/`os.read`
-    // follow it, and the discovery write is `os.write.over(..., createFolders =
-    // true)` (CREATE + TRUNCATE_EXISTING, plus a `makeDir.all` for the parent),
-    // which also follows the link — so discovery output would land at the link's
-    // target, outside the working tree, for BOTH the fresh-write and the append
-    // sub-cases. `os.isLink` (lstat) inspects only the FINAL path component, so
-    // the leaf check alone misses a symlinked `.orca` DIRECTORY: the leaf then
-    // resolves to a plain absent name inside the target and slips through. Guard
-    // BOTH components here, before `ensureClean` and any tree mutation, rather
-    // than at the write site (which runs after the stash).
-    //
-    // `OrcaDir.ensureCache` (via `FlowLock.acquireWorkdir`) already refuses a
-    // symlinked `.orca` earlier in the run; the `.orca` check here is
-    // defense-in-depth on the discovery-write path, which reaches the directory
-    // through `createFolders` rather than through `ensureRoot`.
+    // A repo can commit `.orca/settings.properties` — or `.orca` itself — as a
+    // symlink pointing outside the tree, which `os.read`/`os.write.over` follow,
+    // landing discovery output at the target. `os.isLink` inspects only the
+    // final path component, so a symlinked `.orca` directory would slip past a
+    // leaf-only check; guard both components here, before any tree mutation,
+    // rather than at the post-stash write site. The `.orca` check is
+    // defense-in-depth: `OrcaDir.ensureCache` already refuses a symlinked
+    // `.orca` earlier, but the discovery write reaches the directory through
+    // `createFolders`, not `ensureRoot`.
     abortIfSymlink(OrcaDir.rootPath(workDir))
     abortIfSymlink(projectPath)
     val projectContent: Option[String] =
@@ -565,15 +469,12 @@ object FlowLifecycle:
   /** Abort the run if `path` is a symlink, before any read or write decision —
     * this runs ahead of `ensureClean`, so the abort precedes any tree mutation
     * and leaves the current branch untouched. `os.isLink` does not follow the
-    * final link, so a dangling link (target absent) is caught too, not just one
-    * whose target happens to exist.
+    * final link, so a dangling link is caught too.
     *
     * Accepted residual (TOCTOU): the check runs at read time and the discovery
-    * write happens later, in setup — a purely LOCAL race could swap a plain
-    * `.orca`/leaf for a symlink in that window. That is out of scope under the
-    * committed-repo-symlink threat model (the attacker controls repo content, a
-    * clone runs flows against it; they do not also race the local filesystem
-    * mid-run), so the local-race variant is left open deliberately.
+    * write happens later, so a purely local race could swap in a symlink in
+    * that window. Out of scope under the committed-repo-symlink threat model
+    * (the attacker controls repo content, not the local filesystem mid-run).
     */
   private def abortIfSymlink(path: os.Path): Unit =
     if os.isLink(path) then
@@ -605,30 +506,21 @@ object FlowLifecycle:
 
   /** Fresh run: resolve + create the branch (returned to the caller), then
     * commit the header so it is the branch's first commit. Shared by the
-    * genuinely-absent-log case and the corrupt-log case (which warns, then
-    * falls through to the same fresh start — there is no sane way to resume
-    * from unparseable data). Needs BOTH tokens: `InStage` because branch-name
-    * resolution may call the cheap model
-    * (`BranchNamingStrategy.shortenPrompt`), `WorkspaceWrite` for the git
+    * absent-log case and the corrupt-log case (which warns, then falls through
+    * to the same fresh start). Needs both tokens: `InStage` because branch-name
+    * resolution may call the cheap model, `WorkspaceWrite` for the git
     * checkout/commit and header write.
     *
-    * The resolved name is minted into a [[FeatureBranch]] before it ever
-    * reaches git: a strategy/cheap-model reply that collides with a protected
-    * branch (`main`, `master`, or the repo's detected default) is REFUSED, not
-    * bound to. Refusal falls back to a deterministic
-    * `BranchNamingStrategy.flowFallbackName(args.userPrompt)` (same prompt →
-    * same fallback, so a resumed run still finds the branch) — loudly, via an
-    * `OrcaEvent.Step` — rather than aborting the run: unattended/scheduled runs
-    * must not flip between success and failure purely because the cheap model's
-    * summary happened to phrase itself as "main" this time (mirrors
-    * `shortenPrompt`'s existing "naming never blocks the flow" idiom).
+    * The resolved name is minted into a [[FeatureBranch]] before it reaches
+    * git: a name colliding with a protected branch is refused and falls back to
+    * a deterministic `flowFallbackName` (same prompt → same fallback, so a
+    * resumed run still finds the branch), loudly, rather than aborting —
+    * unattended runs must not flip between success and failure because the
+    * cheap model's summary phrased itself as "main" this time.
     *
-    * The (now protection-checked) name still isn't bound to git yet:
-    * [[createFreshBranch]] applies the SAME "never silently adopt" policy to a
-    * git-level `BranchAlreadyExists` collision — an unrelated pre-existing
-    * branch (leftover from an earlier run, hand-created, or a slug collision
-    * between two different prompts) must never be silently checked out and
-    * carried into this run.
+    * [[createFreshBranch]] then applies the same "never silently adopt" policy
+    * to a git-level `BranchAlreadyExists` collision: an unrelated pre-existing
+    * branch must never be silently checked out and carried into this run.
     */
   private def freshRun(
       args: OrcaArgs,
@@ -645,9 +537,9 @@ object FlowLifecycle:
     val strategy =
       branchNaming.getOrElse(BranchNamingStrategy.shortenPrompt)
     val resolvedName = strategy.resolve(args.userPrompt, agent)
-    // Resolved once, eagerly: a cheap pure hash + set lookup, shared by BOTH
-    // fallback triggers below (a protected-name refusal and a git-level
-    // `BranchAlreadyExists` collision use the exact same deterministic name).
+    // Resolved once, shared by both fallback triggers below (a protected-name
+    // refusal and a git-level `BranchAlreadyExists` collision use the exact
+    // same deterministic name).
     val fallback = resolveFallback(args.userPrompt, protectedBranches)
     val protectionChecked =
       FeatureBranch.resolve(resolvedName, protectedBranches) match
@@ -660,10 +552,9 @@ object FlowLifecycle:
           )
           fallback
         case Left(UnsafeBranchRefRefused(name)) =>
-          // Unreachable: `strategy.resolve` (`BranchNamingStrategy`) always
-          // returns an already-slugged name, so `resolve`'s shape check can
-          // never refuse it. Guarded rather than assumed, matching
-          // `resolveFallback`'s existing defensive re-check below.
+          // Unreachable: `strategy.resolve` always returns an already-slugged
+          // name, so `resolve`'s shape check can never refuse it. Guarded
+          // defensively rather than assumed.
           throw new OrcaFlowException(
             s"internal error: strategy-resolved branch name '$name' is not " +
               "a safe ref"
@@ -671,8 +562,7 @@ object FlowLifecycle:
     val branch = createFreshBranch(git, protectionChecked, fallback, emit)
     // A just-discovered settings file gets its own commit here — after the
     // branch exists, before the header commit below — so the header commit
-    // carries only the progress log its message names (ADR 0019), not the
-    // settings file that the old `add -A` sweep pulled in silently.
+    // carries only the progress log its message names (ADR 0019).
     if discovered then commitDiscoveredSettings(git, workDir)
     store.writeHeader(
       ProgressHeader(
@@ -686,20 +576,15 @@ object FlowLifecycle:
     branch
 
   /** Give the just-discovered settings file its own commit (ADR 0019), so the
-    * header/stage commit that follows carries only what its message names.
-    * Called on both lifecycle arms whenever discovery actually wrote the file:
-    * the fresh arm after branch creation and before the header commit, the
-    * resume arm right after the write (the branch already exists).
+    * commit that follows carries only what its message names. Called on both
+    * lifecycle arms whenever discovery actually wrote the file.
     *
-    * Committed with [[GitTool.commitOnly]], whose commit pathspec guarantees
-    * the commit carries exactly this one path — anything else dirty or
-    * untracked in the tree (e.g. a progress log restored untracked by
-    * [[restoreLogIfMissing]]) stays out. NOT `forceAdd`: a repo that still
-    * ignores `.orca/` must keep the file ignored (the startup migration warning
-    * already covers it), so the commit is SKIPPED outright when
-    * [[GitTool.isIgnored]] reports the path excluded, leaving the file
-    * untracked for the user to commit after fixing the ignore. Only the
-    * progress log punches through the ignore, for resume correctness.
+    * [[GitTool.commitOnly]]'s pathspec guarantees the commit carries exactly
+    * this one path — anything else dirty or untracked stays out. Not
+    * `forceAdd`: a repo that still ignores `.orca/` must keep the file ignored
+    * (the migration warning already covers it), so the commit is skipped when
+    * [[GitTool.isIgnored]] reports the path excluded. Only the progress log
+    * punches through the ignore, for resume correctness.
     */
   private def commitDiscoveredSettings(git: GitTool, workDir: os.Path)(using
       WorkspaceWrite
@@ -710,16 +595,11 @@ object FlowLifecycle:
         "orca: stack settings (discovered)"
       )
 
-  /** The deterministic `flow-<hash>` fallback name for `userPrompt`
-    * (`BranchNamingStrategy.flowFallbackName`), minted into a
-    * [[FeatureBranch]]. Shared by both places `freshRun` needs a
-    * guaranteed-safe rename: a protected-name refusal and a git-level
-    * `BranchAlreadyExists` collision — one computation, so both triggers agree
-    * on (and can compare against) the exact same name.
-    *
-    * Defensive re-check: a `flow-`-prefixed hash can't realistically collide
-    * with a protected name, but re-validating rather than assuming keeps the
-    * invariant airtight instead of merely believed.
+  /** The deterministic `flow-<hash>` fallback name for `userPrompt`, minted
+    * into a [[FeatureBranch]]. Shared by both places `freshRun` needs a
+    * guaranteed-safe rename, so both triggers agree on (and compare against)
+    * the exact same name. Re-validated against the protected set defensively
+    * rather than assumed safe.
     */
   private def resolveFallback(
       userPrompt: String,
@@ -734,23 +614,18 @@ object FlowLifecycle:
             s"'$fallbackName' is itself a protected branch"
         )
 
-  /** Create `candidate` fresh via `git.createBranch`, never falling back to
-    * `checkoutOrCreate`'s old silent-adopt behaviour: a
-    * `Left(BranchAlreadyExists)` means a branch by that name is ALREADY there
-    * for some unrelated reason (an earlier run's leftover, a manually created
-    * branch, a slug collision between two different prompts) — carrying that
-    * branch's prior history into this run with zero signal is exactly the
-    * hazard task 3.4 closes.
+  /** Create `candidate` fresh via `git.createBranch`, never silently adopting
+    * an existing branch: a `Left(BranchAlreadyExists)` means a branch by that
+    * name is already there for some unrelated reason (an earlier run's
+    * leftover, a manual branch, a slug collision), and carrying its prior
+    * history into this run with zero signal is the hazard this closes.
     *
-    * Applies the SAME fallback-rename policy `freshRun` already uses for a
-    * protected-name refusal: retry once, loudly (`Step`), with `fallback` (the
-    * SAME deterministic name `freshRun` resolved once via [[resolveFallback]]).
-    * If `candidate` IS ALREADY `fallback` (the protected-name fallback in
-    * `freshRun` already rewrote it once), retrying would recreate the identical
-    * name and collide again for certain — abort immediately instead of trying a
-    * second time. Either way, a deterministic name colliding on a FRESH run (no
-    * resume in play) means a previous run's branch is genuinely still there;
-    * the user must decide what to do with it, not have orca guess again.
+    * Applies the same fallback-rename policy `freshRun` uses for a
+    * protected-name refusal: retry once, loudly, with `fallback`. If
+    * `candidate` is already `fallback`, retrying would recreate the identical
+    * name and collide again — abort immediately instead. Either way, a
+    * deterministic name colliding on a fresh run means a previous run's branch
+    * is still there; the user must decide what to do with it.
     */
   private def createFreshBranch(
       git: GitTool,
@@ -780,10 +655,7 @@ object FlowLifecycle:
             case Right(()) => fallback
             case Left(_)   => doubleCollisionAbort(fallback.value)
 
-  /** Read the bytes of the progress-log file if it exists. Returns `None` when
-    * the file is absent — the normal fresh-run case and the case where the log
-    * is committed (so the stash can't remove it).
-    */
+  /** Read the bytes of the progress-log file if it exists, else `None`. */
   private[runner] def snapshotLog(path: os.Path): Option[Array[Byte]] =
     if os.exists(path) then Some(os.read.bytes(path)) else None
 
@@ -800,8 +672,8 @@ object FlowLifecycle:
 
   /** Run a teardownSuccess leg best-effort: any `NonFatal` failure is caught
     * and debug-logged (never printed, never surfaced) so it cannot escape
-    * teardown, trigger the failure path, or strand the user on a successful
-    * run. `what` names the leg for the log line.
+    * teardown, trigger the failure path, or strand the user. `what` names the
+    * leg for the log line.
     */
   private def bestEffort(what: String)(op: => Unit): Unit =
     val log = LoggerFactory.getLogger("orca.flow")
@@ -812,35 +684,29 @@ object FlowLifecycle:
 
   /** Successful teardown (ADR 0018 §2.5): remove the progress-log file in a
     * final commit so a merged branch is clean, then hand off to
-    * [[finishBranch]] for where HEAD lands — stay on the feature branch
-    * (default), return to the starting branch (`returnToStartBranch`), or
-    * delete a throwaway and return to start.
+    * [[finishBranch]] for where HEAD lands.
     *
     * Errors during log removal, the cleanup commit, or the branch handoff are
     * cosmetic on an already-successful run — every leg runs through
-    * [[bestEffort]], so none of them can escape teardown, trigger the failure
-    * path, or strand the user. A missing progress-log file
-    * (`NoSuchFileException`, the ordinary "already removed" case) stays fully
-    * silent rather than debug-logged; every other failure is debug-logged.
+    * [[bestEffort]]. A missing progress-log file (the ordinary "already
+    * removed" case) stays fully silent; every other failure is debug-logged.
     */
   private[orca] def teardownSuccess(
       git: GitTool,
       setup: FlowSetup,
       returnToStartBranch: Boolean
   ): Unit =
-    // Teardown is runtime code running outside any user stage, so it mints its
-    // own `WorkspaceWrite` via `RuntimeInStage` — the runtime is the privileged
-    // token constructor. No LLM call happens here, so `InStage` isn't needed.
+    // Teardown runs outside any user stage, so it mints its own
+    // `WorkspaceWrite`. No LLM call happens here, so `InStage` isn't needed.
     given WorkspaceWrite = RuntimeInStage.workspaceToken()
     try
       bestEffort("remove progress log"):
         try
           val _ = os.remove(setup.store.path)
         catch case _: java.nio.file.NoSuchFileException => ()
-      // `add -A` in commit picks up the removal; NothingToCommit (a Left) means
-      // it was never committed — harmless. A genuine commit failure is
-      // cosmetic: the run already succeeded and the progress file is gone
-      // from the tree.
+      // `add -A` in commit picks up the removal; NothingToCommit means it was
+      // never committed — harmless. A genuine commit failure is cosmetic: the
+      // run already succeeded and the progress file is gone from the tree.
       bestEffort("commit progress-log removal"):
         val _ = git.commit("orca: remove progress log")
     finally
@@ -848,12 +714,10 @@ object FlowLifecycle:
         finishBranch(git, setup, returnToStartBranch)
 
   /** Where HEAD ends up after a successful run. A throwaway feature branch
-    * (only orca bookkeeping, no user code vs the start branch — diff excluding
-    * `.orca/` is empty) is always deleted and HEAD returns to the starting
-    * branch: there's nothing to keep. Otherwise the feature branch is kept, and
-    * `returnToStartBranch` chooses where HEAD lands — stay on the feature
-    * branch (the default, so the user ends on the work) or return to the
-    * starting branch (PR flows, done with the branch once the PR is up).
+    * (only orca bookkeeping, no user code vs the start branch) is deleted and
+    * HEAD returns to the starting branch. Otherwise the feature branch is kept,
+    * and `returnToStartBranch` chooses where HEAD lands — stay on the feature
+    * branch (the default) or return to the starting branch (PR flows).
     * Best-effort and success-path-only; never deletes start/protected branches.
     */
   private def finishBranch(
@@ -867,10 +731,9 @@ object FlowLifecycle:
           .diffBranchExcludingOrca(setup.startBranch, setup.featureBranch.value)
           .isBlank
     if throwaway then
-      // The start branch existed when this run began (it's either the repo's
-      // HEAD at setup time or a prior run's recorded header) — a plain
-      // `checkout` is enough; if it's gone mid-run that's genuinely
-      // exceptional, not a case to silently paper over by creating it anew.
+      // The start branch existed when this run began, so a plain `checkout`
+      // suffices; if it's gone mid-run that's genuinely exceptional, not a case
+      // to paper over by creating it anew.
       git.checkout(setup.startBranch).orThrow
       git.deleteBranch(setup.featureBranch.value)
     else if returnToStartBranch then git.checkout(setup.startBranch).orThrow
@@ -878,9 +741,8 @@ object FlowLifecycle:
 
   /** Failure teardown (ADR 0018 §2.5): discard the failed stage's uncommitted
     * partial edits with `git reset --hard` (which restores the last committed
-    * log), and stay on the feature branch so the next run resumes in place.
+    * log), staying on the feature branch so the next run resumes in place.
     */
   private[orca] def teardownFailure(git: GitTool): Unit =
-    // Runtime teardown mints its own token, as in `teardownSuccess`.
     given WorkspaceWrite = RuntimeInStage.workspaceToken()
     git.resetHard()

--- a/runner/src/main/scala/orca/runner/FlowLock.scala
+++ b/runner/src/main/scala/orca/runner/FlowLock.scala
@@ -7,27 +7,21 @@ import java.util.concurrent.atomic.AtomicBoolean
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
-/** Reentrancy/concurrency guards for `flow(...)`.
-  *
-  * A nested or concurrent `flow(...)` today would stash the outer flow's tree,
-  * switch branches under it, and `reset --hard` its work (ADR 0018 §6 flags
-  * this as accepted-but-deferred scope). Two layers, acquired at the very start
-  * of `runFlow` — before `DefaultFlowContext` even exists, since construction
-  * is pure but `FlowLifecycle.setup` mutates git immediately after — and
-  * released in a `finally` around the whole body:
+/** Reentrancy/concurrency guards for `flow(...)`, since a nested or concurrent
+  * flow would corrupt the outer flow's git tree (ADR 0018 §6). Two layers,
+  * acquired at the very start of `runFlow` — before `DefaultFlowContext`
+  * exists, since `FlowLifecycle.setup` mutates git immediately after — and
+  * released in a `finally`:
   *
   *   - A process-wide flag ([[acquireProcess]]): catches same-JVM
-  *     nesting/concurrency cheaply, no I/O, before any git mutation.
+  *     nesting/concurrency cheaply, no I/O.
   *   - A `workDir`-keyed lock file ([[acquireWorkdir]]): catches the
-  *     two-process case a same-JVM flag can't see. Content is the holder's PID;
-  *     on contention, a live PID hard-refuses, a dead one is stolen with a
-  *     warning (crash leftovers must not permanently wedge a working tree).
+  *     two-process case. Content is the holder's PID; on contention a live PID
+  *     hard-refuses, a dead one is stolen with a warning.
   *
-  * Both guards fire before `ctx` exists, so a violation is a plain, unwrapped
-  * exception out of `runFlow` — `flow()`'s stderr backstop (the `NonFatal`
-  * catch below `SurfacedFlowFailure`), not the
-  * event-reported/`SurfacedFlowFailure` path, is what a caller of `flow()`
-  * sees.
+  * Both guards fire before `ctx` exists, so a violation is a plain unwrapped
+  * exception out of `runFlow`, seen via `flow()`'s stderr backstop rather than
+  * the `SurfacedFlowFailure` path.
   */
 private[orca] object FlowLock:
 
@@ -39,30 +33,25 @@ private[orca] object FlowLock:
 
   def releaseProcess(): Unit = processFlowLock.set(false)
 
-  /** Bound on [[acquireWorkdir]]'s total `CREATE_NEW` races (the initial try
-    * plus every re-race after a losing steal or a holder that released
-    * mid-check) — pathological churn must end in a refusal, not a spin.
+  /** Bound on [[acquireWorkdir]]'s total `CREATE_NEW` attempts — pathological
+    * churn must end in a refusal, not a spin.
     */
   private val MaxLockAcquireAttempts = 4
 
   /** Acquire the `workDir`-keyed lock file, returning its path (release it with
-    * [[releaseWorkdir]]). Refuses with the tracker's message when the holder
-    * PID is still alive; steals (after a stderr warning) when it isn't.
+    * [[releaseWorkdir]]). Refuses when the holder PID is still alive; steals
+    * (after a stderr warning) when it isn't.
     *
-    * The lock lives under the self-ignoring `.orca/cache/`, so `git add -A`
-    * (the stage runtime's commit, `GitTool.commit`) can never sweep it into a
-    * commit: [[orca.OrcaDir.ensureCache]] writes the cache's `.gitignore`
-    * before the lock file exists. Linked worktrees are covered too — each
-    * worktree gets its own `.orca/cache/` with its own `.gitignore`.
+    * The lock lives under the self-ignoring `.orca/cache/`, so `git add -A` can
+    * never sweep it into a commit: [[orca.OrcaDir.ensureCache]] writes the
+    * cache's `.gitignore` before the lock file exists.
     *
-    * The only atomic primitive here is `os.write`'s `CREATE_NEW`, so everything
-    * else must funnel back through it: a stale lock is stolen by DELETING it
-    * and re-racing the create (two racing stealers then can't both win — the
-    * loser's `CREATE_NEW` fails and it re-reads the winner's live PID), and a
-    * lock that vanishes between the failed create and the read (the holder just
-    * released) simply retries the create. Bounded at [[MaxLockAcquireAttempts]]
-    * total tries (not retries — `attemptsLeft` below counts attempts remaining,
-    * including the one about to run).
+    * The only atomic primitive is `os.write`'s `CREATE_NEW`, so everything
+    * funnels back through it: a stale lock is stolen by DELETING it and
+    * re-racing the create (two racing stealers can't both win — the loser's
+    * `CREATE_NEW` fails and it re-reads the winner's live PID); a lock that
+    * vanishes between the failed create and the read (holder just released)
+    * retries the create. Bounded at [[MaxLockAcquireAttempts]].
     */
   def acquireWorkdir(workDir: os.Path): os.Path =
     val lockPath = OrcaDir.ensureCache(workDir) / "flow.lock"
@@ -85,15 +74,13 @@ private[orca] object FlowLock:
           catch case _: NoSuchFileException => None
         holderContent match
           case None =>
-            // The holder released between our failed create and the read —
-            // the lock is free again; re-race the atomic create.
+            // Holder released between our failed create and the read — re-race.
             attempt(attemptsLeft - 1)
           case Some(content) =>
             val holderPid = content.toLongOption
-            // `isPresent` alone can report a zombie (terminated, unreaped)
-            // process as a holder; `isAlive` is the authoritative test.
-            // PID reuse can make a stale lock look held — that fails safe
-            // (refusal; the user deletes the lock).
+            // `isAlive`, not `isPresent`: the latter reports a zombie
+            // (terminated, unreaped) process as a holder. PID reuse can make a
+            // stale lock look held — that fails safe (refusal).
             val holderAlive = holderPid.exists(p =>
               ProcessHandle.of(p).map(_.isAlive).orElse(false)
             )
@@ -106,8 +93,8 @@ private[orca] object FlowLock:
                 s"[orca] found a stale lock from PID ${holderPid.getOrElse("?")}, " +
                   "which is no longer running — proceeding"
               )
-              // Steal = delete + re-race the create; never `write.over`, which
-              // would let two concurrent stealers both think they won.
+              // Steal = delete + re-race; never `write.over`, which would let
+              // two concurrent stealers both think they won.
               try os.remove(lockPath): Unit
               catch case NonFatal(_) => ()
               attempt(attemptsLeft - 1)

--- a/runner/src/main/scala/orca/runner/FlowWiring.scala
+++ b/runner/src/main/scala/orca/runner/FlowWiring.scala
@@ -24,16 +24,9 @@ import ox.Ox
   * dispatcher as the defaults — costs/steps reach the tracker and terminal. A
   * caller with a prebuilt agent writes `Some(_ => myAgent)`. All five fields
   * share the `Ox ?=>` shape even though only opencode's default factory needs
-  * it — the opencode backend pins a `serve` process + drain forks to the run
-  * scope at construction, so its factory is applied inside
-  * `WiredAgents.build`'s Ox scope, not at the `flow(...)` argument site (see
-  * `flow`'s param scaladoc) — a plain `AgentWiring => Agent` lambda auto-adapts
-  * to the shape, so the other four fields are unaffected by carrying it too.
-  * That auto-adaptation is a property of INLINE lambda literals against an
-  * expected type, not of the function type itself: a `val`/`def` stored with
-  * the bare `AgentWiring => Agent` type (no `Ox ?=>`) does NOT widen later just
-  * by being passed where the context-function shape is expected — the `Ox ?=>`
-  * has to be in the value's own declared type from the start.
+  * it (it pins a `serve` process + drain forks to the run scope, so its factory
+  * is applied inside `WiredAgents.build`'s Ox scope); a plain `AgentWiring =>
+  * Agent` lambda literal auto-adapts to the shape.
   */
 private[orca] case class FlowWiring(
     claude: Option[AgentWiring => Ox ?=> ClaudeAgent] = None,

--- a/runner/src/main/scala/orca/runner/LoggingListener.scala
+++ b/runner/src/main/scala/orca/runner/LoggingListener.scala
@@ -4,20 +4,15 @@ import orca.events.{OrcaEvent, OrcaListener}
 import org.slf4j.LoggerFactory
 
 /** Mirrors every [[OrcaEvent]] into the slf4j log (logger `orca.flow`) so the
-  * per-run trace file ([[OrcaLog]]) captures the whole execution: stage
-  * transitions, each prompt sent to an agent (full text), assistant turns, tool
-  * uses, steps (git / gh / recovery / …), structured results, token usage, and
-  * errors. Wired into the flow's `EventDispatcher` alongside the cost tracker.
+  * per-run trace file ([[OrcaLog]]) captures the whole execution. Wired into
+  * the flow's `EventDispatcher` alongside the cost tracker.
   *
-  * This is a trace mirror, not a console channel: the whole `orca.*` logger
-  * tree is routed to the trace file only (`OrcaLog` makes it non-additive), so
-  * even the `Error` line — logged at ERROR for greppability — never reaches the
-  * console. The terminal renderer owns the console (it shows the `✖`).
+  * A trace mirror, not a console channel: the whole `orca.*` tree routes to the
+  * trace file only ([[OrcaLog]] makes it non-additive), so even the ERROR line
+  * never reaches the console — the terminal renderer owns that.
   *
-  * Messages are plain ASCII on purpose — the trace file is read back and dumped
-  * to the console verbatim, and glyphs would corrupt under a non-UTF-8 console.
-  * slf4j `{}` placeholders defer string building until an appender consumes the
-  * event.
+  * Messages are plain ASCII on purpose: the trace file is dumped to the console
+  * verbatim, and glyphs would corrupt under a non-UTF-8 console.
   */
 private[orca] class LoggingListener extends OrcaListener:
   private val log = LoggerFactory.getLogger("orca.flow")
@@ -31,10 +26,9 @@ private[orca] class LoggingListener extends OrcaListener:
     case OrcaEvent.ToolUse(tool, args) =>
       log.debug("tool use: {} {}", tool, args)
     case OrcaEvent.StructuredResult(raw, summary) =>
-      // The trace mirror always records the payload: on a deliberately
-      // silent summary (`Some("")`) or a missing one (`None`), log the raw
-      // JSON — display-level silence must not hide the result from the
-      // trace file.
+      // On a deliberately silent summary (`Some("")`) or a missing one
+      // (`None`), log the raw JSON — display silence must not hide the result
+      // from the trace.
       log.debug(
         "structured result: {}",
         summary.filter(_.nonEmpty).getOrElse(raw)

--- a/runner/src/main/scala/orca/runner/OrcaBanner.scala
+++ b/runner/src/main/scala/orca/runner/OrcaBanner.scala
@@ -8,9 +8,9 @@ import java.io.PrintStream
   */
 private[orca] object OrcaBanner:
 
-  /** orca's version from the jar manifest (`Implementation-Version`, written by
-    * sbt's `packageBin`). `"dev"` when running from class directories (a local
-    * `sbt run` or the test suite), where there's no jar manifest.
+  /** orca's version from the jar manifest (`Implementation-Version`). `"dev"`
+    * when running from class directories (local `sbt run` or the test suite),
+    * where there's no jar manifest.
     */
   def version: String =
     Option(getClass.getPackage.getImplementationVersion).getOrElse("dev")

--- a/runner/src/main/scala/orca/runner/OrcaLog.scala
+++ b/runner/src/main/scala/orca/runner/OrcaLog.scala
@@ -13,24 +13,19 @@ import scala.util.control.NonFatal
 /** Per-run execution-trace log.
   *
   * [[start]] creates a fresh temp file and attaches a DEBUG-level logback
-  * `FileAppender` to the `orca` logger, made **non-additive** — so the whole
-  * `orca.*` tree (events via [[LoggingListener]], subprocess invocations via
-  * `orca.proc`) lands in the file and never propagates to the root console
-  * appender. The terminal renderer owns the console; orca's logging is purely
-  * the trace. Framework chatter (netty/tapir/…) is on its own loggers and still
-  * reaches the console's WARN appender, unaffected.
+  * `FileAppender` to the `orca` logger, made non-additive — so the whole
+  * `orca.*` tree lands in the file and never propagates to the root console
+  * appender. Framework chatter (netty/tapir/…) is on its own loggers and still
+  * reaches the console's WARN appender.
   *
-  * The file is intentionally NOT deleted on exit, so it can be inspected after
-  * the run. If logback isn't the active slf4j backend, or the temp file can't
-  * be created, file logging is skipped (best-effort) rather than failing the
-  * flow — [[file]] is then `None`.
+  * The file is NOT deleted on exit, so it can be inspected after the run. If
+  * logback isn't the active slf4j backend, or the temp file can't be created,
+  * file logging is skipped (best-effort) and [[file]] is `None`.
   *
-  * Convention: the trace file carries full diagnostics — every level, including
-  * stacks, for every legitimate error (logged at ERROR) or degraded condition
-  * (WARN). The console shows only high-level lines: framework loggers'
-  * WARN-and-above still reach it (they stay additive), and orca's own code
-  * reaches it only through deliberate `[orca]`-prefixed `System.err` lines for
-  * cases the file-only `orca` logger can't surface on its own.
+  * The trace file carries full diagnostics (every level, including stacks). The
+  * console shows only high-level lines: framework WARN-and-above (still
+  * additive), and orca's own code only through deliberate `[orca]`-prefixed
+  * `System.err` lines.
   */
 private[orca] final class OrcaLog private (
     val file: Option[os.Path],
@@ -40,10 +35,8 @@ private[orca] final class OrcaLog private (
   private val finished = new AtomicBoolean(false)
 
   /** Detach and stop the per-run file appender and restore the `orca` logger to
-    * the additive default (it was set non-additive in [[start]]) — so a later
-    * run, or another test in a shared JVM, logs normally again. The trace is
-    * left on disk for inspection. Idempotent — safe to call from both the error
-    * path (before `System.exit`) and the success path.
+    * additive — so a later run, or another test in a shared JVM, logs normally
+    * again. The trace is left on disk. Idempotent.
     */
   def finish(): Unit =
     if finished.compareAndSet(false, true) then
@@ -81,14 +74,13 @@ private[orca] object OrcaLog:
         orcaLogger.setAdditive(false) // orca.* → file only, never the console
         new OrcaLog(Some(file), Some(appender), Some(orcaLogger))
       case _ =>
-        // No temp file or logback isn't active: skip file logging entirely.
+        // No temp file or logback isn't active: skip file logging.
         new OrcaLog(None, None, None)
 
   /** The bound logback `LoggerContext`. Touching a logger first forces slf4j to
     * finish binding its provider — calling `getILoggerFactory` cold can return
     * a transient `SubstituteLoggerFactory` mid-initialization. `None` when
-    * logback isn't the active backend, so file logging is skipped rather than
-    * crashing the flow.
+    * logback isn't the active backend.
     */
   private def loggerContext(): Option[LoggerContext] =
     val _ = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)

--- a/runner/src/main/scala/orca/runner/RoleAgents.scala
+++ b/runner/src/main/scala/orca/runner/RoleAgents.scala
@@ -6,8 +6,7 @@ import orca.settings.{AgentSettings, AgentSpec}
 
 /** The three role agents resolved for one run — every field an existentially
   * typed [[Agent]] since planning/coding/review can each land on a different
-  * backend. `runFlow` opens the existentials with type-variable patterns to
-  * construct the concretely-typed [[orca.runner.DefaultFlowContext]].
+  * backend.
   */
 private[runner] case class ResolvedRoles(
     planning: Agent[?],
@@ -15,9 +14,9 @@ private[runner] case class ResolvedRoles(
     review: Agent[?]
 )
 
-/** Where a resolved role's agent came from, in precedence order (design
-  * decision 10). Drives the role-announcement `Step`'s `(source)` suffix; the
-  * winning [[AgentSpec]] (if any) drives the `harness[:model]` part.
+/** Where a resolved role's agent came from, in precedence order. Drives the
+  * role-announcement `Step`'s `(source)` suffix; the winning [[AgentSpec]] (if
+  * any) drives the `harness[:model]` part.
   */
 private[runner] enum RoleSource:
   case Override, Project, Global, Default
@@ -34,9 +33,7 @@ private[orca] case class RoleOverrides(
 
 /** Outcome of [[RoleAgents.resolveAll]]: the resolved role agents, the
   * ready-to-emit announcement `Step` text, and any foreign-agent warnings (one
-  * per role whose override escaped the wired set). `runFlow` emits the warnings
-  * and the announcement, then threads the roles into the existential-opening
-  * match and the close guard.
+  * per role whose override escaped the wired set).
   */
 private[orca] case class RoleResolution(
     roles: ResolvedRoles,
@@ -56,27 +53,22 @@ private[orca] object RoleAgents:
       review = one(settings.review, agents)
     )
 
-  /** Resolve all three roles AND everything derived from that resolution, in
-    * one place, so the override>project>global>default precedence is encoded
-    * once (design decision 10). Per role: apply the programmatic override if
-    * present (winning over both files), else resolve the project-or-global spec
-    * against the wired set, else default to claude. The winning [[RoleSource]]
-    * and [[AgentSpec]] are captured as each role resolves and read back by the
-    * announcement, rather than re-derived — so the precedence ladder can't
-    * drift between agent selection and the `(source)` labels.
+  /** Resolve all three roles AND everything derived from that resolution, so
+    * the override>project>global>default precedence is encoded once. Per role:
+    * apply the programmatic override if present (winning over both files), else
+    * resolve the project-or-global spec against the wired set, else default to
+    * claude. The winning [[RoleSource]] and [[AgentSpec]] are captured as each
+    * role resolves and read back by the announcement, so the precedence ladder
+    * can't drift between agent selection and the `(source)` labels.
     *
     * A settings-resolved role is always one of the wired agents; only a
-    * programmatic override can escape the wired set (`_ => myPrebuiltAgent`,
-    * built from a separate `AgentWiring`), so a foreign-agent warning only ever
-    * fires for an override — event-blind, it never reaches this run's
-    * dispatcher.
+    * programmatic override can escape the wired set, so a foreign-agent warning
+    * only ever fires for an override.
     *
     * `onRoleResolved` is invoked with each role's agent AS IT resolves, before
-    * the next role's override runs. `runFlow` uses it to append to the
-    * pre-transfer close guard incrementally, so an EARLIER role that resolved
-    * to a foreign agent is still covered when a LATER override throws and this
-    * method never returns — resolution is atomic in its RESULT (a throw yields
-    * no `RoleResolution`), but the guard must see every agent already built.
+    * the next role's override runs — so an EARLIER role that resolved to a
+    * foreign agent is still covered by the caller's close guard when a LATER
+    * override throws and this method never returns.
     */
   def resolveAll(
       project: AgentSettings,
@@ -170,12 +162,11 @@ private[orca] object RoleAgents:
               foreign = false
             )
 
-  /** One role's announcement segment, `label=harness[:model] (source)` (design
-    * decision 10). The harness/model come from the winning [[AgentSpec]] when
-    * there is one (project/global); otherwise from the resolved backend's tag
-    * (an override shows its backend's harness, no model — the override's pin
-    * isn't a spec — and the built-in default resolves to claude). The
-    * `(source)` label is driven purely by the [[RoleSource]].
+  /** One role's announcement segment, `label=harness[:model] (source)`. The
+    * harness/model come from the winning [[AgentSpec]] when there is one
+    * (project/global); otherwise from the resolved backend's tag (an override
+    * shows its backend's harness, no model; the built-in default resolves to
+    * claude). The `(source)` label is driven purely by the [[RoleSource]].
     */
   private def announce(c: RoleChoice): String =
     val harness = c.spec match

--- a/runner/src/main/scala/orca/runner/StackDiscovery.scala
+++ b/runner/src/main/scala/orca/runner/StackDiscovery.scala
@@ -17,13 +17,10 @@ private[runner] case class DiscoveredCommand(
 ) derives JsonData
 
 /** A task's proposed commands, or a one-line reason it was left unset. The
-  * strict output schema requires BOTH keys on every task (every field is
-  * required, Options nullable — see [[orca.util.JsonSchemaGen]]), so the agent
-  * emits `"commands": []` / `"unsetReason": null` for whichever side doesn't
-  * apply. The Scala-side defaults additionally keep the jsoniter parse lenient
-  * about a genuinely omitted field (opting out of strict jsoniter's
-  * collection-required check); required-field protection lives on the
-  * no-default fields.
+  * strict output schema requires BOTH keys on every task (Options nullable —
+  * see [[orca.util.JsonSchemaGen]]), so the agent emits `"commands": []` /
+  * `"unsetReason": null` for whichever side doesn't apply. The Scala-side
+  * defaults keep the jsoniter parse lenient about a genuinely omitted field.
   */
 private[runner] case class DiscoveredTask(
     commands: List[DiscoveredCommand] = Nil,
@@ -43,13 +40,10 @@ private[runner] case class StackDiscoveryResult(
 /** Single-property envelope around [[StackDiscoveryResult]] — the actual
   * `resultAs` payload. Claude's `--json-schema` mode surfaces the schema's
   * top-level properties as the StructuredOutput tool's parameters, and the
-  * cheap tier (haiku) reliably stuffs the whole result under the FIRST
-  * parameter when there are several (observed deterministically: `{"format":
-  * {"format": ..., "lint": ..., "test": ...}}`, failing CLI-side validation
-  * until the retry budget ran out). Every other payload the cheap tier produces
-  * in production has a single-property root (`SelectedReviewers.names`,
-  * `ReviewResult.issues`) — this envelope gives the discovery reply that same
-  * proven shape.
+  * cheap tier (haiku) reliably misbehaves with several — stuffing the whole
+  * result under the FIRST parameter. A single-property root avoids that; it
+  * matches every other cheap-tier payload in production
+  * (`SelectedReviewers.names`, `ReviewResult.issues`).
   */
 private[runner] case class StackDiscoveryReply(result: StackDiscoveryResult)
     derives JsonData
@@ -67,8 +61,8 @@ private[runner] object StackDiscoveryReply:
   */
 private[runner] object StackDiscovery:
 
-  /** The principle-based discovery prompt (no real stack→command examples — ADR
-    * 0019 records the rejection; one fictional-stack example only).
+  /** The principle-based discovery prompt (no real stack→command examples, one
+    * fictional-stack example only — ADR 0019).
     */
   private[runner] val Prompt: String =
     PromptResource.load("/orca/runner/prompts/stack-discovery.md")
@@ -81,13 +75,11 @@ private[runner] object StackDiscovery:
     * Returns the surviving settings and the full entry list for the caller to
     * render and write.
     *
-    * Deliberately catch-free (ADR 0019): a discovery failure — backend
-    * unavailable, spawn failure, structured output still invalid after the
-    * retry policy — propagates and aborts the run as an ordinary surfaced setup
-    * failure. It is never degraded to writing an all-commented file: under the
-    * frozen-file semantics that would turn a transient outage into a
-    * permanently recorded "gates off", and the run needs the same backend
-    * minutes later anyway.
+    * Deliberately catch-free (ADR 0019): a discovery failure propagates and
+    * aborts the run as an ordinary surfaced setup failure, rather than being
+    * degraded to writing an all-commented file — under the frozen-file
+    * semantics that would turn a transient outage into a permanently recorded
+    * "gates off".
     */
   def discover(
       agent: Agent[?],
@@ -165,23 +157,20 @@ private[runner] object StackDiscovery:
 
   /** First mechanical check (ADR 0019): `None` = resolvable, `Some(reason)` =
     * demote. Strips leading `VAR=` assignment tokens, then resolves the first
-    * remaining word through the execution environment's own lookup — `bash -c
-    * 'command -v'`, builtins included, the same environment stage-time `bash
-    * -c` inherits. The word is passed as an ARGUMENT (`"$1"`) — never
-    * interpolated into the bash script text, so shell metacharacters in an
-    * agent-proposed command cannot execute here. The probe runs with
-    * cwd=`workDir`, so a repo-relative path like `./script.sh` resolves here
-    * too — exactly as the command itself later does at stage time with the same
-    * cwd.
+    * remaining word via `bash -c 'command -v'` (builtins included, the same
+    * environment stage-time `bash -c` inherits). The word is passed as an
+    * ARGUMENT (`"$1"`), never interpolated into the script text, so shell
+    * metacharacters in an agent-proposed command cannot execute here. cwd is
+    * `workDir`, so a repo-relative path like `./script.sh` resolves as it will
+    * at stage time.
     */
   private[runner] def unresolvedReason(
       command: String,
       workDir: os.Path
   ): Option[String] =
     // Naive whitespace tokenization: a quoted token containing spaces (e.g.
-    // `FOO="a b" cargo check`) splits mid-quote, so the probed word is wrong
-    // and the command demotes. The failure direction is safe — a visible
-    // demoted line in the settings file, hand-fixable.
+    // `FOO="a b" cargo check`) splits mid-quote and demotes. Safe direction — a
+    // visible demoted line in the settings file, hand-fixable.
     val words = command.trim.split("\\s+").toList.filter(_.nonEmpty)
     words.dropWhile(w => AssignmentToken.findPrefixOf(w).isDefined) match
       case Nil => Some("empty command")
@@ -207,24 +196,19 @@ private[runner] object StackDiscovery:
     catch case _: IllegalArgumentException => false
 
   /** Assemble the agent's `result` into settings-file entries plus the
-    * [[StackSettings]] the run uses, applying the two mechanical checks —
-    * injected as functions so this stays pure and process-free:
-    * `unresolvedReason` returns the demotion reason for a command whose first
-    * word doesn't resolve, `evidenceExists` answers whether a cited evidence
-    * file is present.
+    * [[StackSettings]] the run uses. The two mechanical checks are injected as
+    * functions so this stays pure and process-free.
     *
     * Per command: passing both checks → a [[SettingsEntry.Command]] carrying
     * its evidence as the comment, and the command joins the returned settings;
-    * failing one → a [[SettingsEntry.Demoted]] with the failure reason. A task
-    * that proposed no commands at all becomes [[SettingsEntry.Unset]] with the
-    * agent's reason (or a stock one); a task whose every command was demoted is
-    * documented by the demoted lines themselves — no contradictory "no evidence
-    * found" line is added.
+    * failing one → a [[SettingsEntry.Demoted]] with the reason. A task that
+    * proposed no commands becomes [[SettingsEntry.Unset]]; a task whose every
+    * command was demoted is documented by the demoted lines themselves.
     */
   def toEntries(
       result: StackDiscoveryResult,
-      // Some = the demotion reason — deliberately a bare String: it is
-      // human-facing text for the demoted line, never branched on.
+      // Some = the demotion reason — a bare String, human-facing text for the
+      // demoted line, never branched on.
       unresolvedReason: String => Option[String],
       evidenceExists: String => Boolean
   ): (List[SettingsEntry], StackSettings) =
@@ -245,10 +229,8 @@ private[runner] object StackDiscovery:
         case None =>
           SettingsEntry.Command(
             key,
-            // Sanitized with the SAME collapse the renderer applies to every
-            // command line (TextUtil.collapseNewlines), so the command the
-            // first run executes is identical to the line the written file
-            // carries.
+            // Same collapse the renderer applies to every command line, so the
+            // command the first run executes is identical to the written line.
             TextUtil.collapseNewlines(cmd.command),
             Some(cmd.evidencePath + cmd.evidenceNote.fold("")("; " + _))
           )

--- a/runner/src/main/scala/orca/runner/WiredAgents.scala
+++ b/runner/src/main/scala/orca/runner/WiredAgents.scala
@@ -22,8 +22,7 @@ import scala.util.control.NonFatal
 
 /** The five agents wired for one run — the [[orca.AgentSet]] the `flow(...)`
   * lead selector resolves against. Built (via [[WiredAgents.build]]) before the
-  * `FlowContext` exists; the context then takes ownership of the bundle at
-  * construction and forwards its accessors here.
+  * `FlowContext` exists; the context then takes ownership of the bundle.
   */
 private[orca] final class WiredAgents(
     val claude: ClaudeAgent,
@@ -33,15 +32,10 @@ private[orca] final class WiredAgents(
     val gemini: GeminiAgent
 ) extends AgentSet:
 
-  /** The five wired agents keyed by backend tag — derived once from the
-    * constructor vals above, not a second source of truth: adding a backend is
-    * still one new field plus one new match arm here. Written as a match over
-    * `BackendTag.values` (not a literal `Map(...)`) so the exhaustiveness
-    * checker — not a human — flags a sixth `BackendTag` case that this map
-    * hasn't been taught about yet. The five concretely-typed accessors
-    * (`claude`, `codex`, …) stay as the public, `AgentSet`-mandated surface,
-    * and `agentFor` is unaffected (the trait default already dispatches on the
-    * same five fields — see [[orca.AgentSet.agentFor]]).
+  /** The five wired agents keyed by backend tag, derived from the constructor
+    * vals. Written as a match over `BackendTag.values` (not a literal
+    * `Map(...)`) so the exhaustiveness checker flags a sixth `BackendTag` case
+    * this map hasn't been taught about.
     */
   private val byTag: Map[BackendTag, Agent[?]] =
     BackendTag.values.map {
@@ -57,20 +51,14 @@ private[orca] final class WiredAgents(
   def all: List[Agent[?]] = byTag.values.toList
 
   /** True when `a` IS one of the five wired agents, or was derived from one via
-    * a `copyTool`-style builder (`_.claude.opus`, `.withReadOnly`, …) — checked
-    * by shared [[orca.agents.Agent.backendIdentity]], compared by REFERENCE
-    * (`eq`, per that method's contract), not `Agent` reference equality,
-    * because a builder-derived sibling is a DIFFERENT `Agent` instance sharing
-    * the SAME backend: a naive `eq` check on the `Agent`s alone would
-    * false-positive-warn on the common `_.claude.opus` selector pattern. The
-    * direct `eq` fallback (on the `Agent`s themselves) exists for agents with
-    * no backend at all (e.g. test stubs built straight on `Agent`, whose
-    * `backendIdentity` is `None`) so a selector that literally returns one of
-    * the five wired agents unchanged still counts as wired even without a
-    * backend token to compare. Used only for the foreign-lead warning at
-    * selector-resolution time, where a false warning (not a resource leak) is
-    * the failure mode — both close fan-outs skip the check and close the lead
-    * unconditionally.
+    * a builder (`_.claude.opus`, `.withReadOnly`, …). A builder-derived sibling
+    * is a different `Agent` instance sharing the same backend, so the primary
+    * test compares shared [[orca.agents.Agent.backendIdentity]] by `eq`; a
+    * naive `eq` on the `Agent`s alone would false-positive-warn on
+    * `_.claude.opus`. The direct `eq` fallback covers agents with no backend
+    * (e.g. test stubs, whose `backendIdentity` is `None`). Used only for the
+    * foreign-lead warning, where a false warning (not a leak) is the failure
+    * mode.
     */
   def isWiredBackend(a: Agent[?]): Boolean =
     byTag.values.exists: w =>
@@ -84,11 +72,9 @@ private[orca] object WiredAgents:
   /** Wire the run's agents, filling every `None` override with the production
     * default. Every factory is applied against `agentWiring` — the run's single
     * bundle of event sink, interaction, workDir and prompts — so a user agent
-    * is wired into the run exactly like a default one. The default configs
-    * (Opus1M/Pro pins) live in the per-backend `*Agents.default` factories, the
-    * single source of truth. Applying each factory against the field's expected
-    * concrete-agent type drives Scala's context-function auto-application — see
-    * [[FlowWiring]] for why every field shares the `Ox ?=>` shape.
+    * is wired into the run exactly like a default one. Default configs live in
+    * the per-backend `*Agents.default` factories. See [[FlowWiring]] for why
+    * every field shares the `Ox ?=>` shape.
     */
   def build(wiring: FlowWiring, agentWiring: AgentWiring)(using
       ox.Ox
@@ -111,11 +97,10 @@ private[orca] object WiredAgents:
     )
 
   /** Best-effort close fan-out over `agents` (each delegates to its backend;
-    * all default to no-op — today only opencode holds a live resource, the
-    * shared `serve` process). Per-agent best-effort: one failing close must not
-    * keep the others from closing. Shared by `DefaultFlowContext.close()` and
-    * `runFlow`'s pre-construction ownership guard so both close the same way,
-    * in the same order.
+    * today only opencode holds a live resource, the shared `serve` process).
+    * One failing close must not keep the others from closing. Shared by
+    * `DefaultFlowContext.close()` and `runFlow`'s pre-construction ownership
+    * guard so both close the same way.
     */
   def closeBestEffort(agents: List[Agent[?]]): Unit =
     agents.foreach: a =>

--- a/runner/src/main/scala/orca/runner/terminal/Ansi.scala
+++ b/runner/src/main/scala/orca/runner/terminal/Ansi.scala
@@ -2,14 +2,9 @@ package orca.runner.terminal
 
 import orca.util.TerminalControl
 
-/** Single source of truth for the "ANSI optional" decision in the renderer
-  * layer. Each renderer carries a `useColor` boolean it chose at construction
-  * time (or auto-detected); this helper strips inbound terminal controls (via
-  * the shared [[orca.util.TerminalControl]]) and applies the fansi attrs only
-  * when colour is on.
-  *
-  * Package-private — callers outside `orca.runner.terminal` have no reason to
-  * reach into our colour decision.
+/** Applies fansi attrs to renderer text: strips inbound terminal controls (via
+  * [[orca.util.TerminalControl]]), then paints only when the renderer's
+  * `useColor` is on.
   */
 private[terminal] object Ansi:
 

--- a/runner/src/main/scala/orca/runner/terminal/ConversationRenderer.scala
+++ b/runner/src/main/scala/orca/runner/terminal/ConversationRenderer.scala
@@ -17,41 +17,30 @@ import org.jline.reader.{
 import org.jline.terminal.{Terminal, TerminalBuilder}
 import ox.Ox
 
-/** Renders a [[Conversation]] to the terminal. The layout aims for a
-  * Claude-Code-like aesthetic: the user's opening prompt sits on its own
-  * section, the agent's prose flushes as a single block at each turn boundary,
-  * and each tool call/result gets a compact one-line summary tagged with a
-  * glyph.
+/** Renders a [[Conversation]] to the terminal: the user's opening prompt sits
+  * on its own section, the agent's prose flushes as a single block at each turn
+  * boundary, and each tool call/result gets a compact one-line glyph-tagged
+  * summary.
   *
-  * All event-log writes flow through the shared [[TerminalOutput]] so the
-  * persistent status row at the bottom doesn't get torn by ad-hoc `print`
-  * calls. The renderer accepts the output directly so it shares the surface
-  * with [[TerminalEventListener]] — a single output, one set of cursor escapes.
+  * All writes go through the shared [[TerminalOutput]] so the persistent status
+  * row isn't torn by ad-hoc prints and this renderer shares one surface with
+  * [[TerminalEventListener]]. Constructed per conversation on the caller
+  * thread; its state doesn't escape. `output.prompt` around the
+  * approval/question prompts keeps live event output from scribbling on top of
+  * `readLine`.
   *
-  * The renderer is constructed per conversation and lives on the caller (body)
-  * thread — it's not shared. State (`textBuffer`, `currentSection`,
-  * `pendingProseStyling`) doesn't escape this thread. Output writes are
-  * fire-and-forget tells; `output.prompt` around the approval/question prompts
-  * keeps live event output from scribbling on top of `readLine`.
-  *
-  * Spacing is controlled by a small section state machine — consecutive tool
-  * events don't grow blank lines between them, but a transition from prose to a
-  * tool block (or back) gets exactly one separator.
+  * A small section state machine controls spacing: consecutive tool events stay
+  * tight, but a prose↔tool transition gets exactly one blank-line separator.
   */
 private[terminal] class ConversationRenderer(
     useColor: Boolean,
     output: TerminalOutput,
     currentIndent: () => String,
     workDir: Option[os.Path] = None,
-    /** When non-empty the conversation is in structured-output mode — the
-      * agent's final assistant text is the JSON payload the library will
-      * deserialize and surface via `OrcaEvent.StructuredResult`. We swallow the
-      * streamed text to avoid showing the raw JSON twice (once mid-stream as
-      * `●`, once via the structured-result event). This drop is safe only
-      * because `TerminalEventListener`'s `StructuredResult` case (ADR 0008)
-      * guarantees a visible result either way: the `Announce[O]` summary as `▶`
-      * when available, otherwise the truncated raw payload as `●` — never
-      * silence.
+    /** When set, the agent's final assistant text is a JSON payload surfaced
+      * via `OrcaEvent.StructuredResult`, so we drop the streamed text to avoid
+      * showing the raw JSON twice. Safe because `TerminalEventListener`'s
+      * `StructuredResult` case (ADR 0008) always renders a visible result.
       */
     structuredMode: Boolean = false,
     prompter: ConversationRenderer.Prompter = ConversationRenderer.JLinePrompter
@@ -59,37 +48,27 @@ private[terminal] class ConversationRenderer(
 
   import ConversationRenderer.*
 
-  /** Section-spacing state. Consecutive `Tool` events stay tight; a `Tool →
-    * Prose` (or vice versa) transition inserts a blank line.
-    */
   private var currentSection: Section = Section.None
 
-  /** Buffer for assistant text in the current turn. Flushed as a single block
-    * at `AssistantTurnEnd` so the prose lands together rather than
-    * delta-by-delta. In structured-output mode the buffer is dropped instead of
-    * flushed — see the `structuredMode` constructor doc.
+  /** Assistant text for the current turn, flushed as a single block at
+    * `AssistantTurnEnd`. Dropped rather than flushed in structured-output mode.
     */
   private val textBuffer = new StringBuilder
 
-  /** Per-turn glyph + style we'll prepend to the buffered text when we flush.
-    * Captured at the first delta so we don't lose the styling between buffering
-    * and flush.
-    */
+  /** Glyph + style to prepend at flush, captured at the first delta. */
   private var pendingProseStyling: Option[ProseStyling] = None
 
-  /** Render the conversation to completion. Returns whatever
-    * `Conversation.awaitResult()` returns — the Either is passed through so the
-    * caller decides whether to throw or surface the cancellation as a value.
+  /** Render the conversation to completion. The `Either` from `awaitResult()`
+    * is passed through so the caller decides whether to throw or surface the
+    * cancellation as a value.
     */
   def render[B <: BackendTag](
       conversation: Conversation[B]
   )(using Ox): Either[OrcaInteractiveCancelled, AgentResult[B]] =
     conversation.events.foreach(dispatch(_, conversation))
-    // The turn grammar (ForkedConversation auto-closes every completed turn)
-    // guarantees each turn ends with an AssistantTurnEnd that already flushed
-    // the buffer, so on the normal path this is a no-op. It only flushes for a
-    // turn the stream left open — abnormal termination (cancellation/crash
-    // mid-turn) the grammar permits; a safety net, not driver-slop compensation.
+    // Normally a no-op: every completed turn ends with an AssistantTurnEnd that
+    // already flushed. Safety net for a turn the stream left open (cancellation
+    // or crash mid-turn).
     flushBufferedText()
     conversation.awaitResult()
 
@@ -101,10 +80,8 @@ private[terminal] class ConversationRenderer(
     case ConversationEvent.AssistantTextDelta(text) =>
       bufferText(text, AssistantGlyph, AssistantGlyphStyle, AssistantTextStyle)
     case ConversationEvent.AssistantThinkingDelta(_) =>
-      // Deliberately dropped: there is no thinking-display toggle, and
-      // buffering thinking into the shared textBuffer/pendingProseStyling
-      // would mis-style the whole turn (whichever delta kind arrives first
-      // wins the styling for the rest of the buffered block).
+      // Dropped: buffering thinking into the shared textBuffer would let the
+      // first delta kind win the styling for the whole turn.
       ()
     case ConversationEvent.AssistantToolCall(name, input) =>
       renderToolCall(name, input)
@@ -122,9 +99,8 @@ private[terminal] class ConversationRenderer(
   private def renderUserMessage(text: String): Unit =
     enterSection(Section.Prose)
     val header = paint(UserHeaderStyle, s"$UserGlyph you")
-    // One line, truncated — matching the autonomous path's `▸` prompt render;
-    // the initial message here is usually a full templated instruction, and
-    // dumping it would dominate the log.
+    // One truncated line: the initial message is usually a full templated
+    // instruction that would otherwise dominate the log.
     val body = paint(
       UserBodyStyle,
       bulletIndent(Text.oneLine(text, MaxUserMessageLength))
@@ -157,11 +133,9 @@ private[terminal] class ConversationRenderer(
     enterSection(Section.Prose)
     appendBlock(paint(ErrorStyle, s"$ErrorGlyph $message"))
 
-  /** Render the buffered text as a single prose block. In structured-output
-    * mode the buffer is dropped — the structured payload arrives via
-    * `OrcaEvent.StructuredResult` instead, so showing the raw JSON inline would
-    * just duplicate. Either way, `pendingProseStyling` and the buffer are
-    * cleared so an empty-buffer turn doesn't leak state.
+  /** Render the buffered text as a single prose block, or drop it in
+    * structured-output mode (the payload arrives via `StructuredResult`).
+    * Always clears the buffer and `pendingProseStyling`.
     */
   private def flushBufferedText(): Unit =
     val styling = pendingProseStyling.getOrElse(
@@ -169,10 +143,7 @@ private[terminal] class ConversationRenderer(
     )
     pendingProseStyling = None
     if textBuffer.isEmpty then ()
-    else if structuredMode then
-      // Drop. The `StructuredResult` event will carry the canonical
-      // text and the listener decides what to render.
-      textBuffer.clear()
+    else if structuredMode then textBuffer.clear()
     else
       val text = textBuffer.toString
       textBuffer.clear()
@@ -182,8 +153,7 @@ private[terminal] class ConversationRenderer(
       appendBlock(rendered)
 
   /** Insert a blank-line separator when crossing a section boundary, then
-    * update the section. No-op when staying in the same kind of section or when
-    * nothing has been emitted yet.
+    * update the section. No-op within a section or before anything is emitted.
     */
   private def enterSection(next: Section): Unit =
     if currentSection != Section.None && currentSection != next then
@@ -213,10 +183,8 @@ private[terminal] class ConversationRenderer(
     appendBlock(
       paint(ApprovalStyle, s"$ApprovalGlyph $toolName requested: $summary")
     )
-    // `prompt` suspends the status (clears the spinner row, buffers
-    // concurrent log tells from other listeners) so the readline lands
-    // cleanly and live events can't scribble on top of the prompt, then
-    // drains/redraws on the way out — even if `respond` throws.
+    // `prompt` suspends the status and buffers concurrent log tells so the
+    // readline lands cleanly, then drains/redraws on the way out.
     output.prompt: () =>
       prompter.ask(
         currentIndent() + paint(ApprovalStyle, "  [y]es / [n]o ? ")
@@ -251,8 +219,8 @@ private[terminal] class ConversationRenderer(
 
   // --- Helpers ---
 
-  /** Inset prose under a header glyph by 2 spaces. Operates on the raw text —
-    * the outer stage-depth indent is added later by [[appendBlock]].
+  /** Inset prose under a header glyph by 2 spaces. The outer stage-depth indent
+    * is added later by [[appendBlock]].
     */
   private def bulletIndent(text: String): String =
     text.linesIterator.map(l => s"  $l").mkString("\n")
@@ -262,12 +230,9 @@ private[terminal] class ConversationRenderer(
 
 private[terminal] object ConversationRenderer:
   val MaxInlineInputLength: Int = 120
-  // Tool results are large file reads or command output; show just
-  // enough for "something happened" without wrapping past one line.
+  // Enough of a large file read / command output to signal "something
+  // happened" without wrapping past one line.
   val MaxInlineContentLength: Int = 100
-  // The interactive session's user message is usually the full templated
-  // instruction; one truncated line identifies the turn (same budget the
-  // autonomous `▸` prompt line uses in TerminalEventListener).
   val MaxUserMessageLength: Int = 100
 
   val UserGlyph: String = "▸"
@@ -278,15 +243,10 @@ private[terminal] object ConversationRenderer:
   val ErrorGlyph: String = "✖"
   val ApprovalGlyph: String = "?"
 
-  // Palette: magenta-bold glyphs are the dominant accent (stages,
-  // steps, assistant prose) — they pop against neutral body text
-  // without the previous wash of cyan/blue. Tool calls move to
-  // yellow-bold so the "the agent is doing something external"
-  // signal stands out from the magenta-bold "primary content"
-  // signal. Secondary text (tool args, tool results) all
-  // stays dark-gray. User prompts keep cyan as their distinctive
-  // colour since they're rare and want to be visually anchored at
-  // the top of an interactive session.
+  // Palette: magenta-bold is the dominant "primary content" accent (stages,
+  // steps, assistant prose); tool calls are yellow-bold so "doing something
+  // external" stands apart; secondary text (tool args/results) is dark-gray;
+  // user prompts keep cyan as their distinctive, rare accent.
   val UserHeaderStyle: fansi.Attrs = fansi.Color.Cyan ++ fansi.Bold.On
   val UserBodyStyle: fansi.Attrs = fansi.Color.Cyan
   val AssistantGlyphStyle: fansi.Attrs = fansi.Color.Magenta ++ fansi.Bold.On
@@ -319,29 +279,24 @@ private[terminal] object ConversationRenderer:
   trait Prompter:
     def ask(prompt: String): PromptOutcome
 
-    /** Release any I/O resources the prompter acquired. Process-scoped: called
-      * once at interaction teardown, never per conversation. The default is a
-      * no-op — a prompter that never opens anything has nothing to release.
+    /** Release any I/O resources the prompter acquired. Called once at
+      * interaction teardown, never per conversation. Default is a no-op.
       */
     def close(): Unit = ()
 
   /** Default production prompter: JLine line reader. Lazy so the terminal is
-    * only opened when an approval prompt actually fires — pure non-interactive
-    * sessions never allocate a terminal.
+    * only opened when an approval prompt fires — non-interactive sessions never
+    * allocate one.
     *
-    * Limitation: this object is process-scoped and its lazy terminal cannot
-    * re-initialize after `close()` — a second `flow(...)` in the same JVM that
-    * fires a prompt is unsupported. Inject a custom [[Prompter]] for
-    * embedded/multi-run scenarios. (A resettable-holder fix is deferred; this
-    * note records the boundary.)
+    * Limitation: process-scoped and its lazy terminal cannot re-initialize
+    * after `close()`, so a second `flow(...)` in the same JVM that fires a
+    * prompt is unsupported. Inject a custom [[Prompter]] for embedded/multi-run
+    * scenarios.
     */
   object JLinePrompter extends Prompter:
-    // Guard so close() never forces the lazy terminal: pure non-interactive
-    // runs must never allocate one (that laziness is the object's whole
-    // point). `opened` records a SUCCESSFUL build — set only after `build()`
-    // returns, inside the lazy-init lock — so a failed build leaves nothing
-    // to close and a later close() won't re-run the failed initializer. Read
-    // from whatever thread calls close(); @volatile keeps that read correct.
+    // `opened` records a SUCCESSFUL build (set inside the lazy-init lock, after
+    // build() returns) so close() never forces the lazy terminal and a failed
+    // build leaves nothing to close. @volatile for the close()-thread read.
     @volatile private var opened = false
     private lazy val terminal: Terminal =
       val t = TerminalBuilder.builder().system(true).dumb(true).build()
@@ -351,14 +306,10 @@ private[terminal] object ConversationRenderer:
       LineReaderBuilder.builder().terminal(terminal).build()
 
     def ask(prompt: String): PromptOutcome =
-      // Ctrl-C (UserInterrupt) and Ctrl-D / closed-stdin (EndOfFile — also hit
-      // by a headless run that reaches an ask-user prompt with no tty) both mean
-      // "the user isn't answering"; map both to the same graceful Interrupted
-      // outcome rather than letting EndOfFileException escape as an opaque,
-      // message-less stage failure. Not unit-tested: `reader` is a private lazy
-      // val bound to the real system terminal, with no seam to inject a throwing
-      // readLine — tests that need scripted outcomes stub the [[Prompter]] trait
-      // instead. The two catch arms are exercised only through the live CLI.
+      // Ctrl-C (UserInterrupt) and Ctrl-D / closed-stdin (EndOfFile, also hit by
+      // a headless run reaching an ask-user prompt with no tty) both mean "the
+      // user isn't answering": map both to Interrupted rather than let
+      // EndOfFileException escape as a message-less stage failure.
       try PromptOutcome.Answer(reader.readLine(prompt))
       catch
         case _: (UserInterruptException | EndOfFileException) =>

--- a/runner/src/main/scala/orca/runner/terminal/TerminalEventListener.scala
+++ b/runner/src/main/scala/orca/runner/terminal/TerminalEventListener.scala
@@ -5,13 +5,10 @@ import orca.events.{OrcaEvent, OrcaListener}
 /** Renders `OrcaEvent`s — stage transitions, steps, tool uses, errors — via a
   * [[TerminalOutput]] and tracks the active stage stack + indent depth.
   *
-  * Dispatcher calls arrive sequentially per event but can come from concurrent
-  * emitter threads for non-stage events. `StageStarted` / `StageCompleted` are
-  * the exception: they're emitted only from `stage`'s bookkeeping
-  * (`orca.Flow`), which is thread-affine by R12 (ADR 0018 §2.2) — so [[stack]]
-  * has a single writer. The [[ConversationRenderer]] reads [[currentIndent]]
-  * lock-free from its own thread, mid-`readLine`; the `@volatile` is the whole
-  * publication story for that cross-thread read.
+  * [[stack]] has a single writer: `StageStarted`/`StageCompleted` are emitted
+  * only from `stage`'s thread-affine bookkeeping (R12, ADR 0018 §2.2).
+  * [[ConversationRenderer]] reads [[currentIndent]] lock-free from its own
+  * thread mid-`readLine`; the `@volatile` is the whole publication story.
   */
 private[runner] class TerminalEventListener(
     output: TerminalOutput,
@@ -31,23 +28,21 @@ private[runner] class TerminalEventListener(
     UserPromptStyle
   }
 
-  // Single-writer (stage events arrive on the one stage thread, R12),
-  // multi-reader (ConversationRenderer polls the indent from its own thread
-  // mid-prompt): a @volatile immutable list is the whole synchronization
-  // story. Head = most-recently-started stage.
+  // Head = most-recently-started stage. See class scaladoc for the
+  // single-writer/@volatile synchronization story.
   @volatile private var stack: List[String] = Nil
 
   def onEvent(event: OrcaEvent): Unit = event match
     case OrcaEvent.StageStarted(name) =>
-      // Format the step line at the *current* depth (so the StageStarted
-      // marker aligns with the enclosing stage's content), then push.
+      // Format at the current depth (so the marker aligns with the enclosing
+      // stage's content), then push.
       val line = formatStepLine(name)
       stack = name :: stack
       output.log(line)
       output.setStatus(stack.headOption)
     case OrcaEvent.StageCompleted(_) =>
-      // Stage completions don't print to the event log — starting the next
-      // event implicitly tells the user the previous one finished.
+      // Completions don't print: starting the next event implies the previous
+      // one finished.
       stack = stack.drop(1)
       output.setStatus(stack.headOption)
     case OrcaEvent.ToolUse(tool, args) =>
@@ -56,21 +51,14 @@ private[runner] class TerminalEventListener(
     case OrcaEvent.TokensUsed(_, _, _, _) =>
       () // Token accounting is owned by CostTracker.
     case OrcaEvent.Step(message) =>
-      // Multi-line `message` (e.g. a wrapped review comment with
-      // hanging-indented continuation lines) re-indents on each newline so
-      // the body stays aligned under the glyph.
       output.log(formatStepLine(message))
     case OrcaEvent.StructuredResult(raw, summary) =>
-      // The conversation renderer suppresses the agent's streamed JSON
-      // when in structured mode; this event is what surfaces the result.
-      // `summary` is tri-state (see the event's scaladoc): a summary text
-      // renders as a `▶` step; `Some("")` — a specific `Announce[O]` that
-      // deliberately says nothing because the call site narrates the
-      // outcome itself (e.g. the review loop's per-reviewer lines) —
-      // renders nothing; `None` — no `Announce[O]` wired at all — falls
-      // back to the raw payload, collapsed to one line and truncated, in
-      // the `●` assistant-message style (ADR 0008: an unannounced result
-      // must stay visible, since the streamed JSON was suppressed).
+      // Surfaces the result the conversation renderer suppressed in structured
+      // mode. `summary` is tri-state (see the event's scaladoc): `Some(s)`
+      // renders as a `▶` step; `Some("")` renders nothing (the call site
+      // narrates the outcome itself); `None` falls back to the raw payload,
+      // collapsed and truncated, in the `●` style — ADR 0008 requires an
+      // unannounced result stay visible since the streamed JSON was suppressed.
       summary match
         case Some("") => ()
         case Some(s)  => output.log(formatStepLine(s))
@@ -79,16 +67,14 @@ private[runner] class TerminalEventListener(
           val glyph = paint(AssistantGlyphStyle, s"$AssistantGlyph ")
           output.log(formatIndented(glyph + collapsed))
     case OrcaEvent.UserPrompt(text) =>
-      // Same one-line treatment as AssistantMessage so a long task
-      // description doesn't dominate the log. Empty payloads are dropped.
+      // One line so a long task description doesn't dominate the log; empty
+      // payloads dropped.
       val collapsed = Text.oneLine(text, MaxAssistantMessageLength)
       if collapsed.nonEmpty then
         val glyph = paint(UserPromptStyle, s"$UserPromptGlyph ")
         output.log(formatIndented(glyph + collapsed))
     case OrcaEvent.AssistantMessage(text) =>
-      // Truncate to one line — the autonomous drain emits these for every
-      // agent prose turn, and full text would dominate the log. Empty
-      // payloads (turn-without-prose) are dropped silently.
+      // One line per prose turn; empty payloads (turn-without-prose) dropped.
       val collapsed = Text.oneLine(text, MaxAssistantMessageLength)
       if collapsed.nonEmpty then
         val glyph = paint(AssistantGlyphStyle, s"$AssistantGlyph ")
@@ -101,10 +87,8 @@ private[runner] class TerminalEventListener(
   /** The current indent string. Lock-free read of the `@volatile` [[stack]]. */
   def currentIndent: String = "  " * stack.length
 
-  /** A `▶` step line: magenta-bold glyph, neutral body. Matches the
-    * assistant-prose styling (magenta `●` + neutral text) so the dominant
-    * accent across the event log is consistent — stages, steps, and prose are
-    * all "primary content".
+  /** A `▶` step line: magenta-bold glyph, neutral body — matching the
+    * assistant-prose styling so the "primary content" accent stays consistent.
     */
   private def formatStepLine(message: String): String =
     val glyph = paint(StepGlyphStyle, s"$StageStartGlyph ")
@@ -127,37 +111,29 @@ private[runner] object TerminalEventListener:
   val AssistantGlyph: String = "●"
 
   /** Marker for the human input sent to the agent. Matches the
-    * [[ConversationRenderer]]'s `▸` user glyph so autonomous and interactive
-    * logs use the same accent for "this is what was asked".
+    * [[ConversationRenderer]]'s `▸` user glyph.
     */
   val UserPromptGlyph: String = "▸"
 
-  /** Stages, steps, and structured-result summaries share the same magenta-
-    * bold glyph — the dominant accent for "primary content" in the event log.
-    * Pulled into a constant so the three render paths can't drift.
+  /** Magenta-bold "primary content" accent shared by stages, steps, and
+    * structured-result summaries. One constant so the render paths can't drift.
     */
   val StepGlyphStyle: fansi.Attrs = fansi.Color.Magenta ++ fansi.Bold.On
 
-  /** Same magenta-bold treatment as [[StepGlyphStyle]] — `●` and `▶` are peer
-    * accents on the "primary content" track. Matches the
-    * [[ConversationRenderer]]'s prose glyph so autonomous and interactive logs
-    * look identical when both surface agent prose.
+  /** `●` prose glyph, same magenta-bold as [[StepGlyphStyle]]; matches the
+    * [[ConversationRenderer]]'s prose glyph.
     */
   val AssistantGlyphStyle: fansi.Attrs = StepGlyphStyle
 
   /** Cyan-bold to mirror the [[ConversationRenderer]]'s user-message header. */
   val UserPromptStyle: fansi.Attrs = fansi.Color.Cyan ++ fansi.Bold.On
 
-  /** Per-turn cap. Long agent prose collapses to one line because the
-    * autonomous drain fires one event per turn and the log would otherwise fill
-    * with multi-paragraph monologues. 100 characters matches the cap the live
-    * renderer uses for tool-result content.
+  /** Per-turn cap collapsing long agent prose to one line. Matches the live
+    * renderer's tool-result-content cap.
     */
   val MaxAssistantMessageLength: Int = 100
 
   /** Cap for the raw-payload fallback in [[OrcaEvent.StructuredResult]] when no
-    * `Announce[O]` summary was provided (ADR 0008). Matches the 200-char budget
-    * `Flow`'s malformed-output snippet uses for the same kind of "show a
-    * bounded slice of raw agent output" fallback.
+    * `Announce[O]` summary was provided (ADR 0008).
     */
   val MaxStructuredResultRawLength: Int = 200

--- a/runner/src/main/scala/orca/runner/terminal/TerminalInteraction.scala
+++ b/runner/src/main/scala/orca/runner/terminal/TerminalInteraction.scala
@@ -16,30 +16,16 @@ import scala.util.control.NonFatal
   * streaming LLM output, and errors to a `PrintStream` (defaults to stderr so
   * the structured output on stdout stays clean).
   *
-  * The output is split in two zones:
-  *   - The **event log** at the top, growing line-by-line as stages start and
-  *     tools fire.
-  *   - A **status line** pinned at the bottom, showing the current activity
-  *     with an animated spinner glyph.
+  * The output has two zones, both owned by [[TerminalOutput]]: an **event log**
+  * growing line-by-line at the top, and a **status line** with an animated
+  * spinner pinned at the bottom. When stderr isn't a TTY (CI, redirected
+  * output, `NO_COLOR`/`ORCA_NO_ANIMATION`) it degrades to plain inline writes.
   *
-  * Both zones are owned by [[TerminalOutput]], which serialises every write on
-  * a single worker thread. When stderr isn't a TTY (CI, redirected output,
-  * `NO_COLOR`/`ORCA_NO_ANIMATION`), the output degrades to plain inline writes
-  * without ANSI escapes.
-  *
-  * The default output stream is forced to UTF-8 (see [[start]]): orca's UI is
-  * built from non-ASCII glyphs, and when the process is launched under a
-  * non-UTF-8 default charset (a `C`/`POSIX` locale — common in containers and
-  * editor sandboxes) the JVM's `System.err` would otherwise encode each glyph
-  * to `?`.
-  *
-  * `drive` runs on the caller's thread (no actor ask). It iterates the
-  * conversation's event stream and tells the output. The spinner runs on a
-  * separate fork inside `TerminalOutput`, so it keeps advancing while drive
-  * blocks on the backend.
-  *
-  * [[close]] is called from `flow(...)`'s `finally` to flush pending writes and
-  * clear the status row before the enclosing scope ends.
+  * The default stream is forced to UTF-8 (see [[start]]) so orca's non-ASCII
+  * glyphs survive a non-UTF-8 default charset. `drive` runs on the caller's
+  * thread; the spinner advances on a separate fork inside `TerminalOutput`
+  * while drive blocks on the backend. [[close]] runs from `flow(...)`'s
+  * `finally` to flush and clear the status row before the scope ends.
   */
 class TerminalInteraction private[terminal] (
     output: TerminalOutput,
@@ -69,15 +55,10 @@ class TerminalInteraction private[terminal] (
       prompter = prompter
     ).render(conversation).orThrow
 
-  /** Close in construction-reverse order: the prompter (process-scoped, shared
-    * across every conversation this interaction drove — renderers never close
-    * it) then the output. A test-injected prompter is closed here too; there's
-    * no hardcoded singleton in this path.
-    *
-    * The prompter close is guarded: it's teardown-only degradation, and a
-    * throwing prompter must never strand the output (leaving the status row
-    * uncleared) or mask whatever error is already unwinding through the
-    * caller's `finally`.
+  /** Close the prompter (shared across every conversation; renderers never
+    * close it), then the output. The prompter close is guarded so a throwing
+    * prompter can't strand the output uncleared or mask an error already
+    * unwinding through the caller's `finally`.
     */
   override def close(): Unit =
     try prompter.close()
@@ -86,10 +67,9 @@ class TerminalInteraction private[terminal] (
 
 object TerminalInteraction:
 
-  /** Build a `TerminalInteraction` in the given Ox scope. Inside, the
+  /** Build a `TerminalInteraction` in the given Ox scope. The
     * [[TerminalOutput]]'s actor and animator fork are tied to the scope and
-    * terminate when it ends. `flow(...)` calls [[close]] in its `finally`
-    * before the scope joins, draining pending writes.
+    * terminate when it ends.
     */
   def start(
       out: PrintStream = utf8Stderr,
@@ -118,14 +98,10 @@ object TerminalInteraction:
     defaultUseColor && !sys.env.contains("ORCA_NO_ANIMATION")
 
   /** `System.err`, re-encoded as UTF-8 regardless of the JVM's default charset.
-    * orca's UI is built from non-ASCII glyphs (`…`, `✖`, `▸`, `●`, braille
-    * spinner); when launched under a non-UTF-8 locale (`C`/`POSIX`, common in
-    * containers and editor sandboxes) the JVM resolves `stderr.encoding` to
-    * US-ASCII and `System.err` would encode each glyph to `?`. Wrapping forces
-    * UTF-8 char→byte encoding; the bytes pass through the underlying
-    * `System.err` unchanged (`PrintStream.write(byte[])` doesn't re-encode).
-    * Never closed by [[TerminalOutput]] (it only prints/flushes), so the
-    * underlying `System.err` stays open.
+    * Under a non-UTF-8 locale (`C`/`POSIX`, common in containers/sandboxes) the
+    * JVM resolves `stderr.encoding` to US-ASCII and would encode orca's
+    * non-ASCII glyphs to `?`; wrapping forces UTF-8 encoding. Never closed by
+    * [[TerminalOutput]], so the underlying `System.err` stays open.
     */
   private[terminal] def utf8Stderr: PrintStream =
     new PrintStream(System.err, true, UTF_8)

--- a/runner/src/main/scala/orca/runner/terminal/TerminalOutput.scala
+++ b/runner/src/main/scala/orca/runner/terminal/TerminalOutput.scala
@@ -9,28 +9,19 @@ import scala.collection.immutable.Queue
 import scala.concurrent.duration.DurationLong
 import scala.util.control.NonFatal
 
-/** The terminal rendering surface. A small set of operations for appending to
-  * the event log and advancing the persistent status row at the bottom of the
-  * terminal.
+/** The terminal rendering surface: appends to the event log and advances the
+  * persistent status row pinned at the bottom.
   *
   * Production builds ([[TerminalOutput.start]]) serialise every method on an
-  * internal Ox actor: a single worker thread owns `out`, log lines and spinner
-  * ticks can't interleave mid-write, and a `forkDiscard` animator inside the
-  * factory `tell`s the actor every `framePeriodMs` so the spinner keeps
-  * advancing while callers do other work.
-  *
-  * Tests can instantiate [[TerminalOutputState]] directly — it implements the
-  * same interface synchronously without an actor or animator fork.
+  * internal Ox actor, so a single worker thread owns `out` and log lines can't
+  * interleave with spinner ticks. Tests can instantiate [[TerminalOutputState]]
+  * directly — the same interface, synchronous, no actor or animator fork.
   *
   * **Prompt transaction.** [[prompt]] is the only way to read from the
-  * terminal: it clears the status row, starts buffering concurrent `log` calls,
-  * runs the given `readUser` thunk, then drains the buffer and redraws the
-  * status row — all as one bracketed unit. A fair semaphore serialises
-  * transactions, so two concurrent interactive prompts (a legal fork
-  * composition) queue up instead of interleaving; the second's `readUser` only
-  * starts once the first's transaction has fully closed. That also serialises
-  * access to the shared `readLine` reader, since `readUser` is exactly where
-  * callers do that read.
+  * terminal: it clears the status row, buffers concurrent `log` calls, runs
+  * `readUser`, then drains and redraws — all as one bracketed unit. A fair
+  * semaphore serialises transactions so two concurrent prompts queue instead of
+  * interleaving, which also serialises the shared `readLine` reader.
   */
 private[terminal] trait TerminalOutput:
   /** Append a (possibly multi-line) chunk to the event log. Trailing newline is
@@ -41,28 +32,24 @@ private[terminal] trait TerminalOutput:
   /** Show / relabel / hide the status row. `None` hides it. */
   def setStatus(label: Option[String]): Unit
 
-  /** Run `readUser` as the only writer of the terminal: clears the status row
-    * and buffers concurrent `log`/`setStatus` calls for the duration, then
-    * drains and redraws on the way out — even if `readUser` throws. A fair
-    * semaphore serialises concurrent callers, so a second `prompt` blocks until
-    * the first's transaction (including its drain/redraw) has closed; this also
-    * protects a shared `readLine` reader from concurrent use.
+  /** Run `readUser` as the only writer of the terminal — see the class
+    * scaladoc's "Prompt transaction". Drains and redraws even if `readUser`
+    * throws.
     */
   def prompt[A](readUser: () => A): A
 
   /** Flush pending writes, clear the status row, and release the renderer.
-    * Tells arriving after close (listener events between this call's return and
-    * scope-end) are still processed against the now-cleared state — `log`
-    * writes inline without a status row, `tick` is a no-op.
+    * Tells arriving after close are still processed against the cleared state:
+    * `log` writes inline without a status row, `tick` is a no-op.
     */
   def close(): Unit
 
 private[terminal] object TerminalOutput:
 
   /** Build a production `TerminalOutput` whose state is owned by an Ox actor +
-    * animator fork in the given scope. The animator is `forkDiscard`: scope-end
-    * interrupts it. The IE from `ox.sleep` propagates out of `forever` and is
-    * absorbed by the supervisor (scope is already winding down).
+    * animator fork in the given scope. The animator is `forkDiscard`, so
+    * scope-end interrupts it; the IE from `ox.sleep` is absorbed by the
+    * supervisor as the scope winds down.
     */
   def start(
       out: PrintStream,
@@ -79,17 +66,14 @@ private[terminal] object TerminalOutput:
           actor.tell(_.tick())
     new ActorTerminalOutput(actor)
 
-/** Actor-backed [[TerminalOutput]]. `log`/`setStatus` are tells
-  * (fire-and-forget); `suspend`/`resume` (private, only reachable through
-  * [[prompt]]) and `close` are asks where the caller needs the operation to
-  * have completed before returning. Close-time throws are swallowed so they
-  * don't mask whatever already failed upstream.
+/** Actor-backed [[TerminalOutput]]. `log`/`setStatus` are tells; `suspend`/
+  * `resume` and `close` are asks (the caller needs completion before
+  * returning). Close-time throws are swallowed so they don't mask an upstream
+  * failure.
   *
-  * `promptGate` serialises the whole suspend/readUser/resume transaction across
-  * concurrent callers: it's acquired before the suspend-ask and released only
-  * after the resume-ask, so a second `prompt` call blocks until the first's
-  * transaction — drain and redraw included — has fully closed. Fair so waiting
-  * forks are served in arrival order rather than risking starvation.
+  * `promptGate` (fair) is held from before the suspend-ask until after the
+  * resume-ask, so a second `prompt` blocks until the first transaction — drain
+  * and redraw included — has fully closed.
   */
 private class ActorTerminalOutput(actor: ActorRef[TerminalOutputState])
     extends TerminalOutput:
@@ -129,27 +113,21 @@ private[terminal] class TerminalOutputState(
 
   private var currentLabel: Option[String] = None
   private var frameIndex: Int = 0
-  // When `suspended`, the status row is cleared and `log` calls accumulate
-  // into `suspendedBuffer` instead of writing to `out`. The animator
-  // short-circuits, so no ticks land while a prompt is being read.
-  //
-  // Cap on the buffer guards against unbounded growth if a flow stays
-  // suspended for a long time (e.g. an unattended prompt) while concurrent
-  // listeners keep emitting. Past the cap we drop the oldest entry — the
-  // newest is more likely to be informative on resume than a stale early
-  // line. Cap is large enough that typical interactive prompts don't trim.
+  // When `suspended`, the status row is cleared and `log` calls accumulate into
+  // `suspendedBuffer` instead of writing to `out`; the animator short-circuits.
+  // Past SuspendedBufferCap the oldest entry is dropped (the newest is more
+  // likely informative on resume) so an unattended prompt can't grow unbounded.
   private var suspended: Boolean = false
   private var suspendedBuffer: Queue[String] = Queue.empty
-  // Set once `close()` has cleared the status row. Late events (from a fork
-  // still unwinding after the scope started closing) may still append log
-  // lines, but must not re-pin a status row nothing will clear again.
+  // Set once `close()` has cleared the status row. Late events (a fork still
+  // unwinding after scope-close) may append log lines but must not re-pin a
+  // status row nothing will clear again.
   private var closed: Boolean = false
 
   def log(text: String): Unit =
     if suspended then
       suspendedBuffer = suspendedBuffer.enqueue(text)
       if suspendedBuffer.size > TerminalOutputState.SuspendedBufferCap then
-        // Queue.dequeue returns (head, rest) — discard the dropped entry.
         suspendedBuffer = suspendedBuffer.tail
     else writeLog(text)
 
@@ -165,9 +143,8 @@ private[terminal] class TerminalOutputState(
             out.flush()
         case Some(_) if closed => () // don't re-pin a status row after close
         case some @ Some(_) if suspended =>
-          // A prompt owns the terminal; store the label so resume's redraw
-          // picks it up, but don't touch `out` — drawing here would repaint
-          // over live readLine input.
+          // A prompt owns the terminal: store the label for resume's redraw but
+          // don't touch `out`, which would repaint over live readLine input.
           currentLabel = some
         case some @ Some(_) =>
           currentLabel = some
@@ -183,41 +160,34 @@ private[terminal] class TerminalOutputState(
       drawStatus()
       out.flush()
 
-  /** Synchronous implementation of the [[TerminalOutput.prompt]] transaction:
-    * this class has no actor and no concurrent callers of its own (production
-    * concurrency is serialised one level up, by [[ActorTerminalOutput]]'s
-    * semaphore — see its scaladoc), so a plain `suspend`/`finally resume`
-    * bracket is enough here.
+  /** Synchronous [[TerminalOutput.prompt]]: no actor or concurrent callers here
+    * (production serialises one level up in [[ActorTerminalOutput]]), so a
+    * plain `suspend`/`finally resume` bracket suffices.
     */
   def prompt[A](readUser: () => A): A =
     suspend()
     try readUser()
     finally resume()
 
-  /** Clear the status row and start buffering `log` calls; kept as its own
-    * method (rather than folded into [[prompt]]) so tests can drive
-    * suspend/resume/tick interaction directly without a `readUser` thunk. Not
-    * part of the [[TerminalOutput]] trait — [[prompt]] is the only public way
-    * to open this window in production.
+  /** Clear the status row and start buffering `log` calls. A separate method
+    * (not folded into [[prompt]]) so tests can drive suspend/resume/tick
+    * directly.
     *
-    * CAUTION: calling `suspend`/`resume` directly (rather than through
-    * [[prompt]]) bypasses the `promptGate` semaphore transaction that
-    * serializes concurrent prompts (see [[ActorTerminalOutput]]) — production
-    * code MUST go through `prompt`; this pair is exposed at package level for
-    * tests only.
+    * CAUTION: calling `suspend`/`resume` directly bypasses the `promptGate`
+    * transaction that serialises concurrent prompts (see
+    * [[ActorTerminalOutput]]) — production code MUST go through [[prompt]].
+    * Exposed at package level for tests only.
     */
   def suspend(): Unit =
     if !suspended then
       suspended = true
-      // Clear the status row so the prompt can land cleanly. We keep
-      // `currentLabel` so resume can redraw the same status without callers
-      // having to remember it.
+      // Keep `currentLabel` so resume can redraw the same status.
       if animated && currentLabel.isDefined then
         out.print(ClearLine)
         out.flush()
 
   /** Drain the buffered log lines and redraw the status row. Pairs with
-    * [[suspend]]; see its scaladoc for why both stay as separate methods here.
+    * [[suspend]].
     */
   def resume(): Unit =
     if suspended then
@@ -270,8 +240,7 @@ private[terminal] class TerminalOutputState(
 private[terminal] object TerminalOutputState:
 
   /** Carriage return + ANSI Erase-In-Line-2 (clear entire line). `\u001b` is
-    * the ESC byte — written as a Unicode escape so the source stays
-    * grep-friendly.
+    * the ESC byte, a Unicode escape so the source stays grep-friendly.
     */
   private val ClearLine: String = "\r\u001b[2K"
 
@@ -283,9 +252,8 @@ private[terminal] object TerminalOutputState:
   /** Maximum characters in the rendered status line before truncation. */
   private val MaxStatusLineWidth: Int = 78
 
-  /** Maximum entries the suspended-log buffer holds. Past this the oldest entry
-    * is dropped so an unattended prompt with concurrent listener traffic can't
-    * grow memory without bound.
+  /** Maximum entries the suspended-log buffer holds before the oldest is
+    * dropped.
     */
   private[terminal] val SuspendedBufferCap: Int = 256
 

--- a/runner/src/main/scala/orca/runner/terminal/Text.scala
+++ b/runner/src/main/scala/orca/runner/terminal/Text.scala
@@ -1,9 +1,7 @@
 package orca.runner.terminal
 
-/** Tiny string helpers shared by the terminal-rendering layer. Scoped
-  * package-private since their tradeoffs (in particular the cheap-and- cheerful
-  * character truncation that doesn't worry about wide graphemes) only make
-  * sense inside this layer.
+/** Tiny string helpers for the terminal-rendering layer. Truncation is
+  * character-based and doesn't account for wide graphemes.
   */
 private[terminal] object Text:
 
@@ -24,10 +22,8 @@ private[terminal] object Text:
     val collapsed = s.replaceAll("\\s+", " ").trim
     truncate(collapsed, max)
 
-  /** Prefix `text` with `indent`, and re-indent every embedded newline so a
-    * multi-line block stays aligned under the leading glyph/indent. Shared by
-    * [[TerminalEventListener]] and [[ConversationRenderer]], the two places
-    * that print a block under the current stage indent.
+  /** Prefix `text` with `indent`, re-indenting every embedded newline so a
+    * multi-line block stays aligned under the leading glyph/indent.
     */
   def indentBlock(indent: String, text: String): String =
     indent + text.replace("\n", "\n" + indent)

--- a/runner/src/main/scala/orca/runner/terminal/ToolCallLine.scala
+++ b/runner/src/main/scala/orca/runner/terminal/ToolCallLine.scala
@@ -1,13 +1,9 @@
 package orca.runner.terminal
 
-/** Shared formatter for the one-line tool-call summary used by both the
-  * autonomous-path [[TerminalEventListener]] and the interactive-path
-  * [[ConversationRenderer]]. Returns the head (`⏺ name`) plus an optional
-  * styled args tail; the caller is responsible for the surrounding stage-depth
-  * indent.
-  *
-  * Lives here so the two render paths can't drift on glyph, styling, or
-  * summarisation rules without one change point.
+/** Shared formatter for the one-line tool-call summary, used by both
+  * [[TerminalEventListener]] and [[ConversationRenderer]] so the two render
+  * paths can't drift on glyph, styling, or summarisation. Returns the head (`⏺
+  * name`) plus an optional styled args tail; the caller adds the indent.
   */
 private[terminal] object ToolCallLine:
   import ConversationRenderer.{

--- a/runner/src/main/scala/orca/runner/terminal/ToolInputSummary.scala
+++ b/runner/src/main/scala/orca/runner/terminal/ToolInputSummary.scala
@@ -3,16 +3,14 @@ package orca.runner.terminal
 import scala.annotation.tailrec
 
 /** Produces a short, human-readable summary of a tool call's raw JSON input —
-  * the bit the renderer shows in parentheses after the tool name. The
-  * implementation is a deliberately small hand-written JSON string extractor: a
-  * full parser would cost a dependency edge and time for what is purely a
-  * display heuristic. If the input doesn't match one of the known "headline"
-  * fields, we fall back to the truncated JSON so nothing is lost.
+  * the bit the renderer shows in parentheses after the tool name. A
+  * deliberately small hand-written JSON string extractor rather than a full
+  * parser, since this is purely a display heuristic; unmatched input falls back
+  * to truncated JSON.
   *
-  * `workDir`, when supplied, is used to relativise paths that fall inside the
-  * flow's working directory — `/tmp/orca-AbC/src/Main.scala` becomes
-  * `src/Main.scala`. Paths outside `workDir` stay absolute, so external file
-  * access remains visually obvious in the output.
+  * `workDir`, when supplied, relativises paths inside the flow's working
+  * directory (`/tmp/orca-AbC/src/Main.scala` → `src/Main.scala`). Paths outside
+  * stay absolute, so external file access remains visually obvious.
   */
 private[terminal] object ToolInputSummary:
 
@@ -31,11 +29,9 @@ private[terminal] object ToolInputSummary:
       "description"
     )
 
-  /** Field names whose values are paths the renderer should try to relativise
-    * against `workDir` (when provided). Subset of [[HeadlineFields]] —
-    * `command`/`pattern`/`query`/`url`/ `description` are free-form strings
-    * that may contain any number of paths interleaved with other text, so we
-    * leave those alone.
+  /** Headline fields whose values are single paths to relativise against
+    * `workDir`. The others are free-form strings that may interleave paths with
+    * other text, so they're left alone.
     */
   private val PathFields: Set[String] = Set("file_path", "path")
 
@@ -83,10 +79,8 @@ private[terminal] object ToolInputSummary:
     WhitespaceRun.matcher(raw).replaceAll(" ").trim
 
   /** Matches a `"field":"value"` entry and walks the value honouring `\"` /
-    * `\\` escapes. Returns `None` if the field isn't present or the string
-    * doesn't terminate. Deliberately not a full JSON parser — escapes beyond
-    * the common shell/path ones round-trip verbatim because they wouldn't
-    * otherwise appear in tool inputs.
+    * `\\` escapes. Returns `None` if the field is absent or the string doesn't
+    * terminate. Escapes beyond the common shell/path ones round-trip verbatim.
     */
   private def extractStringField(json: String, field: String): Option[String] =
     val needle = s""""$field":""""

--- a/runner/src/test/scala/flowtests/FlowCompilesTest.scala
+++ b/runner/src/test/scala/flowtests/FlowCompilesTest.scala
@@ -1,19 +1,15 @@
 package flowtests
 
-// This file deliberately lives outside the `orca.*` package tree — it's
-// the canary for the user-facing DSL. A third-party flow script sees
-// exactly what this file sees: top-level types, accessors, and givens
-// brought in by `import orca.{*, given}` and nothing else. The `given`
-// selector is non-negotiable: Scala 3's plain `import orca.*` excludes
-// givens, and the forwarders in `JsonData.scala` are what let nested
+// This file deliberately lives outside the `orca.*` package tree — it's the
+// canary for the user-facing DSL. A third-party flow script sees exactly what
+// this file sees: top-level types, accessors, and givens from
+// `import orca.{*, given}` and nothing else. The `given` selector is
+// non-negotiable: the forwarders in `JsonData.scala` are what let nested
 // `derives JsonData` find the child Schema during derivation.
 //
-// Each `def` targets one DSL concern so compile errors localise to the
-// affected surface. Nothing here is invoked at runtime; `sbt test`
-// simply requires the file to typecheck.
-//
-// If this file stops compiling, some aspect of the DSL contract has
-// regressed. Fix the API, not the test.
+// Each `def` targets one DSL concern so compile errors localise. Nothing here
+// runs; `sbt test` only requires the file to typecheck. If it stops compiling,
+// fix the API, not the test.
 
 import orca.{*, given}
 // Deliberately NOT in the `orca.*` export wildcard: a recoverable `createPr`
@@ -104,9 +100,6 @@ object FlowCanary:
         claude.chat(session.id).resultAs[FlowPlan].interactive.run(userPrompt)
       for task <- plan.tasks do
         stage(task.description):
-          // The ADR 0019 migration shapes: `formatCommand = Some(x)` became
-          // `formatCommands = Configured.Use(List(x))`, `lint = Some(l)`
-          // became `lint = Configured.Use(l)`.
           reviewAndFixLoop(
             coderSession = session,
             reviewers = allReviewers(claude),
@@ -192,8 +185,7 @@ object FlowCanary:
 
   /** `summarisePr` + `PrSummary` surface; exercised by `examples/issue-pr.sc`.
     * Pins the call shape (`agent`, `diff`, optional `context`, optional
-    * `instructions`) and the result type so a rename or signature drift
-    * surfaces in this test instead of at the next live run.
+    * `instructions`) and the result type.
     */
   def summarisePrSurface(): Unit =
     flow(OrcaArgs()):
@@ -206,9 +198,9 @@ object FlowCanary:
         val _ = summary.title
         val _ = summary.body
 
-  /** 10.3: types newly added to `exports.scala` (`Usage`, `Cost`,
-    * `CostTracker`, `IgnoredIssue`/`IgnoredIssues`, `PushFailure`) must resolve
-    * from `import orca.*` alone, with no side import.
+  /** These `exports.scala` types (`Usage`, `Cost`, `CostTracker`,
+    * `IgnoredIssue`/`IgnoredIssues`, `PushFailure`) must resolve from `import
+    * orca.*` alone, with no side import.
     */
   def exportsSurface(): Unit =
     flow(OrcaArgs()):
@@ -231,7 +223,7 @@ object FlowCanary:
           case Right(_)                            => ()
 
   /** Issue/PR-comment surface on `gh` — exercised by the issue-pr plan in
-    * `examples/`. If any of these signatures move, the canary fails.
+    * `examples/`.
     */
   def issueAndPrSurface(): Unit =
     flow(OrcaArgs()):
@@ -254,11 +246,9 @@ object FlowCanary:
         gh.updatePr(pr, "new title", "new body")
 
   /** Branch + PR surface — exercised by `examples/implement-enhanced.sc`. Pins
-    * the branch ops the runtime still exposes to flow scripts and the
-    * `createPr` `Either` with its recoverable `PrAlreadyExists`. The manual
-    * `Plan.recover`/`ensureClean`/`checkoutOrCreate` resume guard is gone — the
-    * flow runtime now owns branch + resume (ADR 0018 §2.5); the examples'
-    * conversion restored the per-flow branching ceremony.
+    * the branch ops the runtime exposes to flow scripts and the `createPr`
+    * `Either` with its recoverable `PrAlreadyExists`. The flow runtime owns
+    * branch + resume (ADR 0018 §2.5).
     */
   def branchAndPrSurface(): Unit =
     flow(OrcaArgs()):
@@ -276,8 +266,7 @@ object FlowCanary:
   /** Planning grid surface; exercised across `examples/`. Pins the full `mode ×
     * operation` grid: every cell returns `Sessioned[B, <result>]` where the
     * result is `Plan` (`from`), `Verdict[Plan]` (`assessThenPlan`), or `Triage`
-    * (`triage`). A hole in the grid, a return-type drift, or an enum
-    * rename/case removal surfaces here instead of at the next live run.
+    * (`triage`).
     */
   def planningGridSurface(): Unit =
     flow(OrcaArgs()):
@@ -335,12 +324,10 @@ object FlowCanary:
 
   /** Post-planning step (`reviewed`) plus the per-task stage loop — exercised
     * by `examples/implement-enhanced.sc`. Pins that the `Sessioned[B, Plan]`
-    * extension resolves through `import orca.*` alone. Plans are always briefed
-    * (the `brief` rides in the structured output, so `plan.brief` /
-    * `plan.taskPrompt` are always available — no `.briefed` step, no
-    * `PlanWithBrief`). The `Plan.recoverOrCreate` / `implementTaskLoop`
-    * persistence calls are gone — resume is now the stage log (ADR 0018 §2.8),
-    * and the task loop is a plain per-task `stage(...)`.
+    * extension resolves through `import orca.*` alone. Plans are always
+    * briefed: the `brief` rides in the structured output, so `plan.brief` /
+    * `plan.taskPrompt` are always available. Resume is the stage log (ADR 0018
+    * §2.8), and the task loop is a plain per-task `stage(...)`.
     */
   def planReviewAndBriefSurface(): Unit =
     flow(OrcaArgs()):
@@ -357,16 +344,14 @@ object FlowCanary:
           val _ = claude.run(plan.taskPrompt(task))
 
   // -----------------------------------------------------------------------
-  // Example-shape canaries (ADR 0018 §3, Task F2)
-  // Each def mirrors the distinct pattern in one of the `examples/*.sc`
-  // files so a signature drift or missing API surfaces here instead of at
-  // the next live run. Nothing is invoked at runtime.
+  // Example-shape canaries (ADR 0018 §3)
+  // Each def mirrors the distinct pattern in one of the `examples/*.sc` files
+  // so a signature drift or missing API surfaces here. Nothing runs at runtime.
   // -----------------------------------------------------------------------
 
   /** `implement.sc`: autonomous plan → session seeded from brief → task loop
     * with `session.run` + `reviewAndFixLoop`. The session-based shapes
-    * (`session(name, seed=)` → `FlowSession`, `session.run`) are the core
-    * new-API additions.
+    * (`session(name, seed=)` → `FlowSession`, `session.run`) are the core ones.
     */
   def implementFlowShape(): Unit =
     flow(OrcaArgs()):

--- a/runner/src/test/scala/orca/runner/FlowLifecycleTest.scala
+++ b/runner/src/test/scala/orca/runner/FlowLifecycleTest.scala
@@ -41,19 +41,12 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import orca.testkit.{GitRepo, TempDirs}
 
-/** Tests for the flow lifecycle: success teardown, failure teardown, and resume
-  * across two calls. Each test uses a real temp git repo via `GitRepo.seeded()`
-  * and a null-sink `TerminalInteraction` so no TTY is required.
+/** Flow lifecycle tests: success/failure teardown and resume. Each uses a real
+  * temp git repo (`GitRepo.seeded()`) and a null-sink `TerminalInteraction` so
+  * no TTY is required.
   *
-  * The first three tests cover teardown/resume through the public `flow(...)`
-  * and by hand-building state — `flow()` calls `System.exit(1)` on body
-  * failure, so they can't drive a failing invocation directly.
-  *
-  * The last two tests exercise the genuine end-to-end crash→resume path via the
-  * exit-free `runFlow(...)` seam: a body that throws in stage 2 propagates (no
-  * `System.exit`), failure teardown keeps HEAD on the feature branch with stage
-  * 1 recorded, and a second `runFlow` over the same store resumes — replaying
-  * stage 1 instead of re-running it.
+  * `flow()` calls `System.exit(1)` on body failure, so tests that must drive a
+  * failing invocation use the exit-free `runFlow(...)` seam instead.
   */
 class FlowLifecycleTest extends munit.FunSuite:
 
@@ -78,7 +71,6 @@ class FlowLifecycleTest extends munit.FunSuite:
         interaction = Some(interaction)
       ):
         summon[FlowContext].emit(OrcaEvent.Step("body ran"))
-    // After flow returns, HEAD must be back on main (the starting branch).
     val branch =
       os.proc("git", "rev-parse", "--abbrev-ref", "HEAD")
         .call(cwd = workDir)
@@ -86,7 +78,6 @@ class FlowLifecycleTest extends munit.FunSuite:
         .text()
         .trim
     assertEquals(branch, "main")
-    // The progress-log file must have been removed.
     val store = ProgressStore.default(workDir, "lifecycle-success")
     assert(!os.exists(store.path), s"progress log ${store.path} should be gone")
 
@@ -94,9 +85,8 @@ class FlowLifecycleTest extends munit.FunSuite:
     "failure teardown: stays on feature branch with clean working tree and earlier commit present"
   ):
     // Build the pre-failure state manually: feature branch with a committed
-    // progress header + one completed stage entry, then staged (but not yet
-    // committed) partial work from a second stage.
-    // Then apply failure teardown (resetHard) and assert the resulting state.
+    // progress header + one completed stage entry, then staged (uncommitted)
+    // partial work from a second stage. Then apply failure teardown (resetHard).
     val workDir = GitRepo.seeded()
     val git = new OsGitTool(workDir)
     val prompt = "lifecycle-failure"
@@ -134,9 +124,7 @@ class FlowLifecycleTest extends munit.FunSuite:
     // Apply failure teardown (git reset --hard, stay on feature branch).
     git.resetHard()
 
-    // HEAD must still be on the feature branch.
     assertEquals(git.currentBranch(), featureBranch)
-    // Working tree must be clean (staged partial work was discarded).
     val status =
       os.proc("git", "status", "--porcelain")
         .call(cwd = workDir)
@@ -148,10 +136,8 @@ class FlowLifecycleTest extends munit.FunSuite:
       "",
       "working tree must be clean after failure teardown"
     )
-    // Stage one's result must survive in the progress log.
     val ids = store.load().get.entries.map(_.id)
     assert(ids.contains("stage-one#0"), "stage one must remain recorded")
-    // Stage two's partial file must be gone (reset --hard wiped it from index).
     assert(
       !os.exists(workDir / "two.txt"),
       "staged partial file must be wiped by reset --hard"
@@ -187,8 +173,6 @@ class FlowLifecycleTest extends munit.FunSuite:
     )
     git.forceAdd(store.path)
     val _ = git.commit("stage: resumable-stage")
-    // We are on the feature branch (as failure teardown would leave us) and the
-    // progress-log file is present on disk — flow() can read it via store.load().
 
     // Second run: flow detects the header in the store, resumes the feature
     // branch (already there), and skips the already-recorded stage body.
@@ -252,12 +236,10 @@ class FlowLifecycleTest extends munit.FunSuite:
           throw new RuntimeException("boom in stage two")
     assertEquals(thrown.cause.getMessage, "boom in stage two")
 
-    // HEAD must be on the feature branch, not the start branch.
     val branch = git.currentBranch()
     assertNotEquals(branch, startBranch)
     assertEquals(branch, store.load().get.header.branch)
 
-    // Stage one's commit + log entry must survive.
     val ids = store.load().get.entries.map(_.id)
     assert(ids.contains("stage-one#0"), "stage one must be recorded")
     assert(
@@ -289,10 +271,8 @@ class FlowLifecycleTest extends munit.FunSuite:
           throw new RuntimeException("boom")
     assertEquals(stageOneRuns.get(), 1, "stage one runs once in the first run")
 
-    // Failure teardown leaves the repo on the feature branch — which is exactly
-    // the resume entry point: a re-run "in place" (the next invocation inherits
-    // the repo's HEAD, which the crash left on the feature branch) finds the
-    // committed progress log in the working tree and resumes from it.
+    // Failure teardown left HEAD on the feature branch; a re-run "in place"
+    // finds the committed progress log there and resumes from it.
     val featureBranch = git.currentBranch()
     assertNotEquals(featureBranch, startBranch)
 
@@ -390,16 +370,13 @@ class FlowLifecycleTest extends munit.FunSuite:
     "R20: snapshot-before-stash restores the log file if the stash removed it"
   ):
     // The end-to-end stash hazard is belt-and-suspenders (the log is normally
-    // committed, so the stash can't remove it), so cover the helper directly:
-    // a snapshot taken while the file exists restores its exact bytes after the
-    // file is gone, and is a no-op when the file still exists.
+    // committed, so the stash can't remove it), so cover the helper directly.
     val dir = TempDirs.dir()
     val path = dir / ".orca" / "progress-x.json"
     os.write(path, "{\"header\":true}", createFolders = true)
     val snapshot = FlowLifecycle.snapshotLog(path)
     assert(snapshot.isDefined, "snapshot must capture an existing file")
 
-    // Simulate the stash removing the file, then restore it.
     val _ = os.remove(path)
     FlowLifecycle.restoreLogIfMissing(path, snapshot)
     assert(os.exists(path), "log must be restored from the snapshot")
@@ -440,8 +417,8 @@ class FlowLifecycleTest extends munit.FunSuite:
     val _ = git.commit("orca: progress log")
     val currentBranch = git.currentBranch()
 
-    // The abort now surfaces first (reported to the user), then escapes wrapped
-    // in `SurfacedFlowFailure`; the original `OrcaFlowException` is its `cause`.
+    // The abort surfaces first (reported), then escapes wrapped in
+    // `SurfacedFlowFailure`; the original `OrcaFlowException` is its `cause`.
     val thrown = intercept[SurfacedFlowFailure]:
       runFlowForTest(workDir, prompt, store):
         val _ = stage("never-runs"):
@@ -459,12 +436,10 @@ class FlowLifecycleTest extends munit.FunSuite:
     "setup: a corrupt (unparseable) progress log proceeds FRESH — new branch, header written"
   ):
     // A garbage-bytes file at the store's path (a torn/truncated write, not a
-    // "no log yet" absence). `loadDetailed()` returns `Corrupt`, and `setup`
-    // must take the same fresh-run path an absent log would — resolve +
-    // create a branch and commit a brand-new header — rather than throwing or
-    // silently doing nothing. The "starting fresh" warning is now routed
-    // through the threaded `emit` as an `OrcaEvent.Step` (so a Slack-backed
-    // Interaction sees it, not just a terminal), which this test captures.
+    // "no log yet" absence). `setup` must take the same fresh-run path an absent
+    // log would — resolve + create a branch and commit a brand-new header —
+    // rather than throwing. The "starting fresh" warning routes through `emit`
+    // as an `OrcaEvent.Step` so a listener (e.g. Slack) sees it.
     val workDir = GitRepo.seeded()
     val prompt = "corrupt-log-fresh"
     val store = ProgressStore.default(workDir, prompt)
@@ -489,28 +464,23 @@ class FlowLifecycleTest extends munit.FunSuite:
       emit = e => { val _ = emitted.updateAndGet(e :: _) }
     )
 
-    // The corrupt-log warning reached the event surface as a Step (a listener,
-    // e.g. Slack, can observe it) — not only a stderr line.
     val steps = emitted.get().collect { case s: OrcaEvent.Step => s }
     assert(
       steps.exists(_.message.contains("corrupt")),
       s"a Step warning about the corrupt log must be emitted: $steps"
     )
 
-    // A fresh branch was resolved and created, distinct from the start branch
-    // — not an abort, and not a no-op that leaves HEAD where it was.
+    // A fresh branch was resolved and created, distinct from the start branch.
     assertEquals(git.currentBranch(), setup.featureBranch.value)
     assertNotEquals(setup.featureBranch.value, startBranch)
     assertEquals(setup.startBranch, startBranch)
-    // A brand-new header was written and committed — the corrupt bytes are
-    // gone, replaced by a valid fresh log with no entries.
+    // A brand-new header replaced the corrupt bytes: a valid fresh log, no entries.
     val loaded = store.load()
     assert(loaded.isDefined, "a fresh header must have been written")
     assertEquals(loaded.get.header.branch, setup.featureBranch.value)
     assertEquals(loaded.get.entries, Nil)
 
-  // Pinned ADR-0019 migration warning: names the settings path and the likely
-  // gitignore line to remove.
+  // The ADR-0019 gitignored-settings warning message.
   private val settingsIgnoredWarning =
     "stack settings at .orca/settings.properties are gitignored — remove the " +
       "'.orca/' line from .gitignore so they can be committed (scratch " +
@@ -766,9 +736,8 @@ class FlowLifecycleTest extends munit.FunSuite:
     )
     val (setup, steps) =
       setupDiscovering(workDir, CannedDiscoveryAgent(canned), "discover-fresh")
-    // The discovered settings are the run's settings…
     assertEquals(setup.stackSettings, StackSettings(format = List("echo fmt")))
-    // …and the written file is the byte-exact render of the checked entries.
+    // The written file is the byte-exact render of the checked entries.
     assertEquals(
       os.read(OrcaDir.settingsPath(workDir)),
       """# orca settings — edit freely, commit with the project.
@@ -789,14 +758,12 @@ class FlowLifecycleTest extends munit.FunSuite:
       commitMessage(workDir, "HEAD~1"),
       "orca: stack settings (discovered)"
     )
-    // The header commit (HEAD) carries only the progress log its message names —
-    // NOT the settings file.
+    // The header commit (HEAD) carries only the progress log, not the settings file.
     assertEquals(commitMessage(workDir, "HEAD"), "orca: progress log")
     assert(
       !commitFiles(workDir, "HEAD").contains(".orca/settings.properties"),
       s"the header commit must NOT include the settings file, got: ${commitFiles(workDir, "HEAD")}"
     )
-    // The bracketing discovery events reached the event surface.
     assert(
       steps.contains(
         "no .orca/settings.properties — running stack discovery"
@@ -835,14 +802,13 @@ class FlowLifecycleTest extends munit.FunSuite:
       ),
       s"the demoted command must be a commented-out line with its reason: $content"
     )
-    // Parsing the written file yields only the surviving commands…
+    // The written file parses to only the surviving commands, matching the run's.
     assertEquals(
       orca.settings.SettingsFile
         .parse(content, orca.settings.SettingsScope.Project)
         .map(_.stack),
       Right(StackSettings(format = List("echo fmt"), test = List("echo test")))
     )
-    // …which are also what the run got.
     assertEquals(setup.stackSettings.lint, Nil)
     assert(
       steps.contains(
@@ -883,10 +849,9 @@ class FlowLifecycleTest extends munit.FunSuite:
     val (setup, _) =
       setupDiscovering(workDir, CannedDiscoveryAgent(canned), prompt)
     assertEquals(setup.stackSettings, StackSettings(format = List("echo fmt")))
-    // The resume arm gives the rediscovered file its own dedicated commit
-    // (the branch already existed): HEAD advances by exactly that commit,
-    // which carries EXACTLY the settings file under the pinned message — the
-    // file is no longer left untracked.
+    // The resume arm gives the rediscovered file its own dedicated commit (the
+    // branch already existed): HEAD advances by exactly that commit, carrying
+    // exactly the settings file under the pinned message.
     assertEquals(
       os.proc("git", "rev-parse", "HEAD~1").call(cwd = workDir).out.text().trim,
       headBefore,
@@ -1085,8 +1050,7 @@ class FlowLifecycleTest extends munit.FunSuite:
     assert(
       lead.recordedWire("x-1").isEmpty && codex.recordedWire("x-1").isEmpty
     )
-    // Pre-6B.1 this skip was a silent for-comprehension drop; it must now
-    // reach the event surface as a Step, not just vanish.
+    // The skip must reach the event surface as a Step, not vanish silently.
     val steps = listener.events.collect { case s: OrcaEvent.Step => s }
     assert(
       steps.exists(s =>
@@ -1263,13 +1227,11 @@ class FlowLifecycleTest extends munit.FunSuite:
   test(
     "teardownSuccess is best-effort: a non-missing-file removal error does not fail an otherwise-successful run"
   ):
-    // teardownSuccess's doc comment promises log-removal/commit/handoff errors
-    // are "cosmetic — swallowed", but the removal leg only ever caught
-    // NoSuchFileException. Replace the progress-log file with a non-empty
-    // directory (after the last stage's own commit has already landed it as a
-    // plain file) so `os.remove` throws DirectoryNotEmptyException instead —
-    // a real, not-NoSuchFile IO error. The run must still complete: nothing
-    // should escape teardown and turn a successful run into exit 1.
+    // teardownSuccess swallows log-removal/commit/handoff errors as cosmetic.
+    // Replace the progress-log file with a non-empty directory (after the last
+    // stage committed it as a plain file) so `os.remove` throws
+    // DirectoryNotEmptyException — a real, not-NoSuchFile IO error. The run must
+    // still complete: nothing should escape teardown and turn success into exit 1.
     val workDir = GitRepo.seeded()
     val prompt = "bestEffort-teardown"
     val store = ProgressStore.default(workDir, prompt)
@@ -1350,10 +1312,8 @@ class FlowLifecycleTest extends munit.FunSuite:
       ):
         // body does nothing — no code changes
         summon[orca.FlowContext].emit(OrcaEvent.Step("no-op"))
-    // Back on main.
     assertEquals(git.currentBranch(), "main")
-    // The feature branch must be gone (auto-deleted as throwaway).
-    // Verify by checking git branch list: no branch other than main exists.
+    // The feature branch must be gone (auto-deleted as throwaway): only main left.
     val branches = os
       .proc("git", "branch", "--format=%(refname:short)")
       .call(cwd = workDir)
@@ -1432,9 +1392,9 @@ class FlowLifecycleTest extends munit.FunSuite:
         val _ = stage("write code"):
           os.write(workDir / "code.txt", "real code")
           "done"
-    // PR-flow behaviour: HEAD returns to the starting branch…
+    // HEAD returns to the starting branch, but the feature branch is kept (it
+    // holds the work / backs the PR).
     assertEquals(git.currentBranch(), "main")
-    // …but the feature branch is kept (it holds the work / backs the PR).
     val branches = os
       .proc("git", "branch", "--format=%(refname:short)")
       .call(cwd = workDir)
@@ -1462,10 +1422,8 @@ class FlowLifecycleTest extends munit.FunSuite:
         featureBranchName = summon[orca.FlowControl].git.currentBranch()
         val _ = stage[String]("crash"):
           throw new RuntimeException("boom")
-    // On the feature branch, not main.
     assertNotEquals(git.currentBranch(), "main")
     assert(featureBranchName.nonEmpty, "must have captured feature branch name")
-    // Feature branch still exists (not deleted).
     val branches = os
       .proc("git", "branch", "--format=%(refname:short)")
       .call(cwd = workDir)
@@ -1483,12 +1441,9 @@ class FlowLifecycleTest extends munit.FunSuite:
   test(
     "default branchNaming (None) resolves via shortenPrompt: branch name equals slug(prompt)"
   ):
-    // When `branchNaming = None` (the default), `flowSetup` uses
-    // `BranchNamingStrategy.shortenPrompt`. With `StubAgent.claude`, `cheap`
-    // returns `this` (haiku = this) and `autonomous` throws
-    // `UnsupportedOperationException`; `shortenPrompt` catches the failure and
-    // falls back to `slug(userPrompt)`. This pins that the default is
-    // `shortenPrompt`, not the old `fromText`.
+    // With `branchNaming = None`, setup uses `BranchNamingStrategy.shortenPrompt`.
+    // `StubAgent.claude`'s `autonomous` throws, so `shortenPrompt` catches and
+    // falls back to `slug(userPrompt)`.
     val workDir = GitRepo.seeded()
     val prompt = "default-naming"
     val expectedBranch = BranchNamingStrategy.slug(prompt)
@@ -1517,13 +1472,9 @@ class FlowLifecycleTest extends munit.FunSuite:
   test(
     "fresh run refuses to bind to a protected branch name"
   ):
-    // The headline hazard this task closes: a `branchNaming` strategy (or,
-    // in production, the cheap-model reply `shortenPrompt` slugs) that
-    // resolves to "main" must NOT bind the whole flow to the repo's default
-    // branch. Today (pre-fix) `freshRun` calls `checkoutOrCreate("main")`
-    // with zero protected-branch check, so this test is RED before
-    // `FeatureBranch` lands: `featureBranchName` observes "main" and no
-    // protecting Step event is emitted.
+    // A `branchNaming` strategy that resolves to "main" must NOT bind the flow
+    // to the repo's default branch: it falls back to a feature branch and emits
+    // a protecting Step.
     val workDir = GitRepo.seeded()
     val prompt = "fresh-protected"
     val git = new OsGitTool(workDir)
@@ -1570,16 +1521,10 @@ class FlowLifecycleTest extends munit.FunSuite:
   test(
     "fresh run does not silently adopt a pre-existing branch with the same resolved name"
   ):
-    // The other tracker hazard task 3.4 closes: `checkoutOrCreate`'s
-    // silent-adopt path took over ANY existing branch with the resolved
-    // name, binding the whole run to whatever unrelated history that branch
-    // already carried — with zero signal. Pre-create a branch with the exact
-    // name `freshRun` will resolve to (a deterministic `branchNaming`), give
-    // it a commit of its own ("unrelated history"), then run a fresh flow
-    // that resolves to that same name. Today (pre-fix) `checkoutOrCreate`
-    // just checks it out and proceeds silently — this test is RED before the
-    // create/checkout split lands: `featureBranchName` observes
-    // `"taken-name"` and the pre-existing branch's head has moved.
+    // A fresh run must not silently adopt a pre-existing branch with the resolved
+    // name, binding the run to its unrelated history. Pre-create "taken-name"
+    // with a commit of its own, then run a fresh flow that resolves to that same
+    // name: it must fall back and leave the pre-existing branch untouched.
     val workDir = GitRepo.seeded()
     val prompt = "adoption-hazard"
     val git = new OsGitTool(workDir)
@@ -1645,15 +1590,13 @@ class FlowLifecycleTest extends munit.FunSuite:
   test(
     "fresh run aborts loudly when the deterministic fallback branch itself already exists"
   ):
-    // The interaction the brief calls out: if the resolved name already went
-    // to the deterministic `flow-<hash>` fallback (here: because a
-    // protected-name collision fires first), a git-level "already exists"
-    // collision on THAT fallback must abort rather than hash a second time —
-    // a deterministic name colliding twice for the same prompt means a
-    // previous run's branch is genuinely still there, and the user must
-    // decide, not have orca guess again. Pre-create the exact deterministic
-    // fallback name as an unrelated branch, then force the protected-name
-    // fallback to land on it by resolving to "main".
+    // If the resolved name already went to the deterministic `flow-<hash>`
+    // fallback (here because a protected-name collision fires first), a git
+    // "already exists" collision on THAT fallback must abort rather than hash
+    // again: a deterministic name colliding twice for the same prompt means a
+    // previous run's branch is still there, and the user must decide. Pre-create
+    // the fallback name, then force the protected-name fallback onto it by
+    // resolving to "main".
     val workDir = GitRepo.seeded()
     val prompt = "fallback-collision-hazard"
     val store = ProgressStore.default(workDir, prompt)
@@ -1694,10 +1637,8 @@ class FlowLifecycleTest extends munit.FunSuite:
   test(
     "surfaced: a setup resume-refusal reaches the user as one Error and escapes as SurfacedFlowFailure"
   ):
-    // The silent-exit family's headline case: a tampered header makes `setup`
-    // throw the resume refusal. Before the `surfaced` bracket, that escaped
-    // `flow()` unreported — banner + exit 1 and nothing else. Now it must reach
-    // the user's event surface exactly once, and escape marked as surfaced.
+    // A tampered header makes `setup` throw the resume refusal. It must reach
+    // the user's event surface exactly once and escape marked as surfaced.
     val workDir = GitRepo.seeded()
     val prompt = "surfaced-tampered"
     val store = ProgressStore.default(workDir, prompt)
@@ -1727,8 +1668,7 @@ class FlowLifecycleTest extends munit.FunSuite:
       thrown.cause.isInstanceOf[orca.OrcaFlowException],
       s"the surfaced cause must be the original refusal: ${thrown.cause}"
     )
-    // Folded from the deleted R32 (same fixture, same validation branch): the
-    // header-validation failure reason rides along in the same message.
+    // The header-validation failure reason rides along in the same message.
     assert(
       thrown.cause.getMessage.contains("failed validation"),
       s"abort message must mention validation failure: ${thrown.cause.getMessage}"
@@ -1774,10 +1714,9 @@ class FlowLifecycleTest extends munit.FunSuite:
   test(
     "surfaced: a rehydration failure reaches the user as one Error, not a silent exit"
   ):
-    // rehydrateSessions runs OUTSIDE the body's try today; a throw there
-    // escaped unreported exactly like a setup failure. Force one: resume in
-    // place (valid header) with a persisted resume-wire-id, and a lead agent
-    // whose registry throws when the runtime replays it.
+    // rehydrateSessions runs outside the body's try, so a throw there must be
+    // surfaced like a setup failure. Force one: resume in place with a persisted
+    // resume-wire-id and a lead agent whose registry throws on replay.
     val workDir = GitRepo.seeded()
     val prompt = "surfaced-rehydrate"
     val store = ProgressStore.default(workDir, prompt)
@@ -1969,8 +1908,7 @@ class FlowLifecycleTest extends munit.FunSuite:
         ):
           ()
     // `intercept[orca.OrcaFlowException]` above already pins the static type
-    // — an unwrapped `OrcaFlowException`, not a `SurfacedFlowFailure` — since
-    // the two types are unrelated; nothing further to assert on that front.
+    // (unwrapped, not a `SurfacedFlowFailure`); nothing further to assert.
     assertEquals(
       thrown.getMessage,
       s"a flow is already running in this working tree (pid $livePid)"
@@ -2226,9 +2164,9 @@ class FlowLifecycleTest extends munit.FunSuite:
       opencodeOverride: => OpencodeAgent = notWired("opencode"),
       piOverride: => PiAgent = notWired("pi"),
       geminiOverride: => GeminiAgent = notWired("gemini"),
-      /** Records every emitted event — `Nil` (the default) keeps `emit` a true
-        * no-op for tests that don't care; the two rehydration-warning tests
-        * below pass a listener to assert on the emitted `Step`.
+      /** Sink for emitted events; the default no-op suits tests that don't
+        * care, while the rehydration-warning tests pass a listener to assert on
+        * `Step`s.
         */
       emitTo: OrcaEvent => Unit = _ => ()
   ) extends FlowContext:

--- a/runner/src/test/scala/orca/runner/LeadAgentIdentityTest.scala
+++ b/runner/src/test/scala/orca/runner/LeadAgentIdentityTest.scala
@@ -38,18 +38,15 @@ import java.util.concurrent.atomic.AtomicReference
 /** Pins the foreign-agent handling: a per-role override (`codingAgent =
   * Some(...)`) can return an agent built from a backend that isn't wired into
   * this run — event-blind (built against its own `AgentWiring`, not this run's
-  * dispatcher) and, absent this fix, never closed. [[DefaultFlowContext.close]]
-  * unconditionally closes the three resolved role agents alongside all five
-  * wired agents (no wired/foreign branch needed there — a backend's own
-  * `close()` is idempotent), so a foreign role agent's backend is closed too.
-  * `runFlow` separately warns loudly per role when it resolves a foreign agent
-  * against the wired agent set, comparing backend IDENTITY
-  * ([[orca.agents.Agent.backendIdentity]]), not `Agent` reference equality —
-  * the positive case below pins that a `copyTool`-derived sibling of a wired
-  * agent (the common `_.claude.opus` shape) does NOT trip that warning, which a
-  * naive `Agent eq Agent` implementation would get wrong, and that its shared
-  * backend's teardown still runs exactly once despite being closed via two
-  * different `Agent` instances.
+  * dispatcher). [[DefaultFlowContext.close]] unconditionally closes the three
+  * resolved role agents alongside all five wired agents (safe because a
+  * backend's own `close()` is idempotent), so a foreign role agent's backend is
+  * closed too. `runFlow` separately warns per role when it resolves a foreign
+  * agent, comparing backend IDENTITY ([[orca.agents.Agent.backendIdentity]]),
+  * not `Agent` reference equality — the positive case below pins that a
+  * `copyTool`-derived sibling of a wired agent (the common `_.claude.opus`
+  * shape) does NOT trip that warning, and that its shared backend's teardown
+  * still runs exactly once despite two `Agent` instances.
   */
 class LeadAgentIdentityTest extends munit.FunSuite:
 
@@ -267,19 +264,15 @@ class LeadAgentIdentityTest extends munit.FunSuite:
       throw new UnsupportedOperationException
 
   /** A minimal `AgentBackend` that counts REALISED close teardowns —
-    * `runAutonomous`/`runInteractive` are never exercised by these tests (the
-    * lead agent is never actually called, only resolved and closed).
+    * `runAutonomous`/`runInteractive` are never exercised (the lead agent is
+    * only resolved and closed, never called).
     *
-    * `close()` itself is CAS-guarded, mirroring the idempotence every real
-    * backend already provides (the shared `closedFlag` latches via a plain
-    * `set`, opencode's process teardown is CAS-guarded, every other backend's
-    * `close()` is a no-op) — see `DefaultFlowContext.close`'s scaladoc. Since
-    * `DefaultFlowContext.close()` now appends the resolved lead
-    * UNCONDITIONALLY, a lead sharing a wired backend gets `Agent.close()`
-    * invoked on it twice; `closeCount` pins that the doubled CALL still
-    * produces a single observable teardown, which is the actual contract
-    * `close()`'s scaladoc relies on — not that `Agent.close()` is called
-    * exactly once.
+    * `close()` is CAS-guarded, mirroring the idempotence every real backend
+    * provides. Since `DefaultFlowContext.close()` appends the resolved lead
+    * unconditionally, a lead sharing a wired backend gets `Agent.close()`
+    * invoked twice; `closeCount` pins that the doubled call still produces a
+    * single observable teardown — the actual contract, not that `close()` is
+    * called exactly once.
     */
   private class RecordingCloseBackend extends AgentBackend[BackendTag.Pi.type]:
     val workDir: os.Path = os.pwd

--- a/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
+++ b/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
@@ -146,14 +146,12 @@ class OrcaOverridesTest extends munit.FunSuite:
   test(
     "the opencode override slot accepts its own default factory (Ox ?=> result)"
   ):
-    // Item 2 pin: the opencode param is `AgentWiring => Ox ?=> OpencodeAgent`,
-    // so `Some(w => OpencodeAgents.default(w))` — the factory that itself needs
-    // an Ox — compiles at the `flow(...)` argument position, with the Ox
-    // resolved where `WiredAgents.build` applies it. This is a compiles-and-runs
-    // case (not a stub-CLI run): the lead is the claude stub and the body never
-    // touches opencode, and the opencode `serve` spawn is lazy, so the flow
-    // runs to completion without a real process. Building the default opencode
-    // agent via the factory is what's under test.
+    // The opencode param is `AgentWiring => Ox ?=> OpencodeAgent`, so
+    // `Some(w => OpencodeAgents.default(w))` — a factory that itself needs an Ox
+    // — compiles at the `flow(...)` argument position, with the Ox resolved
+    // where `WiredAgents.build` applies it. Compiles-and-runs: the lead is the
+    // claude stub, the body never touches opencode, and opencode's `serve` spawn
+    // is lazy, so the flow completes without a real process.
     var ran = false
     supervised:
       val interaction = TerminalInteraction.start(
@@ -212,10 +210,10 @@ class OrcaOverridesTest extends munit.FunSuite:
   test(
     "an agent-override factory receives the run's event sink: its TokensUsed reaches extraListeners"
   ):
-    // The pin: a user agent built by the override
-    // factory must land on the SAME dispatcher as the defaults, so the tokens
-    // it spends reach the cost tracker and terminal. The factory receives
-    // `w.events`; the stub emits a TokensUsed through it on `run`.
+    // A user agent built by the override factory must land on the SAME
+    // dispatcher as the defaults, so the tokens it spends reach the cost tracker
+    // and terminal. The factory receives `w.events`; the stub emits a TokensUsed
+    // through it on `run`.
     def wiredClaude(events: OrcaListener): ClaudeAgent = new ClaudeAgent:
       val name = "wired"
       def haiku = this

--- a/runner/src/test/scala/orca/runner/RoleSettingsFlowTest.scala
+++ b/runner/src/test/scala/orca/runner/RoleSettingsFlowTest.scala
@@ -36,11 +36,7 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 import java.util.concurrent.atomic.AtomicReference
 
 /** End-to-end coverage of settings-driven role resolution through `runFlow`
-  * (ADR 0020): the three role agents resolve from the project and user-global
-  * settings files (and the per-role programmatic overrides), a malformed file
-  * aborts before any tree mutation, agent keys survive a stack override, and an
-  * agents-only file still triggers stack discovery (appended, not clobbered).
-  * The stub agent factories keep every backend off a real CLI.
+  * (ADR 0020). The stub agent factories keep every backend off a real CLI.
   */
 class RoleSettingsFlowTest extends munit.FunSuite:
 
@@ -174,8 +170,8 @@ class RoleSettingsFlowTest extends munit.FunSuite:
       wiring = wiringWith(claude = StubAgent.claude, codex = canned)
     ):
       // Real committed work keeps the feature branch (a throwaway branch is
-      // deleted on teardown, taking the just-committed settings file with it),
-      // so the appended file is still present to inspect.
+      // deleted on teardown, taking the settings file with it), so the appended
+      // file survives for inspection.
       val _ = orca.stage("work"):
         os.write(workDir / "work.txt", "real code")
         "done"
@@ -215,8 +211,8 @@ class RoleSettingsFlowTest extends munit.FunSuite:
       wiring = wiringWith(claude = canned)
     ):
       // Real committed work keeps the feature branch (a throwaway branch is
-      // deleted on teardown, taking the just-written settings file with it),
-      // so the written file is still present to inspect.
+      // deleted on teardown, taking the settings file with it), so the written
+      // file survives for inspection.
       val _ = orca.stage("work"):
         os.write(workDir / "work.txt", "real code")
         "done"
@@ -230,9 +226,9 @@ class RoleSettingsFlowTest extends munit.FunSuite:
     "a discovery-written file with only commented stack lines does not re-trigger discovery"
   ):
     val workDir = GitRepo.seeded()
-    // The stack lines are all commented (as a discovery-written file leaves
-    // them), so `hasStackLines` is true and discovery must NOT run again — the
-    // plain codex stub would throw if it did.
+    // All stack lines commented (as a discovery-written file leaves them) makes
+    // `hasStackLines` true, so discovery must not run again — the plain codex
+    // stub would throw if it did.
     writeProject(
       workDir,
       "codingAgent = codex\n# format =   (no formatter found)\n"
@@ -279,18 +275,16 @@ class RoleSettingsFlowTest extends munit.FunSuite:
     "a symlinked project settings file aborts before any write or branch mutation"
   ):
     val workDir = GitRepo.seeded()
-    // A committed `.orca/settings.properties` symlink pointing outside the tree:
-    // `os.write.over` follows the link, so discovery would write its output at
-    // `outside`. The link is dangling (target absent), which is exactly the
-    // shape whose `os.exists` reads false and would otherwise drive a
-    // fresh-write discovery straight through the link.
+    // A committed `.orca/settings.properties` symlink pointing outside the tree.
+    // The link is dangling (target absent), the shape whose `os.exists` reads
+    // false and would otherwise drive a fresh-write discovery through the link.
     val outside = TempDirs.dir() / "outside.properties"
     val linkPath = OrcaDir.settingsPath(workDir)
     os.makeDir.all(linkPath / os.up)
     os.symlink(linkPath, outside)
     val startBranch = new OsGitTool(workDir).currentBranch()
-    // A canned discovery agent that WOULD succeed and write, so the abort — not
-    // a discovery failure — is what keeps the target file from being created.
+    // A canned discovery agent that would succeed and write, so it's the abort,
+    // not a discovery failure, that keeps the target file from being created.
     val canned = CannedDiscoveryAgent(
       StackDiscoveryResult(
         format = DiscoveredTask(commands =
@@ -316,18 +310,17 @@ class RoleSettingsFlowTest extends munit.FunSuite:
     "a symlinked `.orca` directory aborts before any write or branch mutation"
   ):
     val workDir = GitRepo.seeded()
-    // A committed `.orca` DIRECTORY symlink (git mode 120000) pointing at an
-    // existing directory outside the tree. The leaf `os.isLink` check misses
-    // this — it inspects only the final path component — so without the
-    // `.orca`-root guard every write (cache, lock, discovery output) would land
-    // inside `outside`, off-tree. `outside` starts empty, so any file appearing
-    // in it is a write that went through the link.
+    // A committed `.orca` DIRECTORY symlink pointing at an existing directory
+    // outside the tree. A leaf-only `os.isLink` check misses this, so without
+    // the `.orca`-root guard every write (cache, lock, discovery output) would
+    // land inside `outside`. `outside` starts empty, so any file appearing in it
+    // is a write that went through the link.
     val outside = TempDirs.dir() / "outside-orca"
     os.makeDir.all(outside)
     os.symlink(OrcaDir.rootPath(workDir), outside)
     val startBranch = new OsGitTool(workDir).currentBranch()
-    // A canned discovery agent that WOULD succeed and write, so the abort — not
-    // a discovery failure — is what keeps the target from being written.
+    // A canned discovery agent that would succeed and write, so it's the abort,
+    // not a discovery failure, that keeps the target from being written.
     val canned = CannedDiscoveryAgent(
       StackDiscoveryResult(
         format = DiscoveredTask(commands =
@@ -353,20 +346,19 @@ class RoleSettingsFlowTest extends munit.FunSuite:
     "a symlinked `.orca/cache` directory aborts before any write or branch mutation"
   ):
     val workDir = GitRepo.seeded()
-    // A committed `.orca` real DIRECTORY holding a `.orca/cache` symlink (git
-    // mode 120000) pointing off-tree. The `.orca`-root guard passes (it's a real
-    // dir), so a leaf-only or root-only check would let `ensureCache`'s
-    // `os.makeDir.all(.orca/cache)` and the flow lock write follow the link into
-    // `outside`. Guarding every component from `.orca` down catches the
-    // symlinked cache dir. `outside` starts empty, so any file appearing in it
-    // is a write that escaped the tree.
+    // A committed `.orca` real DIRECTORY holding a `.orca/cache` symlink pointing
+    // off-tree. The `.orca`-root guard passes (it's a real dir), so a root-only
+    // check would let `ensureCache`'s `os.makeDir.all` and the flow lock write
+    // follow the link into `outside`; guarding every component from `.orca` down
+    // catches the symlinked cache dir. `outside` starts empty, so any file
+    // appearing in it is a write that escaped the tree.
     val outside = TempDirs.dir() / "outside-cache"
     os.makeDir.all(outside)
     os.makeDir.all(OrcaDir.rootPath(workDir))
     os.symlink(OrcaDir.rootPath(workDir) / "cache", outside)
     val startBranch = new OsGitTool(workDir).currentBranch()
-    // A canned discovery agent that WOULD succeed and write, so the abort — not
-    // a discovery failure — is what keeps the target from being written.
+    // A canned discovery agent that would succeed and write, so it's the abort,
+    // not a discovery failure, that keeps the target from being written.
     val canned = CannedDiscoveryAgent(
       StackDiscoveryResult(
         format = DiscoveredTask(commands =
@@ -476,10 +468,7 @@ class RoleSettingsFlowTest extends munit.FunSuite:
       "the malformed-file abort must precede any branch mutation"
     )
 
-  /** A `CodexAgent` stub: every builder returns `this`, every call throws — the
-    * codex sibling of [[StubClaudeAgent]], for a role that must never reach a
-    * real CLI.
-    */
+  /** A `CodexAgent` stub: every builder returns `this`, every call throws. */
   private class StubCodex extends CodexAgent:
     val name = "stub-codex"
     def mini: CodexAgent = this
@@ -507,10 +496,9 @@ class RoleSettingsFlowTest extends munit.FunSuite:
     def resultAs[O: JsonData: Announce]: AgentCall[BackendTag.Gemini.type, O] =
       throw new UnsupportedOperationException
 
-  /** The codex discovery seam, mirroring [[CannedDiscoveryAgent]] for the codex
-    * role: `resultAs[O].autonomous.run` returns the canned discovery result in
-    * the [[StackDiscoveryReply]] envelope; free-text calls throw (branch naming
-    * falls back to the deterministic slug).
+  /** The codex discovery seam, mirroring [[CannedDiscoveryAgent]]:
+    * `resultAs[O].autonomous.run` returns the canned discovery result in the
+    * [[StackDiscoveryReply]] envelope; free-text calls throw.
     */
   private class CannedDiscoveryCodex(result: StackDiscoveryResult)
       extends StubCodex:

--- a/runner/src/test/scala/orca/runner/StackDiscoveryTest.scala
+++ b/runner/src/test/scala/orca/runner/StackDiscoveryTest.scala
@@ -11,10 +11,9 @@ class StackDiscoveryTest extends munit.FunSuite:
   test(
     "a representative always-both envelope shape decodes under the strict codec"
   ):
-    // The strict output schema requires both keys on every task, so agents
-    // emit "commands": [] and "unsetReason": null where a side doesn't apply
-    // — this pins that the strict jsoniter codec accepts exactly that shape,
-    // including the single-property "result" envelope.
+    // The strict schema requires both keys on every task ("commands": [] and
+    // "unsetReason": null where a side doesn't apply); this pins that the codec
+    // accepts that shape, including the single-property "result" envelope.
     val json =
       """{"result":
         | {"format": {"commands": [{"command": "acme style --write",
@@ -57,8 +56,8 @@ class StackDiscoveryTest extends munit.FunSuite:
       )
     )
 
-  /** Checks that pass everything — the assembly tests inject failures
-    * explicitly where a scenario needs them.
+  /** Checks that pass everything; tests inject failures where a scenario needs
+    * them.
     */
   private val allResolvable: String => Option[String] = _ => None
   private val allEvidenceExists: String => Boolean = _ => true

--- a/runner/src/test/scala/orca/runner/StubAgent.scala
+++ b/runner/src/test/scala/orca/runner/StubAgent.scala
@@ -2,8 +2,7 @@ package orca.runner
 
 import orca.agents.ClaudeAgent
 
-/** A `ClaudeAgent` stub for tests that must pass the now-mandatory leading
-  * model to `flow(...)` (ADR 0018 §2.5) but assert wiring/lifecycle, not LLM
+/** A `ClaudeAgent` stub for tests that assert wiring/lifecycle, not LLM
   * behaviour. Every call throws — no test reaches one.
   */
 object StubAgent:

--- a/runner/src/test/scala/orca/runner/StubClaudeAgent.scala
+++ b/runner/src/test/scala/orca/runner/StubClaudeAgent.scala
@@ -14,8 +14,7 @@ import orca.agents.{
 }
 
 /** The shared `ClaudeAgent` skeleton for runner tests: every builder returns
-  * `this`, every call throws. Concrete stubs override only what differs —
-  * [[StubAgent.claude]] nothing, [[CannedDiscoveryAgent]] `resultAs`.
+  * `this`, every call throws. Concrete stubs override only what differs.
   */
 private[runner] abstract class StubClaudeAgent(val name: String)
     extends ClaudeAgent:

--- a/runner/src/test/scala/orca/runner/terminal/ConversationRendererTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/ConversationRendererTest.scala
@@ -85,9 +85,8 @@ class ConversationRendererTest extends munit.FunSuite:
     )
 
   test("UserMessage renders as one truncated line, not the full prompt"):
-    // The initial user message of an interactive session is usually the full
-    // templated instruction; the render identifies the turn like the
-    // autonomous `▸` prompt line does, instead of dumping pages of prompt.
+    // The initial user message is usually the full templated instruction; the
+    // render identifies the turn instead of dumping pages of prompt.
     val buf = new ByteArrayOutputStream()
     val long = "Add a feature to the calculator.\n" + ("detail " * 100)
     val conv = new ScriptedConversation(
@@ -107,9 +106,8 @@ class ConversationRendererTest extends munit.FunSuite:
     )
 
   test("non-structured mode: assistant text flushes verbatim at TurnEnd"):
-    // Off the structured-output path, the renderer doesn't
-    // second-guess the agent's output — JSON-shaped or not, it
-    // streams as `●` prose like everything else.
+    // Off the structured-output path the renderer streams the agent's output as
+    // `●` prose, JSON-shaped or not.
     val buf = new ByteArrayOutputStream()
     val conv = new ScriptedConversation(
       List(
@@ -127,9 +125,8 @@ class ConversationRendererTest extends munit.FunSuite:
   test(
     "structured mode: assistant text is suppressed (StructuredResult takes over)"
   ):
-    // When the conversation was launched with an `outputSchema`,
-    // the agent's final text is the structured payload. Suppressing
-    // it here lets the listener pick the canonical render via
+    // With an `outputSchema` the agent's final text is the structured payload;
+    // suppressing it lets the listener pick the canonical render via
     // `OrcaEvent.StructuredResult` (raw or summary, never both).
     val buf = new ByteArrayOutputStream()
     val conv = new ScriptedConversation(
@@ -272,8 +269,8 @@ class ConversationRendererTest extends munit.FunSuite:
 
   test("render does not close its prompter (prompter is process-scoped)"):
     // The prompter is shared across every conversation in a run; a
-    // per-conversation renderer must never close it, or the next
-    // interactive prompt would operate on closed I/O.
+    // per-conversation renderer must never close it, or the next prompt would
+    // operate on closed I/O.
     val buf = new ByteArrayOutputStream()
     val prompter = new ScriptedPrompter(Nil)
     val conv = new ScriptedConversation(Nil, Right(sampleResult))
@@ -281,9 +278,8 @@ class ConversationRendererTest extends munit.FunSuite:
     assertEquals(prompter.closes.get(), 0)
 
   test("two sequential render+prompt cycles against one prompter both ask"):
-    // Pins the second-prompt-usable property: a single shared prompter
-    // survives across conversations, so a second render still reaches
-    // `ask` rather than a closed reader.
+    // A single shared prompter survives across conversations, so a second
+    // render still reaches `ask` rather than a closed reader.
     val buf = new ByteArrayOutputStream()
     val prompter = new ScriptedPrompter(
       List(PromptOutcome.Answer("yes"), PromptOutcome.Answer("no"))

--- a/runner/src/test/scala/orca/runner/terminal/ScalaCliSmokeTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/ScalaCliSmokeTest.scala
@@ -17,12 +17,10 @@ class ScalaCliSmokeTest extends munit.FunSuite:
     import scala.concurrent.duration.DurationInt
     20.minutes
 
-  /** Memoise the publishLocal step across the suite's tests — every script here
-    * links against the same dynver-computed version, so re-publishing once per
-    * test would just multiply the slowest step. The fixture runs once per
-    * suite, fails fast if sbt fails, and exposes both the repo root and the
-    * published version (read back from sbt because dynver derives it from git
-    * state rather than a static literal).
+  /** Memoises the publishLocal step across the suite (every script links
+    * against the same version). Runs once per suite, fails fast if sbt fails,
+    * and exposes the repo root plus the published version, read back from sbt
+    * because dynver derives it from git state rather than a static literal.
     */
   case class Published(repoRoot: os.Path, version: String)
 
@@ -113,11 +111,10 @@ class ScalaCliSmokeTest extends munit.FunSuite:
     "epic.sc"
   )
 
-  /** Each flow script is a real-world consumer of the library — when a
-    * public-API rename or signature change ships, these scripts are the first
-    * thing that breaks for users. Compile-checking them here closes the gap
-    * between sbt's internal compile (which doesn't see `examples/`) and what a
-    * fresh user actually runs.
+  /** Each flow script is a real-world consumer of the public API, so a rename
+    * or signature change breaks them first. Compile-checking here closes the
+    * gap between sbt's internal compile (which doesn't see `examples/`) and
+    * what a fresh user runs.
     */
   for relPath <- flowScripts do
     test(s"examples/$relPath compiles via scala-cli"):

--- a/runner/src/test/scala/orca/runner/terminal/TerminalEventListenerTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/TerminalEventListenerTest.scala
@@ -4,10 +4,9 @@ import orca.events.{OrcaEvent, Usage}
 import orca.agents.Model
 import java.io.{ByteArrayOutputStream, PrintStream}
 
-/** These tests exercise the listener's synchronous state-mutation behaviour by
-  * driving it directly with a synchronous `TerminalOutputState` — bypassing the
-  * actor so the test reads output immediately rather than racing a worker
-  * thread.
+/** Drives the listener directly against a synchronous `TerminalOutputState`,
+  * bypassing the actor so output is readable immediately rather than racing a
+  * worker thread.
   */
 class TerminalEventListenerTest extends munit.FunSuite:
 
@@ -286,12 +285,11 @@ class TerminalEventListenerTest extends munit.FunSuite:
     )
 
   test("currentIndent stays readable while stages push and pop concurrently"):
-    // A light regression guard for the single-writer / @volatile publication
-    // contract, NOT a race proof: the test thread is the sole writer (pushing
-    // then popping 500 StageStarted/StageCompleted pairs) while a reader thread
-    // polls `currentIndent` from another thread — the same lock-free access the
-    // ConversationRenderer makes mid-readLine. It asserts the reader never
-    // crashes and that the stack unwinds to empty once every pair is balanced.
+    // A regression guard for the single-writer / @volatile publication contract,
+    // NOT a race proof: the sole writer pushes/pops 500 pairs while a reader
+    // polls `currentIndent` (the same lock-free access ConversationRenderer makes
+    // mid-readLine). Asserts the reader never crashes and the stack unwinds to
+    // empty once every pair is balanced.
     val buf = new ByteArrayOutputStream()
     val ps = new PrintStream(buf)
     val output =

--- a/runner/src/test/scala/orca/runner/terminal/TerminalInteractionTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/TerminalInteractionTest.scala
@@ -12,9 +12,9 @@ class TerminalInteractionTest extends munit.FunSuite:
   test(
     "default output stream encodes UTF-8 regardless of the JVM launch locale"
   ):
-    // Regression: under a non-UTF-8 locale (C/POSIX — common in containers and
-    // editor sandboxes) the JVM resolves System.err to US-ASCII and every glyph
-    // (…, ✖, ▸, ●) encodes to '?'. The default stream must force UTF-8.
+    // Under a non-UTF-8 locale (C/POSIX, common in containers) the JVM resolves
+    // System.err to US-ASCII and every glyph (…, ✖, ▸, ●) encodes to '?', so the
+    // default stream must force UTF-8.
     assertEquals(TerminalInteraction.utf8Stderr.charset(), UTF_8)
 
   test("close() closes the interaction's prompter exactly once"):

--- a/runner/src/test/scala/orca/runner/terminal/TerminalOutputActorTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/TerminalOutputActorTest.scala
@@ -100,9 +100,8 @@ class TerminalOutputActorTest extends munit.FunSuite:
           "A"
 
       firstStarted.await()
-      // The first prompt owns the terminal now. A log write and a status
-      // update arriving concurrently must not land on `out` (7B.1) — they
-      // should be deferred until resume.
+      // The first prompt owns the terminal now. A log write and a status update
+      // arriving concurrently must not land on `out`; they defer until resume.
       val sizeDuringPrompt = buf.size()
       output.log("during-first-prompt")
       output.setStatus(Some("stage started"))

--- a/tools/src/main/scala/orca/CheckedPar.scala
+++ b/tools/src/main/scala/orca/CheckedPar.scala
@@ -10,55 +10,35 @@ import ox.flow.Flow
   * checking can enforce the [[InStage]]/[[WorkspaceWrite]] capability split at
   * the fork boundary (ADR 0018 §6).
   *
-  * Why this exists: separation checking rejects an exclusive capability the
-  * moment it is widened away ("hidden") — for a fan-out, that is the thunk
-  * list's impure element type. A `tasks: Seq[() => T]` whose closures capture
-  * an exclusive `WorkspaceWrite`/`FlowControl` (an index-like write racing
-  * across forks — ADR 0018 §6) fails with "Separation failure" right at that
-  * definition, while the load-bearing shared `InStage` capture — reviewers
-  * must reach a gated LLM `run` from inside their fork — compiles, because
-  * `caps.SharedCapability` is separation-exempt. The wrapper's signature alone
-  * does NOT reject: a thunk list with a precise inferred capture set (e.g.
-  * `Seq[() ->{tok} T]` for an exclusive `tok`) passes through unflagged — the
-  * impure `() => T` element type at the call site is what arms the check, and
-  * it fires identically whether the list is then handed to this wrapper or to
-  * raw Ox (all four combinations verified by compiling fixture variants). The
-  * funnel's job is to keep fan-out call sites in the checked shape: its
-  * capture-set-polymorphic signature forces a heterogeneous thunk list to be
-  * widened to a single element type — in practice the impure `() => T` (see
-  * the CC-forced type application in `orca.review.ReviewLoop`) — and it is the
-  * pinned pattern the negative-compile suite compiles fixtures against.
+  * Separation checking rejects an exclusive capability the moment it is widened
+  * away. For a fan-out that is the thunk list's impure `() => T` element type: a
+  * closure capturing an exclusive `WorkspaceWrite`/`FlowControl` fails with a
+  * separation failure at the call site, while a shared `InStage` capture (a
+  * `caps.SharedCapability`, separation-exempt) compiles — reviewers reach a
+  * gated LLM `run` from inside their fork. The check is armed by the impure
+  * element type at the call site, not by this wrapper's signature; the funnel's
+  * job is to keep fan-out call sites in that checked shape, and it is the pinned
+  * pattern the negative-compile suite compiles fixtures against.
   *
-  * Raw Ox stays the unchecked escape hatch until Ox itself is capture-checked
-  * (`Ox` on its roadmap). These wrappers are a bridge designed for deletion:
-  * once `ox.fork`/`Flow` carry capture annotations, the fork-boundary rejection
-  * happens at the Ox call directly and this funnel stops being load-bearing.
-  * Enforcement is per compilation unit — a call site is only checked if its own
-  * file carries the two language imports above.
+  * Raw Ox stays the unchecked escape hatch until Ox itself is capture-checked.
+  * These wrappers are a bridge for deletion: once `ox.fork`/`Flow` carry capture
+  * annotations, the rejection happens at the Ox call directly. Enforcement is
+  * per compilation unit — a call site is only checked if its own file carries
+  * the two language imports above.
   *
-  * The wrappers delegate 1:1 to Ox with no behavioral additions; their value is
-  * purely their compilation mode and their capture-annotated types.
+  * The wrappers delegate 1:1 to Ox with no behavioral additions.
   */
 private[orca] object CheckedPar:
-  /** Capture-checked delegate for the reviewer fan-out's
-    * `Flow.fromIterable(thunks).mapParUnordered(parallelism)(_.apply()).tap(onResult).runToList()`
-    * pipeline. Runs `thunks` concurrently (up to `parallelism` at a time,
-    * results unordered), invoking `onResult` on each result as it completes on
-    * the collecting thread, and returns every result as a list.
+  /** Runs `thunks` concurrently (up to `parallelism` at a time, results
+    * unordered), invoking `onResult` on each result as it completes on the
+    * collecting thread, and returns every result as a list.
     *
-    * The capture-set parameter `C^` is not interchangeable with taking plain
-    * impure thunks (`Seq[() => T]`, i.e. `() ->{caps.cap} T`): with that
-    * signature this method does not compile — applying the elements leaks the
-    * local reach capability `thunks*` into the method's capture scope, and the
-    * compiler error suggests exactly this capset-variable abstraction. `C^`
-    * gives the elements' captures a name this method's body can be checked
-    * against, while the call site keeps the enforcement role: widening thunks
-    * that capture an exclusive `caps.ExclusiveCapability` ([[WorkspaceWrite]],
-    * [[FlowControl]]) to the impure `() => T` element type is rejected there
-    * with a separation failure, while a shared [[InStage]] capture is admitted
-    * (see the object doc for what happens without that widening). `onResult`
-    * is a plain impure closure (it captures the caller's `FlowContext` to emit
-    * progress), unconstrained by `C`.
+    * The capture-set parameter `C^` is not interchangeable with plain impure
+    * thunks (`Seq[() => T]`): that signature does not compile, since applying the
+    * elements leaks the reach capability `thunks*` into the method's capture
+    * scope. `C^` names the elements' captures so the body type-checks, while the
+    * call site keeps the enforcement role (see the object doc). `onResult` is a
+    * plain impure closure, unconstrained by `C`.
     */
   def mapParUnordered[T, C^](
       parallelism: Int

--- a/tools/src/main/scala/orca/InStage.scala
+++ b/tools/src/main/scala/orca/InStage.scala
@@ -11,7 +11,9 @@ import scala.annotation.implicitNotFound
   * `caps.SharedCapability`, so it may be captured freely into a `fork` (the
   * reviewer fan-out's shared `InStage` capture is load-bearing) and is exempt
   * from separation rules. The EXCLUSIVE half — [[WorkspaceWrite]] — gates
-  * mutations that must NOT cross a fork boundary.
+  * mutations that must NOT cross a fork boundary. `caps.SharedCapability` is
+  * non-experimental on 3.8.4, so — unlike [[WorkspaceWrite]] — this file needs
+  * no `captureChecking` language import.
   *
   * Carries no state; it is a real class only so capture checking has a
   * reference to track.

--- a/tools/src/main/scala/orca/InStage.scala
+++ b/tools/src/main/scala/orca/InStage.scala
@@ -2,32 +2,19 @@ package orca
 
 import scala.annotation.implicitNotFound
 
-/** In-stage LLM-call token. A capability the `stage` implementation (which
-  * lives in package `orca`) mints and supplies to its body; user code and tool
-  * wrappers receive it as a `using` parameter but can never fabricate one — the
-  * `private` constructor and `private[orca]` mint ensure that. This gates
-  * stage-bound LLM runs so they cannot accidentally be called outside a running
-  * stage (ADR 0018 §2.2, §6).
+/** In-stage LLM-call token, minted and supplied by the `stage` implementation;
+  * user code receives it `using` but cannot fabricate one (private
+  * constructor). Gates stage-bound LLM runs so they can't run outside a stage
+  * (ADR 0018 §2.2, §6).
   *
-  * `InStage` is the SHARED half of the capability split (ADR 0018 §6): it
-  * extends `caps.SharedCapability`, so once capture checking is adopted it may
-  * be freely captured into a `fork` (the reviewer fan-out's shared `InStage`
-  * capture is load-bearing) and is exempt from separation rules. The EXCLUSIVE
-  * half — [[WorkspaceWrite]] — gates index-like mutations that must NOT cross a
-  * fork boundary. `caps.SharedCapability` is non-experimental on 3.8.4, so this
-  * file needs no language import.
+  * The SHARED half of the capability split (ADR 0018 §6): extends
+  * `caps.SharedCapability`, so it may be captured freely into a `fork` (the
+  * reviewer fan-out's shared `InStage` capture is load-bearing) and is exempt
+  * from separation rules. The EXCLUSIVE half — [[WorkspaceWrite]] — gates
+  * mutations that must NOT cross a fork boundary.
   *
-  * The value carries no state — it is evidence only; nothing reads anything off
-  * it. Making it a real class (rather than an opaque `Unit`) is purely so that
-  * capture checking has a reference to track (a `Unit` value is pure).
-  *
-  * The `@implicitNotFound` message is worded for flow authors, who never need
-  * to know what `InStage` is — only that LLM calls belong inside a
-  * `stage(...)`.
-  *
-  * `private[orca]` still lets any code in the `orca` package — across modules —
-  * call `unsafe`; an accepted guard-rail per ADR 0018 §5, with the convention
-  * that only the `stage` runtime does so.
+  * Carries no state; it is a real class only so capture checking has a
+  * reference to track.
   */
 @implicitNotFound(
   "LLM runs must be made inside a `stage(...)` body, which commits and checkpoints them. Move this call into a stage. If this is a helper meant to run inside a stage, declare it `(using InStage)` so its caller's token flows through."
@@ -36,7 +23,7 @@ final class InStage private () extends caps.SharedCapability
 
 object InStage:
   /** Mint a fresh [[InStage]] token. Called only by `orca.RuntimeInStage` (the
-    * runtime's single named door — see it for the whitelist) and test code;
-    * library code must never call this directly.
+    * runtime's single named door) and test code; library code must never call
+    * this directly.
     */
   private[orca] def unsafe: InStage = new InStage()

--- a/tools/src/main/scala/orca/OrcaDir.scala
+++ b/tools/src/main/scala/orca/OrcaDir.scala
@@ -20,9 +20,9 @@ private[orca] object OrcaDir:
   /** `<workDir>/.orca` — committed project metadata lives at this root. */
   private def root(workDir: os.Path): os.Path = workDir / ".orca"
 
-  /** `<workDir>/.orca` as an absolute path — the committed-metadata root, for
-    * callers that guard it (e.g. the symlink check in
-    * `FlowLifecycle.readSettings`) before writing through it.
+  /** `<workDir>/.orca` — the committed-metadata root, for callers that guard it
+    * (e.g. the symlink check in `FlowLifecycle.readSettings`) before writing
+    * through it.
     */
   def rootPath(workDir: os.Path): os.Path = root(workDir)
 
@@ -45,10 +45,10 @@ private[orca] object OrcaDir:
     abortIfOrcaComponentSymlink(workDir, r)
     r.tap(os.makeDir.all(_))
 
-  /** Idempotently ensure `.orca/cache/` exists — writing its self-ignoring
-    * `.gitignore` and `CACHEDIR.TAG` before returning, so nothing can land in
-    * the dir before the exclusion is in place — and return it. The marker files
-    * are written only when absent, so repeated calls do not churn mtimes.
+  /** Idempotently ensure `.orca/cache/` exists, writing its self-ignoring
+    * `.gitignore` and `CACHEDIR.TAG` before returning so nothing lands in the
+    * dir before the exclusion is in place. Markers are written only when
+    * absent, so repeated calls do not churn mtimes.
     */
   def ensureCache(workDir: os.Path): os.Path =
     val cache = root(workDir) / "cache"
@@ -60,27 +60,15 @@ private[orca] object OrcaDir:
 
   /** Refuse if `.orca` — or any orca-created directory from it down to `dir`
     * (inclusive) — is a symlink, before any `os.makeDir.all`/write through it.
-    * A committed symlink at ANY of these components (git mode 120000) would
-    * redirect orca's writes — cache markers, flow lock, progress log,
-    * discovered settings — to the link's target, outside the working tree.
-    * `.orca` is the only repo-committable subtree, so it and each directory
-    * orca itself makes beneath it (currently just `cache/`) are checked, one
-    * segment at a time: `os.isLink` is lstat/no-follow and inspects only the
-    * FINAL component, so a symlinked ANCESTOR (e.g. a `.orca` DIRECTORY link)
-    * is invisible to a leaf-only check and must be tested on its own. lstat
-    * also does not follow the final link, so a dangling component (target
-    * absent) is caught too.
+    * A committed symlink at any component (git mode 120000) would redirect
+    * orca's writes to the link's target, outside the working tree. Each segment
+    * is checked on its own because `os.isLink` (lstat, no-follow) inspects only
+    * the final component, so a symlinked ancestor would be invisible to a
+    * leaf-only check; the no-follow also catches a dangling final link.
     *
-    * Runs at the earliest touch of each directory — `.orca` on [[ensureRoot]],
-    * `.orca` and `.orca/cache` on [[ensureCache]] (via
-    * `FlowLock.acquireWorkdir`, a run's first `.orca` write) — ahead of the
-    * settings-file guard in `FlowLifecycle.readSettings`.
-    *
-    * Accepted residual (TOCTOU): the check precedes each `makeDir`/write, so a
-    * purely LOCAL race could swap a plain component for a symlink in that
-    * window. That is out of scope under the committed-repo-symlink threat model
-    * (the attacker controls repo content, not the victim's live filesystem
-    * mid-run), so it is left open deliberately.
+    * Accepted residual (TOCTOU): a purely LOCAL race could swap a plain
+    * component for a symlink between the check and the write. Out of scope
+    * under the committed-repo-symlink threat model, so left open deliberately.
     */
   private def abortIfOrcaComponentSymlink(
       workDir: os.Path,
@@ -101,10 +89,10 @@ private[orca] object OrcaDir:
             "writes outside the working tree)"
         )
 
-  // Check-then-write races on the first-ever cache creation: two processes can
-  // both see the file absent before the flow lock exists to serialize them, so
-  // the loser's `os.write` (CREATE_NEW) throws. Both writers carry identical
-  // contents, so losing the create race is harmless.
+  // On first-ever cache creation two processes can both see the file absent
+  // before the flow lock exists to serialize them; the loser's `os.write`
+  // (CREATE_NEW) throws. Both writers carry identical contents, so losing the
+  // race is harmless.
   private def writeIfAbsent(path: os.Path, contents: String): Unit =
     if !os.exists(path) then
       try os.write(path, contents)

--- a/tools/src/main/scala/orca/OrcaFlowException.scala
+++ b/tools/src/main/scala/orca/OrcaFlowException.scala
@@ -5,9 +5,8 @@ package orca
   *
   * Error reporting is orthogonal to this type: the runtime reports each failure
   * exactly once by tracking already-reported throwables in a context-owned
-  * identity set (`FlowContext.markErrorReported` / `errorAlreadyReported`), so
-  * a failure surfaces a single `OrcaEvent.Error` no matter how many stages it
-  * unwinds through — for plain `RuntimeException`s just as for this type.
+  * identity set (`FlowContext.markErrorReported` / `errorAlreadyReported`), for
+  * plain `RuntimeException`s just as for this type.
   */
 class OrcaFlowException(message: String) extends RuntimeException(message)
 
@@ -16,16 +15,11 @@ class OrcaFlowException(message: String) extends RuntimeException(message)
   * [[orca.backend.Interaction.drive]] so the enclosing `stage(...)` can catch
   * it and decide whether to fail the stage or recover.
   *
-  * Deliberately a subtype of [[OrcaFlowException]] even though cancellation is
-  * designed to be caught at the stage driving the conversation: when nobody
-  * catches it, the right default is for the cancellation to end the flow like
-  * any other flow failure (failure teardown, non-zero exit) — the user said
-  * stop and no stage volunteered a recovery. It also makes a blanket
-  * `OrcaFlowException` recovery treat a cancelled conversation as "this attempt
-  * produced no result", which is the reading such a handler wants. Callers
-  * needing cancellation-specific behaviour catch this subtype; direct callers
-  * of `Conversation` pattern-match on the Either instead. The autonomous path —
-  * the only one with a retry policy — cannot produce this (see
+  * Deliberately a subtype of [[OrcaFlowException]]: when nobody catches it, the
+  * right default is to end the flow like any other failure, and a blanket
+  * `OrcaFlowException` recovery treats a cancelled conversation as "this
+  * attempt produced no result". The autonomous path — the only one with a retry
+  * policy — cannot produce this (see
   * [[orca.backend.Conversations.drainAutonomous]]), so subtyping never causes a
   * cancellation to be retried.
   */
@@ -35,21 +29,18 @@ class OrcaInteractiveCancelled(
 
 /** A semantic failure of an agent *turn that actually ran*: the conversation
   * was spawned — so the backend has already registered the session id — and
-  * then ended in a terminal error (`is_error` such as "Prompt is too long", a
-  * rate limit, a non-zero CLI exit, or a clean exit with no result). Distinct
-  * from a pre-spawn *open* failure (e.g. a transient broken pipe before the
-  * session was registered), which stays a plain [[OrcaFlowException]].
+  * then ended in a terminal error (`is_error`, a rate limit, a non-zero CLI
+  * exit, or a clean exit with no result). Distinct from a pre-spawn *open*
+  * failure (e.g. a transient broken pipe before the session was registered),
+  * which stays a plain [[OrcaFlowException]].
   *
-  * Role: this tag marks a failure as non-retryable. Why reusing the locked
-  * session id makes a retry futile is owned at the decision point,
-  * [[orca.backend.ForkedConversation.awaitResult]] (the classifier);
+  * Marks a failure as non-retryable: reusing the locked session id makes a
+  * retry futile. Classified at [[orca.backend.ForkedConversation.awaitResult]];
   * `DefaultAgentCall.runAutonomousWithRetry` is the policy that acts on it.
   *
-  * `cause` is optional (both wrap sites — `awaitResult`'s generic-failure arm
-  * and `runAutonomousWithRetry`'s re-attribution rewrap — pass the throwable
-  * they're wrapping) so `getCause` still reaches the original exception (stack
-  * trace, exact type) for `--verbose`/debug inspection instead of being
-  * flattened into the message string and discarded.
+  * `cause` is optional so `getCause` still reaches the original exception
+  * (stack trace, exact type) for `--verbose`/debug inspection rather than being
+  * flattened into the message string.
   */
 class AgentTurnFailed(message: String, cause: Throwable | Null = null)
     extends OrcaFlowException(message):

--- a/tools/src/main/scala/orca/WorkspaceWrite.scala
+++ b/tools/src/main/scala/orca/WorkspaceWrite.scala
@@ -8,31 +8,18 @@ import scala.annotation.implicitNotFound
   * split (ADR 0018 §6). Gates the Scala-side index-like writes — git/`gh`
   * writes, `fs.write`, progress-store writes — that must be sequenced by the
   * flow thread and must NOT cross a `fork` boundary. Minted and supplied by the
-  * `stage` implementation (package `orca`) exactly like [[InStage]]; user code
-  * and tool wrappers receive it as a `using` parameter but can never fabricate
-  * one — the `private` constructor and `private[orca]` mint ensure that.
+  * `stage` implementation like [[InStage]]; user code receives it `using` but
+  * cannot fabricate one (private constructor).
   *
-  * Where [[InStage]] extends `caps.SharedCapability` (freely capturable into
-  * forks, separation-exempt), `WorkspaceWrite` extends
-  * `caps.ExclusiveCapability`, so once capture checking is adopted separation
-  * checking's hidden-set rules forbid two concurrent closures from both
-  * capturing it — the type-level encoding of "these mutations are
-  * flow-thread-only". `caps.ExclusiveCapability` is `@experimental` on 3.8.4,
-  * so this file carries `import language.experimental.captureChecking`; that
-  * taints only this compilation unit, not consumers (verified — see ADR 0018
-  * §6).
+  * Extends `caps.ExclusiveCapability` (where [[InStage]] is a
+  * `SharedCapability`), so separation checking forbids two concurrent closures
+  * from both capturing it — the type-level encoding of "these mutations are
+  * flow-thread-only". `ExclusiveCapability` is `@experimental` on 3.8.4, so
+  * this file carries `import language.experimental.captureChecking`; that
+  * taints only this compilation unit, not consumers (see ADR 0018 §6).
   *
-  * The value carries no state — it is evidence only; nothing reads anything off
-  * it. Making it a real class is purely so capture checking has a reference to
-  * track.
-  *
-  * `@implicitNotFound` keeps the missing-capability error user-facing: a flow
-  * author never needs to know what `WorkspaceWrite` is, only that these writes
-  * belong inside a `stage(...)` and not inside a `fork`.
-  *
-  * `private[orca]` still lets any code in the `orca` package — across modules —
-  * call `unsafe`; an accepted guard-rail per ADR 0018 §5, with the convention
-  * that only the `stage` runtime does so.
+  * Carries no state; it is a real class only so capture checking has a
+  * reference to track.
   */
 @implicitNotFound(
   "git/file/GitHub writes and progress-log writes must be made inside a `stage(...)` body — and, unlike LLM calls, must NOT be captured into a `fork`. Move this write into a stage (not a fork within one). If this is a helper meant to run inside a stage, declare it `(using WorkspaceWrite)` so its caller's token flows through."
@@ -41,7 +28,7 @@ final class WorkspaceWrite private () extends caps.ExclusiveCapability
 
 object WorkspaceWrite:
   /** Mint a fresh [[WorkspaceWrite]] token. Called only by
-    * `orca.RuntimeInStage` (the runtime's single named door — see it for the
-    * whitelist) and test code; library code must never call this directly.
+    * `orca.RuntimeInStage` (the runtime's single named door) and test code;
+    * library code must never call this directly.
     */
   private[orca] def unsafe: WorkspaceWrite = new WorkspaceWrite()

--- a/tools/src/main/scala/orca/agents/Agent.scala
+++ b/tools/src/main/scala/orca/agents/Agent.scala
@@ -8,21 +8,19 @@ import scala.util.control.NonFatal
   * `flow(...)` block (`claude`, `codex`, etc.). Three rungs, by how long the
   * conversation must live:
   *
-  *   - **`run(prompt)`** — one ephemeral free-text turn on a fresh, throwaway
+  *   - **`run(prompt)`** — one ephemeral free-text turn on a fresh
   *     conversation. `resultAs[O].{autonomous,interactive}.run(input)` is the
   *     structured sibling.
   *   - **`chat()`** — a fresh EPHEMERAL multi-turn conversation ([[Chat]]):
-  *     in-run only, needs only `InStage`, so it works inside a fork (parallel
-  *     fan-outs). Gone on crash/resume.
+  *     in-run only, needs only `InStage` so it works inside a fork. Gone on
+  *     crash/resume.
   *   - **`agent.session(name, seed)`** (a flow extension) — a DURABLE
   *     `orca.FlowSession` that survives a flow crash/resume: named, seeded, and
   *     persisted.
   *
   * Free text is always autonomous; `interactive` (a human steering the turn)
   * exists only under `resultAs[O]`, where the structured payload marks the
-  * conversation's end. For structured calls the autonomous-vs-interactive
-  * choice is never hidden behind a default — it's always visible at the call
-  * site.
+  * conversation's end.
   *
   * Parameterized by the concrete `BackendTag` so session ids and results carry
   * the backend identity at the type level.
@@ -34,11 +32,11 @@ trait Agent[B <: BackendTag]:
     */
   def name: String
 
-  /** Role tag for this agent in the event stream — a second, orthogonal axis on
-    * `OrcaEvent.TokensUsed` alongside [[name]]. `None` for an ordinary agent;
-    * the review loop sets `Some("reviewer")` via [[withRole]] so `CostTracker`
-    * can subtotal reviewer spend without baking a display prefix into [[name]]
-    * itself (the identity a session/selector keys off). Defaults to `None`.
+  /** Role tag for this agent in the event stream — a second axis on
+    * `OrcaEvent.TokensUsed` alongside [[name]]. The review loop sets
+    * `Some("reviewer")` via [[withRole]] so `CostTracker` can subtotal reviewer
+    * spend without baking a prefix into [[name]] (the identity a
+    * session/selector keys off). Defaults to `None`.
     */
   def role: Option[String] = None
 
@@ -61,10 +59,8 @@ trait Agent[B <: BackendTag]:
     autonomous.runWithSession(prompt, SessionId.fresh[B], config, emitPrompt)
 
   /** Start a fresh EPHEMERAL multi-turn conversation — see [[Chat]]. In-run
-    * only: nothing is persisted, so a crash/resume starts over. Runs need only
-    * `InStage`, so a chat can be minted and driven inside an `ox` fork
-    * (parallel reviewers, fan-outs). A plain immutable value — close over it
-    * freely.
+    * only: nothing is persisted, so a crash/resume starts over. Needs only
+    * `InStage`, so a chat can be minted and driven inside an `ox` fork.
     */
   final def chat(): Chat[B] = new Chat(this, SessionId.fresh[B])
 
@@ -94,14 +90,8 @@ trait Agent[B <: BackendTag]:
 
   /** Return a sibling tool tagged with `role` (see [[role]]) for the event
     * stream — used by the review loop to tag a reviewer's run without renaming
-    * it.
-    *
-    * On an `Agent` that doesn't override this, the call is a SILENT NO-OP —
-    * `this` is returned unchanged, mirroring [[withSelfManagedGit]] /
-    * [[withCheapModel]]'s documented pattern for optional capabilities.
-    * `BaseAgent`-derived tools (every real backend) override it; a custom
-    * `Agent` implementation that wants role-tagged `TokensUsed` events must
-    * override it too.
+    * it. No-op default (returns `this`); `BaseAgent`-derived tools override it,
+    * and a custom `Agent` wanting role-tagged `TokensUsed` events must too.
     */
   def withRole(role: String): Agent[B] = this
 
@@ -140,22 +130,17 @@ trait Agent[B <: BackendTag]:
   /** Pin the model that [[cheap]] resolves to, overriding the backend default.
     * Lets a flow specify both a leading and a cheap model, e.g.
     * `_.opencode.anthropicSonnet.withCheapModel(Model("anthropic/claude-haiku-4-5"))`.
-    *
-    * On an `Agent` that doesn't override this, the call is a SILENT NO-OP —
-    * `this` is returned unchanged and the pin is dropped. `BaseAgent`-derived
-    * tools (every real backend) override it; a custom `Agent` implementation
-    * must override it too, or a caller's `.withCheapModel(...)` is silently
-    * ignored and [[cheap]] keeps resolving to [[defaultCheap]].
+    * No-op default (returns `this`, dropping the pin); `BaseAgent`-derived
+    * tools override it, and a custom `Agent` must too or the pin is silently
+    * ignored.
     */
   def withCheapModel(model: Model): Agent[B] = this
 
   /** Best-effort one-line reply from the cheap model, for the runtime's own
-    * incidental text (branch naming, default commit messages). Runs `prompt` on
-    * `cheap.withReadOnly` (no prompt echo), returns the first non-blank line
-    * trimmed — or `fallback` if the reply is empty or the call fails for any
-    * non-fatal reason (markdown fence lines are skipped). Never throws: these
-    * calls must never break a flow. `private[orca]` — internal; flow scripts
-    * use `cheap.run(...)` directly if they want a one-off cheap call.
+    * incidental text (branch naming, default commit messages). Returns the
+    * first non-blank, non-fence line trimmed, or `fallback` if the reply is
+    * empty or the call fails for any non-fatal reason. Never throws: these
+    * calls must never break a flow.
     */
   private[orca] def cheapOneShot(prompt: String, fallback: => String)(using
       InStage
@@ -173,9 +158,8 @@ trait Agent[B <: BackendTag]:
   /** One autonomous text turn with the streaming display suppressed: no `▸`
     * prompt echo and — on `BaseAgent`-derived tools, which override this — no
     * `●` prose or `⏺` tool lines either (`TokensUsed` and `Error` events still
-    * flow). For the runtime's internal turns ([[cheapOneShot]]): their display
-    * channel is the caller's own event (the branch-switch or commit `Step`), so
-    * streaming the reply would show the same text twice.
+    * flow). For the runtime's internal turns ([[cheapOneShot]]), whose display
+    * channel is the caller's own event, so streaming would show the text twice.
     */
   private[orca] def quietTextTurn(prompt: String)(using InStage): String =
     run(prompt, emitPrompt = false)
@@ -184,81 +168,63 @@ trait Agent[B <: BackendTag]:
     * [[AgentConfig.selfManagedGit]] on, suppressing the standing "runtime owns
     * git" rule the runtime otherwise injects (don't `git commit`/`push`/branch;
     * leave edits in the working tree). Use only for a flow that genuinely wants
-    * the agent to drive git; the default keeps git runtime-owned.
+    * the agent to drive git.
     *
-    * Unlike [[withReadOnly]] this carries a no-op default (returns `this`), so
-    * a custom `Agent` that forgets to wire it simply keeps the safe
-    * runtime-owns-git behaviour rather than silently granting the escape hatch.
-    *
-    * On an `Agent` that doesn't override this, the call is a SILENT NO-OP —
-    * `this` is returned unchanged. This one is deliberate (a fail-safe, not a
-    * bug): `BaseAgent`-derived tools override it to actually flip the flag; a
-    * custom `Agent` implementation must override it too if it wants callers'
-    * `.withSelfManagedGit` to take effect.
+    * No-op default (returns `this`), deliberately fail-safe: a custom `Agent`
+    * that forgets to wire it keeps the safe runtime-owns-git behaviour rather
+    * than silently granting the escape hatch. `BaseAgent`-derived tools
+    * override it to flip the flag.
     */
   def withSelfManagedGit: Agent[B] = this
 
   /** The backend's session-durability capability, or `None` for tools without a
-    * backend (lightweight stubs). The ONLY overridable session hook — the
-    * `willContinue` / `resumeWireId` / `registerResumeWireId` trio below is
-    * `final`, implemented uniformly through this. A concrete tool exposes its
-    * backend's whole [[orca.backend.SessionSupport]] or nothing, so it cannot
-    * reflect one session operation while silently defaulting the others.
+    * backend. The ONLY overridable session hook — the `willContinue` /
+    * `resumeWireId` / `registerResumeWireId` trio below is `final`, implemented
+    * uniformly through this, so a tool exposes its backend's whole
+    * [[orca.backend.SessionSupport]] or nothing, never a partial mix.
     */
   private[orca] def sessionSupport: Option[orca.backend.SessionSupport[B]] =
     None
 
   /** This tool's backend tag, or `None` for tools without a backend
-    * (lightweight stubs). Used to stamp [[orca.progress.SessionRecord.backend]]
-    * so a resumed run's targeted rehydration knows which agent a session
-    * belongs to. `BaseAgent` overrides this to `Some(backend.tag)`; a concrete
-    * tool built directly on `Agent` (no backend) keeps the `None` default.
+    * (lightweight stubs). Stamps [[orca.progress.SessionRecord.backend]] so a
+    * resumed run's targeted rehydration knows which agent a session belongs to.
     */
   private[orca] def backendTag: Option[BackendTag] = None
 
   /** An opaque token identifying this tool's underlying backend INSTANCE (not
-    * just its runtime tag/type), or `None` for tools without a backend
-    * (lightweight stubs). Two independently-built backends of the same kind
-    * (e.g. two `ClaudeCode` backends from separate `AgentWiring`s) get
-    * different tokens even though [[backendTag]] can't tell them apart;
-    * `copyTool`-derived siblings (`_.claude.opus`, `.withReadOnly`, …) share
-    * the SAME token because they share the SAME backend object. Used by
-    * [[orca.runner.DefaultFlowContext]] to tell a selector-derived sibling of a
-    * wired agent (safe — same backend, same events, same close latch) apart
-    * from an agent built against a genuinely different backend (foreign —
-    * event-blind, leaked past `close()`), without false-positiving on the
-    * former the way a plain `Agent eq Agent` check would. `BaseAgent` overrides
-    * this to the shared `AgentBackend.closedFlag` reference — already unique
-    * per backend instance, and deliberately shared across sibling backend
-    * instances that opt into it (e.g. claude's `withNetworkTools`), for exactly
-    * this identity purpose.
+    * just its runtime tag/type), or `None` for tools without a backend.
+    * Independently-built backends of the same kind get different tokens even
+    * though [[backendTag]] can't tell them apart; `copyTool`-derived siblings
+    * (`_.claude.opus`, `.withReadOnly`, …) share the SAME token, sharing the
+    * SAME backend object. [[orca.runner.DefaultFlowContext]] uses this to tell
+    * a selector-derived sibling of a wired agent (safe) apart from an agent
+    * built against a genuinely different backend (foreign — event-blind, leaked
+    * past `close()`), which a plain `Agent eq Agent` check couldn't.
+    * `BaseAgent` overrides it to the shared `AgentBackend.closedFlag`
+    * reference.
     *
-    * Compared by REFERENCE (`eq`), never `==`: a token type that happened to
-    * implement structural equality (unlike today's `AtomicBoolean`, which falls
-    * back to reference equality by having none) would silently false-positive
-    * two independently-built backends into looking wired together.
-    * Implementations must mint an identity-unique token per backend instance —
-    * never a value shared across independently-built backends.
+    * Compared by REFERENCE (`eq`), never `==`: a token with structural equality
+    * would false-positive two independently-built backends into looking wired
+    * together. Implementations must mint an identity-unique token per backend
+    * instance.
     */
   private[orca] def backendIdentity: Option[AnyRef] = None
 
   /** Will the NEXT call on `session` continue an already-live conversation
     * (rather than open a fresh one that needs re-seeding)? The durable-session
     * runtime asks this before deciding whether to re-inject the seed + progress
-    * preamble — see [[orca.backend.SessionSupport.willContinue]] for the
-    * durable-probe vs in-process-claim split. Returns `false` — safe re-seed —
-    * when a concrete tool can't reach a backend.
+    * preamble — see [[orca.backend.SessionSupport.willContinue]]. Returns
+    * `false` (safe re-seed) when a concrete tool can't reach a backend.
     */
   final def willContinue(session: SessionId[B]): Boolean =
     sessionSupport.exists(_.willContinue(session))
 
-  /** The wire id to resume `client` against, or `None` if unknown (or the
-    * backend's sessions aren't durably resumable). `client` is orca's stable
-    * handle ([[SessionId]]); the result is the [[WireSessionId]] the backend
-    * actually resumes against — equal to `client` where the client id IS the
-    * wire id (claude), a learned server-thread id for codex/gemini/opencode,
-    * `None` for pi (ephemeral sessions). The flow runtime reads this after a
-    * run to persist the resume wire id into the progress log.
+  /** The [[WireSessionId]] to resume `client` ([[SessionId]], orca's stable
+    * handle) against, or `None` if unknown or not durably resumable — equal to
+    * `client` where the client id IS the wire id (claude), a learned
+    * server-thread id for codex/gemini/opencode, `None` for pi (ephemeral). The
+    * flow runtime reads this after a run to persist it into the progress log.
     */
   final def resumeWireId(client: SessionId[B]): Option[WireSessionId[B]] =
     sessionSupport.flatMap(_.persistableWireId(client))
@@ -275,10 +241,8 @@ trait Agent[B <: BackendTag]:
     sessionSupport.foreach(_.register(client, wireId))
 
   /** Release background resources this agent's backend owns. Delegates to
-    * [[orca.backend.AgentBackend.close]]; a lightweight stub built directly on
-    * `Agent` (no backend) keeps the no-op default. `private[orca]` — the
-    * runtime calls this from `DefaultFlowContext.close()`; flow scripts never
-    * call it directly.
+    * [[orca.backend.AgentBackend.close]]; a stub without a backend keeps the
+    * no-op default. The runtime calls this from `DefaultFlowContext.close()`.
     */
   private[orca] def close(): Unit = ()
 

--- a/tools/src/main/scala/orca/agents/AgentCall.scala
+++ b/tools/src/main/scala/orca/agents/AgentCall.scala
@@ -22,11 +22,9 @@ trait AgentCall[B <: BackendTag, O]:
 trait AutonomousAgentCall[B <: BackendTag, O]:
   /** One ephemeral structured turn on a fresh conversation. When `emitPrompt`
     * is true (the default), fires an `OrcaEvent.UserPrompt` carrying the
-    * human-readable form of `input` (the `AgentInput[I]` serialization) so
-    * listeners can surface what's being asked; framework-internal callers that
-    * produce near-identical prompts in quick succession pass `false` to keep
-    * the event log focused. Other events (`ToolUse`, `StructuredResult`,
-    * `TokensUsed`, etc.) fire regardless.
+    * human-readable form of `input`; internal callers producing near-identical
+    * prompts in quick succession pass `false` to keep the event log focused.
+    * Other events (`ToolUse`, `TokensUsed`, etc.) fire regardless.
     */
   final def run[I: AgentInput](
       input: I,
@@ -48,10 +46,9 @@ trait AutonomousAgentCall[B <: BackendTag, O]:
 
 /** Interactive structured calls — open a conversation the user can drive
   * (clarifying questions, refinements) before the agent produces the final
-  * structured `O`. Same shape as the autonomous variant; continuation goes
-  * through [[Chat]] (`agent.chat()`), never a `FlowSession` — a live human is
-  * steering the turn, so there is no seed to replay on resume, which is why
-  * durable interactive sessions don't exist.
+  * structured `O`. Continuation goes through [[Chat]] (`agent.chat()`), never a
+  * `FlowSession`: a live human is steering the turn, so there is no seed to
+  * replay on resume — hence durable interactive sessions don't exist.
   */
 trait InteractiveAgentCall[B <: BackendTag, O]:
   /** One interactive structured turn on a fresh conversation. */
@@ -86,19 +83,16 @@ private[orca] trait AutonomousTextCall[B <: BackendTag]:
       emitPrompt: Boolean
   )(using orca.InStage): String
 
-/** Default implementation of [[AgentCall]] for any backend.
+/** Default implementation of [[AgentCall]] for any backend, wiring both modes:
   *
-  * The trait splits into `autonomous` and `interactive` sibling objects so the
-  * call site shows which mode it picked. This class wires both:
-  *
-  *   - The autonomous shape goes through `backend.runAutonomous` and shares a
-  *     retry-with-corrective-prompt loop: if the response fails to parse as
-  *     `O`, the next attempt's prompt includes the failed output and the parser
-  *     error so the model can self-correct.
-  *   - The interactive shape opens a [[orca.backend.Conversation]] via the
-  *     backend and hands it to the supplied [[Interaction]] for rendering and
-  *     user steering. No retry: the user is steering, and a parse failure on
-  *     the final payload is more useful surfaced than silently relaunched.
+  *   - The autonomous shape goes through `backend.runAutonomous` with a
+  *     retry-with-corrective-prompt loop: a response that fails to parse as `O`
+  *     re-prompts with the failed output and parser error so the model can
+  *     self-correct.
+  *   - The interactive shape opens a [[orca.backend.Conversation]] and hands it
+  *     to the supplied [[Interaction]] for rendering and user steering. No
+  *     retry: a parse failure on the final payload is more useful surfaced than
+  *     silently relaunched.
   */
 class DefaultAgentCall[B <: BackendTag, O](
     backend: AgentBackend[B],
@@ -106,15 +100,12 @@ class DefaultAgentCall[B <: BackendTag, O](
     prompts: Prompts,
     events: OrcaListener,
     interaction: Interaction,
-    /** Used as the `agent` axis on `OrcaEvent.TokensUsed` — the owning
-      * `Agent.name`, its bare identity. The `model` axis is read from the
-      * response (or the pinned config); this name is the always-present agent
-      * identifier.
+    /** The `agent` axis on `OrcaEvent.TokensUsed` — the owning `Agent.name`.
+      * The `model` axis is read from the response (or the pinned config).
       */
     agentName: String,
-    /** Used as the `role` axis on `OrcaEvent.TokensUsed` — the owning
-      * `Agent.role`, e.g. `Some("reviewer")` for a review-loop run. `None` for
-      * an ordinary agent.
+    /** The `role` axis on `OrcaEvent.TokensUsed` — the owning `Agent.role`,
+      * e.g. `Some("reviewer")` for a review-loop run.
       */
     agentRole: Option[String] = None
 )(using jd: JsonData[O], announce: Announce[O])
@@ -124,22 +115,18 @@ class DefaultAgentCall[B <: BackendTag, O](
   private given com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[O] =
     jd.codec
 
-  /** Derived eagerly (not inside `runAutonomousWithRetry`/`runInteractiveOnce`)
-    * so an unsupported output shape — e.g. a `Map[String, _]` field, which
-    * `JsonSchemaGen` rejects — fails at `resultAs[O]` construction, before this
-    * call's stage does anything (spawns a backend process, consumes a turn),
-    * rather than surfacing remotely as codex/claude's opaque
-    * `invalid_json_schema` after destructive stage work already ran. Also
-    * collapses what was a redundant re-derivation on every `run()` call for the
-    * same handle into a single one.
+  /** Derived eagerly so an unsupported output shape (e.g. a `Map[String, _]`
+    * field, which `JsonSchemaGen` rejects) fails at `resultAs[O]` construction,
+    * before this call's stage spawns a backend process or consumes a turn —
+    * rather than surfacing as codex/claude's opaque `invalid_json_schema` after
+    * destructive stage work already ran.
     */
   private val outputSchema: String = JsonSchemaGen[O]
 
   /** The use-after-close guard's second gate: `resultAs[O]` refuses
-    * construction on a closed agent, but a gateway built BEFORE the flow ended
+    * construction on a closed agent, but a gateway built before the flow ended
     * and stored across the close boundary would still reach the backend — this
-    * per-call check (free, since the closed latch lives on the `backend` this
-    * class already holds) closes that gap with the same user-facing message.
+    * per-call check closes that gap.
     */
   private def checkNotClosed(): Unit =
     if backend.isClosed then
@@ -165,13 +152,11 @@ class DefaultAgentCall[B <: BackendTag, O](
       runInteractiveOnce(input, config, session)
 
   /** Emit a `StructuredResult` event carrying the raw payload and the
-    * `Announce[O]`-derived summary. `summary` is tri-state (documented on
+    * `Announce[O]`-derived summary. `summary` is tri-state (see
     * [[orca.events.OrcaEvent.StructuredResult]]): text from a specific
     * `Announce[O]`; `Some("")` when a specific instance deliberately says
-    * nothing (the call site narrates the outcome itself); `None` when no
-    * specific instance exists — renderers then fall back to the raw payload so
-    * the result stays visible. Non-terminal listeners (Slack, structured logs)
-    * can carry `raw` through unchanged either way.
+    * nothing; `None` when none exists — renderers then fall back to the raw
+    * payload so the result stays visible.
     */
   private def emitStructuredResult(raw: String, value: O): Unit =
     val summary = announce match
@@ -179,13 +164,11 @@ class DefaultAgentCall[B <: BackendTag, O](
       case specific                  => specific.message(value).orElse(Some(""))
     events.onEvent(OrcaEvent.StructuredResult(raw, summary))
 
-  /** THE retry policy — the only place in the framework that decides whether an
-    * autonomous-turn failure gets retried: parse failures (corrective
-    * re-prompt, same session resumed) and pre-spawn open failures (a fresh
-    * spawn) are retried; [[AgentTurnFailed]] never is. Why reopening a locked
-    * session id makes an `AgentTurnFailed` retry futile is owned by the
-    * classifier, [[orca.backend.ForkedConversation.awaitResult]]. On a parse
-    * failure the next attempt swaps the original prompt for a corrective one.
+  /** THE retry policy — the only place that decides whether an autonomous-turn
+    * failure gets retried: parse failures (corrective re-prompt, same session
+    * resumed) and pre-spawn open failures (a fresh spawn) are retried;
+    * [[AgentTurnFailed]] never is (see the classifier,
+    * [[orca.backend.ForkedConversation.awaitResult]]).
     */
   private def runAutonomousWithRetry[I](
       input: I,
@@ -202,25 +185,16 @@ class DefaultAgentCall[B <: BackendTag, O](
       backend.structuredOutputMode
     )
 
-    // Surface `serialized` (the human-readable input) rather than
-    // `initialPrompt` (the schema-wrapped form the agent sees). Listeners
-    // want the question, not the boilerplate that frames it. The retry
-    // branch below emits its own UserPrompt so a parse failure still
-    // shows what the follow-up turn was asked to fix.
+    // Surface `serialized` (the human-readable input), not `initialPrompt` (the
+    // schema-wrapped form the agent sees): listeners want the question.
     if emitPrompt then events.onEvent(OrcaEvent.UserPrompt(serialized))
 
-    // Carries a parse failure into the next attempt's corrective prompt
-    // (below: `lastFailure match { ... }` picks it up to build the retry
-    // text). Method-scope var, sanctioned by the project's FP conventions
-    // because its contract is entirely local: written only in the
-    // `MalformedAgentOutputException` catch a few lines down, read only at
-    // the top of the next `retry` iteration — single-threaded because
-    // `retry` re-executes the block sequentially, never concurrently.
+    // Carries a parse failure into the next attempt's corrective prompt. Local
+    // contract: written only in the `MalformedAgentOutputException` catch below,
+    // read only at the top of the next `retry` iteration, which re-executes the
+    // block sequentially — never concurrently.
     var lastFailure: Option[FailedAttempt] = None
 
-    // Never retry an `AgentTurnFailed` (see the classifier/policy scaladoc
-    // above); every other throwable — parse failures and pre-spawn open
-    // failures alike — is retryable.
     val retryConfig = RetryConfig(
       effective.retrySchedule,
       ResultPolicy.retryWhen[Throwable, O](e =>
@@ -265,10 +239,9 @@ class DefaultAgentCall[B <: BackendTag, O](
             )
             throw e
     catch
-      // Attribute the failure: name the agent and the size of this turn's
-      // input, so "Prompt is too long" becomes actionable (which agent, how
-      // big). The session's accumulated context is larger than this turn's
-      // input — full prompts are captured by the debug log.
+      // Attribute the failure: name the agent and this turn's input size, so
+      // "Prompt is too long" becomes actionable. The session's accumulated
+      // context is larger than this turn's input.
       case e: AgentTurnFailed =>
         throw new AgentTurnFailed(
           s"agent '$agentName' turn failed " +
@@ -293,7 +266,7 @@ class DefaultAgentCall[B <: BackendTag, O](
     // into this Ox, `drive` consumes them, and `cancel` (in the `finally`) tears
     // the conversation down before the scope joins — so a cancelled turn never
     // leaks the subprocess/forks. On cancel `drive` throws, skipping the
-    // sessions.register / TokensUsed bookkeeping below, as before.
+    // register / TokensUsed bookkeeping below.
     val result = ox.supervised:
       val conversation = backend.runInteractive(
         prompt,
@@ -304,15 +277,13 @@ class DefaultAgentCall[B <: BackendTag, O](
       )(using summon[ox.Ox])
       try interaction.drive(conversation)
       finally conversation.cancel()
-    // Codex mints its server thread id inside the drain (not at spawn);
-    // surface it back to the backend so a follow-up call with the same
-    // `session` can resume the right thread. No-op for backends whose
-    // session id IS the client-supplied UUID (claude).
+    // Codex mints its server thread id inside the drain (not at spawn); surface
+    // it back so a follow-up call with the same `session` resumes the right
+    // thread. No-op for backends whose session id IS the client UUID (claude).
     backend.sessions.register(session, result.wireId)
-    // TokensUsed emits on the normal path only. If the user cancels
-    // mid-session, drive throws before this line — and the wire
-    // protocols don't always carry partial usage, so there's nothing
-    // authoritative to emit at cancel time.
+    // Normal path only: on mid-session cancel `drive` throws before this line,
+    // and the wire protocols don't always carry partial usage, so there's
+    // nothing authoritative to emit at cancel time.
     events.onEvent(
       OrcaEvent.TokensUsed(
         agentName,

--- a/tools/src/main/scala/orca/agents/AgentConfig.scala
+++ b/tools/src/main/scala/orca/agents/AgentConfig.scala
@@ -8,26 +8,21 @@ case class AgentConfig(
     model: Option[Model] = None,
     /** Model used by [[orca.agents.Agent.cheap]] for incidental work (branch
       * naming, commit-message summaries, reviewer selection). `None` uses the
-      * backend's built-in cheap tier; set it via `Agent.withCheapModel`.
+      * backend's built-in cheap tier.
       */
     cheapModel: Option[Model] = None,
     systemPrompt: Option[String] = None,
     /** Which tools auto-approve without a permission prompt. Only meaningful
-      * for **interactive** sessions — autonomous turns have no prompt to
-      * answer, so the field is inert there. Backends consult it only when
-      * [[tools]] is [[ToolSet.Full]] (the read-only tiers are autonomous
-      * planners/reviewers). `Only(set)` should list a subset of the tools
-      * [[tools]] makes available; entries outside it are dead. Neither
-      * invariant is type-enforced (one `AgentConfig` feeds both the interactive
-      * and autonomous paths).
+      * for **interactive** sessions consulted only when [[tools]] is
+      * [[ToolSet.Full]] — autonomous turns have no prompt to answer.
+      * `Only(set)` should list a subset of what [[tools]] makes available;
+      * entries outside it are dead. Neither invariant is type-enforced.
       */
     autoApprove: AutoApprove = AutoApprove.All,
     /** Which tools exist for the agent at all — the capability axis (distinct
-      * from [[autoApprove]], the prompting axis). See [[ToolSet]] for the
-      * tiers; `Full` is write-capable, the read-only tiers gate writes. How
-      * strongly each backend actually enforces that gate is [[Enforcement]]
-      * (e.g. `NetworkOnly` is hard on claude/gemini/opencode but prompt-only on
-      * pi/codex, where granting network forces a writable shell).
+      * from [[autoApprove]], the prompting axis). `Full` is write-capable, the
+      * read-only tiers gate writes; how strongly each backend enforces that
+      * gate is [[Enforcement]].
       */
     tools: ToolSet = ToolSet.Full,
     /** Let the agent manage git itself — suppresses the standing "runtime owns
@@ -35,17 +30,14 @@ case class AgentConfig(
       * to every write-capable turn. Off by default: orca's model is that the
       * flow commits/branches/pushes via `git.*`, and a self-committing agent
       * empties the working tree (breaking `reviewAndFixLoop`'s diff-based
-      * reviewer selection). Flip it on only for a flow that genuinely wants the
-      * agent to drive git.
+      * reviewer selection).
       */
     selfManagedGit: Boolean = false,
     retrySchedule: Schedule = AgentConfig.defaultRetrySchedule
 ):
   /** Return a config whose `autoApprove` set also includes `tool`. Backends use
     * this to silently authorise their own host-side tools (e.g. the MCP
-    * `ask_user`) without surfacing a y/n prompt the user can't reasonably
-    * refuse. No-op when `autoApprove = AutoApprove.All` — everything is already
-    * covered.
+    * `ask_user`). No-op when `autoApprove = AutoApprove.All`.
     */
   def autoApproveAlso(tool: String): AgentConfig =
     autoApprove match
@@ -69,12 +61,12 @@ enum AutoApprove:
   *   - Hard — mechanically blocked (permission mode, sandbox, tool allowlist).
   *   - SandboxApprox — approximated by a coarser sandbox; semantics widened.
   *   - PromptOnly — only the prompt forbids it; the tools can physically do it.
-  *   - Ignored — not encoded at all; actual behavior depends on backend/server
+  *   - Ignored — not encoded at all; behaviour depends on backend/server
   *     configuration outside orca's control.
   *
   * The per-backend mapping is machine-checked in
-  * `runner/.../EnforcementTableTest.scala` and rendered in `AGENTS.md`; see
-  * each backend's `*Args.enforcement` for the per-cell rationale.
+  * `runner/.../EnforcementTableTest.scala`; see each backend's
+  * `*Args.enforcement` for the per-cell rationale.
   */
 enum Enforcement:
   case Hard, SandboxApprox, PromptOnly, Ignored
@@ -89,10 +81,7 @@ enum Enforcement:
   *   - **Full** — every tool, write-capable; prompting then follows
   *     [[AgentConfig.autoApprove]].
   *
-  * How strongly each backend actually enforces these — and the approval policy
-  * under `Full` — varies; that is captured as [[Enforcement]] and machine-
-  * checked in `runner/.../EnforcementTableTest.scala` (rendered in
-  * `AGENTS.md`), with per-cell rationale in each backend's `*Args.enforcement`.
+  * How strongly each backend enforces these is captured as [[Enforcement]].
   * This enum only names the tier the caller asks for.
   */
 enum ToolSet:

--- a/tools/src/main/scala/orca/agents/AgentInput.scala
+++ b/tools/src/main/scala/orca/agents/AgentInput.scala
@@ -2,15 +2,11 @@ package orca.agents
 
 import com.github.plokhotnyuk.jsoniter_scala.core.writeToString
 
-/** Typeclass that serializes an arbitrary value into the string that gets
-  * embedded in the prompt sent to the LLM. Every `run` method on
-  * `AutonomousAgentCall` / `InteractiveAgentCall` that accepts an `input: I`
-  * requires an `AgentInput[I]` so callers don't have to pre-stringify their
-  * arguments.
+/** Serializes an arbitrary value into the string embedded in the prompt sent to
+  * the LLM, so callers don't have to pre-stringify their arguments.
   *
   * Two givens ship out of the box: `String` passes through verbatim, and any
   * type with a `JsonData` instance is serialized to JSON via its codec.
-  * `derives JsonData` on a case class provides the JSON path automatically.
   */
 trait AgentInput[A]:
   def serialize(a: A): String

--- a/tools/src/main/scala/orca/agents/Announce.scala
+++ b/tools/src/main/scala/orca/agents/Announce.scala
@@ -5,24 +5,22 @@ package orca.agents
   * result as an `OrcaEvent.StructuredResult`. Provide a specific given in the
   * type's companion to opt into a friendlier rendering.
   *
-  * From a specific given, `Some(text)` is rendered as the result summary and
-  * `None` means "deliberately say nothing" — for results whose outcome the call
-  * site already narrates (e.g. the review loop's per-reviewer lines). A type
-  * with NO specific given resolves to the catch-all [[Announce.default]], which
-  * renderers treat differently: they fall back to showing the raw payload, so
-  * an unannounced result never disappears silently (ADR 0008; ADR 0009
-  * amendment 2026-07-11).
+  * From a specific given, `Some(text)` is the result summary and `None` means
+  * "deliberately say nothing" (for results the call site already narrates, e.g.
+  * the review loop's per-reviewer lines). A type with NO specific given
+  * resolves to the catch-all [[Announce.default]], which renderers fall back to
+  * showing the raw payload for — so an unannounced result never disappears
+  * silently (ADR 0008; ADR 0009).
   */
 trait Announce[O]:
   def message(value: O): Option[String]
 
 object Announce:
 
-  /** The catch-all's class — named (rather than a lambda) so the emission edge
-    * (`DefaultAgentCall.emitStructuredResult`) can tell "no specific instance
-    * exists" (renderers fall back to the raw payload) apart from a specific
-    * instance that returns `None` (deliberate silence). The two are different
-    * display contracts.
+  /** The catch-all's class — named (rather than a lambda) so
+    * `DefaultAgentCall.emitStructuredResult` can distinguish "no specific
+    * instance exists" (fall back to raw payload) from a specific instance
+    * returning `None` (deliberate silence). Different display contracts.
     */
   final private[agents] class NoSpecific[O] extends Announce[O]:
     def message(value: O): Option[String] = None
@@ -42,9 +40,6 @@ object Announce:
       case ""  => None
       case msg => Some(msg)
 
-  /** Construct from a function returning `Option[String]` directly, for cases
-    * where the empty/non-empty distinction is more naturally expressed at the
-    * source.
-    */
+  /** Construct from a function returning `Option[String]` directly. */
   def fromOption[O](f: O => Option[String]): Announce[O] =
     (value: O) => f(value)

--- a/tools/src/main/scala/orca/agents/BackendTag.scala
+++ b/tools/src/main/scala/orca/agents/BackendTag.scala
@@ -1,19 +1,16 @@
 package orca.agents
 
-/** Type tag for a concrete LLM backend. Carried as the `B` parameter on
-  * [[SessionId]], [[orca.backend.AgentResult]], [[orca.backend.Conversation]],
-  * [[Agent]], and [[orca.backend.AgentBackend]] so a session id from one
-  * backend can't accidentally flow into another. Distinct from
-  * [[orca.backend.AgentBackend]], which is the runtime SPI; this enum is the
-  * compile-time discriminator.
+/** Compile-time type tag for a concrete LLM backend. Carried as the `B`
+  * parameter on [[SessionId]], [[orca.backend.AgentResult]],
+  * [[orca.backend.Conversation]], [[Agent]], and [[orca.backend.AgentBackend]]
+  * so a session id from one backend can't accidentally flow into another.
+  * Distinct from the runtime SPI [[orca.backend.AgentBackend]].
   *
   * `wireName` is the STABLE on-disk/wire representation
   * ([[orca.progress.SessionRecord.backend]]) — deliberately independent of the
-  * case name so a future rename can't silently strand every persisted session
-  * (the case name is free to change; `wireName` is not). Frozen at the CURRENT
-  * (pre-codec) `toString` value of each case, so logs written before this codec
-  * existed keep loading unchanged. [[BackendTag.fromWireName]] is the inverse;
-  * see the `BackendTagCodecTest` pinning suite.
+  * case name so a future rename can't silently strand every persisted session.
+  * [[BackendTag.fromWireName]] is the inverse; see the `BackendTagCodecTest`
+  * pinning suite.
   */
 enum BackendTag(val wireName: String):
   case ClaudeCode extends BackendTag("ClaudeCode")
@@ -24,8 +21,7 @@ enum BackendTag(val wireName: String):
 
 object BackendTag:
   /** Parse a wire/log-sourced string into a [[BackendTag]], or `None` if it
-    * matches none of the five frozen [[BackendTag.wireName]]s (an edited log,
-    * or a case that no longer exists). The validated door for
+    * matches no [[BackendTag.wireName]]. The validated door for
     * [[orca.progress.SessionRecord.backend]] — callers that get `None` should
     * skip with a visible warning rather than guess (see
     * `FlowLifecycle.targetAgent`).
@@ -36,26 +32,24 @@ object BackendTag:
 opaque type SessionId[B <: BackendTag] = String
 
 object SessionId:
-  /** The raw, UNCHECKED constructor — `private[orca]` because a string minted
-    * outside the library (a log-sourced or wire-sourced value) must go through
-    * [[parse]] instead. Internal trusted callers ([[fresh]], [[onWire]], and
-    * the two write-policy sites this codec backs) still reach it directly.
+  /** The raw, UNCHECKED constructor — `private[orca]` because a string sourced
+    * outside the library must go through [[parse]] instead. Internal trusted
+    * callers ([[fresh]], [[onWire]], the write-policy sites) reach it directly.
     */
   private[orca] def apply[B <: BackendTag](value: String): SessionId[B] = value
   extension [B <: BackendTag](id: SessionId[B]) def value: String = id
 
-  /** Returns `true` iff `id` is a well-formed session id that is safe to embed
-    * in a file path, regex, or URL without further escaping. Accepted: 1–200
-    * characters from `[A-Za-z0-9_-]`, covering all legitimate ids (UUIDs for
-    * claude/codex/gemini; `ses_…` for opencode). Rejects `.`, `/`, `*`, `[`,
-    * `?`, `#`, `..` and every other character that could enable path traversal,
-    * regex injection, or URL injection.
+  /** Returns `true` iff `id` is safe to embed in a file path, regex, or URL
+    * without further escaping: 1–200 characters from `[A-Za-z0-9_-]`, covering
+    * all legitimate ids (UUIDs for claude/codex/gemini; `ses_…` for opencode).
+    * Rejects `.`, `/`, `*`, `[`, `?`, `#`, `..` and anything else that could
+    * enable path traversal, regex injection, or URL injection.
     *
-    * The predicate behind [[parse]] and the two write-policy guards
+    * The predicate behind [[parse]] and the write-policy guards
     * ([[orca.backend.SessionSupport.register]] /
-    * [[orca.backend.SessionSupport.commitAfterDrain]]); every other re-check
-    * that used to scatter across the codebase is now provably redundant, since
-    * nothing downstream of those doors can hold an id that failed this check.
+    * [[orca.backend.SessionSupport.commitAfterDrain]]); downstream re-checks
+    * are redundant since nothing past those doors can hold an id that failed
+    * here.
     */
   def isSafe(id: String): Boolean =
     id.nonEmpty && id.length <= 200 && id.matches("[A-Za-z0-9_-]+")
@@ -70,11 +64,10 @@ object SessionId:
   def parse[B <: BackendTag](value: String): Option[SessionId[B]] =
     Option.when(isSafe(value))(value)
 
-  /** Mint a fresh session id (random UUID). The id is client-allocated — the
-    * library uses it as a pre-shared key with the backend on the first call.
-    * For claude, this maps to `--session-id <uuid>`; for codex (which doesn't
-    * accept caller-supplied ids), the backend stores a client→server mapping
-    * keyed on this value.
+  /** Mint a fresh session id (random UUID). Client-allocated — used as a
+    * pre-shared key with the backend on the first call. For claude this maps to
+    * `--session-id <uuid>`; for codex (which rejects caller-supplied ids) the
+    * backend stores a client→server mapping keyed on this value.
     */
   def fresh[B <: BackendTag]: SessionId[B] =
     java.util.UUID.randomUUID.toString
@@ -84,17 +77,15 @@ object SessionId:
   * pi's claimed ids) the two coincide; for codex/gemini/opencode the wire id is
   * a server-minted thread id learned from the protocol. A separate opaque type
   * makes returning a wire id as the caller's handle — or resuming against a
-  * client id — a compile error (the bug class behind two shipped resume bugs;
-  * see complexity review finding 1.1).
+  * client id — a compile error.
   */
 opaque type WireSessionId[B <: BackendTag] = String
 
 object WireSessionId:
   /** The raw, UNCHECKED constructor — `private[orca]` for the same reason as
     * [[SessionId.apply]]: a log/wire-sourced string must go through [[parse]].
-    * Internal trusted callers (backends constructing a wire id straight from a
-    * live protocol response, [[SessionId.onWire]], and the two write-policy
-    * sites) still reach it directly.
+    * Internal trusted callers (backends building a wire id from a live protocol
+    * response, [[SessionId.onWire]], the write-policy sites) reach it directly.
     */
   private[orca] def apply[B <: BackendTag](value: String): WireSessionId[B] =
     value

--- a/tools/src/main/scala/orca/agents/BaseAgent.scala
+++ b/tools/src/main/scala/orca/agents/BaseAgent.scala
@@ -4,20 +4,16 @@ import orca.OrcaFlowException
 import orca.backend.{Interaction, AgentBackend, AgentResult}
 import orca.events.{OrcaEvent, OrcaListener}
 
-/** Skeleton shared by Claude and Codex's default tools — and by any future
-  * backend that follows the same `AgentBackend` contract. Centralises the
-  * autonomous-text path (which is otherwise pure delegation to
-  * `backend.runAutonomous` plus `TokensUsed` emission), the `resultAs[O]`
-  * factory, and the `withConfig` / `withSystemPrompt` / `withName` builders.
+/** Skeleton shared by all backends' default tools. Centralises the
+  * autonomous-text path (delegation to `backend.runAutonomous` plus
+  * `TokensUsed` emission), the `resultAs[O]` factory, and the `withConfig` /
+  * `withSystemPrompt` / `withName` builders.
   *
   * Concrete subclasses provide:
   *   - the `Self` type bound (their own `Agent` subtype) so the builders return
   *     the concrete type;
-  *   - a `copyTool` factory that knows the subclass-specific extra params (e.g.
-  *     claude has no extra params; a hypothetical backend that needed more
-  *     config would override `copyTool` to thread them through);
-  *   - the model accessors (`haiku`/`sonnet`/`opus`, `mini`, …) — these are
-  *     backend-specific and stay on the subclass.
+  *   - a `copyTool` factory threading through subclass-specific extra params;
+  *   - the backend-specific model accessors (`haiku`/`sonnet`/`opus`, `mini`).
   */
 abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
     backend: AgentBackend[B],
@@ -27,10 +23,9 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
     interaction: Interaction
 ) extends Agent[B]:
 
-  /** Build a sibling instance with the supplied overrides. Concrete subclasses
-    * call their own constructor with subclass-specific extra parameters
-    * preserved. Used by `withConfig`, `withSystemPrompt`, `withName`, and the
-    * model-pinning accessors.
+  /** Build a sibling instance with the supplied overrides, preserving
+    * subclass-specific extra parameters. Used by `withConfig`,
+    * `withSystemPrompt`, `withName`, and the model-pinning accessors.
     */
   protected def copyTool(
       config: AgentConfig = config,
@@ -51,10 +46,8 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
     copyTool(config = config.copy(selfManagedGit = true))
 
   /** Pin the underlying CLI's `--model` flag for subsequent calls. Public so
-    * each backend trait can surface it (`claude.withModel(...)`,
-    * `codex.withModel(...)`); the named accessors (`haiku`/`sonnet`/`opus`,
-    * `mini`) are conveniences over it. Returns `Self` so they keep the concrete
-    * type.
+    * each backend trait can surface it; the named accessors
+    * (`haiku`/`sonnet`/`opus`, `mini`) are conveniences over it.
     */
   def withModel(model: Model): Self =
     copyTool(config = config.copy(model = Some(model)))
@@ -68,42 +61,33 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
   override def withCheapModel(model: Model): Self =
     copyTool(config = config.copy(cheapModel = Some(model)))
 
-  /** Exposes the backend's whole session-durability capability, so a tool built
-    * on a real [[orca.backend.AgentBackend]] reflects actual session state
-    * rather than the trait's `None` default. The `final` `willContinue` /
-    * `resumeWireId` / `registerResumeWireId` on [[Agent]] route through this.
+  /** Exposes the backend's session-durability capability, so a tool built on a
+    * real [[orca.backend.AgentBackend]] reflects actual session state rather
+    * than the trait's `None` default. `willContinue` / `resumeWireId` /
+    * `registerResumeWireId` on [[Agent]] route through this.
     */
   override private[orca] def sessionSupport
       : Option[orca.backend.SessionSupport[B]] =
     Some(backend.sessions)
 
-  /** Delegates to the backend's runtime tag — see [[Agent.backendTag]].
-    */
   override private[orca] def backendTag: Option[BackendTag] = Some(backend.tag)
 
-  /** Delegates to the shared backend's closed-flag reference — see
-    * [[Agent.backendIdentity]].
-    */
   override private[orca] def backendIdentity: Option[AnyRef] = Some(
     backend.closedFlag
   )
 
   /** Gates [[autonomous]]`.run` and [[resultAs]]'s gateway construction on the
-    * backend's closed latch. A leaked agent handle used after its flow ended
-    * would otherwise silently emit to a closed run's dispatcher — loud on
-    * opencode (a dead `serve` process), invisible on claude/codex. The latch
-    * lives on the shared `backend`, not this instance, so every
-    * `copyTool`-derived sibling (`leaked.opus`, `leaked.withConfig(...)`, …) is
-    * covered too — see [[orca.backend.AgentBackend.markClosed]].
+    * backend's closed latch, so a leaked agent handle used after its flow ended
+    * can't silently emit to a closed run's dispatcher. The latch lives on the
+    * shared `backend`, so every `copyTool`-derived sibling is covered too.
     */
   private def checkNotClosed(): Unit =
     if backend.isClosed then
       throw new OrcaFlowException(AgentBackend.ClosedMessage)
 
   /** Latches the shared backend closed first (so a `run`/`resultAs` call racing
-    * this close observes one consistent state or the other, never a
-    * live-looking agent whose backend has already been torn down), then
-    * delegates resource teardown — see [[Agent.close]].
+    * this close never sees a live-looking agent whose backend is torn down),
+    * then delegates resource teardown.
     */
   override private[orca] def close(): Unit =
     backend.markClosed()
@@ -156,10 +140,8 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
       agentRole = role
     )
 
-  /** `agent` axis is always this tool's name; `model` prefers the
-    * response-reported model (most precise) and falls back to whatever the
-    * caller pinned in config. Stays None when neither is known. `role` is this
-    * tool's [[Agent.role]] tag, unrelated to the model resolution.
+  /** `model` prefers the response-reported model (most precise), falling back
+    * to whatever the caller pinned in config, `None` when neither is known.
     */
   private def emitTokens(effective: AgentConfig, result: AgentResult[B]): Unit =
     val model = result.model.orElse(effective.model)

--- a/tools/src/main/scala/orca/agents/Chat.scala
+++ b/tools/src/main/scala/orca/agents/Chat.scala
@@ -9,22 +9,20 @@ import orca.InStage
   * `agent.session(name, seed)`, is the door for conversations that must
   * survive).
   *
-  * Runs need only [[InStage]] — a shared capability that crosses forks — so
-  * chats are the conversation handle for parallel fan-outs: each fork mints its
-  * own `agent.chat()` and drives multi-turn exchanges without resending context
-  * (the review loop's reviewers work exactly this way).
+  * Runs need only [[InStage]], which crosses forks, so chats are the
+  * conversation handle for parallel fan-outs: each fork mints its own
+  * `agent.chat()` and drives multi-turn exchanges without resending context.
   *
   * The handle bundles the minting [[Agent]] with a reserved [[SessionId]], so
-  * every turn runs on the same agent configuration and the same conversation —
-  * there is no loose id to mis-route. Drive one chat from one place at a time:
-  * concurrent turns against the same backend conversation fail.
+  * every turn runs on the same agent configuration and conversation. Drive one
+  * chat from one place at a time: concurrent turns against the same backend
+  * conversation fail.
   */
 final class Chat[B <: BackendTag] private[orca] (
     private[orca] val agent: Agent[B],
     /** The underlying conversation id. `private[orca]` — the library's own
-      * continuations (the planning grid) reach it; scripts hold the chat
-      * itself, and the only public id-adoption door is `agent.chat(id)` over a
-      * `FlowSession.id`.
+      * continuations reach it; the only public id-adoption door is
+      * `agent.chat(id)` over a `FlowSession.id`.
       */
     private[orca] val id: SessionId[B]
 ):

--- a/tools/src/main/scala/orca/agents/JsonData.scala
+++ b/tools/src/main/scala/orca/agents/JsonData.scala
@@ -52,10 +52,9 @@ object JsonData:
       ConfiguredJsonValueCodec.derived[A](using strictCodecConfig)
     )
 
-  /** Wraps a plain `JsonValueCodec` as a `ConfiguredJsonValueCodec`.
-    * `ConfiguredJsonValueCodec` is a marker interface that extends
-    * `JsonValueCodec` without adding methods, so we just delegate all calls.
-    * Used by the hand-written primitive/generic givens below.
+  /** Wraps a plain `JsonValueCodec` as a `ConfiguredJsonValueCodec` (a marker
+    * interface adding no methods) by delegating all calls. Used by the
+    * hand-written primitive/generic givens below.
     */
   private def wrap[A](c: JsonValueCodec[A]): ConfiguredJsonValueCodec[A] =
     new ConfiguredJsonValueCodec[A]:
@@ -80,13 +79,11 @@ object JsonData:
   given doubleJsonData: JsonData[Double] =
     apply(Schema.schemaForDouble, wrap(JsonCodecMaker.make))
 
-  /** Unit serialises as `{}` (an empty JSON object) — a valid, round-trippable
-    * JSON value that conveys "no meaningful payload". `JsonCodecMaker` does not
-    * support `Unit`, so we write the codec by hand.
-    *
-    * Decode is strict: it requires exactly the empty object `{}` the encoder
-    * produces, rejecting any other token (including `null`). So `Option[Unit]`
-    * round-trips correctly — `None`/`Some(())` map to `null`/`{}`.
+  /** Unit serialises as `{}`, a valid round-trippable "no meaningful payload"
+    * value. `JsonCodecMaker` doesn't support `Unit`, so the codec is hand-
+    * written. Decode is strict: it requires exactly `{}`, rejecting any other
+    * token (including `null`), so `Option[Unit]` round-trips —
+    * `None`/`Some(())` map to `null`/`{}`.
     */
   given unitJsonData: JsonData[Unit] = apply(
     Schema.schemaForUnit,

--- a/tools/src/main/scala/orca/agents/Model.scala
+++ b/tools/src/main/scala/orca/agents/Model.scala
@@ -8,12 +8,10 @@ import com.github.plokhotnyuk.jsoniter_scala.core.{
 import sttp.tapir.Schema
 
 /** The concrete model id a backend served (or will serve) a call with —
-  * `claude-haiku-4-5`, `gpt-5-mini`, … Opaque over `String` so the compiler
-  * rejects accidental mixing with `agent`, `sessionId`, raw prompts, or other
-  * free-floating strings; the bare string is recovered via `.name`.
-  *
-  * The string is whatever the underlying CLI reports or accepts on the
-  * `--model` flag; orca doesn't normalise or validate it.
+  * `claude-haiku-4-5`, `gpt-5-mini`, … Opaque over `String` so it can't mix
+  * with other free-floating strings; the bare string is recovered via `.name`.
+  * Whatever the underlying CLI reports or accepts on `--model`; orca doesn't
+  * normalise or validate it.
   */
 opaque type Model = String
 
@@ -21,16 +19,13 @@ object Model:
   def apply(s: String): Model = s
   extension (m: Model) def name: String = m
 
-  // Model is `String` at runtime, so jsoniter's existing String codec
-  // semantics apply directly — we just retype them.
   given JsonValueCodec[Model] with
     def decodeValue(in: JsonReader, default: Model): Model =
       in.readString(default)
     def encodeValue(value: Model, out: JsonWriter): Unit = out.writeVal(value)
-    // Fail loudly on a raw JSON null — the convention is that model ids
-    // travel as `Option[String]` at the wire layer and wrap to Model at
-    // the seam, so a bare null reaching this codec is a protocol mistake
-    // we'd rather surface than smuggle past the opaque-type boundary.
+    // Model ids travel as `Option[String]` at the wire layer and wrap to Model
+    // at the seam, so a bare null reaching this codec is a protocol mistake to
+    // surface rather than smuggle past the opaque-type boundary.
     def nullValue: Model = throw new IllegalStateException(
       "Model cannot decode JSON null; wrap in Option at the wire layer"
     )

--- a/tools/src/main/scala/orca/agents/Prompts.scala
+++ b/tools/src/main/scala/orca/agents/Prompts.scala
@@ -3,18 +3,15 @@ package orca.agents
 import orca.util.PromptResource
 
 /** Builds the literal prompt strings Orca sends to the LLM for each invocation
-  * mode. Each method takes the serialized user input, the generated JSON Schema
-  * for the expected output, and the active `AgentConfig`, and returns the final
-  * prompt text. Swap the default ([[DefaultPrompts]]) by passing `prompts =
-  * ...` to `flow(...)` when you want to customise phrasing, add guardrails, or
-  * use a different structured-output convention.
+  * mode, from the serialized user input, the generated JSON Schema for the
+  * expected output, and the active `AgentConfig`. Swap the default
+  * ([[DefaultPrompts]]) by passing `prompts = ...` to `flow(...)`.
   */
 trait Prompts:
   /** Prompt for a non-interactive call: the model produces the structured
-    * response in a single agentic turn, with no user turn in between. `mode` is
-    * the backend's declared [[StructuredOutputMode]] — how the wire expects the
-    * payload (a StructuredOutput tool call vs raw reply text) — so the delivery
-    * instruction names the actual mechanism instead of contradicting it.
+    * response in a single agentic turn. `mode` is how the wire expects the
+    * payload (a StructuredOutput tool call vs raw reply text), so the delivery
+    * instruction names the actual mechanism.
     */
   def autonomous(
       input: String,
@@ -25,9 +22,8 @@ trait Prompts:
 
   /** Prompt for an interactive call: the model converses with the user on
     * intermediate turns, then produces a single JSON value matching the output
-    * schema as its final turn. The runtime validates the final value against
-    * the schema via `--json-schema` (or equivalent backend mechanism); no
-    * in-band completion marker is required.
+    * schema as its final turn. The runtime validates it against the schema via
+    * `--json-schema` (or equivalent); no in-band completion marker is required.
     */
   def interactive(
       input: String,
@@ -46,13 +42,10 @@ trait Prompts:
   * init.
   *
   * Both call modes ship the JSON Schema inline in the prompt AND hand it to the
-  * backend (`outputSchema = Some(...)`): claude passes `--json-schema`, which
-  * enforces the schema CLI-side via an injected StructuredOutput tool whose
-  * parameters are the schema's top-level properties; text-only backends rely on
-  * `ResponseParser` + the retry loop for structural validation. The autonomous
-  * delivery rules follow the backend's declared [[StructuredOutputMode]]:
-  * `Tool` backends are told to call the StructuredOutput tool, `RawText`
-  * backends keep the raw-JSON contract.
+  * backend: claude enforces it CLI-side via `--json-schema`; text-only backends
+  * rely on `ResponseParser` + the retry loop. Autonomous delivery rules follow
+  * the backend's [[StructuredOutputMode]]: `Tool` backends call the
+  * StructuredOutput tool, `RawText` backends keep the raw-JSON contract.
   */
 object DefaultPrompts extends Prompts:
 
@@ -63,12 +56,9 @@ object DefaultPrompts extends Prompts:
     PromptResource.load("/orca/agents/prompts/tool-call-rules.md")
 
   // Substitute the shared rules fragments once at init so each call only pays
-  // for the dynamic `{{input}}` / `{{outputSchema}}` / `{{failedResponse}}` /
-  // `{{parseError}}` replacements. The autonomous template exists in one
-  // variant per StructuredOutputMode: same task framing, delivery rules
-  // matching what the backend's wire actually expects. Selection happens via
-  // an exhaustive match in [[autonomous]], so a new mode is a compile error
-  // here rather than a lookup failure at call time.
+  // for the dynamic `{{...}}` replacements. One autonomous template per
+  // StructuredOutputMode, selected via an exhaustive match in [[autonomous]] so
+  // a new mode is a compile error here rather than a lookup failure at runtime.
   private val AutonomousBase: String =
     PromptResource.load("/orca/agents/prompts/autonomous.md")
 

--- a/tools/src/main/scala/orca/agents/ResponseParser.scala
+++ b/tools/src/main/scala/orca/agents/ResponseParser.scala
@@ -10,11 +10,10 @@ import io.circe.parser.{parse as parseCirceJson}
 import scala.annotation.tailrec
 import scala.util.matching.Regex
 
-/** Thrown when the agent returned output that doesn't parse as `O`. Carries the
-  * raw (possibly truncated) response and a short human-readable cause message;
-  * the underlying jsoniter exception (with its hex buffer dump) is attached as
-  * `getCause` for `--verbose` inspection without being part of the default
-  * message.
+/** Thrown when agent output doesn't parse as `O`. Carries the raw (possibly
+  * truncated) response and a short cause message; the underlying jsoniter
+  * exception (with its hex buffer dump) is attached as `getCause` for
+  * `--verbose` inspection, out of the default message.
   */
 class MalformedAgentOutputException(
     val rawOutput: String,
@@ -31,14 +30,12 @@ private[agents] object ResponseParser:
     """(?s)\A```(?:\w+)?\n?(.*?)\n?```\z""".r
 
   /** Parse an LLM-returned JSON string into `O`, tolerating markdown code
-    * fences (optionally with a language tag) and prose preamble/coda around the
-    * JSON body. Tries candidates from the *right* first, so a final answer
-    * `{...}` at the end of the response wins over an incidental `{ ... }` in
-    * prose (e.g. a Java snippet quoted in the explanation). If every direct
-    * attempt fails, also tries unwrapping a lone `{"input": <value>}` envelope
-    * (see [[unwrapInputEnvelope]]) before giving up. On a total parse failure,
-    * raises a [[MalformedAgentOutputException]] carrying the raw output and a
-    * short cause — never jsoniter's hex buffer dump.
+    * fences and prose preamble/coda around the JSON body. Tries candidates from
+    * the *right* first, so a final answer `{...}` at the end wins over an
+    * incidental `{ ... }` in prose. If every direct attempt fails, also tries
+    * unwrapping a lone `{"input": <value>}` envelope (see
+    * [[unwrapInputEnvelope]]) before raising a
+    * [[MalformedAgentOutputException]].
     */
   def parse[O](raw: String)(using JsonValueCodec[O]): O =
     val trimmed = stripFences(raw)
@@ -68,16 +65,14 @@ private[agents] object ResponseParser:
     catch case e: JsonReaderException => Left(e)
 
   /** Some backends (observed: opencode routing a reviewer call through
-    * claude-haiku) echo their own structured-output tool's argument envelope
-    * back as the "response" instead of the model's raw JSON — the tool's sole
-    * parameter happens to be named `input`, so the payload arrives as
-    * `{"input": <value>}` where `<value>` is either the expected JSON
-    * string-encoded (`{"input":"{\"issues\":[]}"}`) or nested directly
-    * (`{"input":{"issues":[]}}`). Unwrap exactly that one shape — a top-level
-    * object with the single key `input` — one level, and retry the normal parse
-    * on what's inside. Anything else (extra keys, a different lone key, a
-    * non-JSON string under `input`) is left alone and falls through to the
-    * ordinary parse failure; this is not a general fuzzy unwrapper.
+    * claude-haiku) echo their structured-output tool's argument envelope back
+    * as the "response" — the tool's sole parameter is named `input`, so the
+    * payload arrives as `{"input": <value>}` with `<value>` either the expected
+    * JSON string-encoded (`{"input":"{\"issues\":[]}"}`) or nested directly
+    * (`{"input":{"issues":[]}}`). Unwrap exactly that shape — a top-level
+    * object with the single key `input` — one level and retry the normal parse.
+    * Anything else falls through to the ordinary parse failure; this is not a
+    * general fuzzy unwrapper.
     */
   private def unwrapInputEnvelope[O: JsonValueCodec](
       candidate: String
@@ -96,10 +91,8 @@ private[agents] object ResponseParser:
       case FencePattern(inner) => inner.trim
       case unfenced            => unfenced
 
-  /** Every balanced `{...}` substring in the input, in source order. The parser
-    * tries these right-to-left so an incidental code snippet in prose doesn't
-    * preempt the real final answer that agents tend to place at the end of a
-    * response.
+  /** Every balanced `{...}` substring in the input, in source order (the parser
+    * tries them right-to-left).
     */
   private def extractJsonObjects(s: String): List[String] =
     @tailrec
@@ -143,9 +136,8 @@ private[agents] object ResponseParser:
               case _ => loop(i + 1, depth, ScanMode.Normal)
     loop(open, 0, ScanMode.Normal)
 
-  /** jsoniter's default `getMessage` bundles the offset + a hex buffer dump —
-    * useful in logs, intimidating in a user-facing error. Keep only the first
-    * line.
+  /** jsoniter's `getMessage` bundles the offset + a hex buffer dump — keep only
+    * the first line for the user-facing error.
     */
   private def shortMessage(e: JsonReaderException): String =
     val msg = Option(e.getMessage).getOrElse(e.getClass.getSimpleName)

--- a/tools/src/main/scala/orca/agents/StructuredOutputMode.scala
+++ b/tools/src/main/scala/orca/agents/StructuredOutputMode.scala
@@ -1,14 +1,14 @@
 package orca.agents
 
 /** How a backend's wire delivers the payload of a structured (`resultAs[O]`)
-  * turn — declared per backend via `AgentBackend.structuredOutputMode` and
-  * consumed by [[Prompts.autonomous]], so the prompt's delivery instruction
-  * names the mechanism the wire actually expects instead of contradicting it.
+  * turn. Declared per backend via `AgentBackend.structuredOutputMode` and
+  * consumed by [[Prompts.autonomous]], so the delivery instruction matches what
+  * the wire actually expects.
   */
 enum StructuredOutputMode:
-  /** The backend's CLI enforces the schema via an injected `StructuredOutput`
-    * tool whose parameters are the schema's top-level properties — the result
-    * arrives as that tool call, never as reply text (claude's `--json-schema`).
+  /** The result arrives as a CLI-injected `StructuredOutput` tool call whose
+    * parameters are the schema's top-level properties, never as reply text
+    * (claude's `--json-schema`).
     */
   case Tool
 

--- a/tools/src/main/scala/orca/backend/AgentBackend.scala
+++ b/tools/src/main/scala/orca/backend/AgentBackend.scala
@@ -15,56 +15,44 @@ import orca.agents.{
 
 import ox.Ox
 
-/** SPI implemented per backend (Claude, Codex, …). The framework calls these
-  * methods from the autonomous-text and structured-output paths
-  * ([[AutonomousTextCall]], [[AgentCall]]).
+/** SPI implemented per backend (Claude, Codex, …), called from the
+  * autonomous-text and structured-output paths ([[AutonomousTextCall]],
+  * [[AgentCall]]).
   *
-  * Each method takes a `session: SessionId[B]` — the framework hands the same
-  * value across calls; the backend decides internally whether this is the first
-  * invocation (and the session needs creating) or a continuation. Two methods
-  * cover the UX shape: `runAutonomous` runs to completion off-screen and
-  * returns the result; `runInteractive` returns a live [[Conversation]] the
-  * caller drives through an [[Interaction]].
+  * Each method takes a `session: SessionId[B]` — the same value across calls;
+  * the backend decides internally whether this is a first invocation (session
+  * needs creating) or a continuation. `runAutonomous` runs to completion
+  * off-screen and returns the result; `runInteractive` returns a live
+  * [[Conversation]] the caller drives through an [[Interaction]].
   *
-  * `prompt` on every method is the full wire-level message sent to the agent —
-  * with whatever template scaffolding, schema, and rules the caller wrapped
-  * around the user's input. `displayPrompt` (interactive only) is what the
-  * renderer shows the user; autonomous has no renderer, hence no
-  * `displayPrompt`.
-  *
-  * `workDir` is fixed at construction (see [[workDir]]) rather than threaded
-  * per call — the runtime never varies it across a backend's lifetime, so
-  * carrying it as a per-call parameter was a phantom degree of freedom.
+  * `prompt` is the full wire-level message sent to the agent, with all template
+  * scaffolding, schema, and rules already wrapped around the user's input.
+  * `displayPrompt` (interactive only) is what the renderer shows the user.
   */
 trait AgentBackend[B <: BackendTag](
     /** Backing store for [[isClosed]]/[[markClosed]]. Defaults to a fresh,
-      * unshared flag, correct for every backend whose builders (`withConfig`,
-      * `withModel`, …) go through `BaseAgent.copyTool` and so stay on the SAME
-      * backend instance. A backend whose builder instead constructs a SIBLING
-      * backend instance (today only claude's `withNetworkTools`, see
+      * unshared flag, correct for every backend whose builders go through
+      * `BaseAgent.copyTool` and stay on the SAME backend instance. A builder
+      * that instead constructs a SIBLING backend (today only claude's
       * [[orca.tools.claude.ClaudeBackend.withNetworkTools]]) MUST pass the
-      * parent's `closedFlag` into the sibling's constructor here, so
-      * `markClosed()` on either instance is visible through both — otherwise a
-      * handle derived via that builder and leaked past flow-end bypasses the
-      * use-after-close guard entirely (it latches a flag nothing else reads).
+      * parent's `closedFlag` here, so `markClosed()` on either instance is
+      * visible through both — otherwise a handle derived via that builder and
+      * leaked past flow-end bypasses the use-after-close guard entirely.
       */
     private[orca] val closedFlag: AtomicBoolean = new AtomicBoolean(false)
 ):
-  /** Run one autonomous turn against `session` and return its result. The
-    * backend decides whether to create the session (first call with this id) or
-    * resume it (subsequent calls).
+  /** Run one autonomous turn against `session` and return its result.
     *
     * `events` receives per-tool-use and per-message progress as the subprocess
-    * runs, so the user has something to watch while the agent works. Defaults
-    * to a no-op listener for callers (typically tests) that don't observe
-    * progress.
+    * runs. Defaults to a no-op listener for callers (typically tests) that
+    * don't observe progress.
     *
     * `outputSchema`, when supplied, is the JSON Schema the final assistant
     * payload must conform to. Backends that enforce schemas natively (claude's
-    * `--json-schema`) pass it to the CLI; backends that don't can ignore it.
-    * Either way the schema is forwarded to the conversation so the autonomous
-    * drain can recognise "the agent's last message IS the structured payload"
-    * and suppress the raw JSON from the user log — the caller surfaces it via
+    * `--json-schema`) pass it to the CLI; others can ignore it. Either way the
+    * schema is forwarded to the conversation so the drain can recognise "the
+    * agent's last message IS the structured payload" and suppress the raw JSON
+    * from the user log — the caller surfaces it via
     * `OrcaEvent.StructuredResult` instead.
     */
   def runAutonomous(
@@ -76,14 +64,13 @@ trait AgentBackend[B <: BackendTag](
   ): AgentResult[B]
 
   /** Launch an interactive session against `session` and return a live
-    * [[Conversation]] the caller hands to [[Interaction.drive]] for rendering
-    * and user steering. The backend owns the subprocess and event parsing; the
-    * channel owns UX.
+    * [[Conversation]] the caller hands to [[Interaction.drive]]. The backend
+    * owns the subprocess and event parsing; the channel owns UX.
     *
     * `outputSchema` is the JSON Schema the agent's final reply must conform to,
     * or `None` for free-form text. Backends that support structured-output
-    * validation (claude's `--json-schema`) enforce it; those that don't can
-    * ignore the parameter and let the caller validate post-hoc.
+    * validation (claude's `--json-schema`) enforce it; others ignore it and let
+    * the caller validate post-hoc.
     */
   def runInteractive(
       prompt: String,
@@ -95,17 +82,15 @@ trait AgentBackend[B <: BackendTag](
 
   /** The working directory the agent subprocess sees, fixed for this backend's
     * whole lifetime — every spawn and every session-existence probe runs
-    * against this SAME path, by construction (no separate per-call value can
-    * drift from it).
+    * against this same path.
     */
   def workDir: os.Path
 
   /** This backend's whole session capability as one structural value: the id
     * scheme plus, for durable backends, the existence probe (see
     * [[SessionSupport.durable]] / [[SessionSupport.ephemeral]]). The framework
-    * reaches sessions exclusively through this — a backend cannot half-wire
-    * resume by providing one of persist/probe/register and forgetting the
-    * others.
+    * reaches sessions exclusively through this, so a backend cannot half-wire
+    * resume by providing persist/probe/register piecemeal.
     */
   def sessions: SessionSupport[B]
 
@@ -114,41 +99,32 @@ trait AgentBackend[B <: BackendTag](
     */
   def tag: B
 
-  /** How strongly THIS backend enforces the restriction that a `(tools,
+  /** How strongly THIS backend enforces the restriction a `(tools,
     * autoApprove)` combination requests — a pure classification of the flags
-    * this backend's `*Args` would build, with no side effects. The mapping
-    * differs materially across backends (a `Full` + `AutoApprove.Only` is a
-    * mechanical allowlist on claude but a whole-sandbox approximation on codex
-    * and unencoded on the rest), so it is surfaced as data rather than left in
-    * scattered scaladoc.
+    * this backend's `*Args` would build. The mapping differs materially across
+    * backends (a `Full` + `AutoApprove.Only` is a mechanical allowlist on
+    * claude but a whole-sandbox approximation on codex and unencoded on the
+    * rest), so it is surfaced as data. The complete matrix is machine-checked
+    * in `runner/src/test/scala/orca/runner/EnforcementTableTest.scala`; each
+    * backend delegates to its `*Args.enforcement`, where the per-cell rationale
+    * lives.
     *
-    * The complete matrix is machine-checked in
-    * `runner/src/test/scala/orca/runner/EnforcementTableTest.scala` — that test
-    * is the human-readable source of truth; each backend implements this by
-    * delegating to its `*Args.enforcement`, where the per-cell rationale lives.
-    *
-    * Abstract, not defaulted to `Enforcement.Ignored`: a silent fallback would
-    * let a new backend ship without ever answering this and without anyone
-    * noticing (the matrix test only helps if its author remembers to add a
-    * row). REAL backends must implement this AND add their rows to
-    * `EnforcementTableTest` (which pins the five shipped ones); test doubles
-    * that never call `enforcement` add a one-line override — conservatively
-    * `Enforcement.Ignored` — same as they'd have gotten from the old default.
+    * Abstract, not defaulted to `Enforcement.Ignored`, so a new backend cannot
+    * ship without answering this. Real backends implement it and add their rows
+    * to `EnforcementTableTest`; test doubles that never call `enforcement` add
+    * a one-line `Enforcement.Ignored` override.
     */
   def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement
 
-  /** How THIS backend's wire delivers a structured (`resultAs[O]`) payload — as
-    * a CLI-injected StructuredOutput tool call, or as the reply text
+  /** How THIS backend's wire delivers a structured (`resultAs[O]`) payload
     * ([[orca.agents.StructuredOutputMode]]). Prompt assembly
-    * ([[orca.agents.Prompts.autonomous]]) branches on this declaration, so a
-    * backend that misdeclares gets an instruction that contradicts its wire and
-    * steers weak models into malformed replies.
+    * ([[orca.agents.Prompts.autonomous]]) branches on it, so a backend that
+    * misdeclares gets an instruction that contradicts its wire and steers weak
+    * models into malformed replies.
     *
-    * Abstract, not defaulted, for the same reason as [[enforcement]]: a silent
-    * fallback would let a new backend ship without ever answering this. REAL
-    * backends declare what their CLI actually does (see each override's
-    * evidence comment); test doubles that never assemble prompts add a one-line
-    * `RawText` override.
+    * Abstract, not defaulted, for the same reason as [[enforcement]]. Real
+    * backends declare what their CLI actually does; test doubles that never
+    * assemble prompts add a one-line `RawText` override.
     */
   def structuredOutputMode: StructuredOutputMode
 
@@ -160,20 +136,15 @@ trait AgentBackend[B <: BackendTag](
     */
   def close(): Unit = ()
 
-  // The use-after-close latch lives HERE, on the backend, not on the Agent
-  // instance: every builder (`withConfig`, `withModel`, `opus`, `withName`, …)
-  // goes through `BaseAgent.copyTool`, which constructs a NEW agent instance
-  // sharing this same backend — a per-agent flag would silently reset to
-  // "open" on every derived handle, letting `leaked.opus.autonomous.run(...)`
-  // bypass the guard. `closedFlag` itself is a constructor parameter (see
-  // above) rather than a fresh field here, so a backend-swapping builder can
-  // thread the SAME flag into a sibling instance instead of resetting it.
+  // The use-after-close latch lives on the backend, not the Agent instance:
+  // every builder goes through `BaseAgent.copyTool`, which constructs a new
+  // agent sharing this same backend — a per-agent flag would reset to "open"
+  // on every derived handle, letting a leaked handle bypass the guard.
 
   /** Latch this backend as closed — its owning flow has ended, and every run
     * entry point gated on [[isClosed]] must refuse from now on. Called by
-    * `BaseAgent.close()` alongside (before) [[close]]; separate from [[close]]
-    * so a subclass overriding `close()` for resource teardown cannot forget the
-    * latch.
+    * `BaseAgent.close()` before [[close]]; separate from it so a subclass
+    * overriding `close()` for resource teardown cannot forget the latch.
     */
   private[orca] final def markClosed(): Unit = closedFlag.set(true)
 
@@ -184,10 +155,8 @@ trait AgentBackend[B <: BackendTag](
 
 object AgentBackend:
   /** The use-after-close guard's user-facing message, thrown by every
-    * `isClosed` gate (`BaseAgent.checkNotClosed`,
-    * `DefaultAgentCall.checkNotClosed`) so a leaked-handle failure reads
-    * identically no matter which gate caught it. Single home for the string
-    * rather than one literal copy per gate.
+    * `isClosed` gate so a leaked-handle failure reads identically no matter
+    * which gate caught it.
     */
   private[orca] val ClosedMessage: String =
     "agent used after its flow ended — agents are scoped to the flow(...) that created them"

--- a/tools/src/main/scala/orca/backend/AgentResult.scala
+++ b/tools/src/main/scala/orca/backend/AgentResult.scala
@@ -3,25 +3,23 @@ package orca.backend
 import orca.agents.{BackendTag, Model, WireSessionId}
 import orca.events.{Usage}
 
-/** Outcome of a single LLM call. Returned by [[AgentBackend.runAutonomous]] /
-  * [[AgentBackend.continueAutonomous]] for the autonomous path, and by
-  * [[Conversation.awaitResult]] / [[Interaction.drive]] for the interactive
-  * path.
+/** Outcome of a single LLM call. Returned by [[AgentBackend.runAutonomous]] for
+  * the autonomous path and by [[Conversation.awaitResult]] /
+  * [[Interaction.drive]] for the interactive path.
   */
 case class AgentResult[B <: BackendTag](
-    /** The session id the backend reported for this turn — the WIRE id (server
-      * thread id for codex/gemini/opencode; the claimed client id for
-      * claude/pi). Callers wanting the stable client handle already hold it —
-      * they passed it in; this field exists so the registry can learn the
-      * mapping.
+    /** The WIRE session id the backend reported for this turn (server thread id
+      * for codex/gemini/opencode; the claimed client id for claude/pi). Exists
+      * so the registry can learn the wire↔client mapping — callers already hold
+      * the stable client handle they passed in.
       */
     wireId: WireSessionId[B],
     output: String,
     usage: Usage,
     /** Model the backend reports it actually served the call with — usually
       * present for autonomous calls (the CLI returns it), absent for some
-      * conversation paths. Used as the bucket key in `CostTracker` so spend is
-      * attributed to the concrete model rather than just the tool name.
+      * conversation paths. The bucket key in `CostTracker`, so spend is
+      * attributed to the concrete model rather than the tool name.
       */
     model: Option[Model] = None
 )

--- a/tools/src/main/scala/orca/backend/AgentWiring.scala
+++ b/tools/src/main/scala/orca/backend/AgentWiring.scala
@@ -4,10 +4,9 @@ import orca.agents.Prompts
 import orca.events.OrcaListener
 
 /** Everything the runtime wires into an agent at construction: the run's event
-  * sink (costs/steps land in the tracker and terminal), the interaction, the
-  * working directory, and the prompt templates. Override factories receive this
-  * so user-supplied agents are first-class citizens of the run — wired into the
-  * same dispatcher as the defaults, not event-blind.
+  * sink, the interaction, the working directory, and the prompt templates.
+  * Override factories receive this so user-supplied agents wire into the same
+  * dispatcher as the defaults rather than being event-blind.
   */
 final case class AgentWiring(
     events: OrcaListener,

--- a/tools/src/main/scala/orca/backend/AskUserEchoes.scala
+++ b/tools/src/main/scala/orca/backend/AskUserEchoes.scala
@@ -3,22 +3,18 @@ package orca.backend
 /** Tracks the tool-call ids of `ask_user` invocations whose wire echo must be
   * dropped from the conversation event stream.
   *
-  * Every stream backend that bridges `ask_user` through the host-side MCP
-  * surfaces the question as a [[ConversationEvent.UserQuestion]], so
-  * re-emitting the agent's own tool-call block AND the paired tool-result would
-  * render the exchange twice — the user's typed answer reappearing as `⎿
-  * <answer>` right after the prompt already showed it. Each driver therefore
-  * suppresses the `ask_user` tool-call and drops its matching result.
+  * A bridged `ask_user` question is already surfaced as a
+  * [[ConversationEvent.UserQuestion]], so re-emitting the agent's tool-call
+  * block and paired tool-result would render the exchange twice. Each driver
+  * suppresses the tool-call and drops its matching result.
   *
-  * What is shared is exactly this id bookkeeping. What is NOT shared — and
-  * stays at each call site — is the matcher for "is this an `ask_user` call",
-  * because the backends name the tool differently: claude
-  * `mcp__<server>__<tool>`, codex a `(server, tool)` pair, gemini
-  * `<server>__<tool>` or the bare slug. (Gemini notably must NOT match any name
-  * merely *containing* the slug.)
+  * Only this id bookkeeping is shared; the matcher for "is this an `ask_user`
+  * call" stays per call site, because backends name the tool differently
+  * (claude `mcp__<server>__<tool>`, codex a `(server, tool)` pair, gemini
+  * `<server>__<tool>` or the bare slug — and gemini must NOT match a name
+  * merely containing the slug).
   *
-  * Single-threaded: like the rest of the `ForkedConversation` subclass state,
-  * it is touched only from the reader thread.
+  * Single-threaded: touched only from the reader thread.
   */
 private[orca] final class AskUserEchoes:
   private var ids: Set[String] = Set.empty
@@ -27,9 +23,9 @@ private[orca] final class AskUserEchoes:
     */
   def suppress(id: String): Unit = ids = ids + id
 
-  /** True iff `id` was suppressed — and forgets it, since the echo arrives
-    * once. Returns false (and does nothing) for an id that was never
-    * suppressed, so it is safe to call on every tool-result.
+  /** True iff `id` was suppressed, forgetting it (the echo arrives once). False
+    * and a no-op for an unsuppressed id, so it is safe to call on every
+    * tool-result.
     */
   def consume(id: String): Boolean =
     val hit = ids.contains(id)

--- a/tools/src/main/scala/orca/backend/CliArgs.scala
+++ b/tools/src/main/scala/orca/backend/CliArgs.scala
@@ -10,8 +10,7 @@ import orca.agents.AgentConfig
 private[orca] object CliArgs:
 
   /** Render an optional value as its two-token flag `Seq(name, render(value))`,
-    * or an empty `Seq` for `None` — the `opt.toSeq.flatMap(v => Seq(name, …))`
-    * idiom the arg builders repeat for every optional flag, in one place.
+    * or an empty `Seq` for `None`.
     */
   def flag[A](name: String, opt: Option[A])(render: A => String): Seq[String] =
     opt.toSeq.flatMap(v => Seq(name, render(v)))

--- a/tools/src/main/scala/orca/backend/Conversation.scala
+++ b/tools/src/main/scala/orca/backend/Conversation.scala
@@ -19,52 +19,43 @@ import ox.Ox
   */
 trait Conversation[B <: BackendTag]:
 
-  /** The JSON-schema string the conversation was launched with, when the caller
-    * asked for a structured payload via `claude.resultAs[O].interactive(...)`
-    * or similar. `None` means the conversation is free-form prose.
-    *
-    * Renderers and channels can consult this to decide whether the agent's
-    * final assistant text is the structured payload (and therefore noise to
-    * suppress in favour of an `OrcaEvent.StructuredResult` event), or genuine
-    * prose to flush verbatim.
+  /** The JSON-schema string the conversation was launched with, or `None` for
+    * free-form prose. Renderers and channels consult it to decide whether the
+    * agent's final assistant text is the structured payload (noise to suppress
+    * in favour of an `OrcaEvent.StructuredResult`) or genuine prose to flush.
     */
   def outputSchema: Option[String]
 
   /** Events from the subprocess, in arrival order. Blocks on `next()` until a
-    * line has been parsed or the session ends. `hasNext` returns false once the
+    * line has been parsed or the session ends; `hasNext` returns false once the
     * terminal event has been consumed.
     *
-    * Takes `using Ox`: a stream-driven driver starts its background workers on
-    * first touch of the surface, forking into the caller's per-turn scope (the
-    * one the drain shell already opened).
+    * Takes `using Ox`: a stream-driven driver forks its background workers into
+    * the caller's per-turn scope on first touch of the surface.
     */
   def events(using Ox): Iterator[ConversationEvent]
 
   /** Block until the session finishes, then return its outcome.
     *
     *   - `Right(result)` — the session produced an [[AgentResult]] cleanly.
-    *   - `Left(cancelled)` — the user (or some peer) called [[cancel]], or the
-    *     subprocess died in a way the driver classified as a cancellation.
-    *     Recoverable: the caller can render a "cancelled" message, fail the
-    *     stage, or propagate.
+    *   - `Left(cancelled)` — [[cancel]] was called, or the subprocess died in a
+    *     way the driver classified as a cancellation. Recoverable: the caller
+    *     can render a "cancelled" message, fail the stage, or propagate.
     *
     * Genuine subprocess failures (parse errors, the agent reporting `is_error`,
-    * abnormal exit codes) keep throwing [[OrcaFlowException]] — those aren't
-    * recoverable signals; they're "the backend is broken, panic" cases.
+    * abnormal exit codes) keep throwing [[OrcaFlowException]] — non-recoverable
+    * "the backend is broken" cases.
     *
-    * Takes `using Ox` for the same reason as [[events]]: it ensures the workers
-    * are started (in the caller's per-turn scope) before it joins the reader.
+    * Takes `using Ox` for the same reason as [[events]].
     */
   def awaitResult()(using Ox): Either[OrcaInteractiveCancelled, AgentResult[B]]
 
-  /** Whether the agent can pause to ask the host user a clarifying question
-    * (and have the answer routed back into its turn). When `true`, the driver
-    * emits [[ConversationEvent.UserQuestion]] events whose `respond` closure
-    * delivers the typed answer to the blocked agent. Both claude (via its
-    * `ask_user` MCP tool over `--mcp-config`) and codex (via the same shared
-    * `AskUserMcpServer` registered with `-c mcp_servers.orca.url=…`) return
-    * `true` on interactive sessions; autonomous sessions and backends that
-    * don't wire the bridge return `false`.
+  /** Whether the agent can pause to ask the host user a clarifying question and
+    * have the answer routed back into its turn. When `true`, the driver emits
+    * [[ConversationEvent.UserQuestion]] events whose `respond` closure delivers
+    * the typed answer to the blocked agent. True for interactive claude and
+    * codex sessions (both via the shared `AskUserMcpServer`); false for
+    * autonomous sessions and backends that don't wire the bridge.
     */
   def canAskUser: Boolean
 

--- a/tools/src/main/scala/orca/backend/ConversationEvent.scala
+++ b/tools/src/main/scala/orca/backend/ConversationEvent.scala
@@ -1,17 +1,13 @@
 package orca.backend
 
-/** Event the driver emits for the channel to render. One full session is
-  * represented by a sequence of these, terminated by the `events` iterator on
-  * [[Conversation]] closing; the final outcome (success or cancel) is read via
+/** Event the driver emits for the channel to render. One session is a sequence
+  * of these, terminated by the `events` iterator on [[Conversation]] closing;
+  * the final outcome (success or cancel) is read via
   * [[Conversation.awaitResult]].
   *
-  * Partial deltas (`AssistantTextDelta`, `AssistantThinkingDelta`) arrive as
-  * the agent streams its response. `AssistantTurnEnd` marks the boundary
-  * between turns. `AssistantToolCall` is purely informational — the agent
-  * narrated a tool invocation. `ToolResult` echoes what the SDK reported back
-  * to the model after running the tool. `ApproveTool` is the only event the
-  * channel must respond to — it carries a `respond` closure the channel invokes
-  * exactly once with its decision.
+  * The deltas stream as the agent responds. `AssistantToolCall` is purely
+  * informational; `ToolResult` echoes what the SDK reported back to the model.
+  * `ApproveTool` is the only event the channel must respond to.
   *
   * Distinct from [[OrcaEvent]], which fans out flow-wide; conversation events
   * stay between driver and channel.
@@ -34,21 +30,17 @@ package orca.backend
   *
   * `ToolResult.toolName` is `Some(name)` when the wire carries the name and
   * `None` when it doesn't (claude's `tool_result` blocks carry only a tool-use
-  * id, so claude emits `None`). It is never `Some("")`.
+  * id). It is never `Some("")`.
   *
   * [[opensTurn]] is the single source of truth for the activity/neutral split
-  * above — an exhaustive match, so a new case added to this enum without a
-  * classification fails to compile rather than silently falling into the
-  * neutral bucket. [[ForkedConversation.EventQueue.enqueue]] (the funnel) and
-  * [[orca.backend.ConversationEventConformance]] (tools test sources, the
-  * oracle that asserts this grammar over a recorded sequence) both dispatch on
-  * it; backend scripted tests wire the oracle in.
+  * above, dispatched on by both [[ForkedConversation.EventQueue.enqueue]] (the
+  * funnel) and [[orca.backend.ConversationEventConformance]] (the oracle that
+  * asserts this grammar over a recorded sequence).
   */
 enum ConversationEvent:
-  /** A user turn — either the opening prompt (emitted by the driver when the
-    * session starts) or a mid-session reply. Letting the channel render these
-    * alongside agent output gives the user visible context about their own
-    * input; a long agent response to an unseen prompt feels unmoored.
+  /** A user turn — the opening prompt (emitted by the driver at session start)
+    * or a mid-session reply. Rendered so the user sees context for their own
+    * input alongside agent output.
     */
   case UserMessage(text: String)
   case AssistantTextDelta(text: String)
@@ -76,9 +68,7 @@ enum ConversationEvent:
 
   /** The agent wants a free-form answer from the user. The channel displays
     * `question`, reads a reply, and calls `respond` exactly once with what the
-    * user typed. The driver feeds the answer back into the conversation as a
-    * tool result (the backend-specific machinery surfaces these via an
-    * `ask_user` MCP tool or equivalent).
+    * user typed; the driver feeds the answer back as a tool result.
     *
     * Only emitted by backends whose [[Conversation.canAskUser]] is true —
     * claude and codex (both via the shared `AskUserMcpServer`).
@@ -86,15 +76,12 @@ enum ConversationEvent:
   case UserQuestion(question: String, respond: String => Unit)
 
   /** True for the events the "Turn grammar" scaladoc above classifies as
-    * assistant activity (open/continue a turn); false for the neutral events
-    * that never affect turn state. Deliberately exhaustive — no wildcard arm —
-    * so a future case added to this enum is a compile error here until it's
-    * explicitly classified, rather than silently defaulting to neutral in both
-    * the funnel ([[ForkedConversation.EventQueue.enqueue]]) and the oracle
-    * ([[orca.backend.ConversationEventConformance.assertGrammar]]).
-    * `AssistantTurnEnd` classifies as `false` (neutral) here — it has its own
-    * forward/drop arm in the funnel and its own assertion arm in the oracle,
-    * both ahead of the activity/neutral split this method drives.
+    * assistant activity (open/continue a turn); false for neutral events that
+    * never affect turn state. Deliberately exhaustive — no wildcard arm — so a
+    * future case is a compile error here until explicitly classified.
+    * `AssistantTurnEnd` classifies as `false` (neutral): it has its own
+    * forward/drop and assertion arms ahead of this split, in the funnel and the
+    * oracle respectively.
     */
   def opensTurn: Boolean = this match
     case ConversationEvent.AssistantTextDelta(_)     => true

--- a/tools/src/main/scala/orca/backend/ConversationMode.scala
+++ b/tools/src/main/scala/orca/backend/ConversationMode.scala
@@ -2,34 +2,27 @@ package orca.backend
 
 /** The autonomous vs interactive choice that drives the SPI's `open`-side
   * branching: whether to wire the MCP `ask_user` tool, whether to enqueue an
-  * opening `UserMessage` for a renderer to anchor on, whether the agent's prose
-  * is consumed by a drain loop or handed to an `Interaction`. Schema
-  * enforcement is *orthogonal* to this — both modes can be structured or
-  * free-form — so `outputSchema` stays a separate SPI parameter.
+  * opening `UserMessage`, whether the agent's prose is drained or handed to an
+  * `Interaction`. Schema enforcement is orthogonal — both modes can be
+  * structured or free-form — so `outputSchema` stays a separate SPI parameter.
   *
-  * `private[orca]` because the SPI exposes the choice through paired methods
-  * (`runAutonomous` / `runInteractive`) rather than a `mode: …` argument on
-  * user-facing methods. The mode value only travels as far as the
-  * backend-internal `openConversation` helper, where the four sites that
-  * diverge (MCP server, mcp-config arg, ask_user hint in system prompt,
-  * autoApprove entry) can pattern-match on it once.
+  * Internal: the mode travels only as far as the backend-internal
+  * `openConversation` helper, where the four diverging sites (MCP server,
+  * mcp-config arg, ask_user hint in system prompt, autoApprove entry)
+  * pattern-match on it once.
   */
 private[orca] enum ConversationMode:
   case Autonomous
   case Interactive(prompt: String)
 
-  /** The prompt a renderer anchors on, or `""` for autonomous — autonomous
-    * calls have no renderer to show it to. Saves the backend call sites that
-    * only need this one projection from writing out the full `match`.
+  /** The prompt a renderer anchors on, or `""` for autonomous (no renderer to
+    * show it to).
     */
   def displayPrompt: String = this match
     case Autonomous          => ""
     case Interactive(prompt) => prompt
 
-  /** True for [[Interactive]] — every call site that branches on the mode only
-    * needs this boolean; the prompt itself is read separately via
-    * [[displayPrompt]].
-    */
+  /** True for [[Interactive]]. */
   def isInteractive: Boolean = this match
     case Autonomous     => false
     case Interactive(_) => true

--- a/tools/src/main/scala/orca/backend/Conversations.scala
+++ b/tools/src/main/scala/orca/backend/Conversations.scala
@@ -10,32 +10,23 @@ import ox.{Ox, supervised}
   *
   * Structured mode (`conv.outputSchema.isDefined`) withholds the last assistant
   * turn so the closing JSON payload doesn't surface as an `AssistantMessage` —
-  * the caller emits it via `OrcaEvent.StructuredResult` instead. Outside
-  * structured mode every turn flushes immediately. The withheld-turn state
-  * machine lives in [[TurnBuffer]]; a normal end drops the withheld payload and
-  * flushes any unfinished buffer, while an abnormal (thrown) end flushes
-  * everything — a mid-turn crash never silently loses partial output.
+  * the caller emits it via `OrcaEvent.StructuredResult` instead. The
+  * withheld-turn state machine lives in [[TurnBuffer]].
   *
-  * Interactive-only events that nevertheless reach this drain are handled
-  * explicitly rather than dropped: `ApproveTool` is auto-denied (the subprocess
-  * would otherwise block waiting for a response), and `UserQuestion` is
-  * auto-answered with a placeholder for the same reason. Both also surface as
-  * `OrcaEvent.Error` so the user sees what happened.
-  *
-  * `Left(OrcaInteractiveCancelled)` from `awaitResult()` is rethrown — the
-  * autonomous shape never exposes a cancel button to the caller.
+  * Interactive-only events that reach this drain are handled explicitly to
+  * avoid blocking the subprocess: `ApproveTool` is auto-denied and
+  * `UserQuestion` auto-answered, both also surfacing as `OrcaEvent.Error`.
   */
 private[orca] object Conversations:
 
   /** Structured-mode turn buffer: streams every completed turn EXCEPT the most
-    * recent one, which is withheld one turn (the final turn is the JSON payload
-    * — the caller re-surfaces it via OrcaEvent.StructuredResult). Consequence:
-    * turn N renders when turn N+1 completes — a deliberate one-turn display
-    * delay, the price of live streaming without showing the payload as prose.
-    * In non-structured mode every turn flushes immediately.
+    * recent, which is withheld one turn (the final turn is the JSON payload,
+    * the caller re-surfaces it via OrcaEvent.StructuredResult). Turn N thus
+    * renders when turn N+1 completes — a one-turn display delay that keeps the
+    * payload out of the prose stream. In non-structured mode every turn flushes
+    * immediately.
     *
-    * All state is confined to one drain's single-threaded event loop: the drain
-    * owns the instance and calls it from exactly one thread.
+    * State is confined to the drain's single-threaded event loop.
     */
   private final class TurnBuffer(structuredMode: Boolean, emit: String => Unit):
     private val current = new StringBuilder
@@ -57,26 +48,20 @@ private[orca] object Conversations:
         else emit(text)
 
     /** Normal end of stream: the withheld turn IS the payload — drop it (the
-      * caller emits StructuredResult); flush any unfinished current buffer. (In
-      * non-structured mode `withheld` is always empty, so the drop is a no-op
-      * and only the unfinished buffer flushes — matching the historical
-      * end-of-stream behaviour.)
+      * caller emits StructuredResult); flush any unfinished current buffer.
       *
-      * Post-turn-grammar (ForkedConversation auto-closes every completed turn),
-      * a normally-completed session always ends its last turn with an
-      * `AssistantTurnEnd` that already ran `turnEnd()`, so `current` is empty
-      * and `flushCurrent()` is a no-op. It only flushes something for a turn
-      * the stream left open — i.e. abnormal termination (cancel/crash mid-turn)
-      * the grammar explicitly permits. It is a safety net, not driver-slop
-      * compensation.
+      * Since ForkedConversation auto-closes every completed turn, a normal
+      * session ends its last turn with an `AssistantTurnEnd` that already ran
+      * `turnEnd()`, leaving `current` empty. `flushCurrent()` is a safety net
+      * for a turn the stream left open (abnormal termination mid-turn).
       */
     def finishNormally(): Unit =
       withheld = None
       flushCurrent()
 
-    /** Abnormal end (the drain threw mid-stream): nothing here is reliably the
-      * payload — flush EVERYTHING (withheld + partial) rather than silently
-      * dropping prose. Worst case the user sees a JSON blob once.
+    /** Abnormal end (the drain threw mid-stream): nothing is reliably the
+      * payload, so flush everything rather than drop prose. Worst case the user
+      * sees a JSON blob once.
       */
     def finishAbnormally(): Unit =
       withheld.foreach(emit)
@@ -107,10 +92,9 @@ private[orca] object Conversations:
         case ConversationEvent.Error(msg) =>
           events.onEvent(OrcaEvent.Error(msg))
         case ConversationEvent.ApproveTool(toolName, _, respond) =>
-          // The subprocess is blocking on stdin waiting for our decision;
-          // autonomous mode has no user to ask. Deny with an explanatory
-          // reason (so the agent can adapt) and surface the denial as a
-          // visible error — silently dropping would deadlock the call.
+          // The subprocess blocks on stdin waiting for our decision and
+          // autonomous mode has no user to ask, so deny with a reason (so the
+          // agent can adapt) and surface as an error; dropping would deadlock.
           respond(
             ApprovalDecision.Deny(
               Some(
@@ -126,12 +110,10 @@ private[orca] object Conversations:
             )
           )
         case ConversationEvent.UserQuestion(_, respond) =>
-          // Defensive: in autonomous mode the ask_user MCP bridge isn't
-          // wired (see `ConversationMode.Autonomous`), so this event should be
-          // unreachable. If a future change ever lands one here, the
-          // bridge thread is blocked on `respond` — unblock it instead of
-          // leaking the thread. The synthetic answer surfaces in the
-          // tool result the agent receives.
+          // The ask_user MCP bridge isn't wired in autonomous mode (see
+          // `ConversationMode.Autonomous`), so this should be unreachable. If it
+          // ever fires, the bridge thread is blocked on `respond` — unblock it
+          // rather than leak the thread.
           respond("[autonomous mode: no user available to answer]")
           events.onEvent(
             OrcaEvent.Error(
@@ -139,56 +121,35 @@ private[orca] object Conversations:
             )
           )
         case ConversationEvent.UserMessage(_) =>
-          // Wire-level echo of input we already sent. Surfaced upstream as
-          // `OrcaEvent.UserPrompt` from the Agent layer; nothing to do
-          // here.
+          // Wire-level echo of input we already sent; surfaced upstream as
+          // `OrcaEvent.UserPrompt` from the Agent layer.
           ()
         case ConversationEvent.ToolResult(_, _, _) =>
-          // Tool output volume is unbounded (full cargo-test logs, etc.).
-          // The matching `AssistantToolCall` already surfaced as
-          // `OrcaEvent.ToolUse`; the agent's follow-up turn summarises the
-          // outcome. Listeners that need raw output should subscribe at
-          // the `ConversationEvent` layer instead.
+          // Tool output volume is unbounded (full cargo-test logs, etc.), so it
+          // isn't surfaced here; the matching `AssistantToolCall` already went
+          // out as `OrcaEvent.ToolUse`. Listeners needing raw output subscribe
+          // at the `ConversationEvent` layer instead.
           ()
-      // The loop ran to completion: the withheld turn is the payload, drop it;
-      // flush any unfinished buffer. See TurnBuffer.finishNormally.
       buffer.finishNormally()
     catch
       case t: Throwable =>
-        // The loop threw mid-turn: nothing is reliably the payload, so flush
-        // everything rather than dropping prose, then rethrow the original
-        // failure. See TurnBuffer.finishAbnormally.
         buffer.finishAbnormally()
         throw t
     conv.awaitResult() match
       case Right(result) => result
-      // Autonomous callers can't produce a Left; surface as a throw so the
-      // AgentResult call shape is honoured.
+      // Autonomous callers can't produce a Left; throw to honour the
+      // AgentResult call shape.
       case Left(cancelled) => throw cancelled
 
-  /** The shared autonomous-turn finalize for the subprocess backends
-    * (claude/codex/gemini/pi): drain the conversation, then — on success only —
-    * commit the session as resumable. Returns the drained result verbatim. The
-    * result carries the backend-reported wire id under its own
-    * [[orca.agents.WireSessionId]] type, so there is nothing to re-stamp:
-    * callers hand back the stable client handle they already hold, and the wire
-    * id lives on the result only for the registry to learn the mapping.
+  /** Shared autonomous-turn finalize for the subprocess backends: drain the
+    * conversation, then — on success only — commit the session as resumable.
+    * Returns the drained result verbatim.
     *
     * The commit runs only after a clean drain, so a subprocess that crashed
     * before registering its session doesn't wedge the registry into resuming a
-    * session that was never created. Drain failures propagate verbatim — the
+    * session that was never created. Drain failures propagate verbatim; the
     * retryability classification already happened in
-    * [[ForkedConversation.awaitResult]], the sole place that decides whether a
-    * failure is an [[orca.AgentTurnFailed]] or a plain retryable
-    * [[orca.OrcaFlowException]]; relabelling here would only obscure that
-    * decision.
-    *
-    * `sessions.commitAfterDrain(session, result.wireId)` carries the throwing
-    * wire-id guard and is uniform across both id schemes:
-    * [[IdScheme.ServerMinted]] records the learned server id, while
-    * [[IdScheme.ClientClaimed]] records the client id itself. Taking the
-    * backend's [[SessionSupport]] means a backend physically can't hand this
-    * shell bookkeeping other than the one backing its declared `sessions`.
+    * [[ForkedConversation.awaitResult]].
     */
   def drainAndCommit[B <: BackendTag](
       conv: Conversation[B],
@@ -201,10 +162,10 @@ private[orca] object Conversations:
     result
 
   /** The complete autonomous-turn shell shared by all backends: open the
-    * conversation inside its own supervised scope, drain + commit, and ALWAYS
-    * cancel before the scope joins (the cancel is load-bearing on failure paths
-    * — `drainAndCommit` does not tear down). `open` runs inside the scope so
-    * the conversation's forks bind to it.
+    * conversation inside its own supervised scope, drain + commit, and always
+    * cancel before the scope joins (load-bearing on failure paths —
+    * `drainAndCommit` does not tear down). `open` runs inside the scope so the
+    * conversation's forks bind to it.
     */
   def runAutonomous[B <: BackendTag](
       session: SessionId[B],

--- a/tools/src/main/scala/orca/backend/ForkedConversation.scala
+++ b/tools/src/main/scala/orca/backend/ForkedConversation.scala
@@ -20,55 +20,35 @@ import scala.util.control.NonFatal
   * '''Startup''': the workers (a stderr drain, an optional ask-user drainer,
   * and the reader) are started once, lazily, by [[ensureStarted]] — invoked
   * from the conversation surface ([[events]] / [[awaitResult]]), never from
-  * this constructor. Two reasons the capability lives on the surface methods
-  * rather than the constructor: (1) spawning from the constructor would race
-  * the subclass's own field initializers (which run after this
-  * super-constructor) and let the reader fork call [[handleLine]] against
+  * this constructor. Forking from the constructor would race the subclass's own
+  * field initializers and let the reader fork call [[handleLine]] against
   * half-built subclass state; by the time a consumer touches the surface,
-  * construction has finished. (2) keeping constructors capability-free (the
-  * owner's Ox method-scoping rule) — the `using Ox` the workers fork into is
-  * the per-turn supervised scope the backend's drain shell already opened
-  * (`Conversations.runAutonomous` / `AgentCall.runInteractiveOnce`), which is
-  * also the scope construction happens in, so the fork lifetime is unchanged.
+  * construction has finished. The scope the workers fork into is the per-turn
+  * supervised scope the backend's drain shell already opened.
   *
-  * '''Outcome plumbing''': there's no polled outcome ref — the reader fork
-  * RETURNS the `Outcome[B]`, and [[awaitResult]] is just the reader fork's join
-  * mapped. An in-stream settle ([[succeedWith]] / [[failWith]], run on the
-  * reader thread from inside [[handleLine]]) stashes its result for the
-  * reader's end-of-stream to pick up.
+  * '''Outcome plumbing''': the reader fork RETURNS the `Outcome[B]` and
+  * [[awaitResult]] is its join mapped. An in-stream settle ([[succeedWith]] /
+  * [[failWith]], run on the reader thread from inside [[handleLine]]) stashes
+  * its result for the reader's end-of-stream to pick up.
   *
-  * Subclasses implement a driver by supplying these hooks, grouped by role:
-  *   - '''Per-line translation''': [[handleLine]] (abstract — parse one stdout
-  *     line into enqueues and/or a settle) and [[handleStderr]] (default:
-  *     enqueue as an `Error`; the `StderrPipeline` mix-ins override it `final`
-  *     and vary only their `isStderrNoise` predicate).
-  *   - '''Settle''': [[succeedWith]] / [[failWith]] end the turn with a result
-  *     or a failure.
-  *   - '''Turn-grammar reads''': [[turnIsOpen]] / [[isSettled]] let a driver
-  *     ask "did activity stream this turn?" / "have we already settled?"
-  *     without its own bookkeeping.
-  *   - '''Lifecycle''': [[onFinalize]] (drain background streams, release
-  *     session resources — runs exactly once), [[onCancelRequested]] (genuine
-  *     mid-turn cancel only, never a routine post-success teardown), and
-  *     [[cleanExitWithoutResult]] (the exception for a zero-exit stream that
-  *     never sent a terminal message).
-  *   - '''Diagnostics''': [[diagnosticContext]] / [[appendContext]] fold
-  *     optional buffered context into failure messages.
-  *   - '''Ask-user''': [[askUser]] wires an MCP `ask_user` bundle; the base
-  *     spawns its drainer fork and closes it at finalize.
+  * Subclasses implement a driver by supplying these hooks:
+  *   - '''Per-line translation''': [[handleLine]] (parse one stdout line into
+  *     enqueues and/or a settle) and [[handleStderr]].
+  *   - '''Settle''': [[succeedWith]] / [[failWith]].
+  *   - '''Turn-grammar reads''': [[turnIsOpen]] / [[isSettled]].
+  *   - '''Lifecycle''': [[onFinalize]] (runs exactly once),
+  *     [[onCancelRequested]] (genuine mid-turn cancel only), and
+  *     [[cleanExitWithoutResult]].
+  *   - '''Diagnostics''': [[diagnosticContext]] / [[appendContext]].
+  *   - '''Ask-user''': [[askUser]] wires an MCP `ask_user` bundle.
   *   - '''Enqueue contract''': all events reach the channel through
-  *     `eventQueue.enqueue`, which enforces the [[ConversationEvent]] turn
-  *     grammar by construction. Callers from a background fork (the stderr
-  *     loop, the ask-user drainer) MUST only ever pass NEUTRAL events — see
-  *     [[EventQueue]]'s confinement contract.
+  *     `eventQueue.enqueue`; callers from a background fork MUST only pass
+  *     NEUTRAL events — see [[EventQueue]]'s confinement contract.
   */
 private[orca] abstract class ForkedConversation[B <: BackendTag](
     source: StreamSource,
     /** Used in fork-internal debug traces, parse-error messages, and the
       * default stderr error prefix. Should match the user-facing backend name.
-      * `protected` so [[StderrPipeline]]'s hoisted `handleStderr` can build the
-      * same `"$backendName: $line"` prefix each subprocess backend used to
-      * hardcode individually.
       */
     protected val backendName: String,
     initialPrompt: String = "",
@@ -83,49 +63,36 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
 
   /** Bounded event channel: a slow consumer applies backpressure to the
     * producer (the reader's `send` blocks once full) so it flows back into the
-    * subprocess pipe. Created with the explicit capacity so no `BufferCapacity`
-    * needs threading through the backends.
+    * subprocess pipe.
     */
   private val channel: Channel[ConversationEvent] =
     Channel.buffered(EventQueueCapacity)
 
-  /** `enqueue` / `close` facade over the channel for subclass drivers. It
-    * centralises the swallow-on-closed decision in one place: both use the
-    * `*OrClosed` variants so a late enqueue (e.g. the ask-user drainer racing
-    * the reader's close) is a no-op rather than a thrown `ChannelClosed` that
-    * would tear the scope.
+  /** `enqueue` / `close` facade over the channel for subclass drivers. Both use
+    * the `*OrClosed` variants so a late enqueue (e.g. the ask-user drainer
+    * racing the reader's close) is a no-op rather than a thrown `ChannelClosed`
+    * that would tear the scope.
     *
-    * It ALSO enforces the [[ConversationEvent]] turn grammar by construction,
-    * so backends no longer hand-roll it: activity events open the current turn,
-    * an `AssistantTurnEnd` closes an open turn (and is DROPPED as an empty turn
-    * if none is open), and the settle helpers auto-close a still-open turn (see
-    * [[succeedWith]] / [[failWith]]). The activity/neutral classification
-    * routes through [[ConversationEvent.opensTurn]], the single source of truth
-    * for that split — an exhaustive match, so a future `ConversationEvent` case
-    * can't silently fall through as neutral here.
+    * It ALSO enforces the [[ConversationEvent]] turn grammar by construction:
+    * activity events open the current turn, an `AssistantTurnEnd` closes an
+    * open turn (and is DROPPED as an empty turn if none is open), and the
+    * settle helpers auto-close a still-open turn (see [[succeedWith]] /
+    * [[failWith]]). The activity/neutral split routes through
+    * [[ConversationEvent.opensTurn]].
     *
     * '''Confinement contract''': `enqueue` mutates the reader-thread-confined
     * [[turnIsOpen]] state, so any caller from a background fork (`stderrLoop`,
-    * `askUserDrain`) MUST only ever pass NEUTRAL events — verified today across
-    * all five backends (stderr enqueues only `Error`; the ask-user drainer only
-    * `UserQuestion`). A future driver that emits an activity event or an
-    * `AssistantTurnEnd` off the reader thread would race `turnIsOpen` with no
-    * compiler or test signal; see [[turnIsOpen]]'s single-writer note.
+    * `askUserDrain`) MUST only ever pass NEUTRAL events — see [[turnIsOpen]]'s
+    * single-writer note.
     */
   protected final class EventQueue:
     def enqueue(event: ConversationEvent): Unit =
       event match
-        // AssistantTurnEnd has its own forward/drop arm, ahead of the
-        // activity/neutral split below: it closes an open turn, or is DROPPED
-        // as an empty turn if none is open (fixes gemini's unconditional
-        // pre-result end and claude's suppressed ask_user-only turn).
+        // Closes an open turn, or is dropped as an empty turn if none is open.
         case ConversationEvent.AssistantTurnEnd =>
           if openTurn then
             openTurn = false
             channel.sendOrClosed(event).discard
-        // Activity (turn-opening) vs. neutral (UserMessage, Error,
-        // ApproveTool, UserQuestion): ConversationEvent.opensTurn is the
-        // exhaustive, single-source-of-truth classifier — see its scaladoc.
         case _ if event.opensTurn =>
           openTurn = true
           channel.sendOrClosed(event).discard
@@ -137,20 +104,14 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
 
   /** In-stream settled outcome, written once by [[succeedWith]] / [[failWith]]
     * (on the reader thread, inside [[handleLine]]) and read by the reader at
-    * end-of-stream (`runReader`, same thread) — that side is still a
-    * single-WRITER property: every caller of `succeedWith`/`failWith` across
-    * the backends (claude, codex, gemini, pi, opencode) settles from inside its
-    * `handleLine` dispatch, so "first write wins" needs no CAS.
+    * end-of-stream — a single-writer property, so "first write wins" needs no
+    * CAS.
     *
-    * But [[isSettled]] is also read from [[cancel]], which runs on the DRIVING
-    * thread (the caller's `finally`, e.g. `AgentCall`/`Conversations`, or
-    * `ConversationRenderer` on a prompt interrupt) — a genuinely cross-thread
-    * read racing the reader's write with no channel operation or other
-    * synchronization action between them. `@volatile` is what makes that read
-    * see a completed settle rather than a stale `None`; without it a cancel
-    * racing the reader's last line could observe `isSettled == false` and fire
-    * a backend's real abort-the-turn hook ([[onCancelRequested]]) on a turn
-    * that just succeeded.
+    * `@volatile` because [[isSettled]] is also read from [[cancel]], which runs
+    * on the DRIVING thread — a cross-thread read racing the reader's write with
+    * no synchronization between them. Without it a cancel racing the reader's
+    * last line could observe `isSettled == false` and fire
+    * [[onCancelRequested]] on a turn that just succeeded.
     */
   @volatile private var settledOutcome: Option[Outcome[B]] = None
 
@@ -161,49 +122,32 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
 
   /** Whether a turn is currently open — set by [[EventQueue.enqueue]] when an
     * activity event flows and cleared by the closing `AssistantTurnEnd` (or the
-    * settle auto-close). Read by the settle helpers here and exposed to
-    * subclasses so a driver can ask "did activity stream this turn?" without
-    * its own bookkeeping.
+    * settle auto-close).
     *
-    * '''Reader-thread-confined invariant''' (distinct from [[settledOutcome]]'s
-    * — that field has a genuine cross-thread reader in [[cancel]], which is why
-    * it's `@volatile`; `openTurn` has no such reader): `openTurn` is written
-    * only from `enqueue` on activity/turn-end events and from the settle-time
-    * auto-close — all of which run on the reader thread, inside [[handleLine]]
-    * or the reader's end-of-stream — and read only via [[turnIsOpen]] from that
-    * same thread ([[closeOpenTurn]], and subclasses' reads happen from inside
-    * their own `handleLine`). The other two `enqueue` producers run on
-    * different threads (`stderrLoop`, `askUserDrain`) but only ever pass
-    * NEUTRAL events, which don't touch this field (the confinement contract
-    * stated on [[EventQueue]]). So both single-writer AND single-reader are
-    * plain-`var` properties, not a coincidence — but an implicit one: a future
-    * driver emitting activity off the reader thread, or a cross-thread read of
-    * [[turnIsOpen]], would silently break it.
+    * '''Reader-thread-confined invariant''': `openTurn` is written and read
+    * only from the reader thread (via `enqueue` on activity/turn-end events,
+    * the settle-time auto-close, and [[turnIsOpen]] reads inside `handleLine`),
+    * so a plain `var` is correct with no `@volatile`. The
+    * `stderrLoop`/`askUserDrain` producers run on other threads but pass only
+    * NEUTRAL events, which don't touch this field (the [[EventQueue]]
+    * confinement contract). A future driver emitting activity off the reader
+    * thread, or a cross-thread [[turnIsOpen]] read, would silently break it.
     */
   private var openTurn: Boolean = false
 
-  /** The reader thread's identity, captured once at the top of [[runReader]]
-    * (before any [[handleLine]] dispatch can run) so [[succeedWith]] /
-    * [[failWith]] can assert the single-writer invariant [[settledOutcome]]'s
-    * scaladoc documents — every backend settles from inside its own
-    * `handleLine`, on this thread — rather than let a future backend #6 that
-    * settles from a background fork silently violate it. Written once,
-    * read-after-write on the same thread that wrote it (the reader), so a plain
-    * `var` needs no `@volatile`: unlike [[settledOutcome]], nothing reads this
-    * cross-thread. `null` only before the reader fork starts, which is also
-    * before either settle method can possibly run.
+  /** The reader thread's identity, captured once at the top of [[runReader]] so
+    * [[succeedWith]] / [[failWith]] can assert [[settledOutcome]]'s
+    * single-writer invariant (every settle happens on the reader thread).
+    * Written and read only on the reader thread, so a plain `var` suffices;
+    * `null` only before the reader fork starts, which is also before either
+    * settle method can run.
     */
   private var readerThread: Thread | Null = null
 
   /** Single-writer check for [[succeedWith]] / [[failWith]]: neither may run
-    * off the reader thread. A plain (unelided) `assert` rather than an
-    * `OrcaDebug`-gated one — this is a backend-authoring contract violation (a
-    * driver settling from a background fork instead of `handleLine`), always a
-    * bug and never a legitimate runtime condition a production flow should
-    * tolerate silently, so it's not worth hiding behind a debug flag a real
-    * user run would never think to set. Deliberately does NOT touch
-    * [[isSettled]]'s read from [[cancel]], which runs on the driving thread by
-    * design.
+    * off the reader thread. A plain (unelided) `assert` because a driver
+    * settling from a background fork is always a backend-authoring bug, never a
+    * legitimate runtime condition to tolerate silently.
     */
   private def assertReaderThread(caller: String): Unit =
     assert(
@@ -215,8 +159,7 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
     )
 
   /** True iff a turn is currently open (activity streamed since the last
-    * `AssistantTurnEnd`). The base reads it to decide the settle auto-close;
-    * subclasses may read it in place of their own turn-openness flags.
+    * `AssistantTurnEnd`).
     */
   protected final def turnIsOpen: Boolean = openTurn
 
@@ -230,10 +173,9 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
   private val finalized: AtomicBoolean = new AtomicBoolean(false)
 
   /** Optional `ask_user` MCP resource bundle for this conversation. Interactive
-    * subclasses override (via `override val askUser` on the ctor param) to
-    * point the base at the bundle; the base spawns the drainer fork when the
-    * workers start and closes the bundle in the finalize. Autonomous calls
-    * leave the default `None`.
+    * subclasses override to point the base at the bundle; the base spawns the
+    * drainer fork when the workers start and closes the bundle in the finalize.
+    * Autonomous calls leave the default `None`.
     */
   protected def askUser: Option[AskUserSession] = None
 
@@ -242,45 +184,39 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
     */
   final def canAskUser: Boolean = nativeAskUser || askUser.isDefined
 
-  // Surface the opening prompt before any agent output, so the channel has
-  // something to anchor the eventual response against instead of sitting silent
-  // while the agent warms up. Lands in the buffer now; the consumer reads it
-  // first once the reader starts.
+  // Surface the opening prompt before any agent output, so the channel isn't
+  // silent while the agent warms up. Lands in the buffer now; the consumer
+  // reads it first once the reader starts.
   if initialPrompt.nonEmpty then
     eventQueue.enqueue(ConversationEvent.UserMessage(initialPrompt))
 
   // --- Workers (Ox forks) ---
   //
-  // Started once, lazily, from the conversation surface ([[ensureStarted]], via
-  // [[events]] / [[awaitResult]]), never from this constructor (see the class
-  // scaladoc). The reader is `forkUnsupervised` so its (by-design impossible)
-  // stray exception surfaces via `join` rather than tearing the per-turn scope;
-  // it returns an `Outcome[B]` and never throws. The stderr-drain and ask-user
+  // The reader is `forkUnsupervised` so its (by-design impossible) stray
+  // exception surfaces via `join` rather than tearing the per-turn scope; it
+  // returns an `Outcome[B]` and never throws. The stderr-drain and ask-user
   // forks are ordinary daemon `fork`s the scope cancels at its end.
 
   private case class Workers(reader: UnsupervisedFork[Outcome[B]])
 
-  /** The started workers, written once by [[ensureStarted]]. Read by
-    * [[awaitResult]] (reader join) on the consuming thread — `@volatile` so a
+  /** The started workers, written once by [[ensureStarted]]. `@volatile` so a
     * `cancel` racing the first `events` / `awaitResult` sees the started fork
     * (or a definite `None`), never a torn half-initialised reference.
     */
   @volatile private var workers: Option[Workers] = None
 
   /** The stderr-drain fork handle, in its own field written BEFORE the reader
-    * fork starts: the reader's happy-path finalize joins [[stderrDrainFork]]
-    * from the reader's own thread, and on an instant-EOF stream it can get
-    * there before `ensureStarted`'s later writes land — reading `None` there
-    * would silently skip the drain join and drop the stderr diagnostics from
-    * the failure message.
+    * fork starts: the reader's happy-path finalize joins it from the reader's
+    * own thread, and on an instant-EOF stream it can get there before
+    * `ensureStarted`'s later writes land — reading `None` there would drop the
+    * stderr diagnostics from the failure message.
     */
   @volatile private var stderrFork: Option[Fork[Unit]] = None
 
   /** Start the reader / stderr / ask-user forks on first touch of the surface;
-    * a no-op thereafter, returning the already-started set. The auxiliary
-    * workers are forked (and [[stderrFork]] published) before the reader, so
-    * stderr/ask-user are running — and the drain handle is visible to the
-    * reader's finalize — before the reader consumes stdout. The consumer is
+    * a no-op thereafter. The auxiliary workers are forked (and [[stderrFork]]
+    * published) before the reader, so the drain handle is visible to the
+    * reader's finalize before the reader consumes stdout. The consumer is
     * single-threaded ([[events]] then [[awaitResult]] on the same thread), so
     * the check-then-start needs no lock.
     */
@@ -303,10 +239,9 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
     * the turn has run and the wire session may already exist, so a retry
     * against the same id would only cascade into "already in use" / a broken
     * pipe rather than a clean re-attempt. Pre-spawn *open* failures never reach
-    * this method at all — they throw from `openConversation` (before a
-    * `Conversation` exists to call `awaitResult` on) as plain
-    * [[OrcaFlowException]]s and stay retryable. The retry POLICY that acts on
-    * this classification lives in `DefaultAgentCall.runAutonomousWithRetry`.
+    * this method — they throw from `openConversation` as plain
+    * [[OrcaFlowException]]s and stay retryable. The retry POLICY lives in
+    * `DefaultAgentCall.runAutonomousWithRetry`.
     */
   def awaitResult()(using
       Ox
@@ -323,19 +258,16 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
 
   def cancel(): Unit =
     if cancelled.compareAndSet(false, true) then
-      // Only a turn that hasn't settled yet is a GENUINE cancel (the user hit
-      // Ctrl-C, or the driving loop unwound mid-turn); a turn already settled
-      // via succeedWith/failWith is merely being torn down here in a
-      // `finally` after it finished on its own, so the hook must not see it
-      // as a cancellation. Checked before the interrupt/destroy sequence,
-      // which must always run regardless (idle teardown is harmless there).
+      // Only a turn that hasn't settled yet is a GENUINE cancel; a turn already
+      // settled via succeedWith/failWith is merely being torn down here in a
+      // `finally`, so the hook must not see it as a cancellation. The
+      // interrupt/destroy below always runs regardless (idle teardown is
+      // harmless there).
       if !isSettled then onCancelRequested()
-      // Graceful SIGINT first, then the guaranteed forcible backstop, so the
+      // Graceful SIGINT first, then the forcible backstop, so the
       // non-interruptible reader's `source.lines` always reaches EOF and the
-      // scope join never hangs. On the happy path both are no-ops (the source
-      // already ended). Then run the full finalize (subsuming the old
-      // `finalizeLoop` resource close); the `finalized` guard means the reader,
-      // if it got there first, isn't re-run.
+      // scope join never hangs. Both are no-ops on the happy path. The
+      // `finalized` guard means the reader, if it got there first, isn't re-run.
       source.interrupt()
       source.destroyForcibly()
       runFinalize()
@@ -355,11 +287,8 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
     source.interrupt()
 
   /** Assemble an [[AgentResult]] from a driver's synthesised turn values and
-    * settle with it via [[succeedWith]]. Wraps the reported wire-id string in
-    * [[WireSessionId]]`[B]` and the optional model-id string in [[Model]] —
-    * collapsing the byte-identical settle scaffolding every driver used to
-    * spell out (a `WireSessionId[…]` + `Model.apply` +
-    * `succeedWith(AgentResult(…))`).
+    * settle with it via [[succeedWith]]. Wraps the wire-id string in
+    * [[WireSessionId]]`[B]` and the optional model-id string in [[Model]].
     */
   protected def settleSuccess(
       wireId: String,
@@ -387,11 +316,10 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
     source.interrupt()
 
   /** Terminate an open turn at settle time by enqueuing the owed
-    * `AssistantTurnEnd` (which closes it via the funnel). A no-op when no turn
-    * is open, so a driver that already emitted its own protocol-driven turn end
-    * before settling never double-emits — its end closed the turn, this sees
-    * none open. Runs on the reader thread, before `settledOutcome` is set, so
-    * the closing event reaches the channel ahead of the reader's close.
+    * `AssistantTurnEnd`. A no-op when no turn is open, so a driver that already
+    * emitted its own turn end before settling never double-emits. Runs on the
+    * reader thread, before `settledOutcome` is set, so the closing event
+    * reaches the channel ahead of the reader's close.
     */
   private def closeOpenTurn(): Unit =
     if turnIsOpen then eventQueue.enqueue(ConversationEvent.AssistantTurnEnd)
@@ -415,20 +343,17 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
   /** Hook called inside the finalize **before** the failure outcome is
     * computed, so subclasses can drain background streams whose buffered state
     * [[diagnosticContext]] / [[cleanExitWithoutResult]] depend on (join the
-    * [[stderrDrainFork]] here). Also where backends release session-scoped
-    * resources. Runs exactly once (reader happy-path OR [[cancel]]). Default:
-    * no-op.
+    * [[stderrDrainFork]] here), and release session-scoped resources. Runs
+    * exactly once (reader happy-path OR [[cancel]]). Default: no-op.
     */
   protected def onFinalize(): Unit = ()
 
-  /** Hook called from inside [[cancel]]'s idempotence guard, but ONLY when the
-    * turn hasn't already settled (see [[isSettled]]) — i.e. exactly the genuine
-    * "torn down mid-turn" case, never the routine `finally cancel()` that every
-    * caller runs after a turn that already succeeded or failed on its own. Runs
-    * before the interrupt/destroy sequence. Default: no-op. Backends that need
-    * to notify a remote peer the turn is being abandoned (e.g. OpenCode's `POST
-    * /abort`) override this instead of [[cancel]], so that notification never
-    * fires for a session merely being torn down after a normal turn.
+  /** Hook called from inside [[cancel]], but ONLY when the turn hasn't already
+    * settled — i.e. the genuine "torn down mid-turn" case, never the routine
+    * `finally cancel()` after a turn that finished on its own. Runs before the
+    * interrupt/destroy sequence. Default: no-op. Backends that must notify a
+    * remote peer the turn is being abandoned (e.g. OpenCode's `POST /abort`)
+    * override this instead of [[cancel]].
     */
   protected def onCancelRequested(): Unit = ()
 
@@ -441,8 +366,7 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
 
   /** The exception used when the subprocess exits with code 0 without having
     * sent its [[terminalMessageNoun]]. Folds [[diagnosticContext]] into the
-    * message (a no-op for backends that carry none); backends vary only the
-    * noun, not this assembly.
+    * message; backends vary only the noun, not this assembly.
     */
   protected def cleanExitWithoutResult(): Throwable =
     new OrcaFlowException(
@@ -454,13 +378,12 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
   /** Optional context the base folds into the non-zero-exit / clean-exit
     * failure messages, so noop-listener callers still get something useful in
     * the thrown exception. Default `None`; backends override to attach buffered
-    * stderr. Overrides return just the payload, never the separator.
+    * stderr, returning just the payload, never the separator.
     */
   protected def diagnosticContext: Option[String] = None
 
   /** Fold the [[diagnosticContext]] payload (if any) onto a failure-message
-    * base — newline + two-space-indented payload. Centralised so every consumer
-    * gets the same framing.
+    * base — newline + two-space-indented payload.
     */
   protected def appendContext(base: String): String =
     diagnosticContext.fold(base)(ctx => s"$base\n  $ctx")
@@ -479,7 +402,7 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
   // --- Internals ---
 
   /** Sole outcome producer. Catches everything and RETURNS an `Outcome[B]` —
-    * never throws (H1), so the reader fork's `join()` always yields an outcome.
+    * never throws, so the reader fork's `join()` always yields an outcome.
     */
   private def runReader(): Outcome[B] =
     readerThread = Thread.currentThread()
@@ -550,11 +473,11 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
 
   private def runFinalize(): Unit =
     if finalized.compareAndSet(false, true) then
-      // 1. Subclass hook — typically joins the stderr-drain fork so trailing
-      //    lines reach the queue / `diagnosticContext` before the outcome.
+      // Subclass hook — typically joins the stderr-drain fork so trailing lines
+      // reach the queue / `diagnosticContext` before the outcome.
       onFinalize()
-      // 2. Close the ask_user bundle (bridge → server → extras) if wired, after
-      //    `onFinalize` so any cleanup depending on it runs first. Idempotent.
+      // Close the ask_user bundle if wired, after `onFinalize` so any cleanup
+      // depending on it runs first. Idempotent.
       askUser.foreach(_.close())
 
   private def outcomeFromExit(exitCode: Option[Int]): Outcome[B] =
@@ -603,10 +526,7 @@ private[orca] object ForkedConversation:
     */
   val EventQueueCapacity: Int = 1024
 
-  /** Internal outcome of the session as the reader sees it. Modelled as a
-    * sealed trait + cases so `Cancelled` / `Failed` are backend-agnostic
-    * (`Nothing` for their `B` keeps them assignable to any `Outcome[B]` while
-    * the match still narrows `Success`'s `B`). `Outcome` is invariant in `B`
+  /** Internal outcome of the session as the reader sees it. Invariant in `B`
     * because `AgentResult[B]` is.
     */
   sealed trait Outcome[B <: BackendTag]

--- a/tools/src/main/scala/orca/backend/SessionSupport.scala
+++ b/tools/src/main/scala/orca/backend/SessionSupport.scala
@@ -6,59 +6,50 @@ import org.slf4j.LoggerFactory
 
 import scala.util.control.NonFatal
 
-/** Whether a backend call against a given caller-supplied session id should
-  * start a fresh session or resume an existing one. Each backend has its own id
-  * scheme (see [[IdScheme]]), but the call site only cares about the two cases.
+/** Whether a backend call against a caller-supplied session id starts a fresh
+  * session or resumes an existing one.
   *
-  * `Resume` always carries the `wireId` the consumer puts on the wire —
-  * [[SessionSupport]] has already decided which one it is (claude's client
-  * UUID, codex's server thread id). `Fresh` carries an OPTIONAL claim:
-  * `Some(id)` only under [[IdScheme.ClientClaimed]], where the caller-allocated
-  * id IS the wire id and the CLI is told to create the session under it
-  * (claude's `--session-id`); `None` under [[IdScheme.ServerMinted]], where the
-  * server mints its own id at first use so there is nothing legitimate to put
-  * on the wire yet. Making the claim an `Option` (rather than always a real
-  * `WireSessionId`) stops a server-minting backend from naively forwarding a
-  * fabricated client id onto the wire. Consumers pattern-match on `Fresh` vs
-  * `Resume` and forward the id to the CLI.
+  * `Resume` carries the `wireId` to put on the wire (already resolved by
+  * [[SessionSupport]]). `Fresh`'s claim is `Some(id)` only under
+  * [[IdScheme.ClientClaimed]], where the caller-allocated id IS the wire id and
+  * the CLI creates the session under it; `None` under
+  * [[IdScheme.ServerMinted]], where the server mints its own id at first use.
+  * The `Option` stops a server-minting backend from forwarding a fabricated
+  * client id onto the wire.
   */
 enum Dispatch[B <: BackendTag]:
   case Fresh(claim: Option[WireSessionId[B]])
   case Resume(wireId: WireSessionId[B])
 
-/** How a backend's wire-level session ids come to be — the axis that decides
-  * what a `Fresh` dispatch may put on the wire and which id a commit records.
+/** How a backend's wire-level session ids come to be — decides what a `Fresh`
+  * dispatch may put on the wire and which id a commit records.
   */
 enum IdScheme:
-  /** The caller-allocated client id IS the wire id: the CLI is told to create
-    * the session under it and resumes against it (claude's `--session-id
-    * <uuid>` → `--resume <uuid>`; pi's `--session <id>`).
+  /** The caller-allocated client id IS the wire id: the CLI creates the session
+    * under it and resumes against it (claude's `--session-id <uuid>` →
+    * `--resume <uuid>`; pi's `--session <id>`).
     */
   case ClientClaimed
 
-  /** The server mints the wire id at first use; it is learned from the protocol
+  /** The server mints the wire id at first use, learned from the protocol
     * response and mapped to the stable client id (codex/gemini thread ids,
     * opencode's `ses_…`). A fresh session puts nothing on the wire.
     */
   case ServerMinted
 
-/** A backend's whole session capability as ONE value: [[IdScheme]] says how
+/** A backend's whole session capability as one value: [[IdScheme]] says how
   * wire ids come to be, and the presence of a `probe` says whether sessions
-  * survive a process restart. Construct via [[SessionSupport.durable]]
-  * (sessions outlive the process: claude's on-disk transcripts,
-  * codex/gemini/opencode's server-side threads) or [[SessionSupport.ephemeral]]
-  * (nothing survives the process: pi's `deleteOnExit` session dirs).
+  * survive a process restart. Construct via [[SessionSupport.durable]] or
+  * [[SessionSupport.ephemeral]].
   *
-  * Bundling the client→wire bookkeeping, the id scheme, and the durability
-  * probe into a single value keeps the capability whole-or-nothing: there is no
-  * way to wire the resume read without the commit hook, or the probe without
-  * either — the half-wiring that ships resume bugs. The bookkeeping is
-  * internal; every consumer goes through the methods below.
+  * Bundling the client→wire bookkeeping, id scheme, and durability probe into
+  * one value keeps the capability whole-or-nothing: no way to wire the resume
+  * read without the commit hook, the half-wiring that ships resume bugs.
   *
   * The `dispatchFor` → spawn → `register`/`commitAfterDrain` sequence is NOT
-  * atomic, so callers must not share a session id across concurrent calls —
-  * each reviewer mints its own conversation via `agent.chat()`. The internal
-  * map is concurrent because flows fan reviewers out via `mapParUnordered`.
+  * atomic, so callers must not share a session id across concurrent calls. The
+  * internal map is concurrent because flows fan reviewers out via
+  * `mapParUnordered`.
   */
 final class SessionSupport[B <: BackendTag] private (
     scheme: IdScheme,
@@ -67,9 +58,7 @@ final class SessionSupport[B <: BackendTag] private (
 
   /** client id → wire id, learned at commit. Under [[IdScheme.ClientClaimed]]
     * the stored wire id is the client id itself. Backends commit at whatever
-    * protocol point makes the id durable (autonomous turns commit after a clean
-    * drain via `Conversations.drainAndCommit`; claude's interactive path
-    * commits at spawn; other interactive paths commit after the drive settles).
+    * protocol point makes the id durable.
     */
   private val wireIds =
     new java.util.concurrent.ConcurrentHashMap[String, String]()
@@ -86,24 +75,18 @@ final class SessionSupport[B <: BackendTag] private (
           case IdScheme.ClientClaimed => Dispatch.Fresh(Some(client.onWire))
           case IdScheme.ServerMinted  => Dispatch.Fresh(None)
 
-  /** Record the client→wire mapping, so a follow-up call on the same client id
-    * resumes the right thread. On resume the flow runtime also calls this to
-    * rehydrate the map from the persisted log.
+  /** Record the client→wire mapping so a follow-up call on the same client id
+    * resumes the right thread; also called on resume to rehydrate the map from
+    * the persisted log.
     *
-    * The LOG-AND-SKIP wire-id guard, for the interactive path
-    * (`AgentCall.runInteractiveOnce`) and rehydration
-    * (`Agent.registerResumeWireId`). An unsafe wire id (empty, or failing
-    * [[orca.agents.SessionId.isSafe]]) would make the NEXT call dispatch
-    * `resume ""`/`resume ../etc`; a poisoned log would rehydrate it. So if the
-    * id is unsafe we LOG at ERROR and record NOTHING — we do NOT throw. On the
-    * interactive path the user's completed session output must survive a
-    * bookkeeping failure, and rehydration must not hard-abort setup over one
-    * stale field; the safe fallback is that the next call re-seeds a fresh
-    * session.
-    *
-    * The autonomous drain uses the sibling [[commitAfterDrain]] instead (a
-    * THROWING guard). Both doors live here and the bookkeeping is encapsulated,
-    * so EVERY resume-mapping write funnels through one of the two.
+    * Log-and-skip wire-id guard for the interactive path and rehydration: an
+    * unsafe wire id (empty, or failing [[orca.agents.SessionId.isSafe]]) would
+    * make the next call dispatch `resume ""`/`resume ../etc`, so an unsafe id
+    * is logged at ERROR and NOTHING is recorded — no throw. The user's
+    * completed session output must survive a bookkeeping failure, and
+    * rehydration must not hard-abort setup over one stale field; the next call
+    * then re-seeds a fresh session. The autonomous drain uses the throwing
+    * [[commitAfterDrain]].
     */
   def register(client: SessionId[B], server: WireSessionId[B]): Unit =
     if !SessionId.isSafe(WireSessionId.value(server)) then
@@ -113,14 +96,11 @@ final class SessionSupport[B <: BackendTag] private (
       )
     else commit(client, server)
 
-  /** The THROWING wire-id guard for the autonomous drain (see
-    * [[Conversations.drainAndCommit]]): commit the client→wire mapping only
-    * after a clean drain, refusing an unsafe id by throwing. Unlike
-    * [[register]]'s log-and-skip, this runs pre-commit, autonomous, and
-    * retryable — throwing BEFORE the commit leaves the bookkeeping untouched,
-    * so a retry (which may see a healthy init event) needn't unwind a bad
-    * commit, and re-seeding a finished-but-unrecorded turn is the wrong
-    * trade-off here where nothing has been consumed yet.
+  /** Throwing wire-id guard for the autonomous drain: commit the client→wire
+    * mapping only after a clean drain, refusing an unsafe id by throwing.
+    * Throwing before the commit leaves the bookkeeping untouched, so a retry
+    * needn't unwind a bad commit — and nothing has been consumed yet, so
+    * re-seeding is not warranted.
     */
   def commitAfterDrain(client: SessionId[B], server: WireSessionId[B]): Unit =
     val wire = WireSessionId.value(server)
@@ -142,38 +122,33 @@ final class SessionSupport[B <: BackendTag] private (
       case IdScheme.ServerMinted  => WireSessionId.value(server)
     val _ = wireIds.putIfAbsent(SessionId.value(client), wire)
 
-  /** Pure, thread-safe read of the wire id recorded for `client`, or `None`
-    * when no mapping is known. Every id in the map already passed
-    * [[orca.agents.SessionId.isSafe]] at [[register]] or [[commitAfterDrain]] —
-    * the only two write doors — so no re-check is needed downstream.
+  /** The wire id recorded for `client`, or `None` when no mapping is known.
+    * Every id in the map already passed [[orca.agents.SessionId.isSafe]] at its
+    * write door ([[register]] or [[commitAfterDrain]]), so no re-check is
+    * needed.
     */
   private def resumeWire(client: SessionId[B]): Option[WireSessionId[B]] =
     Option(wireIds.get(SessionId.value(client))).map(WireSessionId[B](_))
 
-  /** The wire id to resume `client` against for the flow runtime to persist
-    * into the progress log, or `None` when nothing durable is known — always
-    * `None` for an ephemeral backend, since its sessions leave nothing to
-    * resume across a restart. Pure, thread-safe, side-effect-free.
+  /** The wire id to persist into the progress log for resuming `client`, or
+    * `None` when nothing durable is known — always `None` for an ephemeral
+    * backend, whose sessions leave nothing to resume across a restart.
     */
   def persistableWireId(client: SessionId[B]): Option[WireSessionId[B]] =
     if probe.isDefined then resumeWire(client) else None
 
-  /** Will the NEXT call on `client` continue an already-live conversation
-    * (rather than start a fresh one that must be re-seeded)? This is the
-    * question the durable-session runtime asks before deciding whether to
-    * re-inject the seed + progress preamble.
+  /** Will the next call on `client` continue an already-live conversation
+    * (rather than start a fresh one that must be re-seeded)? The
+    * durable-session runtime asks this before deciding whether to re-inject the
+    * seed + progress preamble; re-seeding on `false` is always safe.
     *
     * For a durable backend this resolves the recorded wire id (no mapping ⇒
-    * `false`) and runs the `probe` on it — best-effort and non-destructive: the
-    * probe must NOT create, mutate, or resume the session, ANY non-fatal probe
-    * failure reads as "won't continue", and the caller re-seeds on `false`,
-    * which is always safe.
+    * `false`) and runs the `probe` on it: the probe must NOT create, mutate, or
+    * resume the session, and any non-fatal failure reads as "won't continue".
     *
-    * An ephemeral backend (pi) differs crucially: it keeps no durable
-    * transcript to probe — yet within a live process its bookkeeping DOES track
-    * the in-process claim, and the CLI is genuinely told to continue. So the
-    * answer is simply whether a mapping is recorded: `false` on the first call,
-    * `true` once the session has been committed this run.
+    * An ephemeral backend keeps no durable transcript to probe, but its
+    * bookkeeping tracks the in-process claim, so the answer is simply whether a
+    * mapping is recorded.
     */
   def willContinue(client: SessionId[B]): Boolean =
     probe match
@@ -189,9 +164,8 @@ object SessionSupport:
   private val log = LoggerFactory.getLogger(classOf[SessionSupport[?]])
 
   /** Sessions outlive the process (claude's on-disk transcripts,
-    * codex/gemini/opencode's server-side threads). `probe` is the backend's
-    * best-effort, non-destructive existence check, run against the resolved
-    * wire id (see [[SessionSupport.willContinue]]).
+    * codex/gemini/opencode's server-side threads). `probe` is a best-effort,
+    * non-destructive existence check (see [[SessionSupport.willContinue]]).
     */
   def durable[B <: BackendTag](
       scheme: IdScheme,
@@ -200,9 +174,8 @@ object SessionSupport:
     new SessionSupport(scheme, Some(probe))
 
   /** Sessions live only for the process lifetime (pi's `deleteOnExit` session
-    * dirs). Fresh-vs-resume is still tracked within the run, but nothing is
-    * durably resumable, so [[SessionSupport.persistableWireId]] always reports
-    * absence.
+    * dirs). Fresh-vs-resume is tracked within the run, but nothing is durably
+    * resumable, so [[SessionSupport.persistableWireId]] always reports absence.
     */
   def ephemeral[B <: BackendTag](scheme: IdScheme): SessionSupport[B] =
     new SessionSupport(scheme, None)

--- a/tools/src/main/scala/orca/backend/StderrPipeline.scala
+++ b/tools/src/main/scala/orca/backend/StderrPipeline.scala
@@ -8,19 +8,15 @@ import java.util.concurrent.atomic.AtomicReference
 /** Bounded-stderr diagnostics shared by the subprocess [[ForkedConversation]]s
   * (codex, gemini, pi). Keeps the last few trimmed stderr lines (capped on
   * count and bytes) so a non-zero exit / clean-exit-without-result carries the
-  * real failure context in the thrown exception — listener subscribers saw each
-  * line as a `ConversationEvent.Error`, but a noop listener (tests, simple
-  * scripts) would otherwise lose it. Also joins the stderr drain at finalize so
-  * trailing lines reach the queue before it closes.
+  * real failure context in the thrown exception — a noop listener (tests,
+  * simple scripts) would otherwise lose the per-line
+  * `ConversationEvent.Error`s.
   *
-  * This trait also owns the full stderr pipeline (see [[handleStderr]]): strip
-  * terminal control sequences → trim → drop known noise → surface as an `Error`
-  * event → record for the bounded diagnostic buffer. The three mixing-in
-  * drivers used to hand-roll this identically (and, pre-hoist, only pi stripped
-  * control sequences — the other two are deliberately brought up to the same
-  * behavior here); each keeps ONLY its own [[isStderrNoise]] predicate. A
-  * driver needing extra teardown overrides `onFinalize` and calls
-  * `super.onFinalize()`.
+  * Also owns the full stderr pipeline (see [[handleStderr]]): strip terminal
+  * control sequences → trim → drop known noise → surface as an `Error` event →
+  * record for the bounded diagnostic buffer. Each mixing-in driver varies only
+  * its own [[isStderrNoise]] predicate. A driver needing extra teardown
+  * overrides `onFinalize` and calls `super.onFinalize()`.
   */
 private[orca] trait StderrPipeline[B <: BackendTag]
     extends ForkedConversation[B]:
@@ -31,12 +27,8 @@ private[orca] trait StderrPipeline[B <: BackendTag]
 
   /** The last stderr line surfaced (post-strip/trim/noise-filter), used to
     * collapse a run of identical lines into one — some CLIs repeat the same
-    * warning on every invocation (claude's `ANTHROPIC_API_KEY overrides…` fired
-    * ~8×/run). Reader-thread-confined like `ForkedConversation.openTurn`:
-    * [[handleStderr]] is only ever called from the single `stderrDrainFork`
-    * (`ForkedConversation.stderrLoop` iterates `source.errorLines` on one
-    * fork), so a plain `var` needs no synchronisation — an atomic would be
-    * theatre.
+    * warning on every invocation. Confined to the single `stderrDrainFork` that
+    * calls [[handleStderr]], so a plain `var` needs no synchronisation.
     */
   private var lastStderrLine: Option[String] = None
 
@@ -48,9 +40,8 @@ private[orca] trait StderrPipeline[B <: BackendTag]
 
   /** Strip terminal control sequences, trim, drop [[isStderrNoise]] lines, drop
     * a line identical to the one just surfaced (see [[lastStderrLine]]), and
-    * surface anything real as both an `Error` event (`"$backendName: $line"`)
-    * and a recorded diagnostic line (see [[recordStderr]]). `final` — the
-    * pipeline itself is identical across backends, so subclasses vary only
+    * surface anything real as both an `Error` event and a recorded diagnostic
+    * line (see [[recordStderr]]). `final` — subclasses vary only
     * [[isStderrNoise]].
     */
   final override protected def handleStderr(line: String): Unit =
@@ -67,11 +58,9 @@ private[orca] trait StderrPipeline[B <: BackendTag]
     val _ = stderrBuffer.updateAndGet(appendBounded(_, line))
 
   /** Wait for the stderr drain so trailing lines reach the queue before the
-    * failure outcome is computed. No timeout is needed: `cancel()`'s
-    * `destroyForcibly` (and a real process's exit) always EOFs the stderr
-    * stream, so the drain fork terminates. `None` (workers never started —
-    * constructed-but-never-consumed, then cancelled) means there is no drain to
-    * wait for.
+    * failure outcome is computed. No timeout needed: `destroyForcibly` (and a
+    * real process's exit) always EOFs the stderr stream, so the drain fork
+    * terminates. `None` means workers never started (nothing to wait for).
     */
   override protected def onFinalize(): Unit =
     stderrDrainFork.foreach(_.join())

--- a/tools/src/main/scala/orca/backend/StreamSource.scala
+++ b/tools/src/main/scala/orca/backend/StreamSource.scala
@@ -2,13 +2,11 @@ package orca.backend
 
 import orca.subprocess.PipedCliProcess
 
-/** The line-oriented source a [[orca.backend.ForkedConversation]] drives.
-  *
-  * Abstracts the four things the driver needs from its producer — a primary
-  * line stream, an optional secondary diagnostic stream, a way to stop it, and
-  * a terminal status — so one driver serves both a subprocess
-  * ([[StreamSource.fromProcess]], used by the Claude/Codex backends) and any
-  * other line producer (the OpenCode `GET /event` SSE connection).
+/** The line-oriented source a [[orca.backend.ForkedConversation]] drives: a
+  * primary line stream, an optional secondary diagnostic stream, a way to stop
+  * it, and a terminal status — so one driver serves both a subprocess
+  * ([[StreamSource.fromProcess]]) and any other line producer (the OpenCode
+  * `GET /event` SSE connection).
   *
   * Thread-safety: [[lines]] and [[errorLines]] are each single-consumer (one
   * reader thread per stream). [[interrupt]] must tolerate calls from any

--- a/tools/src/main/scala/orca/backend/SubprocessSpawn.scala
+++ b/tools/src/main/scala/orca/backend/SubprocessSpawn.scala
@@ -6,33 +6,27 @@ import orca.subprocess.PipedCliProcess
 import scala.util.control.NonFatal
 
 /** The two-level spawn-and-build teardown every subprocess stream backend
-  * (claude/codex/gemini/pi) needs, factored out so the resource-leak handling —
-  * the part most dangerous to get subtly wrong — lives in one place.
+  * (claude/codex/gemini/pi) needs, factored out so resource-leak handling lives
+  * in one place.
   *
-  * The lifecycle:
+  *   - `spawn` builds the argv and launches the process. If it throws, the
+  *     process never came up, so only `resources` are released.
+  *   - `build` wraps the live process in a [[Conversation]]. If it throws after
+  *     the spawn, the child is SIGINT-ed and the failure is rethrown as "Failed
+  *     to open <sessionLabel> session".
+  *   - `resources` are the session-scoped `AutoCloseable`s the conversation
+  *     takes ownership of on success — on the happy path they ride through the
+  *     conversation's `onFinalize`, so this closes them (in reverse) only when
+  *     spawn or build fails.
   *
-  *   - `spawn` builds the argv (system-prompt files, MCP config, the
-  *     fresh-vs-resume dispatch lookup) and launches the process. If it throws,
-  *     the process never came up, so only `resources` are released.
-  *   - `build` wraps the live process in a [[Conversation]] (writing the
-  *     opening turn, closing stdin, etc.). If it throws after the spawn, the
-  *     child is SIGINT-ed (so it doesn't linger) and the failure is rethrown as
-  *     "Failed to open <sessionLabel> session".
-  *   - `resources` are the session-scoped `AutoCloseable`s (the ask_user
-  *     bundle, pi's temp files) the conversation takes ownership of on success
-  *     — on the happy path they ride through the conversation's `onFinalize`,
-  *     so this closes them (in reverse) only when spawn or build fails.
-  *
-  * `sessionLabel` is the backend's own descriptor for the failure message
-  * ("claude stream-json", "codex", "gemini", "pi RPC") — deliberately not the
-  * bare backend name, which is pinned by tests.
+  * `sessionLabel` is the backend's descriptor for the failure message —
+  * deliberately not the bare backend name, which is pinned by tests.
   */
 private[orca] object SubprocessSpawn:
 
-  /** Returns an `AutoCloseable` that best-effort deletes the given file when
-    * closed. Shared by the backends (claude's MCP config, codex's schema temp
-    * file) that write a per-call temp file and need it removed on both the
-    * failure path (via `open`'s `resources`) and the success path (via the
+  /** An `AutoCloseable` that best-effort deletes the given file when closed.
+    * Used by backends that write a per-call temp file needing removal on both
+    * the failure path (via `open`'s `resources`) and the success path (via the
     * conversation's `onFinalize`).
     */
   def deleteFileResource(path: os.Path): AutoCloseable =

--- a/tools/src/main/scala/orca/backend/SystemPromptComposer.scala
+++ b/tools/src/main/scala/orca/backend/SystemPromptComposer.scala
@@ -2,31 +2,24 @@ package orca.backend
 
 import orca.agents.{AgentConfig, ToolSet}
 
-/** Shared helper for assembling a backend-agnostic "system prompt body" from
-  * the configured [[AgentConfig.systemPrompt]], an optional caller-supplied
-  * `extraHint` (typically the shared `ask_user` MCP hint on interactive calls),
-  * and the standing [[RuntimeOwnsGit]] rule. Concatenates non-empty pieces with
-  * a blank line between them.
+/** Assembles a backend-agnostic system-prompt body from the configured
+  * [[AgentConfig.systemPrompt]], an optional `extraHint` (typically the
+  * `ask_user` MCP hint on interactive calls), and the standing
+  * [[RuntimeOwnsGit]] rule, joining non-empty pieces with a blank line.
   *
-  * Returns `None` only when nothing applies (a read-only turn with no
-  * systemPrompt and no hint). Each backend decides how to deliver the resulting
-  * string — claude writes it to a temp file for `--append-system-prompt-file`;
-  * codex and gemini have no such flag and fold it into the user prompt via
-  * [[foldIntoPrompt]].
+  * Returns `None` when nothing applies. Each backend delivers the result its
+  * own way — claude writes it to a temp file for `--append-system-prompt-file`;
+  * codex and gemini have no such flag and use [[foldIntoPrompt]].
   */
 private[orca] object SystemPromptComposer:
 
   /** Standing rule appended to every write-capable agent turn: orca's runtime
     * owns git, so the agent must never commit, push, or switch branches itself.
     * Without it, coding agents routinely `git commit` their own work, which
-    * empties the working tree and then (a) turns the flow's own
-    * `git.commit(...)` into a `NothingToCommit` no-op, and (b) leaves
-    * `git.diff()` empty so `reviewAndFixLoop`'s reviewer selection sees no
-    * changed files and runs no reviewers. Omitted on read-only turns (planning,
-    * triage, reviewer selection — they can't write anyway) and on
-    * [[AgentConfig.selfManagedGit]] turns (the caller's explicit escape hatch
-    * via `agent.withSelfManagedGit`). Otherwise an invariant of orca's
-    * runtime-owns-git model, applied on top of any `withSystemPrompt`.
+    * empties the working tree and then turns the flow's own `git.commit(...)`
+    * into a `NothingToCommit` no-op and leaves `git.diff()` empty, so reviewer
+    * selection sees no changed files and runs no reviewers. Omitted on
+    * read-only turns and on [[AgentConfig.selfManagedGit]] turns.
     */
   val RuntimeOwnsGit: String =
     "Git is managed by the runtime. Do NOT run `git commit`, `git push`, or " +
@@ -45,8 +38,8 @@ private[orca] object SystemPromptComposer:
       case Nil    => None
       case pieces => Some(pieces.mkString("\n\n"))
 
-  /** Deliver the composed system prompt by folding it into `userPrompt` as a
-    * `"System guidance:"` preamble, used by backends whose CLI has no
+  /** Fold the composed system prompt into `userPrompt` as a `"System
+    * guidance:"` preamble, for backends whose CLI has no
     * `--append-system-prompt` flag (codex, gemini). Returns `userPrompt`
     * unchanged when nothing applies.
     */

--- a/tools/src/main/scala/orca/backend/mcp/AskUserBridge.scala
+++ b/tools/src/main/scala/orca/backend/mcp/AskUserBridge.scala
@@ -12,17 +12,14 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
   *
   * One queue carries `(question, reply)` pairs from the handler side; each call
   * brings its own private reply channel so concurrent `ask_user` invocations
-  * from a busy agent don't cross wires. The handler thread blocks on its reply
-  * channel until the host signals it; the host's consumer loop takes from the
-  * question queue, surfaces a `UserQuestion`, and calls the `respond` closure
-  * with the typed answer.
+  * don't cross wires. The handler thread blocks on its reply channel until the
+  * host's consumer loop takes from the queue, surfaces a `UserQuestion`, and
+  * calls `respond` with the typed answer.
   *
-  * **Closure.** [[close]] errors any still-blocked `reply.receive()` calls and
-  * `done`s the question queue, so the drainer loop and Netty workers exit
-  * cleanly when the owning conversation ends. The owner (e.g.
-  * `ClaudeConversation.onFinalize` or `CodexConversation.onFinalize`) calls
-  * `close` after the conversation's read loop drains — before the MCP server's
-  * Netty binding stops, so handlers see the bridge close first.
+  * [[close]] errors any still-blocked `reply.receive()` calls and `done`s the
+  * question queue so the drainer loop and Netty workers exit cleanly. The owner
+  * calls `close` after the conversation's read loop drains — before the MCP
+  * server's Netty binding stops, so handlers see the bridge close first.
   */
 private[orca] class AskUserBridge(using BufferCapacity):
 
@@ -37,17 +34,15 @@ private[orca] class AskUserBridge(using BufferCapacity):
     new AtomicReference(Set.empty)
 
   /** Called by the MCP handler. Blocks the calling thread until the host
-    * answers via the closure returned by [[take]]. Each call gets its own
-    * one-shot reply channel so concurrent invocations stay isolated. Throws
-    * [[ChannelClosedException]] if the bridge is closed while blocked — the
-    * handler should surface that as a tool error to the agent.
+    * answers. Each call gets its own one-shot reply channel so concurrent
+    * invocations stay isolated. Throws [[ChannelClosedException]] if the bridge
+    * is closed while blocked — the handler surfaces that as a tool error.
     *
-    * The reply channel is always `done`'d when `ask` exits (success or
-    * exception). Without this, a handler that exits early — e.g. the HTTP
-    * client aborts after its own timeout — would leave the rendezvous dangling:
-    * the renderer's later `respond(answer)` would block forever on a `send`
-    * with no matching receiver. Closing the channel makes that `send` raise a
-    * recoverable `ChannelClosedException` instead.
+    * The reply channel is always `done`'d on exit. Otherwise a handler that
+    * exits early (e.g. the HTTP client aborts after its own timeout) would
+    * leave the rendezvous dangling, and the renderer's later `respond(answer)`
+    * would block forever on a `send` with no receiver; the `done` makes that
+    * `send` raise a recoverable `ChannelClosedException` instead.
     */
   def ask(question: String): String =
     val reply: Channel[String] = Channel.rendezvous
@@ -64,14 +59,11 @@ private[orca] class AskUserBridge(using BufferCapacity):
     * no question is queued; throws [[ChannelClosedException]] when the bridge
     * is closed.
     *
-    * The returned `respond` closure is idempotent — only the first call
-    * delivers the answer to the rendezvous; later calls are no-ops. Protects
-    * against a renderer that double-fires (retry, reentrant cancel).
-    *
-    * If the originating `ask` has already exited (e.g. the handler thread was
-    * unwound by a client-side timeout), the reply channel is `done`'d.
-    * `respond` then uses `sendOrClosed` so the caller sees a no-op rather than
-    * an exception escaping into the renderer's dispatch loop.
+    * The returned `respond` closure is idempotent (only the first call
+    * delivers) to protect against a renderer that double-fires. It uses
+    * `sendOrClosed` so that if the originating `ask` has already exited (its
+    * reply channel `done`'d), the caller sees a no-op rather than an exception
+    * escaping into the renderer's dispatch loop.
     */
   def nextQuestion(): PendingQuestion =
     val (question, reply) = pending.receive()

--- a/tools/src/main/scala/orca/backend/mcp/AskUserMcpServer.scala
+++ b/tools/src/main/scala/orca/backend/mcp/AskUserMcpServer.scala
@@ -8,24 +8,19 @@ import sttp.tapir.server.netty.sync.NettySyncServer
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
-/** Input shape of the `ask_user` MCP tool. The agent fills in `question`; we
-  * hand the typed answer back as the tool result. `private[mcp]` — only the
-  * handler in this file references it (the server's `ServerName`/`ToolSlug`/
-  * `ToolTimeout`/`Hint` stay `private[orca]` because the backends consult
-  * them).
+/** Input shape of the `ask_user` MCP tool: the agent fills in `question` and
+  * gets the typed answer back as the tool result.
   */
 private[mcp] case class AskUserInput(question: String) derives Codec, Schema
 
-/** Boots a tiny MCP HTTP server exposing the `ask_user` tool. The handler
-  * closes over an [[AskUserBridge]] — each tool invocation enqueues the
-  * question on the bridge and blocks until the host process supplies an answer.
+/** A tiny MCP HTTP server exposing the `ask_user` tool. The handler closes over
+  * an [[AskUserBridge]] — each invocation enqueues the question and blocks
+  * until the host supplies an answer.
   *
-  * Bound on `127.0.0.1` at an ephemeral port so multiple conversations inside
-  * one flow don't collide. Lifecycle is **caller-owned**: the factory returns
-  * an `AutoCloseable` whose `close()` stops the Netty binding. Callers should
-  * tie that close to the lifetime of the conversation it serves (e.g. via
-  * `Conversation.onFinalize`) so per-call bindings don't accumulate over a long
-  * flow.
+  * Bound on `127.0.0.1` at an ephemeral port so conversations don't collide.
+  * Lifecycle is caller-owned: `close()` stops the Netty binding, and callers
+  * should tie it to the conversation's lifetime (e.g. via
+  * `Conversation.onFinalize`) so per-call bindings don't accumulate.
   */
 private[orca] class AskUserMcpServer private[mcp] (
     /** The bound port. Useful when the caller wants to disambiguate per-server
@@ -44,10 +39,8 @@ private[orca] class AskUserMcpServer private[mcp] (
 private[orca] object AskUserMcpServer:
 
   /** MCP server name advertised to every backend (`mcp_servers.<name>` in
-    * codex's config, the `mcpServers` map key in claude's `.mcp.json`). The two
-    * backends are required to use the same name so a single MCP host binding
-    * serves both; promoting the literal here keeps that identity explicit
-    * instead of letting each backend re-declare it.
+    * codex's config, the `mcpServers` map key in claude's `.mcp.json`). All
+    * backends must use the same name so a single MCP host binding serves them.
     */
   private[orca] val ServerName: String = "orca"
 
@@ -58,31 +51,25 @@ private[orca] object AskUserMcpServer:
     */
   private[orca] val ToolSlug: String = "ask_user"
 
-  /** Upper bound on how long one `ask_user` invocation can take, from the
-    * agent's MCP request to the user's answer. Both backend MCP clients
-    * (claude, codex) and this server's Netty binding must agree on a value
-    * larger than any reasonable user delay — otherwise the client times out
-    * client-side, the agent synthesises a tool failure, and a follow-up
-    * `ask_user` fires while the user is still typing. Each consumer converts to
-    * its native unit (claude wants ms, codex wants seconds, Netty wants
-    * `FiniteDuration`).
-    *
-    * One of three renderings of this value across backends — claude JSON ms /
-    * codex TOML sec / gemini settings.json ms; keep in sync.
+  /** Upper bound on one `ask_user` invocation, from the agent's MCP request to
+    * the user's answer. Both backend MCP clients and this server's Netty
+    * binding must agree on a value larger than any reasonable user delay —
+    * otherwise the client times out, the agent synthesises a tool failure, and
+    * a follow-up `ask_user` fires while the user is still typing. Each consumer
+    * converts to its native unit (claude JSON ms, codex TOML sec, gemini
+    * settings.json ms, Netty `FiniteDuration`); keep in sync.
     */
   private[orca] val ToolTimeout: FiniteDuration = 1.hour
 
-  /** Mount the `ask_user` MCP endpoint on a fresh Netty binding. The Ox
-    * capability is used to start the server in the enclosing scope; the caller
-    * is responsible for calling `close()` (or relying on scope tear-down) to
-    * stop it.
+  /** Mount the `ask_user` MCP endpoint on a fresh Netty binding in the
+    * enclosing Ox scope; the caller calls `close()` (or relies on scope
+    * tear-down).
     *
     * The handler blocks until the host user types an answer, which can take
-    * arbitrarily long. Netty's default 20s `requestTimeout` (and 60s
-    * `idleTimeout`) would close the connection mid-prompt; raise both to match
-    * [[ToolTimeout]] so a thoughtful user gets time without leaving the binding
-    * open forever. `idleTimeout` adds a minute of slop because Netty's docs
-    * require `idleTimeout > requestTimeout`.
+    * arbitrarily long, so Netty's default request/idle timeouts are raised to
+    * [[ToolTimeout]] to avoid closing the connection mid-prompt. `idleTimeout`
+    * adds a minute of slop because Netty requires `idleTimeout >
+    * requestTimeout`.
     */
   def start(bridge: AskUserBridge)(using Ox): AskUserMcpServer =
     val askUserTool =
@@ -105,7 +92,7 @@ private[orca] object AskUserMcpServer:
 
   /** Short system-prompt hint telling the agent it has an `ask_user` tool for
     * clarifying questions. Worded conservatively — agents over-use tools
-    * they're told about. Used by every backend's interactive setup.
+    * they're told about.
     */
   val Hint: String =
     """When you genuinely need a piece of information from the user to

--- a/tools/src/main/scala/orca/backend/mcp/AskUserSession.scala
+++ b/tools/src/main/scala/orca/backend/mcp/AskUserSession.scala
@@ -5,17 +5,15 @@ import ox.channels.BufferCapacity
 
 import scala.util.control.NonFatal
 
-/** One-conversation ask-user wiring: the host-side [[AskUserBridge]] (which
-  * surfaces `UserQuestion` events to the renderer), the Netty-backed
-  * [[AskUserMcpServer]], and any backend-specific `extras` (e.g. claude's
-  * workDir-local `.orca-mcp-<port>.json` config file deletion). Lifetime is
-  * tied to a single conversation; the framework closes it after the read loop
-  * drains.
+/** One-conversation ask-user wiring: the host-side [[AskUserBridge]], the
+  * Netty-backed [[AskUserMcpServer]], and any backend-specific `extras` (e.g.
+  * claude's `.orca-mcp-<port>.json` config file deletion). The framework closes
+  * it after the read loop drains.
   *
-  * Encapsulates close-order: bridge first (errors any in-flight `ask` so
-  * blocked handlers exit before the binding tears down), then the server, then
-  * extras. Each close is wrapped — one resource's failure mustn't skip the
-  * next, and close-time failure mustn't mask the caller's original throw.
+  * Close-order: bridge first (errors any in-flight `ask` so blocked handlers
+  * exit before the binding tears down), then server, then extras. Each close is
+  * wrapped so one resource's failure doesn't skip the next or mask the caller's
+  * original throw.
   */
 private[orca] case class AskUserSession(
     bridge: AskUserBridge,
@@ -31,9 +29,8 @@ private[orca] case class AskUserSession(
 
 private[orca] object AskUserSession:
 
-  /** Stand up the bridge + Netty MCP server, then invoke the backend- specific
-    * `extras` callback to allocate any additional cleanup-needing artefacts
-    * (claude writes a workDir-local config file; codex doesn't need any). If
+  /** Stand up the bridge + Netty MCP server, then invoke the backend-specific
+    * `extras` callback to allocate any additional cleanup-needing artefacts. If
     * the callback throws, the bridge + server are closed before the throw
     * escapes so no Netty binding leaks.
     */
@@ -45,10 +42,8 @@ private[orca] object AskUserSession:
     try AskUserSession(bridge, server, extras(server))
     catch
       case NonFatal(e) =>
-        // No drainer thread is running yet so the bridge has no blocked
-        // callers to error, but close it for symmetry with the normal
-        // tear-down path — if anything moves drainer-start earlier later,
-        // the cleanup stays right.
+        // No drainer thread is running yet, but close the bridge too for
+        // symmetry with the normal tear-down path.
         swallow(bridge.close())
         swallow(server.close())
         throw e

--- a/tools/src/main/scala/orca/events/OrcaEvent.scala
+++ b/tools/src/main/scala/orca/events/OrcaEvent.scala
@@ -4,58 +4,44 @@ import orca.agents.Model
 
 /** Flow-level event fanned out to every registered [[OrcaListener]]. Covers
   * stage transitions, tool invocations, token usage, structured results, and
-  * errors — anything observers like the status bar, cost tracker, or external
-  * log shippers want to see across the entire flow.
+  * errors.
   *
-  * Events exist for observability only — progress display, cost accounting,
-  * trace logging, log shipping. They are NOT a control-flow mechanism: no
-  * runtime decision reads them back (the production listeners render,
-  * accumulate, or log — nothing more), listeners return `Unit`, and the
-  * dispatcher isolates the emitter from listener failures (see
-  * [[OrcaListener]]), so an observer cannot alter the flow's outcome. Anything
-  * that must drive logic travels through return values or exceptions, never
-  * through this event stream.
+  * Events exist for observability only — no runtime decision reads them back,
+  * listeners return `Unit`, and the dispatcher isolates the emitter from
+  * listener failures (see [[OrcaListener]]), so an observer cannot alter the
+  * flow's outcome. Anything that drives logic travels through return values or
+  * exceptions instead.
   *
   * Distinct from [[orca.backend.ConversationEvent]], which is scoped to a
-  * single live LLM conversation: assistant text deltas, tool-approval prompts,
-  * etc., consumed only by the [[orca.backend.Interaction]] that drives that
-  * conversation. Conversation events stay between driver and channel;
-  * `OrcaEvent`s fan out to all listeners.
+  * single live LLM conversation and consumed only by the
+  * [[orca.backend.Interaction]] that drives it; `OrcaEvent`s fan out to all
+  * listeners.
   */
 enum OrcaEvent:
   case StageStarted(name: String)
   case StageCompleted(name: String)
   case ToolUse(tool: String, args: String)
 
-  /** A single instantaneous note in the event log — neither a stage (no
-    * completion) nor a stream-of-text (no continuation). Tools emit these for
-    * discrete progress: "switched to branch X", "discarded N issues", etc.
+  /** A single instantaneous note in the event log — neither a stage nor a
+    * stream-of-text. Tools emit these for discrete progress: "switched to
+    * branch X", "discarded N issues", etc.
     */
   case Step(message: String)
 
-  /** Token usage for a single LLM call, attributed along three independent
-    * axes:
+  /** Token usage for a single LLM call, attributed along three independent axes
+    * that `CostTracker` summarises separately:
     *
-    *   - `agent` is the [[Agent.name]] that issued the call — always the
-    *     agent's bare identity (`claude`, `codex`, `performance`, …), never a
-    *     display-prefixed copy: renaming a reviewer's agent for cost grouping
-    *     is what `role` (below) replaced.
-    *   - `model` is the concrete model the backend reports it actually served
-    *     the call with. `None` when the response didn't carry it and no model
-    *     was pinned via `AgentConfig.model`. Coarser groupings (model family /
-    *     provider — claude, gpt, gemini) are deliberately NOT a fourth axis:
-    *     they are derivable from this id at display time, whereas emission
-    *     sites would have to guess them for provider-agnostic backends
-    *     (opencode routes many providers, and orca doesn't normalise model ids
-    *     — see [[orca.agents.Model]]).
+    *   - `agent` is the [[Agent.name]] that issued the call — always the bare
+    *     identity (`claude`, `codex`, …), never a display-prefixed copy.
+    *   - `model` is the concrete model the backend reports it served the call
+    *     with. `None` when the response didn't carry it and no model was pinned
+    *     via `AgentConfig.model`. Coarser groupings (family / provider) are not
+    *     a fourth axis: they are derivable at display time, whereas emission
+    *     sites would have to guess them for provider-agnostic backends (orca
+    *     doesn't normalise model ids — see [[orca.agents.Model]]).
     *   - `role` is the [[Agent.role]] tag, set at the emission edge (e.g. the
     *     review loop's `Some("reviewer")`, via `withRole`). `None` for an
-    *     ordinary call. Purely a grouping/display hint — never parsed back out
-    *     of `agent`.
-    *
-    * `CostTracker` summarises usage along all three axes — by-agent shows where
-    * the tokens were spent, by-model shows which models cost what, and by-role
-    * optionally subtotals e.g. all reviewer spend together.
+    *     ordinary call. Purely a grouping/display hint.
     */
   case TokensUsed(
       agent: String,
@@ -68,31 +54,27 @@ enum OrcaEvent:
     * the verbatim text the agent produced (typically JSON); `summary` is the
     * `Announce[O]`-derived human-readable form, tri-state:
     *
-    *   - `Some(text)` — a specific `Announce[O]` produced a summary; renderers
-    *     show it;
-    *   - `Some("")` — a specific `Announce[O]` deliberately says nothing (the
-    *     call site narrates the outcome itself, e.g. the review loop's
-    *     per-reviewer lines); renderers show nothing;
+    *   - `Some(text)` — a summary to show;
+    *   - `Some("")` — the `Announce[O]` deliberately says nothing (the call
+    *     site narrates the outcome itself); renderers show nothing;
     *   - `None` — no specific `Announce[O]` exists; renderers fall back to the
     *     raw payload so the result stays visible.
     */
   case StructuredResult(raw: String, summary: Option[String])
 
-  /** The human-readable input that was sent to the agent at the start of an
-    * autonomous call. Fires once per call (before [[TokensUsed]] /
-    * [[StructuredResult]] / [[AssistantMessage]]), so the user sees what the
-    * agent is being asked to do. Interactive calls surface this through the
+  /** The human-readable input sent to the agent at the start of an autonomous
+    * call. Fires once per call, before [[TokensUsed]] / [[StructuredResult]] /
+    * [[AssistantMessage]]. Interactive calls surface this through the
     * conversation renderer's own user-message line and do not emit this event.
-    * The terminal listener renders it as a `▸` line, truncated to one line —
-    * full text is available to non-terminal listeners.
+    * The terminal listener renders it as a one-line `▸`; full text reaches
+    * non-terminal listeners.
     */
   case UserPrompt(text: String)
 
-  /** A turn of free-form prose from the agent. The autonomous drain emits one
-    * per [[ConversationEvent.AssistantTurnEnd]] so the user sees what the agent
-    * is doing without the interactive renderer attached. The terminal listener
-    * renders it as a `●` line, truncated to one line — full text is available
-    * to non-terminal listeners.
+  /** A turn of free-form prose from the agent, one per
+    * [[ConversationEvent.AssistantTurnEnd]] on the autonomous drain (the
+    * interactive renderer surfaces these itself). The terminal listener renders
+    * it as a one-line `●`; full text reaches non-terminal listeners.
     */
   case AssistantMessage(text: String)
 
@@ -101,28 +83,23 @@ enum OrcaEvent:
 /** Sink for [[OrcaEvent]]s.
   *
   * **Implementations MUST be thread-safe.** `onEvent` is called from parallel
-  * agent forks (e.g. concurrent reviewers via `reviewAndFixLoop`, concurrent
-  * LLM calls via `ox.par`), often without any external synchronization on the
-  * caller side. Listeners that mutate shared state must do so atomically
-  * (`AtomicReference`, `synchronized`, etc.); listeners that delegate to other
-  * sinks must ensure those sinks tolerate concurrent calls too. Implementations
-  * should not throw from `onEvent`, but if they do, the dispatcher logs the
-  * failure at ERROR, announces it on stderr, and quarantines the listener —
-  * permanently excluded from all further dispatch for the rest of the run,
-  * since its internal state is presumed unrecoverable. A listener failure is
-  * never surfaced to the emitting flow, and deliberately does NOT end the run:
-  * quarantine is per-listener (every other listener still sees every event),
-  * events are observability-only (see [[OrcaEvent]] — an observer must not be
-  * able to abort the run it merely watches), and `emit` being total is
-  * load-bearing: failure-teardown paths emit from `catch` blocks where a
-  * listener throw would mask the original failure the user needs to see (see
-  * `FlowLifecycle`).
+  * agent forks (concurrent reviewers, `ox.par` LLM calls) without external
+  * synchronization, so listeners mutating shared state must do so atomically,
+  * and listeners delegating to other sinks must ensure those tolerate
+  * concurrent calls too.
+  *
+  * A throw from `onEvent` never reaches the emitting flow and does not end the
+  * run: the dispatcher logs it at ERROR, announces it on stderr, and
+  * quarantines that one listener (presumed unrecoverable) while every other
+  * listener keeps seeing every event. `emit` being total is load-bearing:
+  * failure-teardown paths emit from `catch` blocks where a listener throw would
+  * otherwise mask the original failure (see `FlowLifecycle`).
   */
 trait OrcaListener:
   def onEvent(event: OrcaEvent): Unit
 
 object OrcaListener:
-  /** Drops every event. The default for tools that may run without a wired-up
+  /** Drops every event. Default for tools that run without a wired-up
     * dispatcher (unit tests, lightweight scripts).
     */
   val noop: OrcaListener = (_: OrcaEvent) => ()

--- a/tools/src/main/scala/orca/events/Usage.scala
+++ b/tools/src/main/scala/orca/events/Usage.scala
@@ -2,21 +2,19 @@ package orca.events
 
 /** Token + cost accounting for one or more LLM calls.
   *
-  * **Normalisation contract.** All backends map onto the same axes so that
-  * summing `Usage` across calls and across backends is apples-to-apples:
+  * **Normalisation contract.** All backends map onto the same axes so summing
+  * `Usage` across calls and backends is apples-to-apples:
   *
   *   - `inputTokens` is the TOTAL prompt tokens, **inclusive** of any served
   *     from prompt cache. `outputTokens` is the total completion tokens.
-  *   - `cachedInputTokens` is the cache-served sub-portion (`cachedInputTokens
-  *     <= inputTokens`); `reasoningOutputTokens` is the internal-reasoning
-  *     sub-portion of `outputTokens` (codex / o-series). Both are
-  *     non-cumulative breakdowns, surfaced so callers can report cache-hit and
-  *     reasoning ratios without re-deriving them.
+  *   - `cachedInputTokens` is the cache-served sub-portion (`<= inputTokens`);
+  *     `reasoningOutputTokens` is the internal-reasoning sub-portion of
+  *     `outputTokens` (codex / o-series). Both are non-cumulative breakdowns so
+  *     callers can report cache-hit and reasoning ratios directly.
   *
-  * Backends reach this contract from different wire shapes, so a NEW backend
-  * must fold any cache-served tokens INTO `inputTokens` rather than report them
-  * alongside it. The per-backend arithmetic (and why it differs) is documented
-  * at each driver's `Usage(...)` construction site.
+  * A new backend must fold any cache-served tokens INTO `inputTokens` rather
+  * than report them alongside it. The per-backend arithmetic is documented at
+  * each driver's `Usage(...)` construction site.
   */
 case class Usage(
     inputTokens: Long,

--- a/tools/src/main/scala/orca/subprocess/CliProcess.scala
+++ b/tools/src/main/scala/orca/subprocess/CliProcess.scala
@@ -6,36 +6,33 @@ trait CliProcess:
   def waitForExit(): Int
 
   /** Forcibly terminate this process (SIGKILL for the OS-backed process; close
-    * the pipes for fakes), the guaranteed backstop a [[StreamSource]] uses
-    * after a graceful `sendSigInt` so a reader blocked on stdout always
-    * unblocks. Must tolerate calls from any thread and more than once; on the
-    * normal path the process has already exited, making this a no-op.
+    * the pipes for fakes), the backstop after a graceful `sendSigInt` so a
+    * reader blocked on stdout always unblocks. Must tolerate calls from any
+    * thread and more than once; on the normal path the process has already
+    * exited, making this a no-op.
     */
   def destroyForcibly(): Unit
 
-  /** Forcibly terminate this process AND any descendants. Default = just this
+  /** Forcibly terminate this process AND any descendants. Defaults to just this
     * process; override where a launch wrapper (e.g. `ollama launch opencode`)
     * forks the real process, which inherits the stdout/stderr pipe fds: a
-    * single-PID kill would orphan it and leave those write-ends open, so a
-    * reader blocked on the pipe would never see EOF. Same call-anywhere /
-    * idempotent contract as [[destroyForcibly]].
+    * single-PID kill would orphan it, leaving those write-ends open so a reader
+    * blocked on the pipe never sees EOF. Same call-anywhere / idempotent
+    * contract as [[destroyForcibly]].
     */
   def destroyForciblyTree(): Unit = destroyForcibly()
 
 /** A spawned process whose stdin / stdout / stderr are connected to pipes the
-  * caller controls. The backend writes the opening user turn (or any further
-  * input) via `writeLine` and consumes responses as they arrive from
-  * `stdoutLines`. `closeStdin` signals end-of-input — the agent CLI then emits
-  * its final result and exits. Both backends close stdin once the opening turn
-  * has been written: claude (with `--input-format stream-json`) waits for EOF
-  * before flushing the final `result`; codex `exec --json` reads its prompt
-  * argv-side and ignores stdin entirely once the spawn settles.
+  * caller controls. The backend writes input via `writeLine` and consumes
+  * responses from `stdoutLines`. `closeStdin` signals end-of-input — the agent
+  * CLI then emits its final result and exits. claude (with `--input-format
+  * stream-json`) waits for EOF before flushing the final `result`; codex `exec
+  * --json` reads its prompt argv-side and ignores stdin once the spawn settles.
   *
   * Reads on `stdoutLines` / `stderrLines` block until a line is available or
   * the stream closes. Each iterator must be consumed by a single thread;
-  * internal buffering of pending lines is not thread-safe across readers.
-  * Implementations memoise the iterator so repeated property accesses return
-  * the same underlying stream.
+  * pending-line buffering is not thread-safe across readers. Implementations
+  * memoise the iterator so repeated accesses return the same stream.
   */
 trait PipedCliProcess extends CliProcess:
   def writeLine(line: String): Unit
@@ -43,8 +40,7 @@ trait PipedCliProcess extends CliProcess:
   def stdoutLines: Iterator[String]
   def stderrLines: Iterator[String]
 
-  /** Non-blocking exit probe. `None` while still running; `Some(code)` once the
-    * process has exited. The reader fork uses this to tell a clean EOF from a
-    * crash.
+  /** Non-blocking exit probe: `None` while running, `Some(code)` once exited.
+    * The reader fork uses this to tell a clean EOF from a crash.
     */
   def tryExitCode: Option[Int]

--- a/tools/src/main/scala/orca/subprocess/CliRunner.scala
+++ b/tools/src/main/scala/orca/subprocess/CliRunner.scala
@@ -9,15 +9,14 @@ trait CliRunner:
   ): CliResult
 
   /** Spawn the command with pipes on stdin / stdout / stderr for programmatic
-    * orchestration (stream-json, tool-approval, etc.). See [[PipedCliProcess]]
+    * orchestration (stream-json, tool-approval, etc.); see [[PipedCliProcess]]
     * for the I/O surface.
     *
     * `pipeStderr = false` (default) inherits the child's stderr to the parent's
-    * terminal — appropriate for chatty CLIs whose stderr can fill the pipe
-    * buffer faster than the driver drains it (claude with `--verbose`). Set to
-    * `true` when the driver wants to see stderr lines as
-    * `ConversationEvent.Error`s and the child's stderr volume is bounded enough
-    * that a 64KB pipe is safe.
+    * terminal — needed for chatty CLIs whose stderr can fill the pipe buffer
+    * faster than the driver drains it (claude with `--verbose`). Set `true`
+    * when the driver wants stderr lines as `ConversationEvent.Error`s and the
+    * child's stderr volume is bounded enough that a 64KB pipe is safe.
     */
   def spawnPiped(
       args: Seq[String],

--- a/tools/src/main/scala/orca/subprocess/OsProcCliRunner.scala
+++ b/tools/src/main/scala/orca/subprocess/OsProcCliRunner.scala
@@ -5,15 +5,13 @@ import org.slf4j.LoggerFactory
 import scala.jdk.CollectionConverters.given
 
 /** Runs external commands via os-lib. `check = false` is intentional — callers
-  * inspect `exitCode` and `stderr` rather than handling thrown exceptions,
-  * since non-zero exits from tools like `claude -p` carry actionable
-  * information.
+  * inspect `exitCode` and `stderr` rather than handle exceptions, since
+  * non-zero exits from tools like `claude -p` carry actionable information.
   */
 object OsProcCliRunner extends CliRunner:
-  // Trace every external invocation (gh, git, claude, codex) to the per-run
-  // log. Prompts travel over stdin, not argv, so this records the command +
-  // flags + exit code without leaking prompt bodies; the prompt itself is
-  // logged separately via the `UserPrompt` event.
+  // Traces command + flags + exit code to the per-run log. Prompts travel over
+  // stdin, not argv, so this doesn't leak prompt bodies (logged separately via
+  // the `UserPrompt` event).
   private val log = LoggerFactory.getLogger("orca.proc")
 
   def run(
@@ -22,10 +20,8 @@ object OsProcCliRunner extends CliRunner:
       env: Map[String, String],
       cwd: os.Path
   ): CliResult =
-    // Delegates to QuietProc for the actual `os.proc(...).call(...)` — it's
-    // the one place in `orca.subprocess` that guarantees captured stderr, so
-    // subprocess output never bypasses the renderer's StatusBar. See
-    // [[QuietProc]] for the full rationale.
+    // Delegates to QuietProc, which guarantees captured stderr so subprocess
+    // output never bypasses the renderer's StatusBar (see [[QuietProc]]).
     log.debug("exec: {} (cwd={})", args.mkString(" "), cwd)
     val result = QuietProc.call(args, cwd = cwd, env = env, stdin = stdin)
     log.debug("exit {}: {}", result.exitCode, args.headOption.getOrElse("?"))
@@ -45,11 +41,10 @@ object OsProcCliRunner extends CliRunner:
         env = env,
         stdin = os.Pipe,
         stdout = os.Pipe,
-        // Defaults to Inherit — piping risks a buffer-fill hang when the
-        // child emits more stderr than the driver drains in time (claude
-        // with --verbose is chatty). Bounded-stderr backends (codex)
-        // opt into piping so the driver can surface stderr lines as
-        // ConversationEvent.Errors.
+        // Inherit by default: piping risks a buffer-fill hang when the child
+        // emits more stderr than the driver drains (claude --verbose).
+        // Bounded-stderr backends (codex) opt into piping to surface stderr
+        // lines as ConversationEvent.Errors.
         stderr = if pipeStderr then os.Pipe else os.Inherit
       )
     new OsPipedSubProcess(sub, pipeStderr)
@@ -59,21 +54,17 @@ private final class OsPipedSubProcess(
     stderrPiped: Boolean
 ) extends PipedCliProcess:
 
-  // Memoised so repeated calls return the same iterator, avoiding a
-  // second `BufferedReader` leak against the pipe.
+  // Memoised so repeated calls return the same iterator, avoiding a second
+  // `BufferedReader` leak against the pipe.
   //
   // CRITICAL: must read line-by-line as the child emits — NOT
-  // `sub.stdout.lines()`, which dispatches to `geny.ByteData.lines()` and
-  // reads the whole stream to EOF before returning a `Vector[String]`. That
-  // version turns stream-json into a no-op until the subprocess exits, with
-  // all events appearing in a single burst at the end. Using the underlying
-  // `BufferedReader` (already wired by os-lib) gives a properly lazy
-  // line-by-line iterator.
+  // `sub.stdout.lines()`, which reads the whole stream to EOF before returning
+  // a `Vector[String]`, turning stream-json into a no-op until the subprocess
+  // exits. The underlying `BufferedReader` gives a lazy line-by-line iterator.
   private lazy val stdoutIterator: Iterator[String] =
     sub.stdout.buffered.lines().iterator().asScala
-  // When stderr is inherited to the parent, expose an empty iterator so
-  // the `PipedCliProcess` contract still holds without reading from a
-  // nonexistent pipe; when piped, expose the actual stream.
+  // Empty iterator when stderr is inherited, so the `PipedCliProcess` contract
+  // holds without reading a nonexistent pipe; the actual stream when piped.
   private lazy val stderrIterator: Iterator[String] =
     if stderrPiped then sub.stderr.buffered.lines().iterator().asScala
     else Iterator.empty
@@ -88,13 +79,13 @@ private final class OsPipedSubProcess(
 
   override def destroyForciblyTree(): Unit =
     // Descendants first, then the root: a launch wrapper that forked the real
-    // `serve` child leaves it holding the inherited stdout/stderr pipe
-    // write-ends, so killing only the root PID would never EOF a blocked drain.
+    // child leaves it holding the inherited stdout/stderr pipe write-ends, so
+    // killing only the root PID would never EOF a blocked drain.
     // `descendants()` is a best-effort snapshot of live parent→child linkage; it
     // catches a wrapper that stays alive as the worker's parent (the `ollama
-    // launch` case). It would NOT catch a wrapper that double-forks and exits,
-    // reparenting the worker to init — that would need a process-group kill or a
-    // recorded worker PID. No current launcher does that.
+    // launch` case), but NOT one that double-forks and exits, reparenting the
+    // worker to init — that would need a process-group kill or a recorded worker
+    // PID. No current launcher does that.
     val handle = sub.wrapped.toHandle
     handle.descendants().forEach(h => { val _ = h.destroyForcibly() })
     val _ = handle.destroyForcibly()

--- a/tools/src/main/scala/orca/subprocess/QuietProc.scala
+++ b/tools/src/main/scala/orca/subprocess/QuietProc.scala
@@ -1,26 +1,17 @@
 package orca.subprocess
 
-/** The single quiet-shell-out implementation: subprocess invocation that
-  * **guarantees captured stderr**.
+/** Subprocess invocation that **guarantees captured stderr**.
   *
-  * Why this exists: os-lib 0.11.x defaults `os.proc(...).call(...)`'s `stderr`
-  * to `os.Inherit`. A flow tool that uses `os.proc` directly therefore lets the
-  * child write its stderr straight to the parent's terminal — bypassing the
-  * renderer's [[orca.runner.terminal.StatusBar]] and producing visible
-  * artifacts (a stray "Switched to a new branch" appearing on the same physical
-  * row as the spinner glyph, mid-redraw).
+  * os-lib defaults `os.proc(...).call(...)`'s `stderr` to `os.Inherit`, which
+  * lets the child write straight to the parent's terminal — bypassing the
+  * renderer's [[orca.runner.terminal.StatusBar]] and producing torn frames
+  * (e.g. a stray "Switched to a new branch" on the spinner's row mid-redraw).
+  * So any tool that shells out from a flow goes through `QuietProc.call` (or a
+  * `CliRunner`, which delegates here via [[OsProcCliRunner]]); a direct
+  * `os.proc(...).call(...)` in production tool code is a leak.
   *
-  * The rule, encoded as a code-level helper rather than a comment:
-  *
-  * *Any tool that shells out from a flow goes through `QuietProc.call` (or a
-  * `CliRunner`, which — via [[OsProcCliRunner]] — delegates to it). Direct
-  * `os.proc(...).call(...)` in production tool code is a leak — the tool's
-  * terminal output becomes invisible to the StatusBar's clear-line discipline
-  * and the user sees torn frames.*
-  *
-  * Subprocess errors aren't dropped: stderr is captured into `result.err`,
-  * which the caller surfaces in error messages (see [[orca.tools.OsGitTool]]'s
-  * `git` helper).
+  * Captured stderr lands in `result.err`, which the caller surfaces in error
+  * messages (see [[orca.tools.OsGitTool]]'s `git` helper).
   */
 private[orca] object QuietProc:
 
@@ -29,15 +20,11 @@ private[orca] object QuietProc:
   /** Run `args` to completion. stdout + stderr are captured into the returned
     * [[os.CommandResult]]; `check = false` means non-zero exits don't throw —
     * the caller inspects `exitCode` / `err.text()` and decides how to react.
-    * Mirrors the os-lib `call` shape so migration from `os.proc(...).call(...)`
-    * is mechanical.
     *
-    * `cwd` and `env` default to concrete values (the current directory / an
-    * empty map merged onto the inherited environment) rather than os-lib's own
-    * `null`-means-inherit convention, per this codebase's no-null style; the
-    * two are behaviourally identical (os-lib treats a `null` `cwd` as `os.pwd`
-    * and an empty `env` map contributes no overrides on top of the inherited
-    * environment either way).
+    * `cwd` and `env` default to concrete values (current directory / an empty
+    * map merged onto the inherited environment) rather than os-lib's
+    * `null`-means-inherit, per this codebase's no-null style; behaviourally
+    * identical either way.
     */
   def call(
       args: Seq[String],

--- a/tools/src/main/scala/orca/tools/FsTool.scala
+++ b/tools/src/main/scala/orca/tools/FsTool.scala
@@ -8,21 +8,18 @@ import java.nio.file.FileSystems
   * accessor. Reads, writes, and globs files against the flow's working
   * directory.
   *
-  * Paths passed to `read` and `write` are resolved relative to the flow's
-  * working directory unless they are absolute (an absolute path is used as-is).
-  * `list` does not support this: it only accepts a glob *relative* to the
-  * working directory. A leading `/`, or a `.`/`..` path segment, is rejected
-  * with [[orca.OrcaFlowException]] at call time rather than resolved — an
-  * absolute glob could otherwise only ever silently match nothing (see
-  * [[OsFsTool.list]]). `list` accepts a glob pattern (e.g. `src/**/*.scala`)
-  * following the JVM's default glob syntax and returns matching file paths as
-  * strings relative to the same working directory.
+  * `read`/`write` paths are resolved relative to the working directory unless
+  * absolute. `list` instead takes a glob (JVM default syntax, e.g.
+  * `src/**/*.scala`) that must be *relative* to the working directory and
+  * returns matching paths relative to it; a leading `/` or a `.`/`..` segment
+  * is rejected with [[orca.OrcaFlowException]] rather than resolved (see
+  * [[OsFsTool.list]]).
   */
 trait FsTool:
 
-  /** Read the file at `path`. Returns `None` when no file exists at that
-    * location — a recoverable miss the caller can branch on. Throws for
-    * system-level failures (permission, IO).
+  /** Read the file at `path`. `None` when no file exists there — a recoverable
+    * miss the caller can branch on. Throws for system-level failures
+    * (permission, IO).
     */
   def read(path: String): Option[String]
 
@@ -30,9 +27,8 @@ trait FsTool:
   def list(glob: String): List[String]
 
 /** `FsTool` implementation backed by os-lib. Path resolution and glob semantics
-  * are specified on the trait; this class wires them to `os.read` /
-  * `os.write.over` / `os.walk.stream` and narrows the `list` traversal to the
-  * deepest wildcard-free prefix of the glob.
+  * are specified on the trait; the `list` traversal is narrowed to the deepest
+  * wildcard-free prefix of the glob.
   */
 private[orca] class OsFsTool(base: os.Path = os.pwd) extends FsTool:
 
@@ -61,13 +57,10 @@ private[orca] class OsFsTool(base: os.Path = os.pwd) extends FsTool:
     os.Path(path, base)
 
   /** Reject glob shapes `globRoot`'s segment fold can't handle cleanly: a
-    * leading `/` (os-lib throws `InvalidSegment` walking an empty first
-    * segment, or — if that were papered over — the glob would only ever match
-    * nothing, since found paths are always relative to `base`) and any `.`/`..`
-    * segment (os-lib rejects both outright; `..` in particular has no defined
-    * meaning for a glob rooted at `base`). Fails fast with a message naming
-    * `list` and the offending glob, rather than letting os-lib's generic
-    * `IllegalArgumentException` (no `list`-level context) surface instead.
+    * leading `/` (would only ever match nothing, since found paths are relative
+    * to `base`) and any `.`/`..` segment (no defined meaning for a glob rooted
+    * at `base`). Fails fast with a message naming `list`, rather than letting
+    * os-lib's generic `IllegalArgumentException` surface.
     */
   private def validateGlob(glob: String): Unit =
     if glob.startsWith("/") then
@@ -80,9 +73,8 @@ private[orca] class OsFsTool(base: os.Path = os.pwd) extends FsTool:
         s"fs.list: glob must not contain '.' or '..' segments: '$glob'"
       )
 
-  /** Walk only the deepest directory that contains no wildcards — e.g. for
-    * `src/main/**/*.scala` start at `src/main`. Cuts traversal cost for
-    * patterns rooted in a subtree.
+  /** Walk only the deepest wildcard-free directory — e.g. for
+    * `src/main/**/*.scala` start at `src/main` — to cut traversal cost.
     */
   private def globRoot(glob: String): os.Path =
     glob

--- a/tools/src/main/scala/orca/tools/GhJson.scala
+++ b/tools/src/main/scala/orca/tools/GhJson.scala
@@ -6,15 +6,14 @@ import com.github.plokhotnyuk.jsoniter_scala.macros.{
   JsonCodecMaker
 }
 
-// Wire-format DTOs for the `gh`/`git` JSON output that `OsGitHubTool` parses.
-// Kept separate from the public GitHubTool contract: these mirror the GitHub
-// CLI/API shape and change for a different reason than the tool's own API.
-// All `private[orca]` — internal to the tools layer, never part of the public
-// surface (callers see `Comment`/`Issue`/`PrHandle`, not these).
+// Wire-format DTOs for the `gh`/`git` JSON that `OsGitHubTool` parses. Kept
+// separate from the public GitHubTool contract: they mirror the GitHub CLI/API
+// shape and change for a different reason than the tool's own API. Callers see
+// `Comment`/`Issue`/`PrHandle`, not these.
 
 private[tools] case class GhCheck(
-    // CheckRun entries use `status`/`conclusion`; legacy commit-status entries
-    // use only `state`. Both are optional so a single codec handles both.
+    // CheckRun entries use `status`/`conclusion`; commit-status entries use
+    // only `state`. All optional so a single codec handles both.
     status: Option[String] = None,
     conclusion: Option[String] = None,
     state: Option[String] = None,
@@ -30,9 +29,8 @@ private[tools] case class GhCommentJson(
     user: GhUserJson
 ) derives ConfiguredJsonValueCodec
 
-/** Comment JSON with its numeric id, used internally by [[OsGitHubTool]] to
-  * support the PATCH path in `upsertComment`. The id is a GitHub-issued int.
-  * Not exposed publicly — callers see the id-free [[Comment]] type.
+/** Comment JSON with its GitHub-issued numeric id, used by [[OsGitHubTool]] for
+  * the PATCH path in `upsertComment`. Callers see the id-free [[Comment]] type.
   */
 private[tools] case class GhIdentifiedCommentJson(
     id: Long,
@@ -40,10 +38,9 @@ private[tools] case class GhIdentifiedCommentJson(
     user: GhUserJson
 ) derives ConfiguredJsonValueCodec
 
-/** Minimal PR fields returned by `gh pr list --json number,url`. Used by
-  * [[OsGitHubTool.findOpenPr]] to map a head branch to an open PR. Only the URL
-  * is needed: the owner/repo/number are extracted from it via [[PrUrlPattern]]
-  * so no separate `headRefName` field is required.
+/** Minimal PR fields from `gh pr list --json number,url`, used by
+  * [[OsGitHubTool.findOpenPr]] to map a head branch to an open PR. The
+  * owner/repo/number are extracted from the URL via [[PrUrlPattern]].
   */
 private[tools] case class GhPrListJson(
     number: Int,
@@ -55,8 +52,8 @@ private[tools] case class GhUserJson(login: String)
 
 private[tools] case class GhIssueJson(
     title: String,
-    // Issues without a body return `null` from the API; the codec
-    // treats a missing key as None and a null literal as None too.
+    // Issues without a body return `null`; the codec maps both a missing key
+    // and a null literal to None.
     body: Option[String] = None,
     user: GhUserJson,
     state: String

--- a/tools/src/main/scala/orca/tools/GitHubTool.scala
+++ b/tools/src/main/scala/orca/tools/GitHubTool.scala
@@ -11,34 +11,26 @@ import ox.scheduling.Schedule
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
-/** A handle to an open pull request. `derives JsonData` so `stage` can record
-  * and replay a `PrHandle` result — e.g. when a push-and-open-PR stage is the
-  * checkpoint before a CI wait (ADR 0018 §3.2).
+/** A handle to an open pull request. `derives JsonData` so a `stage` can record
+  * and replay a `PrHandle` result (ADR 0018 §3.2).
   */
 case class PrHandle(owner: String, repo: String, number: Int) derives JsonData:
-  /** `<owner>/<repo>#<number>` — the canonical GitHub short-form. Used in
-    * commit messages, PR descriptions (`Closes …`), and log output.
-    */
+  /** Canonical GitHub short-form `<owner>/<repo>#<number>`. */
   def shortRef: String = s"$owner/$repo#$number"
 
-  /** Browser URL for the PR, the same value `gh pr view --web` would open. */
+  /** Browser URL for the PR. */
   def url: String = s"https://github.com/$owner/$repo/pull/$number"
 
-/** Lightweight reference to a GitHub issue. The number is what `gh issue view
-  * <n>` shows; the owner/repo route the API call.
-  */
 case class IssueHandle(owner: String, repo: String, number: Int):
-  /** `<owner>/<repo>#<number>` — the canonical GitHub short-form. Used in
-    * commit messages, PR descriptions (`Closes …`), and log output.
-    */
+  /** Canonical GitHub short-form `<owner>/<repo>#<number>`. */
   def shortRef: String = s"$owner/$repo#$number"
 
 object IssueHandle:
   private val ShortRefPattern =
     """\s*([^/\s]+)/([^#\s]+)#(\d+)\s*""".r
 
-  /** Parse the canonical `<owner>/<repo>#<number>` short-form. Leading and
-    * trailing whitespace are tolerated; everything else is rejected.
+  /** Parse the canonical `<owner>/<repo>#<number>` short-form (surrounding
+    * whitespace tolerated).
     */
   def parse(s: String): Either[String, IssueHandle] =
     s match
@@ -47,9 +39,8 @@ object IssueHandle:
       case _ =>
         Left(s"expected '<owner>/<repo>#<number>', got: '$s'")
 
-  /** Same as [[parse]] but throws [[OrcaFlowException]] on malformed input —
-    * convenient for flow scripts that want the message to bubble up through the
-    * stage error path the way `fail(...)` would.
+  /** Same as [[parse]] but throws [[OrcaFlowException]] on malformed input, so
+    * the message bubbles up through the stage error path.
     */
   def parseOrThrow(s: String): IssueHandle =
     parse(s) match
@@ -58,8 +49,7 @@ object IssueHandle:
 
 case class Comment(author: String, body: String)
 
-/** Snapshot of an issue's top-level fields — the bits a flow typically wants
-  * when triaging or planning from an issue body. Comments live on a separate
+/** Snapshot of an issue's top-level fields. Comments live on a separate
   * endpoint and are read via [[GitHubTool.readIssueComments]].
   */
 case class Issue(
@@ -75,30 +65,23 @@ enum BuildOutcome:
   case Failure
 
 /** @param checkCount
-  *   number of entries in the PR's `statusCheckRollup`, preserved from
-  *   [[buildStatus]] as a structured fact rather than re-derived downstream
-  *   from `log.nonEmpty` (a rendered-string projection fragile to changes in
-  *   how an individual check line happens to render).
+  *   number of entries in the PR's `statusCheckRollup`, kept as a structured
+  *   fact so callers need not re-derive it from the rendered `log`.
   */
 case class BuildStatus(outcome: BuildOutcome, log: String, checkCount: Int)
 
 /** Total classification of a single [[GhCheck]] entry, parsed once at the DTO
-  * boundary so the rest of the tool reasons about a closed, named shape instead
-  * of re-deriving meaning from `status`/`conclusion`/`state` everywhere it
-  * matters.
+  * boundary so the rest of the tool reasons about a closed, named shape.
   *
   *   - [[CheckState.Pending]]: still running, or a required check that hasn't
-  *     reported yet (including GitHub's legacy `EXPECTED` commit status — a
-  *     required external CI context registered but not started).
+  *     reported yet (including GitHub's legacy `EXPECTED` commit status).
   *   - [[CheckState.Success]]: completed with a successful conclusion (or
   *     legacy `state = SUCCESS`).
   *   - [[CheckState.Failure]]: completed with a recognised non-successful
-  *     conclusion (or legacy failure state) — a real CI failure.
+  *     conclusion (or legacy failure state).
   *   - [[CheckState.Unknown]]: a shape [[OsGitHubTool.stateOf]] doesn't
-  *     recognise (e.g. a conclusion/state value GitHub added after this code
-  *     was written). Kept distinct from [[CheckState.Failure]] so it can be
-  *     surfaced in [[BuildStatus.log]] rather than silently read as a confirmed
-  *     CI failure.
+  *     recognise. Kept distinct from [[CheckState.Failure]] so it can be
+  *     surfaced in [[BuildStatus.log]] rather than read as a confirmed failure.
   */
 enum CheckState:
   case Pending
@@ -123,24 +106,23 @@ final class NoCommitsToPr
       "no commits to open a pull request from — push the branch first"
     )
 
-/** Common parent for recoverable [[GitHubTool.waitForBuild]] failure modes —
-  * both manifest as a `Left` rather than a thrown exception, but subclass
-  * `OrcaFlowException` so a caller's `.orThrow` still surfaces them.
+/** Common parent for recoverable [[GitHubTool.waitForBuild]] failure modes:
+  * returned as a `Left`, but subclass `OrcaFlowException` so a caller's
+  * `.orThrow` still surfaces them.
   */
 sealed abstract class BuildWaitFailed(message: String)
     extends OrcaFlowException(message)
 
 /** Returned when the overall `waitForBuild` deadline elapsed while the build
-  * was still pending (real CI was running, just slowly). The caller can decide
-  * whether to keep waiting, escalate to a human, or abort.
+  * was still pending (CI running, just slowly).
   */
 final class BuildTimedOut(timeout: FiniteDuration)
     extends BuildWaitFailed(s"build did not finish within $timeout")
 
 /** Returned when no CI check was ever registered against the PR after
-  * `noChecksGrace`. Typically means the target repo has no CI workflow set up —
-  * distinct from a real CI run that timed out. Surfaced as a separate type so
-  * the caller can give a more actionable error message than "CI didn't finish".
+  * `noChecksGrace` — typically the target repo has no CI workflow set up.
+  * Distinct from [[BuildTimedOut]] so the caller can give a more actionable
+  * error.
   */
 final class NoChecksConfigured(grace: FiniteDuration)
     extends BuildWaitFailed(
@@ -157,9 +139,8 @@ trait GitHubTool:
       WorkspaceWrite
   ): Either[PrCreateFailed, PrHandle]
 
-  /** Replace an existing PR's title and body. Used to refresh a PR opened with
-    * a tentative description (e.g. when only a failing test had landed) once
-    * later work — the fix — is pushed.
+  /** Replace an existing PR's title and body, e.g. to refresh a PR opened with
+    * a tentative description once later work is pushed.
     */
   def updatePr(pr: PrHandle, title: String, body: String)(using
       WorkspaceWrite
@@ -168,9 +149,7 @@ trait GitHubTool:
   /** Fetch the issue's title, body, author, and state. */
   def readIssue(issue: IssueHandle): Issue
 
-  /** Fetch the conversation comments on an issue (the comments the GitHub UI
-    * shows under the body, in posting order).
-    */
+  /** Fetch the conversation comments on an issue, in posting order. */
   def readIssueComments(issue: IssueHandle): List[Comment]
 
   /** Fetch the conversation comments on a PR (issue-style comments, not
@@ -178,24 +157,20 @@ trait GitHubTool:
     */
   def readPrComments(pr: PrHandle): List[Comment]
 
-  /** Post a top-level issue-style comment on a pull request (the comments the
-    * GitHub UI shows under the description, not line-level review comments).
+  /** Post a top-level issue-style comment on a pull request (not a line-level
+    * review comment).
     */
   def writeComment(pr: PrHandle, body: String)(using WorkspaceWrite): Unit
 
-  /** Post a top-level comment on an issue. Used by assess-then-act flows to
-    * surface a follow-up question / critique / rebuff back to the reporter when
-    * no PR will be opened.
-    */
+  /** Post a top-level comment on an issue. */
   def writeComment(issue: IssueHandle, body: String)(using WorkspaceWrite): Unit
 
-  /** Idempotent comment on a PR. Finds the first existing comment whose body
-    * contains `marker`, then updates it via a REST PATCH; if none is found,
-    * creates a new comment with `body` followed by `marker` on a separate line.
-    * The `marker` is an HTML comment the caller embeds (e.g. `<!--
-    * orca:<hash>:<purpose> -->`) so a re-run can locate and update its own
-    * comment instead of duplicating it. Plain [[writeComment]] stays
-    * append-only.
+  /** Idempotent comment on a PR. Updates (via REST PATCH) the first existing
+    * comment whose body contains `marker`, else creates a new one with `body`
+    * followed by `marker` on a separate line. The caller embeds `marker` as an
+    * HTML comment (e.g. `<!-- orca:<hash>:<purpose> -->`) so a re-run finds and
+    * updates its own comment instead of duplicating it. Plain [[writeComment]]
+    * stays append-only.
     */
   def upsertComment(pr: PrHandle, marker: String, body: String)(using
       WorkspaceWrite
@@ -210,11 +185,10 @@ trait GitHubTool:
 
   /** Aggregate status of the checks attached to `pr`.
     *
-    * Contract for the empty-rollup case: implementations MUST treat an empty
-    * check list as `BuildOutcome.Pending`, not `Success`. GitHub returns an
-    * empty rollup for several seconds after a push while the workflow is being
-    * registered — collapsing to `Success` there races with CI startup and
-    * produces a false "build green". The [[waitForBuild]] grace period is what
+    * Implementations MUST treat an empty check list as `BuildOutcome.Pending`,
+    * not `Success`: GitHub returns an empty rollup for several seconds after a
+    * push while the workflow is being registered, so collapsing to `Success`
+    * would produce a false "build green". [[waitForBuild]]'s grace period
     * disambiguates the "no CI configured" case after the fact.
     */
   def buildStatus(pr: PrHandle): BuildStatus
@@ -224,11 +198,10 @@ trait GitHubTool:
     *
     *   - `timeout` is the overall deadline. When it elapses while the build is
     *     still pending, returns `Left(BuildTimedOut)`.
-    *   - `noChecksGrace` catches the "repo has no CI workflow configured" case.
-    *     When no check has registered after that grace, returns
+    *   - `noChecksGrace` catches the "repo has no CI workflow configured" case:
+    *     when no check has registered after that grace, returns
     *     `Left(NoChecksConfigured)` immediately rather than burning the rest of
-    *     `timeout`. Defaults to 90 seconds — long enough to absorb normal CI
-    *     startup, short enough to give a useful error fast.
+    *     `timeout`. Defaults to 90 seconds.
     */
   def waitForBuild(
       pr: PrHandle,
@@ -237,13 +210,9 @@ trait GitHubTool:
   ): Either[BuildWaitFailed, BuildStatus]
 
 /** GitHubTool implementation that shells out to the `gh` CLI via a `CliRunner`.
-  * `waitForBuild` polls `buildStatus` every `pollInterval` until a terminal
-  * outcome or the caller-supplied timeout expires.
   *
   * `events` lets the tool publish a [[OrcaEvent.Step]] when a PR is opened so
-  * the URL surfaces in the event log without the flow developer having to log
-  * it. Optional — defaults to `OrcaListener.noop` so callers that don't wire a
-  * dispatcher (unit tests, ad-hoc scripts) still work.
+  * the URL surfaces in the event log. Defaults to `OrcaListener.noop`.
   */
 private[orca] class OsGitHubTool(
     cli: CliRunner,
@@ -256,9 +225,8 @@ private[orca] class OsGitHubTool(
   import OsGitHubTool.*
 
   /** Retry policy for the idempotent, read-only `gh` invocations ([[ghRead]]):
-    * absorb a transient gh/GitHub failure (dropped connection, 5xx — surfaced
-    * as a non-zero `gh` exit, i.e. an `OrcaFlowException`) under a bounded
-    * backoff before the failure propagates.
+    * absorb a transient gh/GitHub failure (surfaced as a non-zero `gh` exit,
+    * i.e. an `OrcaFlowException`) under a bounded backoff.
     */
   private val readRetryConfig: RetryConfig[Throwable, String] =
     RetryConfig(
@@ -274,10 +242,10 @@ private[orca] class OsGitHubTool(
   def createPr(title: String, body: String)(using
       WorkspaceWrite
   ): Either[PrCreateFailed, PrHandle] =
-    // Inspect exit code + stderr ourselves so we can split the recoverable
-    // "branch already has a PR" / "no commits to push" cases out from
-    // genuine system failures — so this goes through `runGhResult` (which
-    // returns the raw result) rather than `ghRead`/`ghMutate` (which abort).
+    // Inspect exit code + stderr ourselves to split the recoverable "branch
+    // already has a PR" / "no commits to push" cases from genuine system
+    // failures, so this uses `runGhResult` (raw result) rather than
+    // `ghRead`/`ghMutate` (which abort on non-zero exit).
     val result = runGhResult("pr", "create", "--title", title, "--body", body)
     if result.exitCode == 0 then
       val output = result.stdout.trim
@@ -293,8 +261,8 @@ private[orca] class OsGitHubTool(
     else
       val combined = result.stdout + "\n" + result.stderr
       if OsGitHubTool.isPrAlreadyExists(combined) then
-        // R24: look up the existing open PR rather than failing — crash-safe
-        // for flows that may re-enter a "push + open PR" stage.
+        // Look up the existing open PR rather than failing — crash-safe for
+        // flows that may re-enter a "push + open PR" stage.
         findOpenPr(currentBranchGit()) match
           case Some(pr) =>
             events.onEvent(OrcaEvent.Step(s"Reusing existing PR: ${pr.url}"))
@@ -305,9 +273,8 @@ private[orca] class OsGitHubTool(
       else fail("gh pr create", result)
 
   /** Resolve the current branch name via `git rev-parse --abbrev-ref HEAD`.
-    * Used by [[createPr]] to pass the head branch to [[findOpenPr]]. Carries
-    * [[OsGitTool.nonInteractiveEnv]] like every other git invocation in this
-    * codebase, so an ssh/credential prompt on this one path can't hang a flow.
+    * Carries [[OsGitTool.nonInteractiveEnv]] so an ssh/credential prompt can't
+    * hang a flow.
     */
   private def currentBranchGit(): String =
     val result = cli.run(
@@ -318,15 +285,9 @@ private[orca] class OsGitHubTool(
     if result.exitCode == 0 then result.stdout.trim
     else fail("git rev-parse", result)
 
-  /** Find an open PR whose head branch matches `head`, using `gh pr list --head
-    * <head> --state open --json number,url`. Returns the first match, or `None`
-    * when no open PR is found. Uses [[ghRead]] (with retry) because this is an
-    * idempotent read.
-    *
-    * Matching on head-only: this suffices in practice because a branch can only
-    * have one open PR targeting any given base at a time, and `createPr` is
-    * called from within an orca-managed branch where hijacking a stacked PR is
-    * not expected.
+  /** Find the first open PR whose head branch matches `head`, or `None`.
+    * Head-only matching suffices: a branch has at most one open PR per base,
+    * and `createPr` runs from an orca-managed branch.
     */
   private def findOpenPr(head: String): Option[PrHandle] =
     val output = ghRead(
@@ -362,10 +323,9 @@ private[orca] class OsGitHubTool(
     readCommentsAt(issue.owner, issue.repo, issue.number)
 
   def readPrComments(pr: PrHandle): List[Comment] =
-    // GitHub's `/issues/{n}/comments` endpoint returns the conversation
-    // comments for both issues and PRs (a PR is an issue in the data
-    // model). Line-level review comments live at `/pulls/{n}/comments`
-    // and aren't covered here.
+    // The `/issues/{n}/comments` endpoint returns conversation comments for
+    // both issues and PRs. Line-level review comments live at
+    // `/pulls/{n}/comments` and aren't covered here.
     readCommentsAt(pr.owner, pr.repo, pr.number)
 
   private def readCommentsAt(
@@ -385,9 +345,9 @@ private[orca] class OsGitHubTool(
       WorkspaceWrite
   ): Unit =
     // Use the REST API directly rather than `gh pr edit`: the latter runs a
-    // GraphQL metadata query that selects `projectCards` before applying any
-    // edit, which fails outright on repos where GitHub has sunset Projects
-    // (classic). The REST PATCH endpoint doesn't touch projects.
+    // GraphQL query selecting `projectCards`, which fails on repos where GitHub
+    // has sunset Projects (classic). The REST PATCH endpoint doesn't touch
+    // projects.
     val _ = ghMutate(
       "api",
       "-X",
@@ -436,11 +396,9 @@ private[orca] class OsGitHubTool(
     upsertCommentAt(issue.owner, issue.repo, issue.number, marker, body):
       writeComment(issue, _)
 
-  /** Shared upsert logic for both PR and issue targets. Fetches comments with
-    * their ids, finds the first comment containing `marker`, then either
-    * PATCHes that comment or delegates to `createFn` to post a new one. The
-    * body stored (both on create and update) is `<body>\n\n<marker>` so future
-    * re-runs can locate and update the same comment.
+  /** Shared upsert logic for both PR and issue targets. PATCHes the first
+    * comment containing `marker`, else delegates to `createFn`. The stored body
+    * is `<body>\n\n<marker>` so future re-runs can locate the same comment.
     */
   private def upsertCommentAt(
       owner: String,
@@ -458,9 +416,8 @@ private[orca] class OsGitHubTool(
       case None =>
         createFn(markedBody)
 
-  /** Fetch comments for a PR/issue with their numeric ids. Returns an internal
-    * list used only by [[upsertCommentAt]]; ids are GitHub-issued ints and
-    * never leak into the public API.
+  /** Fetch comments for a PR/issue with their GitHub-issued numeric ids, for
+    * [[upsertCommentAt]]. The ids never leak into the public API.
     */
   private def fetchIdentifiedComments(
       owner: String,
@@ -474,9 +431,7 @@ private[orca] class OsGitHubTool(
     )
     readFromString[List[GhIdentifiedCommentJson]](output)
 
-  /** PATCH an existing issue/PR comment body via the REST API. `id` is the
-    * GitHub-issued numeric comment id returned by the comments endpoint.
-    */
+  /** PATCH an existing issue/PR comment body via the REST API. */
   private def patchComment(
       owner: String,
       repo: String,
@@ -507,10 +462,8 @@ private[orca] class OsGitHubTool(
     val log = rollup.statusCheckRollup
       .map: c =>
         val tag = OsGitHubTool.stateOf(c) match
-          // Unrecognised shapes are called out explicitly rather than
-          // rendered as if they were an understood status/conclusion value,
-          // so a human reading the log can tell "we don't understand this"
-          // apart from a real CI failure.
+          // Called out explicitly so the log distinguishes an unrecognised
+          // shape from a real CI failure.
           case CheckState.Unknown(raw) => s"unknown ($raw)"
           case _ =>
             c.conclusion.orElse(c.state).orElse(c.status).getOrElse("?")
@@ -529,16 +482,14 @@ private[orca] class OsGitHubTool(
 
     @scala.annotation.tailrec
     def loop(sawAnyCheck: Boolean): Either[BuildWaitFailed, BuildStatus] =
-      // `buildStatus` already retries a transient gh/GitHub blip internally
-      // ([[ghRead]]); a failure here means the read failed past that budget.
+      // `buildStatus` already retries transient gh/GitHub blips internally; a
+      // failure here means the read failed past that budget.
       val status = buildStatus(pr)
       val now = System.nanoTime()
-      // Sticky watermark: once we've seen even one non-empty rollup, the
-      // "no CI configured" hypothesis is disproven, so a later transient
-      // empty rollup (API blip, retry) can't fire NoChecksConfigured. Driven
-      // by the structured `checkCount`, not `log.nonEmpty` — the rendered
-      // log is a projection that could in principle render empty for a
-      // present check, silently breaking this watermark.
+      // Sticky watermark: once one non-empty rollup is seen, the "no CI
+      // configured" hypothesis is disproven, so a later transient empty rollup
+      // can't fire NoChecksConfigured. Driven by structured `checkCount`, not
+      // the rendered `log`.
       val seen = sawAnyCheck || status.checkCount > 0
       if status.outcome != BuildOutcome.Pending then Right(status)
       else if !seen && now >= noChecksDeadline then
@@ -550,27 +501,26 @@ private[orca] class OsGitHubTool(
 
     loop(sawAnyCheck = false)
 
-  /** Run `gh` once and return the raw [[CliResult]]. The single point every gh
-    * invocation funnels through. Used directly only by [[createPr]], which
-    * inspects the exit code itself to split recoverable cases from failures;
-    * every other call goes through [[ghRead]] or [[ghMutate]].
+  /** Run `gh` once and return the raw [[CliResult]] — the single point every gh
+    * invocation funnels through. Used directly only by [[createPr]] (which
+    * inspects the exit code itself); other calls go through [[ghRead]] or
+    * [[ghMutate]].
     */
   private def runGhResult(args: String*): CliResult =
     cli.run("gh" +: args, cwd = workDir)
 
-  /** Run `gh` once, returning stdout or aborting on a non-zero exit. The shared
-    * abort-on-failure logic behind [[ghRead]] and [[ghMutate]] — NOT called
-    * directly, so the read-vs-mutate (and thus retry-vs-no-retry) choice is
-    * always explicit at the call site via one of those two wrappers.
+  /** Run `gh` once, returning stdout or aborting on a non-zero exit. Not called
+    * directly — always via [[ghRead]] or [[ghMutate]], so the retry-vs-no-retry
+    * choice is explicit at each call site.
     */
   private def runGh(args: String*): String =
     val result = runGhResult(args*)
     if result.exitCode != 0 then fail(s"gh ${args.mkString(" ")}", result)
     result.stdout
 
-  /** Abort with a uniform `"<label> failed (exit N): <stderr>"` message for an
-    * unrecoverable CLI failure. Callers handle the EXPECTED non-zero exits (PR
-    * already exists, no commits) as `Left`s before reaching here.
+  /** Abort with a uniform message for an unrecoverable CLI failure. Callers
+    * handle the expected non-zero exits (PR already exists, no commits) as
+    * `Left`s before reaching here.
     */
   private def fail(label: String, result: CliResult): Nothing =
     throw OrcaFlowException(
@@ -578,51 +528,44 @@ private[orca] class OsGitHubTool(
     )
 
   /** Run an **idempotent read** (`api` GET, `pr view`, `pr list`), retrying a
-    * transient failure under [[readRetryConfig]]. Safe to retry precisely
-    * because it has no side effect.
+    * transient failure under [[readRetryConfig]] — safe because it has no side
+    * effect.
     */
   private def ghRead(args: String*): String =
     retry(readRetryConfig)(runGh(args*))
 
-  /** Run a **mutating** `gh` call (`pr comment`, `pr edit`, …) exactly once —
-    * deliberately NOT retried: a retry after a lost response would double the
-    * side effect (duplicate comment / PR edit). Use [[ghRead]] for reads. The
-    * one-PR-per-branch idempotency for `pr create` is handled separately in
-    * [[createPr]] (it inspects the exit code itself), which is why it doesn't
-    * go through this wrapper.
+  /** Run a **mutating** `gh` call exactly once, deliberately NOT retried: a
+    * retry after a lost response would double the side effect (duplicate
+    * comment / PR edit). `pr create` idempotency is handled separately in
+    * [[createPr]].
     */
   private def ghMutate(args: String*): String = runGh(args*)
 
 private[orca] object OsGitHubTool:
 
-  /** Default retry for idempotent read-only `gh` calls (`readIssue`,
-    * `read*Comments`, `buildStatus`): ride out a transient gh/GitHub failure
-    * with a bounded exponential backoff before giving up. Injectable on the
-    * constructor so tests can use a no-delay schedule.
+  /** Default retry for idempotent read-only `gh` calls: bounded exponential
+    * backoff. Injectable on the constructor so tests can use a no-delay
+    * schedule.
     */
   val defaultReadRetry: Schedule =
     Schedule.exponentialBackoff(1.second).maxRetries(4)
 
   // --- Recoverable `gh pr create` stderr/stdout predicates ---
   //
-  // gh has no machine-readable signal for "an open PR already exists" or "the
-  // branch has no commits", so `createPr` splits these recoverable cases from a
-  // system failure by matching gh's human-readable output (combined
-  // stdout+stderr). gh's messages are UI text, not a contract, so the matchers
-  // are centralised here — named, documented, unit-tested — and kept lenient so
-  // a wording tweak doesn't reclassify a recoverable failure as fatal. Each
-  // case-folds its input internally, so callers pass gh's output verbatim.
+  // gh has no machine-readable signal for these cases, so `createPr` matches
+  // gh's human-readable output (combined stdout+stderr). That output is UI
+  // text, not a contract, so the matchers are centralised, unit-tested, and
+  // kept lenient. Each case-folds its input, so callers pass gh's output
+  // verbatim.
 
   /** True when `gh pr create` reported that an open PR already exists for the
-    * head branch — the case `createPr` resolves by reusing the existing PR
-    * (R24). Takes gh's combined stdout+stderr verbatim and case-folds itself.
+    * head branch — the case `createPr` resolves by reusing the existing PR.
     */
   private[tools] def isPrAlreadyExists(combined: String): Boolean =
     combined.toLowerCase.contains("already exists")
 
-  /** True when `gh pr create` reported there is nothing to open a PR from (the
-    * branch has no commits ahead of base, or hasn't been pushed yet).
-    * Case-folds internally (see [[isPrAlreadyExists]]).
+  /** True when `gh pr create` reported there is nothing to open a PR from (no
+    * commits ahead of base, or branch not pushed).
     */
   private[tools] def isNoCommitsToPr(combined: String): Boolean =
     val lower = combined.toLowerCase
@@ -630,11 +573,10 @@ private[orca] object OsGitHubTool:
 
   private val StatusCompleted = "COMPLETED"
   private val SuccessfulConclusions = Set("SUCCESS", "NEUTRAL", "SKIPPED")
-  // The CheckRun `conclusion` values GitHub documents beyond the successful
-  // ones above. Named explicitly (rather than "anything that isn't a
-  // success") so a conclusion value GitHub adds later doesn't silently read
-  // as a confirmed failure — it falls through to `CheckState.Unknown`
-  // instead, see `stateOf`.
+  // The documented failing CheckRun `conclusion` values. Named explicitly
+  // (rather than "anything that isn't a success") so a conclusion GitHub adds
+  // later falls through to `CheckState.Unknown` rather than reading as a
+  // confirmed failure.
   private val FailureConclusions = Set(
     "FAILURE",
     "CANCELLED",
@@ -645,21 +587,18 @@ private[orca] object OsGitHubTool:
   )
   private val LegacyStateSuccess = "SUCCESS"
   private val LegacyStatePending = "PENDING"
-  // GitHub's legacy commit-status / GraphQL `StatusState` enum: a required
-  // status context that has been registered but hasn't reported yet —
-  // distinct from `PENDING` (which is actively running). Both mean "not
-  // resolved yet" from the caller's perspective.
+  // Legacy `StatusState`: a required status context registered but not yet
+  // reported — distinct from `PENDING` (actively running); both mean "not
+  // resolved yet".
   private val LegacyStateExpected = "EXPECTED"
   private val LegacyFailureStates = Set("FAILURE", "ERROR")
 
-  /** Reduce a heterogeneous list of check entries to a single outcome. Empty
-    * list is treated as Pending: just after a push, GitHub returns zero checks
-    * for several seconds while the workflow is being registered, so collapsing
-    * empty to Success would race with CI startup and surface as a false "build
-    * green" before CI even ran. Callers that hit a repo with no CI configured
-    * at all will see Pending until `waitForBuild`'s `noChecksGrace` window
-    * elapses, at which point it converts to `NoChecksConfigured` — a more
-    * actionable diagnostic than a generic "build didn't finish" timeout.
+  /** Reduce a list of check entries to a single outcome. Empty list is treated
+    * as Pending: just after a push GitHub returns zero checks for several
+    * seconds while the workflow registers, so collapsing empty to Success would
+    * surface a false "build green". A repo with no CI at all stays Pending
+    * until `waitForBuild`'s `noChecksGrace` converts it to
+    * `NoChecksConfigured`.
     */
   def aggregateOutcome(checks: List[GhCheck]): BuildOutcome =
     if checks.isEmpty then BuildOutcome.Pending
@@ -667,17 +606,15 @@ private[orca] object OsGitHubTool:
       val states = checks.map(stateOf)
       if states.contains(CheckState.Pending) then BuildOutcome.Pending
       else if states.forall(_ == CheckState.Success) then BuildOutcome.Success
-      // `CheckState.Failure` and the unrecognised `CheckState.Unknown` both
-      // collapse to `BuildOutcome.Failure` here — `BuildOutcome` has no
-      // fourth case — but `Unknown` stays distinguishable in
-      // `BuildStatus.log` (see `buildStatus`) rather than vanishing.
+      // Both `Failure` and unrecognised `Unknown` collapse to
+      // `BuildOutcome.Failure` here, but `Unknown` stays distinguishable in
+      // `BuildStatus.log`.
       else BuildOutcome.Failure
 
   /** Classify a single check entry into a total [[CheckState]]. `GhCheck`
     * mirrors two GitHub shapes (CheckRun's `status`/`conclusion`, and the
-    * legacy commit-status/GraphQL `state`) in one flat DTO; this is the one
-    * place that maps either shape to a state the rest of the tool reasons
-    * about.
+    * legacy commit-status `state`) in one flat DTO; this is the one place that
+    * maps either shape to a [[CheckState]].
     */
   private[tools] def stateOf(c: GhCheck): CheckState =
     if c.status.exists(_ != StatusCompleted) then CheckState.Pending
@@ -694,9 +631,8 @@ private[orca] object OsGitHubTool:
     else if c.state.exists(LegacyFailureStates.contains) then CheckState.Failure
     else CheckState.Unknown(rawShape(c))
 
-  /** Render a check's raw field values for [[CheckState.Unknown]]'s payload —
-    * enough to diagnose an unrecognised shape from the log without needing to
-    * re-fetch the rollup.
+  /** Render a check's raw field values for [[CheckState.Unknown]]'s payload, so
+    * an unrecognised shape is diagnosable from the log without re-fetching.
     */
   private def rawShape(c: GhCheck): String =
     s"status=${c.status.getOrElse("none")} conclusion=${c.conclusion

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -11,11 +11,10 @@ case class CommitInfo(hash: String, message: String, author: String)
 /** Which diff semantics [[GitTool.diffVsBase]] should produce.
   *
   *   - [[DiffMode.MergeBase]] (default) — three-dot syntax (`base...HEAD`).
-  *     Matches what GitHub renders in a PR view: changes the current branch
-  *     introduces since it forked off `base`, ignoring any commits `base` has
-  *     gained since the fork. The right choice for `summarisePr`.
+  *     Changes the current branch introduces since it forked off `base`,
+  *     ignoring commits `base` gained since the fork (GitHub's PR view).
   *   - [[DiffMode.Direct]] — two-dot syntax (`base..HEAD`). Compares HEAD
-  *     directly to `base`'s current tip (fast-forward preview, rebase status).
+  *     directly to `base`'s current tip.
   */
 enum DiffMode:
   case MergeBase
@@ -29,8 +28,7 @@ case class Worktree(path: os.Path, branch: String)
 /** Returned in the `Left` of [[GitTool.createBranch]] when a branch by that
   * name already exists. Distinguished from system-level git failures (binary
   * missing, IO error) which surface as thrown `OrcaFlowException`. Subclasses
-  * `OrcaFlowException` so callers can `.orThrow` to recover the throwing
-  * behaviour when the case is genuinely unexpected.
+  * `OrcaFlowException` so callers can `.orThrow` when the case is unexpected.
   */
 class BranchAlreadyExists(name: String)
     extends OrcaFlowException(s"branch '$name' already exists")
@@ -49,19 +47,18 @@ class NothingToCommit
     extends OrcaFlowException("nothing to commit; working tree is clean")
 
 /** Returned in the `Left` of [[GitTool.push]] when the remote rejected the push
-  * for a reason the caller might recover from. Two shapes, with different
+  * for a reason the caller might recover from. Two shapes with different
   * recovery contracts:
   *
   *   - [[PushFailure.NonFastForward]]: the remote branch moved on since the
-  *     local history was based (`non-fast-forward` / `fetch first`). The caller
-  *     can recover by fetching and rebasing.
+  *     local history was based (`non-fast-forward` / `fetch first`).
+  *     Recoverable by fetching and rebasing.
   *   - [[PushFailure.RemoteDeclined]]: the remote refused the push by policy —
   *     a server-side hook, branch protection, or a required review (e.g.
-  *     GitHub's `GH006`) — not by history divergence. Fetching and rebasing
-  *     will not help; retrying the same push will fail the same way.
+  *     GitHub's `GH006`) — not history divergence. Rebasing will not help.
   *
-  * Other push failures (auth, network, bad refspec) aren't locally recoverable
-  * and remain thrown as `OrcaFlowException`.
+  * Other push failures (auth, network, bad refspec) remain thrown as
+  * `OrcaFlowException`.
   */
 sealed abstract class PushFailure(message: String)
     extends OrcaFlowException(message)
@@ -107,35 +104,32 @@ trait GitTool:
   def checkout(name: String)(using WorkspaceWrite): Either[BranchNotFound, Unit]
 
   /** Stage all tracked + untracked changes, then commit them with `message`.
-    * Flow scripts rarely want to manage the index separately, so staging is
-    * part of the commit contract. Returns `Left(NothingToCommit)` when the tree
-    * is already clean.
+    * Staging is part of the commit contract. Returns `Left(NothingToCommit)`
+    * when the tree is already clean.
     */
   def commit(message: String)(using
       WorkspaceWrite
   ): Either[NothingToCommit, Unit]
 
   /** Commit exactly the given path: stage it, then `git commit -m <message> --
-    * <path>`. The commit pathspec makes the single-path scope a property of the
-    * command itself — anything else dirty or untracked in the working tree
-    * stays out of the commit, in contrast to [[commit]], whose `add -A` sweeps
-    * the whole tree into the commit. Throws `OrcaFlowException` when the path
-    * has no changes to commit or on system-level failures.
+    * <path>`. The commit pathspec scopes the commit to the single path —
+    * anything else dirty or untracked stays out, in contrast to [[commit]]'s
+    * `add -A`. Throws `OrcaFlowException` when the path has no changes to
+    * commit or on system-level failures.
     */
   def commitOnly(path: os.Path, message: String)(using WorkspaceWrite): Unit
 
   /** Force-stage `path` (`git add -f`), bypassing `.gitignore`. The stage
     * runtime uses this to stage its progress-log file even when the project
     * gitignores `.orca/`, so the log travels with the branch (ADR 0018 §2.1).
-    * Always a single explicit path — never a glob or directory — so nothing
-    * else gitignored is swept in.
+    * Always a single explicit path — never a glob or directory.
     */
   def forceAdd(path: os.Path)(using WorkspaceWrite): Unit
 
-  /** Stage `path` (`git add`), respecting `.gitignore`. Unlike [[forceAdd]]
-    * this does NOT bypass the ignore: an ignored path is left unstaged, so the
-    * settings-file commit (ADR 0019) never punches a `.orca/`-ignored file into
-    * history. Always a single explicit path — never a glob or directory.
+  /** Stage `path` (`git add`), respecting `.gitignore`: an ignored path is left
+    * unstaged, so the settings-file commit (ADR 0019) never punches a
+    * `.orca/`-ignored file into history. Always a single explicit path — never
+    * a glob or directory.
     */
   def add(path: os.Path)(using WorkspaceWrite): Unit
 
@@ -149,18 +143,16 @@ trait GitTool:
   def currentBranch(): String
 
   /** True when git ignores `relPath` relative to the working directory (`git
-    * check-ignore`). READ-ONLY; no [[WorkspaceWrite]] needed. Best-effort:
-    * `false` whenever the probe cannot answer (not a git repo, git unavailable)
-    * — callers use this for warnings, never for decisions that must be right.
+    * check-ignore`). READ-ONLY. Best-effort: `false` whenever the probe cannot
+    * answer (not a git repo, git unavailable) — callers use this for warnings,
+    * never for decisions that must be right.
     */
   def isIgnored(relPath: os.SubPath): Boolean
 
   /** Best-effort name of the repository's default branch, read from the
-    * remote's recorded `origin/HEAD` (`refs/remotes/origin/HEAD` →
-    * `origin/<name>` → `<name>`). READ-ONLY; no [[WorkspaceWrite]] needed.
-    * Returns `None` when there is no remote, `origin/HEAD` is unset, or any
-    * error occurs — callers treat that as "no extra protected branch beyond
-    * main/master" (ADR 0018).
+    * remote's recorded `origin/HEAD`. READ-ONLY. Returns `None` when there is
+    * no remote, `origin/HEAD` is unset, or any error occurs — callers treat
+    * that as "no extra protected branch beyond main/master" (ADR 0018).
     */
   def defaultBranch(): Option[String]
 
@@ -170,17 +162,13 @@ trait GitTool:
     * committed progress log) intact, so a re-run resumes cleanly (ADR 0018
     * §2.5).
     *
-    * '''`reset --hard` does NOT remove untracked files''' — only tracked
-    * changes (modified/staged/deleted) are discarded. A failed stage's *new*
-    * files (the typical shape of agent output: freshly created source/test
-    * files) survive this call and remain in the working tree. They aren't lost
-    * — the next `flow(...)` invocation's start-of-run `ensureClean` stashes the
-    * dirty tree (`git stash push -u`, which does sweep untracked paths), so the
-    * leftovers end up co-mingled into that stash alongside any genuine user
-    * WIP, rather than discarded outright. If leftovers should instead be
-    * deleted at teardown, that needs a scoped clean of run-touched paths (not
-    * blanket `git clean -fd`, which would also delete pre-existing untracked
-    * user files) — an intentionally separate decision, not made by this method.
+    * '''`reset --hard` does NOT remove untracked files''' — a failed stage's
+    * newly created files survive in the working tree. They aren't lost: the
+    * next run's start-of-run `ensureClean` stashes the dirty tree (`git stash
+    * push -u`), sweeping them into that stash alongside any genuine user WIP.
+    * Deleting leftovers at teardown would need a scoped clean of run-touched
+    * paths (blanket `git clean -fd` would also delete pre-existing untracked
+    * user files) — an intentionally separate decision, not made here.
     */
   def resetHard()(using WorkspaceWrite): Unit
 
@@ -193,22 +181,18 @@ trait GitTool:
     * `base` would carry (three-dot, merge-base semantics — GitHub's PR view).
     * `mode = Direct` compares HEAD directly to `base`'s tip.
     *
-    * Typical bases: `"origin/HEAD"` (the remote's default branch, set
-    * automatically on `git clone`), `"main"`, `"master"`. For a freshly `git
-    * init`ed local repo, `origin/HEAD` may not be set — see [[defaultBase]] for
-    * a probe-with-fallback helper.
+    * Typical bases: `"origin/HEAD"`, `"main"`, `"master"`. `origin/HEAD` may
+    * not be set on a freshly `git init`ed repo — see [[defaultBase]] for a
+    * probe-with-fallback helper.
     */
   def diffVsBase(base: String, mode: DiffMode = DiffMode.MergeBase): String
 
   /** Best-effort default base ref for "branch vs main" diffs. Tries
-    * `origin/HEAD` first (set automatically by `git clone`; resolves to the
-    * remote's default branch), then falls back to `origin/main` and
-    * `origin/master` — common defaults on a freshly `git init`ed + pushed repo
-    * where `origin/HEAD` was never set.
+    * `origin/HEAD` first, then falls back to `origin/main` and `origin/master`.
     *
-    * Throws `OrcaFlowException` when none of these refs exist — typically means
-    * the repo has no remote configured, in which case the caller can substitute
-    * a local branch name (e.g. `"main"`).
+    * Throws `OrcaFlowException` when none of these refs exist — typically the
+    * repo has no remote configured, in which case the caller can substitute a
+    * local branch name (e.g. `"main"`).
     */
   def defaultBase(): String
 
@@ -217,13 +201,11 @@ trait GitTool:
   /** Verify the working tree is clean. If it isn't, `git stash push` with the
     * supplied message and emit a `Step` event so the user can recover the
     * changes later via `git stash pop`. Used by resumable flows that need a
-    * known-clean starting state without silently destroying the user's
-    * work-in-progress.
+    * known-clean starting state without destroying the user's work-in-progress.
     *
-    * The stash-recovery hint rides on the `Step` reaching the run's dispatcher
-    * — a custom `GitTool` (e.g. via [[orca.flow]]'s `git` override) built
-    * without wiring in the run's listener loses this hint, and the user never
-    * learns to `git stash pop`.
+    * The stash-recovery hint rides on the `Step` reaching the run's dispatcher:
+    * a custom `GitTool` built without the run's listener loses the hint, and
+    * the user never learns to `git stash pop`.
     *
     * Returns `true` if a stash was created, `false` if the tree was already
     * clean.
@@ -272,14 +254,12 @@ trait GitTool:
   ): String
 
 /** `GitTool` implementation that shells out to the `git` CLI via os-lib.
-  * Contract semantics (commit auto-staging, push upstream setup, diff vs HEAD,
-  * worktree branch-exists handling) are specified on the trait; this class
-  * handles the subprocess plumbing and the worktree-list parser.
+  * Contract semantics are specified on the trait; this class handles the
+  * subprocess plumbing and the worktree-list parser.
   *
-  * `events` lets the tool publish [[OrcaEvent.Step]]s for the operations the
-  * user cares to see in the event log (branch switches, commits, pushes). It's
-  * optional — defaults to `OrcaListener.noop` so callers that don't yet wire a
-  * dispatcher still work.
+  * `events` publishes [[OrcaEvent.Step]]s for operations shown in the event log
+  * (branch switches, commits, pushes). Optional — defaults to
+  * `OrcaListener.noop`.
   */
 private[orca] class OsGitTool(
     workDir: os.Path = os.pwd,
@@ -380,13 +360,10 @@ private[orca] class OsGitTool(
     )
 
   def push()(using WorkspaceWrite): Either[PushFailure, Unit] =
-    // `-u origin HEAD` sets upstream on first push and is a no-op afterwards.
-    // We need to inspect stderr on failure to distinguish the recoverable
-    // cases (non-fast-forward, remote-declined) from auth/network errors, so
-    // use `gitProc` (which returns the result) rather than `git` (which
-    // throws on non-zero). For a github remote `pushArgs` appends a
-    // last-resort credential helper so the push authenticates even when git
-    // has none configured (see its doc).
+    // Uses `gitProc` (returns the result) rather than `git` (throws on
+    // non-zero) so failure stderr can be inspected to split the recoverable
+    // cases (non-fast-forward, remote-declined) from auth/network errors.
+    // `pushArgs` appends a last-resort github credential helper (see its doc).
     val originUrl = gitConfigGet("remote.origin.url")
     val envToken = sys.env
       .get("GH_TOKEN")
@@ -398,13 +375,9 @@ private[orca] class OsGitTool(
       Right(())
     else
       val stderr = result.err.text()
-      // Checked in this order — non-fast-forward before remote-declined —
-      // but the order isn't load-bearing: `push()` targets a single ref per
-      // call, so its stderr carries at most one rejection reason (history
-      // divergence vs. a policy decline are mutually exclusive causes for
-      // the same ref), making a stderr that matches both patterns an
-      // unrealistic shape in practice, not a real ambiguity this ordering
-      // resolves.
+      // Order isn't load-bearing: `push()` targets a single ref per call, so
+      // its stderr carries at most one rejection reason (divergence vs. policy
+      // decline are mutually exclusive for the same ref).
       if OsGitTool.isNonFastForward(stderr) then
         Left(new PushFailure.NonFastForward(stderr.trim))
       else if OsGitTool.isRemoteDeclined(stderr) then
@@ -579,12 +552,10 @@ private[orca] class OsGitTool(
     else None
 
   private def git(args: String*): String =
-    // Route through QuietProc so git's stderr ("Switched to a new
-    // branch", "Already on 'main'", etc.) is captured rather than
-    // leaked to the parent terminal where it would tear the renderer's
-    // status row. The branch-state changes themselves still surface in
-    // the event log via the OrcaEvent.Step calls in the public methods
-    // above; we don't need git's verbose stderr for that.
+    // Route through QuietProc so git's stderr ("Switched to a new branch",
+    // etc.) is captured rather than leaked to the parent terminal, where it
+    // would tear the renderer's status row. Branch-state changes surface in the
+    // event log via the OrcaEvent.Step calls in the public methods above.
     val result = gitProc("git" +: args)
     if result.exitCode != 0 then fail(s"git ${args.mkString(" ")}", result)
     result.out.text()
@@ -594,26 +565,23 @@ private[orca] object OsGitTool:
   // --- Recoverable-failure stderr predicates ---
   //
   // git exits non-zero with a uniform code for many distinct failures, so the
-  // ONLY way to split a recoverable case (caller gets a `Left`) from a system
+  // only way to split a recoverable case (caller gets a `Left`) from a system
   // failure (we throw) is to match git's human-readable stderr. These strings
   // are git porcelain, not a stable contract, so the matchers are centralised
-  // here — named, documented, and unit-tested — rather than inlined at the call
-  // sites, so the fragile coupling lives in one place. Each is intentionally
-  // lenient (substring, any matching phrase) so a wording tweak across git
-  // versions doesn't silently reclassify a recoverable failure as fatal.
+  // here — named and unit-tested. Each is intentionally lenient (substring) so
+  // a wording tweak across git versions doesn't reclassify a recoverable
+  // failure as fatal.
 
-  /** True when `git push` stderr indicates the remote branch moved on since the
-    * local history was based (`non-fast-forward` / `fetch first`) — the caller
-    * can resolve this by fetching and rebasing. Distinguished from
-    * [[isRemoteDeclined]], where rebasing would not help.
+  /** True when `git push` stderr indicates the remote branch moved on
+    * (`non-fast-forward` / `fetch first`) — resolvable by fetching and
+    * rebasing, unlike [[isRemoteDeclined]].
     */
   private[tools] def isNonFastForward(stderr: String): Boolean =
     stderr.contains("non-fast-forward") || stderr.contains("fetch first")
 
   /** True when `git push` stderr indicates the remote refused the push by
     * policy — a server-side hook, branch protection, or a required review (e.g.
-    * GitHub's `GH006`) — rather than by history divergence. Fetching and
-    * rebasing will not make this push succeed.
+    * GitHub's `GH006`). Rebasing will not make this push succeed.
     */
   private[tools] def isRemoteDeclined(stderr: String): Boolean =
     stderr.contains("hook declined") ||
@@ -622,19 +590,17 @@ private[orca] object OsGitTool:
 
   /** True when `git worktree add` stderr indicates the target path or branch is
     * already a worktree (`… already exists` / `… is already checked out`) — the
-    * recoverable case. Anything else is a system failure.
+    * recoverable case.
     */
   private[tools] def isWorktreeAlreadyPresent(stderr: String): Boolean =
     stderr.contains("already exists") || stderr.contains("already checked out")
 
   /** Environment that forces git — and any ssh it spawns — to run
-    * non-interactively. A flow subprocess has no usable TTY, so an HTTPS
-    * username/password prompt or an SSH key-passphrase prompt would block the
-    * flow forever rather than failing. `GIT_TERMINAL_PROMPT=0` disables the
-    * former; `-o BatchMode=yes` on the ssh command disables the latter. The ssh
-    * command is appended to (not replaced) so a user's custom `GIT_SSH_COMMAND`
-    * is preserved. These merge onto the inherited environment, so `PATH` etc.
-    * are unaffected.
+    * non-interactively. A flow subprocess has no usable TTY, so a credential or
+    * key-passphrase prompt would block the flow forever rather than failing.
+    * `GIT_TERMINAL_PROMPT=0` disables the former; `-o BatchMode=yes` on the ssh
+    * command disables the latter. The ssh command is appended (not replaced) so
+    * a user's custom `GIT_SSH_COMMAND` is preserved.
     */
   private[tools] val nonInteractiveEnv: Map[String, String] =
     val baseSsh = sys.env.getOrElse("GIT_SSH_COMMAND", "ssh")
@@ -660,11 +626,10 @@ private[orca] object OsGitTool:
 
   /** The `git push` argv. For a github.com origin it appends a credential
     * helper scoped to github.com HTTPS, so the push authenticates even when git
-    * has no helper configured. It is *appended* (after any config-file helpers,
-    * so a credential setup the user already has still wins) and added *only*
-    * for github remotes (a github.com-scoped helper is meaningless elsewhere).
-    * When a token is in the environment it is used directly (see
-    * [[githubHelper]]), otherwise the `gh` CLI's own auth resolution is used.
+    * has no helper configured. Appended after any config-file helpers, so a
+    * user's existing credential setup still wins. When a token is in the
+    * environment it is used directly (see [[githubHelper]]), otherwise the `gh`
+    * CLI's own auth resolution is used.
     */
   private[tools] def pushArgs(
       originUrl: Option[String],

--- a/tools/src/main/scala/orca/util/JsonSchemaGen.scala
+++ b/tools/src/main/scala/orca/util/JsonSchemaGen.scala
@@ -14,39 +14,33 @@ import sttp.tapir.docs.apispec.schema.TapirSchemaToJsonSchema
   *   - every object node carries `additionalProperties: false`;
   *   - every object's `required` array lists every key in `properties`.
   *
-  * Tapir's default output is JSON-Schema-valid but more permissive than
-  * OpenAI's strict mode, so codex rejects it with `invalid_json_schema`.
-  * Optional fields and fields with Scala-side defaults (`List` → `Nil`, etc.)
-  * are marked nullable via `markOptionsAsNullable = true`, so requiring them is
-  * safe — the agent emits `null` or an empty list rather than omitting.
+  * Tapir's default output is more permissive than strict mode, so codex rejects
+  * it with `invalid_json_schema`. Optional fields and fields with Scala-side
+  * defaults are marked nullable via `markOptionsAsNullable = true`, so
+  * requiring them is safe — the agent emits `null` or an empty list rather than
+  * omitting.
   *
   * A `Map[String, _]` field has no fixed key set, so it can't be expressed in
-  * OpenAI's strict dialect (which requires every object's exact key set up
-  * front); such a field makes this throw [[orca.OrcaFlowException]] rather than
-  * emit a schema the backend would reject anyway, later and more opaquely.
+  * the strict dialect; such a field makes this throw [[orca.OrcaFlowException]]
+  * rather than emit a schema the backend would reject later and more opaquely.
   *
-  * The strict post-processing applies to EVERY backend, not just the two
-  * OpenAI-dialect ones — which is why it lives here, at the backend-agnostic
-  * `resultAs[O]` seam, rather than in a backend module. The one schema string
-  * per `O` is both passed to native schema flags (claude `--json-schema`, codex
+  * The post-processing applies to every backend, which is why it lives at the
+  * backend-agnostic `resultAs[O]` seam. The one schema string per `O` is both
+  * passed to native schema flags (claude `--json-schema`, codex
   * `--output-schema`) and embedded into the prompt template all backends
   * receive (`Prompts`; pi/gemini/opencode have no native flag). Strict-mode
-  * output is still standard, valid JSON Schema — just more constrained — so the
-  * strictest dialect any backend requires is safe as the single common form,
-  * and it keeps the native flag, the prompt text, and the parse step in
-  * agreement about the expected shape.
+  * output is still valid JSON Schema, just more constrained, so the strictest
+  * dialect any backend requires is safe as the single common form.
   */
 object JsonSchemaGen:
   def apply[O](using schema: Schema[O]): String =
     val jsonSchema =
       TapirSchemaToJsonSchema(schema, markOptionsAsNullable = true)
     // Tapir stamps `$schema: .../draft/2020-12/schema` on its output; the
-    // claude CLI (observed on 2.1.207) validates `--json-schema` input with a
-    // validator that has no 2020-12 meta-schema registered and rejects any
-    // schema DECLARING that dialect ("no schema with key or ref ..."), before
-    // the turn starts. No consumer needs the declaration — codex/claude
-    // interpret the strict subset regardless, and prompt-embedded schemas
-    // carry their meaning in the nodes themselves — so strip it.
+    // claude CLI (observed on 2.1.207) has no 2020-12 meta-schema registered
+    // and rejects any schema declaring that dialect ("no schema with key or ref
+    // ...") before the turn starts. No consumer needs the declaration, so strip
+    // it.
     toOpenAiStrict(jsonSchema.asJson).mapObject(_.remove("$schema")).noSpaces
 
   /** Walk every object subtree and inject the two OpenAI-strict-mode
@@ -72,14 +66,12 @@ object JsonSchemaGen:
     else recursed
 
   /** Tapir renders a `Map[String, T]` field as an object node whose
-    * `additionalProperties` is `T`'s own sub-schema (there's no `properties`
-    * key — the keys are unbounded). OpenAI's strict structured-output mode
-    * requires `additionalProperties: false` on every object node, which would
-    * silently discard the value-type constraint if we overwrote it — so instead
-    * fail fast here, at schema-generation time, with a message naming the
-    * actual fix, rather than letting the non-strict schema reach codex/claude
-    * and bounce back as an opaque `invalid_json_schema` after a stage has
-    * already run.
+    * `additionalProperties` is `T`'s own sub-schema (no `properties` key — the
+    * keys are unbounded). Strict mode requires `additionalProperties: false` on
+    * every object node, which would silently discard the value-type constraint
+    * if overwritten — so fail fast here, with a message naming the fix, rather
+    * than letting the schema bounce back as an opaque `invalid_json_schema`
+    * after a stage has already run.
     */
   private def rejectMapShapedAdditionalProperties(obj: JsonObject): Unit =
     obj("additionalProperties").filterNot(_.isBoolean).foreach { _ =>
@@ -92,10 +84,9 @@ object JsonSchemaGen:
     }
 
   /** A node is an "object schema" — eligible for the strict-mode constraints —
-    * when it declares `"type": "object"` AND carries a `"properties"` object.
-    * The properties check rules out empty/marker objects like
-    * `{"type":"object"}` which would otherwise get `additionalProperties:
-    * false` with no purpose.
+    * when it declares `"type": "object"` AND carries a non-empty `"properties"`
+    * object. The properties check rules out empty/marker objects like
+    * `{"type":"object"}`.
     */
   private def isObjectSchemaNode(obj: JsonObject): Boolean =
     obj("type").flatMap(_.asString).contains("object") &&
@@ -105,10 +96,9 @@ object JsonSchemaGen:
     val props =
       obj("properties").flatMap(_.asObject).getOrElse(JsonObject.empty)
     val allKeys = props.keys.toList
-    // A non-boolean `additionalProperties` (the Map[String, T] shape) was
-    // already rejected by `rejectMapShapedAdditionalProperties` above, so
-    // anything reaching here is either absent or already `true`/`false` —
-    // don't clobber an explicit boolean, only fill in the missing default.
+    // The Map[String, T] shape was already rejected above, so
+    // `additionalProperties` here is absent or already boolean — don't clobber
+    // an explicit boolean, only fill in the missing default.
     val withAdditional =
       if obj.contains("additionalProperties") then obj
       else obj.add("additionalProperties", Json.False)

--- a/tools/src/main/scala/orca/util/OrcaDebug.scala
+++ b/tools/src/main/scala/orca/util/OrcaDebug.scala
@@ -1,13 +1,12 @@
 package orca.util
 
 /** One place that knows which `ORCA_*` debug environment variables exist. The
-  * flags are read once at object initialization (env vars don't change
-  * mid-process), so the booleans are safe to pin in cold paths.
+  * flags are read once at object initialization, so the booleans are safe to
+  * pin in cold paths.
   *
   * Display-side env vars (`NO_COLOR`, `ORCA_NO_ANIMATION`, `CI`) live in
-  * `orca.runner.terminal.TerminalInteraction`'s companion since they're
-  * terminal-rendering specific; this object covers only the debug/diagnostic
-  * switches that more than one module reads.
+  * `orca.runner.terminal.TerminalInteraction`'s companion; this object covers
+  * only the debug/diagnostic switches that more than one module reads.
   */
 private[orca] object OrcaDebug:
 

--- a/tools/src/main/scala/orca/util/PromptResource.scala
+++ b/tools/src/main/scala/orca/util/PromptResource.scala
@@ -8,24 +8,15 @@ private[util] case class ParsedPrompt(
     body: String
 )
 
-/** Loads prompt templates from classpath resources. The convention is one `.md`
-  * file per template, placed under `src/main/resources/<pkg>/prompts/<name>.md`
-  * — keeping the prose out of `.scala` files makes the text easier to edit (no
-  * `.stripMargin` margins, no double-escaped quotes) and treats prompts as the
-  * user-facing artifacts they are.
+/** Loads prompt templates from classpath resources, one `.md` file per template
+  * under `src/main/resources/<pkg>/prompts/<name>.md`.
   *
-  * Templates use `{{name}}` placeholders. Dynamic values supplied at call time
-  * go through [[render]]; static fragments shared between templates (e.g. a
-  * common rules block) should be substituted once at object initialization to
-  * keep per-call cost minimal.
+  * Templates use `{{name}}` placeholders. Dynamic values go through [[render]];
+  * static fragments shared between templates should be substituted once at
+  * object initialization. Templates needing richer metadata carry a YAML-ish
+  * frontmatter block between two `---` markers; use [[loadWithMetadata]].
   *
-  * Templates that need richer metadata (e.g. a reviewer agent with a
-  * machine-readable description for an LLM-driven selector) carry a YAML-ish
-  * frontmatter block between two `---` markers; use [[loadWithMetadata]] to
-  * parse it.
-  *
-  * Missing-resource failures surface as `RuntimeException` at object-init time
-  * — desirable fail-fast behaviour for what is effectively a packaging mistake.
+  * Missing resources fail fast as `RuntimeException` at object-init time.
   */
 private[orca] object PromptResource:
 
@@ -111,14 +102,13 @@ private[orca] object PromptResource:
       if c == '\\' && i + 1 < s.length then
         val next = s.charAt(i + 1)
         val toAppend = next match
-          case 'n'   => "\n"
-          case 't'   => "\t"
-          case 'r'   => "\r"
-          case '"'   => "\""
-          case '\\'  => "\\"
+          case 'n'  => "\n"
+          case 't'  => "\t"
+          case 'r'  => "\r"
+          case '"'  => "\""
+          case '\\' => "\\"
           case other =>
-            // Preserve unknown sequences verbatim — caller can deal with them.
-            "\\" + other
+            "\\" + other // preserve unknown sequences verbatim
         val _ = sb.append(toAppend)
         i += 2
       else

--- a/tools/src/main/scala/orca/util/RawJson.scala
+++ b/tools/src/main/scala/orca/util/RawJson.scala
@@ -6,21 +6,18 @@ import com.github.plokhotnyuk.jsoniter_scala.core.{
   JsonWriter
 }
 
-/** Opaque wrapper for "a JSON subtree, held in its serialized form". Used for
-  * message fields whose shape varies too much to be worth modelling — tool
-  * inputs, MCP tool arguments, structured-output payloads, MCP tool results —
-  * and for the progress log's type-erased stage results, where embedding the
-  * subtree verbatim (rather than as an escaped string) keeps the file readable
-  * when debugging. The codec reads and writes the raw bytes straight through
-  * without re-parsing.
+/** Opaque wrapper for a JSON subtree held in its serialized form. Used for
+  * message fields whose shape varies too much to model (tool inputs, MCP
+  * arguments and results, structured-output payloads) and for the progress
+  * log's type-erased stage results, where embedding the subtree verbatim keeps
+  * the file readable. The codec reads and writes raw bytes without re-parsing.
   *
-  * Public (not `private[orca]`) because it appears in the public progress-log
-  * surface: [[orca.progress.StageEntry.resultJson]], reachable through the
-  * `ProgressStore` a `flow(...)` caller may supply.
+  * Public because it appears in the progress-log surface
+  * ([[orca.progress.StageEntry.resultJson]]).
   *
-  * `nullValue` is the literal four-character string `"null"` — i.e., a missing
-  * field decodes indistinguishably from an actual JSON `null`. Fields that need
-  * to detect absence must wrap `RawJson` in `Option`.
+  * `nullValue` is the string `"null"`, so a missing field decodes
+  * indistinguishably from a JSON `null`; fields that must detect absence wrap
+  * `RawJson` in `Option`.
   */
 opaque type RawJson = String
 
@@ -31,24 +28,20 @@ object RawJson:
 
   given JsonValueCodec[RawJson] with
     def decodeValue(in: JsonReader, default: RawJson): RawJson =
-      // `readRawValAsBytes` returns the next JSON value verbatim, including
-      // whitespace around nested structures; we re-interpret as UTF-8.
+      // The next JSON value verbatim, re-interpreted as UTF-8.
       new String(
         in.readRawValAsBytes(),
         java.nio.charset.StandardCharsets.UTF_8
       )
 
     def encodeValue(x: RawJson, out: JsonWriter): Unit =
-      // Writing from the String directly avoids an intermediate
-      // `getBytes` allocation — jsoniter's writer converts once.
       out.writeRawVal(x.value.getBytes(java.nio.charset.StandardCharsets.UTF_8))
 
     def nullValue: RawJson = "null"
 
-  /** For `Schema.derived` on container types (the progress log's
-    * [[orca.progress.StageEntry]]). Those containers are persistence DTOs, not
-    * LLM-facing output types, so this schema is never rendered into an agent's
-    * `--json-schema`; `string` is the closest honest primitive for "an opaque
-    * serialized subtree".
+  /** For `Schema.derived` on container types (e.g.
+    * [[orca.progress.StageEntry]]). These are persistence DTOs, never rendered
+    * into an agent's `--json-schema`; `string` is the closest primitive for an
+    * opaque serialized subtree.
     */
   given sttp.tapir.Schema[RawJson] = sttp.tapir.Schema.string

--- a/tools/src/main/scala/orca/util/TextUtil.scala
+++ b/tools/src/main/scala/orca/util/TextUtil.scala
@@ -1,15 +1,10 @@
 package orca.util
 
-/** Small cross-package text helpers that don't belong to any one feature — kept
-  * here (alongside [[TextWrap]]) so callers across the flow/runner/backend
-  * packages share one implementation rather than re-deriving these one-liners.
-  */
+/** Small cross-package text helpers that don't belong to any one feature. */
 private[orca] object TextUtil:
 
   /** A throwable's human message: its `getMessage` (or the class name when
-    * blank), optionally collapsed to its first line. Used by `stage` (first
-    * line, for a tidy one-line `✖`) and the flow boundary (whole message, so
-    * multi-line diagnostics like opencode's start-failure stderr survive).
+    * blank), optionally collapsed to its first line.
     */
   def throwableMessage(e: Throwable, firstLineOnly: Boolean = false): String =
     val msg = Option(e.getMessage).filter(_.nonEmpty)
@@ -17,24 +12,18 @@ private[orca] object TextUtil:
       if firstLineOnly then msg.flatMap(_.linesIterator.nextOption()) else msg
     picked.getOrElse(e.getClass.getName)
 
-  /** Pluralize an English noun by appending "s" when `n != 1`. The same count
-    * goes into the rendered string (`"1 review comment"` / `"3 review
-    * comments"`), so this also encodes the count. Centralised here so callers
-    * across packages produce consistent wording.
+  /** Render `n` with an English noun, appending "s" when `n != 1` (`"1 review
+    * comment"` / `"3 review comments"`).
     */
   def pluralize(n: Int, singular: String): String =
     s"$n $singular${if n == 1 then "" else "s"}"
 
-  /** Collapse every whitespace run (including newlines) to a single space — the
-    * one-physical-line guard shared by the settings-file renderer and the
-    * discovery narration.
-    */
+  /** Collapse every whitespace run (including newlines) to a single space. */
   def collapseWhitespace(s: String): String = s.replaceAll("""\s+""", " ")
 
   /** Collapse each newline run (with adjacent whitespace) to a single space,
-    * leaving other whitespace intact — the settings-file one-physical-line
-    * contract for command lines. Shared by the renderer (writing `key =
-    * command` lines) and discovery assembly (the commands the first run
-    * executes), so the executed command and the written line are identical.
+    * leaving other whitespace intact. Enforces the settings-file
+    * one-physical-line contract for command lines, so the executed command and
+    * the written `key = command` line stay identical.
     */
   def collapseNewlines(s: String): String = s.replaceAll("""\s*\R\s*""", " ")

--- a/tools/src/main/scala/orca/util/TextWrap.scala
+++ b/tools/src/main/scala/orca/util/TextWrap.scala
@@ -1,30 +1,22 @@
 package orca.util
 
-/** Simple word-wrapping helper. Used to format multi-line event-log messages
-  * (review comments etc.) so they fit a fixed display width with a hanging
-  * indent on continuation lines, regardless of which channel renders them.
+/** Word-wrapping helper for multi-line event-log messages (review comments
+  * etc.), with a hanging indent on continuation lines.
   *
-  * Wrapping happens at flow time, not render time, because a single
-  * channel-agnostic wrap width keeps output predictable across terminal / Slack
-  * / HTTP. Channels that want a different width can post-process; the default
-  * 76 columns leaves room for the `▶ ` glyph in the terminal at typical
-  * stage-depth indents.
+  * Wrapping happens at flow time, not render time, so a single channel-agnostic
+  * width keeps output predictable across terminal / Slack / HTTP; channels
+  * wanting a different width post-process. The default 76 columns leaves room
+  * for the `▶ ` glyph at typical stage-depth indents.
   */
 private[orca] object TextWrap:
 
   /** Wrap `s` to `maxWidth` characters, breaking at whitespace. Continuation
-    * lines are prefixed with `continuation` so they sit under the first
-    * character of the message rather than under any leading glyph the renderer
-    * adds. Existing `\n`s in `s` are respected — each pre-existing line wraps
-    * independently.
+    * lines are prefixed with `continuation`. Existing `\n`s are respected —
+    * each pre-existing line wraps independently.
     *
     *   - Pure whitespace input collapses to "".
-    *   - A single token longer than `maxWidth` is emitted on its own line and
-    *     overflows; we don't break inside a word.
-    *
-    * Defaults are tuned for a typical 80-column terminal at moderate
-    * stage-depth indent: 76 chars wide, 2-space hanging indent (the width of
-    * the renderer's `▶ ` glyph + space).
+    *   - A single token longer than `maxWidth` overflows on its own line; words
+    *     are never broken.
     */
   def wrap(
       s: String,
@@ -40,10 +32,8 @@ private[orca] object TextWrap:
       maxWidth: Int,
       continuation: String
   ): String =
-    // Split off any leading whitespace and preserve it on the first
-    // emitted line — `s.split("\\s+")` would otherwise drop it,
-    // collapsing intentional indents in the source string (e.g. the
-    // "  suggestion:" prefix the caller used to align under a glyph).
+    // Preserve leading whitespace on the first line — `split("\\s+")` would
+    // drop it, collapsing intentional source indents.
     val (leading, rest) = line.span(_.isWhitespace)
     val tokens = rest.split("\\s+").filter(_.nonEmpty)
     if tokens.isEmpty then ""

--- a/tools/src/test/scala/orca/InStageTest.scala
+++ b/tools/src/test/scala/orca/InStageTest.scala
@@ -1,10 +1,6 @@
 package orca
 
-/** Tests for the InStage capability type (ADR 0018 §2.2).
-  *
-  * Positive test: verifies that runtime code (in package `orca`) can mint and
-  * use an InStage token.
-  */
+/** Tests for the InStage capability type (ADR 0018 §2.2). */
 class InStageTest extends munit.FunSuite:
 
   test(

--- a/tools/src/test/scala/orca/OrcaDirTest.scala
+++ b/tools/src/test/scala/orca/OrcaDirTest.scala
@@ -22,9 +22,7 @@ class OrcaDirTest extends munit.FunSuite:
   test("second ensureCache call leaves existing marker files untouched"):
     val wd = TempDirs.dir()
     val cache = OrcaDir.ensureCache(wd)
-    // Canary edits: a rewrite on the second call would restore the pinned
-    // contents, so surviving canaries prove the files are written only when
-    // absent.
+    // Surviving canaries prove the files are written only when absent.
     os.write.over(cache / ".gitignore", "canary-gitignore")
     os.write.over(cache / "CACHEDIR.TAG", "canary-tag")
     assertEquals(OrcaDir.ensureCache(wd), cache)

--- a/tools/src/test/scala/orca/agents/BackendTagCodecTest.scala
+++ b/tools/src/test/scala/orca/agents/BackendTagCodecTest.scala
@@ -1,19 +1,15 @@
 package orca.agents
 
-/** Machine-checked source of truth for [[BackendTag]]'s wire codec (6B.1).
-  * `wireName` is the on-disk/wire representation persisted into
-  * [[orca.progress.SessionRecord.backend]] — it must stay pinned to the CURRENT
-  * (pre-codec) `toString` of every case, or every already-persisted session log
-  * silently strands on the next resume. Mirrors `EnforcementTableTest`'s "the
-  * rendered/frozen contract lives elsewhere; this test is what keeps it honest"
-  * shape.
+/** Machine-checked source of truth for [[BackendTag]]'s wire codec. `wireName`
+  * is the on-disk representation persisted into
+  * [[orca.progress.SessionRecord.backend]]; it must stay pinned to each case's
+  * frozen value, or already-persisted session logs strand on the next resume.
   */
 class BackendTagCodecTest extends munit.FunSuite:
 
   test("wireName is pinned to each case's pre-codec toString value"):
-    // Frozen literals, not `case.toString` — a test that compared against
-    // `.toString` would silently stop pinning anything the moment a case is
-    // renamed, exactly the failure mode this codec exists to prevent.
+    // Frozen literals, not `case.toString`: comparing against `.toString` would
+    // stop pinning the moment a case is renamed — the failure this test guards.
     val expected = Map(
       BackendTag.ClaudeCode -> "ClaudeCode",
       BackendTag.Codex -> "Codex",
@@ -25,8 +21,7 @@ class BackendTagCodecTest extends munit.FunSuite:
       BackendTag.values.map(t => t -> t.wireName).toMap,
       expected
     )
-    // Every case is covered above — a new case added without updating this
-    // table fails here, not silently.
+    // A new case added without updating the table above fails here.
     assertEquals(BackendTag.values.toSet, expected.keySet)
 
   test("fromWireName round-trips every case's wireName"):

--- a/tools/src/test/scala/orca/agents/BaseAgentTest.scala
+++ b/tools/src/test/scala/orca/agents/BaseAgentTest.scala
@@ -39,9 +39,9 @@ class BaseAgentTest extends munit.FunSuite:
       AgentBackend.ClosedMessage
     )
 
-  // An unsupported output shape (a Map[String, _] field, which
-  // JsonSchemaGen rejects) must fail at `resultAs[O]` construction — before
-  // any stage runs — not remotely, after `.run()` spawns a backend process.
+  // An unsupported output shape (a Map[String, _] field, rejected by
+  // JsonSchemaGen) must fail at `resultAs[O]` construction, before any stage
+  // runs — not remotely, after `.run()` spawns a backend process.
   test("resultAs[O] with a Map field throws OrcaFlowException at construction"):
     val tool = new StubTool(StubBackend)
     val thrown = intercept[orca.OrcaFlowException]:
@@ -61,11 +61,10 @@ class BaseAgentTest extends munit.FunSuite:
       AgentBackend.ClosedMessage
     )
 
-  // The closed latch lives on the shared backend, so it must survive the two
-  // ways a leaked handle can re-derive a "fresh" object after close: the
-  // copyTool builders (`withName`/`withConfig`/model accessors — a new Agent
-  // instance over the same backend) and a resultAs gateway built before the
-  // close and invoked after (a DefaultAgentCall holding the backend directly).
+  // The closed latch lives on the shared backend, so it survives the two ways a
+  // leaked handle re-derives a "fresh" object after close: copyTool builders (a
+  // new Agent over the same backend) and a resultAs gateway built before close
+  // and invoked after.
   test("a copyTool-derived handle after close() throws OrcaFlowException"):
     val tool = new StubTool(new RecordingCloseBackend)
     tool.close()
@@ -88,10 +87,9 @@ class BaseAgentTest extends munit.FunSuite:
       AgentBackend.ClosedMessage
     )
 
-  // The runtime's internal cheap turns (branch naming, commit messages)
-  // consume their reply and re-surface it as the caller's own Step event —
-  // streaming the turn too would print the same text twice (e.g. a stray
-  // `● <branch-slug>` line right before "Switched to a new branch ...").
+  // The runtime's internal cheap turns (branch naming, commit messages) consume
+  // their reply and re-surface it as the caller's own Step event; streaming the
+  // turn too would print the same text twice.
   test(
     "cheapOneShot suppresses the turn's display events; TokensUsed still flows"
   ):
@@ -119,10 +117,9 @@ class BaseAgentTest extends munit.FunSuite:
       s"cost accounting must still flow on a quiet turn: $events"
     )
 
-  // Pins finding 6.3's fix: `config` is `Option[AgentConfig]`, not the old
-  // `AgentConfig.default` eq-sentinel. An explicit `Some(...)` wholly
-  // replaces the tool-level config (no per-field merge); omission (`None`)
-  // inherits it — see `BaseAgent.effectiveConfig`.
+  // An explicit `Some(...)` config wholly replaces the tool-level config (no
+  // per-field merge); omission (`None`) inherits it — see
+  // `BaseAgent.effectiveConfig`.
   test(
     "run(config = Some(AgentConfig())) wholly replaces the tool-level config"
   ):
@@ -161,10 +158,9 @@ class BaseAgentTest extends munit.FunSuite:
         StubInteraction
       ):
     val name: String = "stub"
-    // Mirrors every production implementation: a NEW instance over the SAME
-    // backend — so the copyTool-after-close test exercises the real leak
-    // shape (a fresh Agent object whose only tie to the closed flow is the
-    // shared backend), not a trivial same-instance alias.
+    // A new instance over the same backend, as production implementations do, so
+    // the copyTool-after-close test exercises the real leak shape rather than a
+    // same-instance alias.
     protected def copyTool(
         config: AgentConfig = toolConfig,
         name: String = name,

--- a/tools/src/test/scala/orca/agents/DefaultPromptsTest.scala
+++ b/tools/src/test/scala/orca/agents/DefaultPromptsTest.scala
@@ -13,10 +13,9 @@ class DefaultPromptsTest extends munit.FunSuite:
     assert(prompt.contains("no markdown code fences"))
 
   test("autonomous delivery rules follow the declared structured-output mode"):
-    // Tool-mode backends (claude with --json-schema) receive their reply via
-    // a CLI-injected StructuredOutput tool — telling the model "raw JSON only"
-    // there contradicts the wire and steers weak models into malformed tool
-    // calls. RawText backends keep the raw-JSON contract verbatim.
+    // Tool-mode backends receive their reply via a CLI-injected StructuredOutput
+    // tool, so "raw JSON only" would contradict the wire; RawText backends keep
+    // the raw-JSON contract verbatim.
     val raw = DefaultPrompts
       .autonomous(input, schema, config, StructuredOutputMode.RawText)
     val tool = DefaultPrompts
@@ -26,7 +25,6 @@ class DefaultPromptsTest extends munit.FunSuite:
     assert(tool.contains("calling the StructuredOutput tool"))
     assert(tool.contains("top-level fields as the tool's arguments"))
     assert(!tool.contains("raw JSON only"))
-    // Same task framing either way — only the delivery rules differ.
     assert(tool.contains(input) && tool.contains(schema))
 
   test("retry prompt includes the failed response, error, and raw-JSON rules"):
@@ -43,7 +41,6 @@ class DefaultPromptsTest extends munit.FunSuite:
     val prompt = DefaultPrompts.interactive(input, schema, config)
     assert(prompt.contains(input))
     assert(prompt.contains(schema))
-    // Explicit negative checks: the stream-json path uses --json-schema for
-    // validation, not a sentinel + transcript scrape.
+    // The stream-json path validates via --json-schema, not a sentinel marker.
     assert(!prompt.contains("<<<"))
     assert(!prompt.contains("marker"))

--- a/tools/src/test/scala/orca/agents/ResponseParserTest.scala
+++ b/tools/src/test/scala/orca/agents/ResponseParserTest.scala
@@ -5,8 +5,7 @@ import com.github.plokhotnyuk.jsoniter_scala.macros.ConfiguredJsonValueCodec
 case class ParsedSample(name: String, count: Int)
     derives ConfiguredJsonValueCodec
 
-// Mirrors the reviewer verdict shape (`{"issues":[...]}`) from the live-test
-// crash log, so the regression test below reproduces the exact bytes.
+// Reviewer verdict shape (`{"issues":[...]}`) for the input-envelope regression.
 case class IssuesSample(issues: List[String]) derives ConfiguredJsonValueCodec
 
 class ResponseParserTest extends munit.FunSuite:
@@ -47,13 +46,10 @@ class ResponseParserTest extends munit.FunSuite:
     assert(!e.getMessage.contains("+---"))
     assert(!e.getMessage.contains("\n"))
 
-  // Regression: opencode (reviewer routed through claude-haiku) echoed its own
-  // structured-output tool's argument envelope — the tool's sole parameter is
-  // named `input` — back as the agent response instead of the bare schema
-  // value. Live-test finding B: `{"input":"{\"issues\":[]}"}` aborted the
-  // whole flow with a MalformedAgentOutputException.
+  // Regression: some backends echo their structured-output tool's argument
+  // envelope (sole parameter named `input`) instead of the bare schema value,
+  // e.g. `{"input":"{\"issues\":[]}"}`. Unwrap the lone `input` key.
   test("unwraps a lone input-key envelope whose value is a JSON string"):
-    // The exact payload observed in the opencode live-test crash log.
     val observed = """{"input":"{\"issues\":[]}"}"""
     assertEquals(
       ResponseParser.parse[IssuesSample](observed),

--- a/tools/src/test/scala/orca/backend/AppendBoundedTest.scala
+++ b/tools/src/test/scala/orca/backend/AppendBoundedTest.scala
@@ -21,8 +21,6 @@ class AppendBoundedTest extends munit.FunSuite:
     // would blow the cap, forcing the oldest out.
     val big = "x" * (MaxBytes / 2 + 10)
     val after = appendBounded(Vector(big, big), "newest")
-    // Single structural assertion: fails informatively if the byte loop
-    // trims too much (e.g. down to just "newest") or too little.
     assertEquals(after, Vector(big, "newest"))
 
   test("keeps at least one line even if it alone exceeds the byte cap"):

--- a/tools/src/test/scala/orca/backend/ConversationEventConformanceTest.scala
+++ b/tools/src/test/scala/orca/backend/ConversationEventConformanceTest.scala
@@ -5,8 +5,6 @@ import orca.backend.ConversationEvent.*
 /** Self-test for [[ConversationEventConformance.assertGrammar]] — pins the
   * helper's own verdicts so a regression in the checker (which every backend's
   * scripted tests trust) fails here rather than silently passing bad sequences.
-  * munit's `assert`/`fail` both throw `FailException <: AssertionError`, so an
-  * expected rejection is an intercepted `AssertionError`.
   */
 class ConversationEventConformanceTest extends munit.FunSuite:
 

--- a/tools/src/test/scala/orca/backend/ConversationsTest.scala
+++ b/tools/src/test/scala/orca/backend/ConversationsTest.scala
@@ -110,13 +110,8 @@ class ConversationsTest extends munit.FunSuite:
     "a plain OrcaFlowException propagates verbatim through drainAndCommit " +
       "(no relabelling)"
   ):
-    // Same shape as the AgentTurnFailed test above, but with a plain
-    // OrcaFlowException — the exact type the deleted branch used to catch
-    // and rewrap as "$backendName CLI failed: ...". Both tests throw through
-    // the identical drainAndCommit code path; this one is the one that would
-    // actually fail if the relabelling branch were reintroduced, since a
-    // plain OrcaFlowException (unlike AgentTurnFailed) matches its catch
-    // clause.
+    // A plain OrcaFlowException must reach the caller unchanged — not rewrapped
+    // with a backend-specific "CLI failed" prefix.
     val client = SessionId.fresh[BackendTag.Codex.type]
     val support = SessionSupport
       .durable[BackendTag.Codex.type](IdScheme.ServerMinted, _ => false)
@@ -181,9 +176,8 @@ class ConversationsTest extends munit.FunSuite:
     assertEquals(thrown, cancelled)
 
   test("AssistantToolCall emits OrcaEvent.ToolUse with the raw input"):
-    // The drain hands the raw JSON through unchanged; the terminal listener
-    // does summarisation so non-terminal listeners (structured logs, Slack)
-    // see the full input.
+    // The drain passes the raw JSON through unchanged; summarisation happens in
+    // the terminal listener, so other listeners see the full input.
     val recorder = new RecordingListener
     val conv = new ScriptedConversation(
       List(
@@ -346,12 +340,10 @@ class ConversationsTest extends munit.FunSuite:
   test(
     "structured mode flushes an unfinished trailing buffer on a clean close"
   ):
-    // Structured mode, clean drain, but the stream ended with deltas and no
-    // closing TurnEnd. The payload is always a COMPLETED turn (the withheld
-    // one, dropped by finishNormally); an unfinished trailing buffer never
-    // became the payload, so finishNormally flushes it rather than dropping
-    // prose. Here there is no completed turn at all, so only the partial
-    // surfaces.
+    // Structured mode, clean drain, stream ended with deltas and no closing
+    // TurnEnd. The JSON payload is always a completed turn; an unfinished
+    // trailing buffer is never the payload, so it flushes rather than being
+    // dropped. Here there is no completed turn, so only the partial surfaces.
     val recorder = new RecordingListener
     val conv = new ScriptedConversation(
       List(
@@ -370,12 +362,11 @@ class ConversationsTest extends munit.FunSuite:
   test(
     "structured mode: an abnormal mid-stream end flushes withheld + partial"
   ):
-    // Turn 1 completes (and is withheld, awaiting the next turn to decide if
-    // it's the payload); turn 2 streams deltas, then the stream crashes before
-    // its TurnEnd. On an abnormal end nothing is reliably the payload, so both
-    // the withheld completed turn AND the partial are flushed — the old drain
-    // dropped the partial (and only surfaced turn 1 via a finally-side
-    // closeTurn). The crash is rethrown verbatim.
+    // Turn 1 completes (withheld, awaiting the next turn to decide if it's the
+    // payload); turn 2 streams deltas, then the stream crashes before its
+    // TurnEnd. On an abnormal end nothing is reliably the payload, so both the
+    // withheld completed turn and the partial flush. The crash is rethrown
+    // verbatim.
     val recorder = new RecordingListener
     val crash = new OrcaFlowException("stream died mid-turn")
     val conv = new CrashingConversation(

--- a/tools/src/test/scala/orca/backend/SessionSupportTest.scala
+++ b/tools/src/test/scala/orca/backend/SessionSupportTest.scala
@@ -112,11 +112,7 @@ class SessionSupportTest extends munit.FunSuite:
     assert(s.willContinue(client) && probed == List("srv-1"))
 
   test("willContinue (durable): a throwing probe is 'won't continue'"):
-    // No isSafe re-check on the resolved wire id here: every id that reaches
-    // the bookkeeping does so through `register`/`commitAfterDrain`, both of
-    // which already validate it — the unsafe-id defense is pinned at those
-    // two tests below. This test covers the other absence case: a probe that
-    // throws.
+    // A probe that throws counts as "won't continue".
     val s = SessionSupport.durable[BackendTag.Codex.type](
       IdScheme.ServerMinted,
       _ => throw RuntimeException("boom")
@@ -143,13 +139,9 @@ class SessionSupportTest extends munit.FunSuite:
   test(
     "register: an invalid wire id records nothing (skip-don't-throw guard)"
   ):
-    // The central guard covering the interactive + rehydration paths: an empty
-    // (or otherwise unsafe) wire id must be logged-and-dropped, never recorded,
-    // so the NEXT call can't dispatch `resume ""`. It must NOT throw — the
-    // completed session output / setup must survive a bookkeeping failure.
-    // The SessionSupport-level test suffices; `Agent.registerResumeWireId`
-    // funnels straight into this same `register`, so no separate harness is
-    // needed to exercise the rehydration path's guard.
+    // An empty (or otherwise unsafe) wire id must be dropped, never recorded, so
+    // the next call can't dispatch `resume ""`. It must not throw — completed
+    // session output must survive a bookkeeping failure.
     val s = SessionSupport.durable[BackendTag.Codex.type](
       IdScheme.ServerMinted,
       _ => true

--- a/tools/src/test/scala/orca/backend/SupervisedBackend.scala
+++ b/tools/src/test/scala/orca/backend/SupervisedBackend.scala
@@ -3,24 +3,17 @@ package orca.backend
 import ox.{Ox, supervised}
 
 /** Test scaffold for backend constructors that require `using Ox` (opencode
-  * pins a shared `serve` process to the Ox scope's lifetime at construction,
-  * which forces that constraint onto every test that instantiates it). Opens a
-  * `supervised:` scope, invokes the supplied factory, yields the backend to the
-  * test body, and `close()`s it in the body's `finally` — BEFORE the scope
-  * joins its forks, mirroring the production flow teardown. Opencode depends on
-  * that ordering: its server drain forks block on non-interruptible reads that
-  * only the close-triggered process kill unblocks, so a scope exit without the
-  * close deadlocks the join.
-  *
-  * Per-suite `withBackend` wrappers stay readable as one-liners around this
-  * helper; the shared scope is also what interactive backends need to call
-  * `runInteractive(...)(using Ox)`.
+  * pins a shared `serve` process to the Ox scope's lifetime). Opens a
+  * `supervised:` scope, invokes the factory, yields the backend to the test
+  * body, and `close()`s it in the body's `finally` — before the scope joins its
+  * forks. That ordering is load-bearing: opencode's server-drain forks block on
+  * non-interruptible reads that only the close-triggered process kill unblocks,
+  * so a scope exit without the close deadlocks the join.
   */
 private[orca] object SupervisedBackend:
 
-  /** `body` is a context function so the scope's `Ox` is visible inside it —
-    * interactive backends need it to call `runInteractive(...)(using Ox)`.
-    * Autonomous bodies simply ignore the given.
+  /** `body` receives the scope's `Ox` so interactive backends can call
+    * `runInteractive(...)(using Ox)`.
     */
   def using[B <: AgentBackend[?], T](make: Ox ?=> B)(body: Ox ?=> B => T): T =
     supervised:

--- a/tools/src/test/scala/orca/backend/SystemPromptComposerTest.scala
+++ b/tools/src/test/scala/orca/backend/SystemPromptComposerTest.scala
@@ -11,8 +11,7 @@ class SystemPromptComposerTest extends munit.FunSuite:
     assertEquals(out, Some(gitRule))
 
   test("read-only turn with neither config nor hint returns None"):
-    // Read-only turns can't commit, so the git rule is omitted — and with no
-    // systemPrompt or hint there's nothing left to compose.
+    // Read-only turns can't commit, so the git rule is omitted; nothing else to compose.
     val out = SystemPromptComposer.combine(
       AgentConfig().copy(tools = ToolSet.ReadOnly),
       None
@@ -44,8 +43,7 @@ class SystemPromptComposerTest extends munit.FunSuite:
     assertEquals(out, Some("be terse"))
 
   test("selfManagedGit escape hatch omits the git rule"):
-    // `agent.withSelfManagedGit` flips this flag; the runtime then stays out of
-    // the agent's git so the agent may commit/push itself.
+    // With this flag the runtime stays out of the agent's git, so the agent may commit/push itself.
     val out = SystemPromptComposer.combine(
       AgentConfig().copy(selfManagedGit = true),
       extraHint = None
@@ -53,8 +51,7 @@ class SystemPromptComposerTest extends munit.FunSuite:
     assertEquals(out, None)
 
   test("joins config + hint + git rule with blank lines, in order"):
-    // Pins both the order (config, hint, rule) and the separator (\\n\\n) —
-    // backends rely on blank lines so the agent reads distinct paragraphs.
+    // Backends rely on the blank-line separator so the agent reads distinct paragraphs.
     val out = SystemPromptComposer.combine(
       AgentConfig().copy(systemPrompt = Some("be terse")),
       extraHint = Some("the hint")

--- a/tools/src/test/scala/orca/backend/TurnGrammarTest.scala
+++ b/tools/src/test/scala/orca/backend/TurnGrammarTest.scala
@@ -9,24 +9,16 @@ import ox.supervised
 /** Base-level grammar suite: drives a minimal fake [[ForkedConversation]]
   * through raw `ConversationEvent`-level sequences (bypassing all wire parsing)
   * and asserts the emitted stream satisfies
-  * [[ConversationEventConformance.assertGrammar]]. This is where the turn-
-  * boundary grammar is pinned ONCE, for all five backends at once — the base
-  * class guarantees it by construction, so the per-backend suites only need to
-  * check they translate protocol frames into the right payloads.
-  *
-  * It covers the exact sequences each broken driver used to route around before
-  * task 4A moved enforcement into `EventQueue.enqueue` + the settle helpers:
-  * claude's deltas-then-error, codex's tool-only turn, gemini's activity-free
-  * result end, claude's suppressed `ask_user`-only turn, and pi's
-  * failWith-after-activity — plus the abnormal-termination carve-out the
-  * grammar deliberately still allows.
+  * [[ConversationEventConformance.assertGrammar]]. Pins the turn-boundary
+  * grammar once for all backends, since the base class guarantees it by
+  * construction.
   */
 class TurnGrammarTest extends munit.FunSuite:
 
   /** Fake driver whose `handleLine` interprets each scripted stdout line as a
-    * direct `ConversationEvent`-level command. Everything runs on the reader
-    * thread inside `handleLine`, exactly as a real driver's enqueues do — so
-    * the `openTurn` single-writer confinement is exercised faithfully.
+    * direct `ConversationEvent`-level command. Runs on the reader thread inside
+    * `handleLine`, like a real driver, so `openTurn` single-writer confinement
+    * is exercised faithfully.
     */
   private class GrammarFakeConversation(source: StreamSource)
       extends ForkedConversation[BackendTag.ClaudeCode.type](
@@ -58,11 +50,7 @@ class TurnGrammarTest extends munit.FunSuite:
         case other =>
           throw new IllegalStateException(s"unknown script line: $other")
 
-  /** Run a scripted sequence and return the EMITTED events. `closeAtEnd`
-    * signals stdout EOF after the script; leave it on except for the abnormal-
-    * termination case, where the script settles nothing and we want the source
-    * to just end mid-turn.
-    */
+  /** Run a scripted sequence and return the emitted events. */
   private def runScript(lines: String*): List[ConversationEvent] =
     supervised:
       val process = new FakePipedCliProcess()
@@ -159,9 +147,9 @@ class TurnGrammarTest extends munit.FunSuite:
       completedNormally = false
     )
 
-  /** Fake driver whose only purpose is counting
-    * [[ForkedConversation.onCancelRequested]] invocations, so `cancel()`'s
-    * settled-gate can be pinned independently of any backend's own hook body.
+  /** Fake driver counting [[ForkedConversation.onCancelRequested]] invocations,
+    * so `cancel()`'s settled-gate can be pinned independently of any backend's
+    * hook body.
     */
   private class HookFakeConversation(source: StreamSource)
       extends ForkedConversation[BackendTag.ClaudeCode.type](
@@ -201,16 +189,15 @@ class TurnGrammarTest extends munit.FunSuite:
       process.closeStderr()
       conv.events.foreach(_ => ())
       val _ = conv.awaitResult()
-      // The routine `finally cancel()` every caller runs after a turn that
-      // already succeeded on its own — must be a pure teardown, no hook.
+      // The routine `finally cancel()` after a turn that already succeeded must
+      // be a pure teardown, no hook.
       conv.cancel()
       assertEquals(conv.cancelRequests, 0)
 
-  /** Fake driver whose only purpose is exposing `succeedWith` to a caller on an
-    * arbitrary thread, so 12.2's single-writer assertion can be exercised from
-    * outside `handleLine` (every real backend only ever calls it from inside
-    * `handleLine`, on the reader thread — this deliberately breaks that
-    * contract to prove the check fires).
+  /** Fake driver exposing `succeedWith` to a caller on an arbitrary thread, so
+    * the write-side single-writer assertion can be exercised from outside
+    * `handleLine` — every real backend only ever settles from inside
+    * `handleLine` on the reader thread.
     */
   private class ThreadInvariantFakeConversation(source: StreamSource)
       extends ForkedConversation[BackendTag.ClaudeCode.type](
@@ -238,10 +225,8 @@ class TurnGrammarTest extends munit.FunSuite:
       process.closeStdout()
       process.closeStderr()
       conv.events.foreach(_ => ())
-      // Reader thread has now settled once via a real handleLine dispatch —
-      // its identity is recorded. A second settle from a genuinely different
-      // thread (never legitimate — every backend settles from inside
-      // handleLine) must trip the assertion rather than silently no-op.
+      // The reader thread's identity is recorded on its first settle. A second
+      // settle from a different thread must trip the assertion, not silently no-op.
       val _ = conv.awaitResult()
       var caught: Throwable = null
       val t = new Thread(() =>

--- a/tools/src/test/scala/orca/backend/mcp/AskUserBridgeTest.scala
+++ b/tools/src/test/scala/orca/backend/mcp/AskUserBridgeTest.scala
@@ -24,10 +24,9 @@ class AskUserBridgeTest extends munit.FunSuite:
       given BufferCapacity = BufferCapacity(8)
       val bridge = new AskUserBridge
 
-      // Two parallel asks; arrival order at the queue is non-deterministic
-      // (depends on fork scheduling). The host loop routes each reply by
-      // matching on the question content; each fork must receive *its* own
-      // matching answer, never the sibling's.
+      // Arrival order at the queue is non-deterministic. The host routes each
+      // reply by matching question content; each fork must receive its own
+      // answer, never the sibling's.
       val first = forkUser(bridge.ask("Q1"))
       val second = forkUser(bridge.ask("Q2"))
 
@@ -52,8 +51,8 @@ class AskUserBridgeTest extends munit.FunSuite:
           "completed-unexpectedly"
         catch case _: ChannelClosedException => "closed"
 
-      // nextQuestion ensures the ask reached the rendezvous (so its
-      // reply channel is registered as in-flight) before we close.
+      // nextQuestion ensures the ask reached the rendezvous — its reply channel
+      // is registered as in-flight — before we close.
       val pending = bridge.nextQuestion()
       assertEquals(pending.question, "blocked?")
 
@@ -68,11 +67,9 @@ class AskUserBridgeTest extends munit.FunSuite:
       bridge.close() // must not throw
 
   test("respond after ask exits early is a no-op, not a deadlock"):
-    // Pins the safety contract: if the handler thread unwinds before
-    // respond is called (e.g. the HTTP client aborts the request after
-    // its own timeout), the orphaned reply channel must be `done`'d so
-    // the renderer's later respond doesn't block forever on a send with
-    // no receiver. Without the fix, this test deadlocks.
+    // If the handler thread unwinds before respond is called (e.g. the HTTP
+    // client aborts the request), the orphaned reply channel must be `done`'d
+    // so the renderer's later respond doesn't block forever on a receiver-less send.
     supervised:
       given BufferCapacity = BufferCapacity(8)
       val bridge = new AskUserBridge
@@ -86,12 +83,11 @@ class AskUserBridgeTest extends munit.FunSuite:
       val pending = bridge.nextQuestion()
       assertEquals(pending.question, "anyone there?")
 
-      // Simulate the handler thread exiting early by closing the bridge
-      // — this `done`s every in-flight reply channel.
+      // Simulate the handler exiting early by closing the bridge, which `done`s
+      // every in-flight reply channel.
       bridge.close()
       assertEquals(askFork.join(), "closed")
 
-      // The renderer didn't know the handler is gone; it eventually calls
-      // respond with the user's typed answer. Without the fix, this hangs
-      // forever; with the fix, the closed-channel send is a no-op.
+      // The renderer, unaware the handler is gone, eventually responds; the
+      // closed-channel send must be a no-op rather than hang forever.
       pending.respond("the answer that arrived too late")

--- a/tools/src/test/scala/orca/backend/mcp/AskUserMcpServerTest.scala
+++ b/tools/src/test/scala/orca/backend/mcp/AskUserMcpServerTest.scala
@@ -8,12 +8,9 @@ import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 
 class AskUserMcpServerTest extends munit.FunSuite:
 
-  /** Smoke test: spin up the server, send a `tools/list` JSON-RPC request,
-    * assert the `ask_user` tool is advertised in the response.
-    *
-    * No bridge interaction — the handler isn't invoked here, just the
-    * tools-discovery path. Bridge-driven end-to-end behaviour belongs in a
-    * higher-level integration test once the Claude wiring lands.
+  /** Smoke test of the tools-discovery path: a `tools/list` JSON-RPC request
+    * must advertise `ask_user`. No bridge interaction — the handler isn't
+    * invoked here.
     */
   test("tools/list advertises ask_user"):
     supervised:

--- a/tools/src/test/scala/orca/backend/mcp/AskUserSessionTest.scala
+++ b/tools/src/test/scala/orca/backend/mcp/AskUserSessionTest.scala
@@ -10,11 +10,9 @@ class AskUserSessionTest extends munit.FunSuite:
   test(
     "allocate closes the bridge + server when the extras callback throws"
   ):
-    // Pins the defensive cleanup in `allocate`'s catch block: if the
-    // backend-specific `extras` callback fails (e.g. workDir write fails),
-    // the partially-allocated Netty binding must still be torn down so
-    // the test process can rebind the same port and so long-running
-    // flows don't leak.
+    // If the backend-specific `extras` callback fails, the partially-allocated
+    // Netty binding must still be torn down so the port can be rebound and
+    // long-running flows don't leak.
     supervised:
       given BufferCapacity = BufferCapacity(8)
       val thrown = intercept[RuntimeException]:
@@ -25,9 +23,8 @@ class AskUserSessionTest extends munit.FunSuite:
       assertEquals(thrown.getMessage, "extras callback boom")
 
   test("close runs each closer once even when an earlier one throws"):
-    // Pins the per-step `swallow`: one resource failing during teardown
-    // must not skip the others. We can't see bridge/server post-close,
-    // so use the extras slot to count.
+    // One resource failing during teardown must not skip the others. Bridge and
+    // server aren't observable post-close, so count via the extras slot.
     supervised:
       given BufferCapacity = BufferCapacity(8)
       val calls = new AtomicInteger(0)

--- a/tools/src/test/scala/orca/subprocess/FakePipedCliProcess.scala
+++ b/tools/src/test/scala/orca/subprocess/FakePipedCliProcess.scala
@@ -8,12 +8,12 @@ import java.util.concurrent.atomic.{
 }
 
 /** Test double for `PipedCliProcess`. Tests push stdout lines via
-  * `enqueueStdout` (optionally in response to observed writes) and read what
-  * the subject wrote to stdin via `writes`. Both queues are thread-safe so a
-  * test can drive the subject from one thread while asserting on another.
+  * `enqueueStdout` and read what the subject wrote to stdin via `writes`. Both
+  * queues are thread-safe, so a test can drive the subject from one thread
+  * while asserting on another.
   *
-  * `stdoutLines` blocks on read, same as the real piped process; tests that
-  * might deadlock a driver should call `closeStdout()` to signal EOF.
+  * `stdoutLines` blocks on read like the real piped process; call
+  * `closeStdout()` to signal EOF.
   */
 class FakePipedCliProcess(
     initiallyAlive: Boolean = true
@@ -37,9 +37,8 @@ class FakePipedCliProcess(
 
   /** Forcible kill: close both streams so a reader blocked on `stdoutLines` /
     * `stderrLines` unblocks, mirroring the real process's pipes closing. Unlike
-    * `sendSigInt`, this does not bump `sigIntCount` — it is the backstop, not a
-    * SIGINT. Idempotent (closing an already-closed queue just offers another
-    * EOF sentinel, which the single-consumer iterator ignores).
+    * `sendSigInt`, does not bump `sigIntCount`. Idempotent — a repeated EOF
+    * sentinel is ignored by the single-consumer iterator.
     */
   def destroyForcibly(): Unit =
     alive.set(false)
@@ -90,8 +89,7 @@ class FakePipedCliProcess(
 
       def hasNext: Boolean =
         if next0.get() == null then
-          // `take()` blocks until something lands; Some means a line,
-          // None means EOF.
+          // `take()` blocks until something lands; None means EOF.
           next0.set(q.take())
         next0.get().isDefined
 

--- a/tools/src/test/scala/orca/subprocess/OsProcCliRunnerTest.scala
+++ b/tools/src/test/scala/orca/subprocess/OsProcCliRunnerTest.scala
@@ -11,13 +11,10 @@ class OsProcCliRunnerTest extends munit.FunSuite:
     while alive(pid) && System.currentTimeMillis < deadline do Thread.sleep(20)
     !alive(pid)
 
-  /** Regression guard for the opencode-serve teardown fix: a launch wrapper
-    * forks the real worker, which inherits the stdout/stderr pipes, so killing
-    * only the wrapper PID would orphan it and leave a drain reader blocked on a
-    * never-EOF'd pipe. `destroyForciblyTree` must reap the descendant too. This
-    * fails if the method ever regresses to the PID-only `destroyForcibly`
-    * default: the reparented `sleep` would survive and `awaitDead` would time
-    * out.
+  /** A launch wrapper forks a worker that inherits the stdout/stderr pipes, so
+    * killing only the wrapper PID would orphan it and leave a drain reader
+    * blocked on a never-EOF'd pipe. `destroyForciblyTree` must reap the
+    * descendant too, unlike the PID-only `destroyForcibly`.
     */
   test("destroyForciblyTree reaps a forked descendant"):
     // `$!` is the backgrounded sleep's PID; `wait` keeps bash alive as its

--- a/tools/src/test/scala/orca/subprocess/QuietProcTest.scala
+++ b/tools/src/test/scala/orca/subprocess/QuietProcTest.scala
@@ -2,11 +2,9 @@ package orca.subprocess
 
 class QuietProcTest extends munit.FunSuite:
 
-  /** Pin the contract: a subprocess that writes to stderr must have its output
-    * captured into `result.err`, never inherited to the parent's terminal. The
-    * renderer's StatusBar relies on this invariant — any subprocess invocation
-    * that bypasses [[QuietProc]] (or another stderr-capturing layer)
-    * reintroduces the staircase-spinner artifact.
+  /** A subprocess writing to stderr must have its output captured into
+    * `result.err`, never inherited to the parent's terminal — the renderer's
+    * StatusBar relies on this to avoid the staircase-spinner artifact.
     */
   test("call captures stderr into result.err"):
     val result = QuietProc.call(

--- a/tools/src/test/scala/orca/subprocess/SpawnStubCliRunner.scala
+++ b/tools/src/test/scala/orca/subprocess/SpawnStubCliRunner.scala
@@ -3,12 +3,8 @@ package orca.subprocess
 import java.util.concurrent.atomic.AtomicReference
 
 /** CliRunner that hands out a pre-scripted [[FakePipedCliProcess]] on each
-  * `spawnPiped` call. Records the args. Single-call: each prepared process is
-  * consumed by exactly one spawn; running out throws so a test failure doesn't
-  * drift into an unrelated stack.
-  *
-  * `run` is unsupported — drivers that need both shapes shouldn't share a
-  * runner instance.
+  * `spawnPiped` call and records the args. Each prepared process is consumed by
+  * exactly one spawn; running out throws. `run` is unsupported.
   */
 class SpawnStubCliRunner(prepared: List[FakePipedCliProcess]) extends CliRunner:
   private val queue = new AtomicReference[List[FakePipedCliProcess]](prepared)

--- a/tools/src/test/scala/orca/subprocess/StubCliRunner.scala
+++ b/tools/src/test/scala/orca/subprocess/StubCliRunner.scala
@@ -10,10 +10,9 @@ case class CliCall(
 )
 
 /** A `CliRunner` that returns a pre-configured response and records every `run`
-  * invocation for later assertions. The response can be swapped via
-  * `setResponse` so tests can simulate external state changes across polls.
-  * Tests that need a piped subprocess construct `FakePipedCliProcess` directly
-  * — this stub's `spawnPiped` is a no-op that throws.
+  * invocation. `setResponse` swaps the response so tests can simulate external
+  * state changes across polls. `spawnPiped` throws; use `FakePipedCliProcess`
+  * directly for piped subprocesses.
   */
 class StubCliRunner(
     initialResponse: CliResult = CliResult(0, "", "")

--- a/tools/src/test/scala/orca/testkit/GitRepo.scala
+++ b/tools/src/test/scala/orca/testkit/GitRepo.scala
@@ -1,13 +1,8 @@
 package orca.testkit
 
 /** Test helper: a throwaway temp git repo. `empty` does `git init -b main` plus
-  * user config; `seeded` adds one `seed.txt` commit so a flow's stash/branch/
-  * commit lifecycle (ADR 0018 §2.5) runs in isolation from the dev checkout.
-  *
-  * Every repo's temp root is registered with [[TempDirs]] and swept at JVM
-  * shutdown — see `TempDirs` scaladoc for why that (rather than plain
-  * `os.temp.dir(deleteOnExit = true)`) is required to actually reclaim these
-  * directories.
+  * user config; `seeded` adds one `seed.txt` commit. Every repo's temp root is
+  * registered with [[TempDirs]] for cleanup at JVM shutdown.
   */
 object GitRepo:
   /** Fresh temp repo: `git init -b main` + test user config. No commits. */

--- a/tools/src/test/scala/orca/testkit/TempDirs.scala
+++ b/tools/src/test/scala/orca/testkit/TempDirs.scala
@@ -5,23 +5,15 @@ import java.util.concurrent.ConcurrentLinkedQueue
 /** Shared temp-dir cleanup for tests.
   *
   * `os.temp.dir(..., deleteOnExit = true)` relies on JVM `File.deleteOnExit`,
-  * which only removes an *empty* directory at shutdown — it silently no-ops on
-  * a non-empty tree. Every git-repo fixture (`GitRepo`) and every backend
-  * workDir under test gets files written into it after creation, so on the
-  * default `os.temp.dir()` behavior every one of those directories leaked
-  * permanently. This is what once filled an 8G tmpfs with ~35k orphaned fixture
-  * dirs in a single day of test runs.
+  * which only removes an *empty* directory at shutdown and silently no-ops on a
+  * non-empty tree — so every fixture that gets files written into it leaks.
+  * Instead, `register`/`dir` track every temp root and recursively remove it
+  * (`os.remove.all`, which handles non-empty trees) via a single JVM shutdown
+  * hook.
   *
-  * `register`/`dir` track every temp root handed out and recursively remove it
-  * (`os.remove.all`, which — unlike `deleteOnExit` — handles non-empty trees)
-  * via a single JVM shutdown hook. Cleanup timing depends on how tests run:
-  * only the `runner` module forks its tests (`Test / fork := true` in
-  * `build.sbt`); the other modules run in-process in sbt's JVM. A one-shot `sbt
-  * test` from a shell — the dominant CI/agent pattern per AGENTS.md — exits
-  * that JVM when the command finishes, so the hook fires and every fixture dir
-  * is swept per invocation either way. Under a long-lived interactive session
-  * (`sbt ~test`) on an unforked module, dirs accumulate until the session exits
-  * — bounded, session-scoped growth, not the old permanent leak.
+  * Cleanup timing depends on the run mode: a one-shot `sbt test` exits its JVM
+  * when done, so the hook sweeps every fixture per invocation. A long-lived
+  * `sbt ~test` on an unforked module accumulates dirs until the session exits.
   */
 object TempDirs:
   private val roots = new ConcurrentLinkedQueue[os.Path]()

--- a/tools/src/test/scala/orca/tools/OsFsToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsFsToolTest.scala
@@ -6,8 +6,7 @@ import orca.testkit.TempDirs
 class OsFsToolTest extends munit.FunSuite:
 
   // Tests exercise gated mutators directly; mint the workspace-write token once
-  // for the whole suite (tests are package `orca.tools`, so
-  // `WorkspaceWrite.unsafe` is in reach).
+  // for the whole suite (package `orca.tools` can reach `WorkspaceWrite.unsafe`).
   private given WorkspaceWrite = WorkspaceWrite.unsafe
 
   private def withFs(body: (OsFsTool, os.Path) => Unit): Unit =
@@ -53,9 +52,9 @@ class OsFsToolTest extends munit.FunSuite:
     withFs: (fs, _) =>
       assertEquals(fs.list("does/not/exist/*.txt"), Nil)
 
-  // An absolute glob previously reached os-lib's `globRoot` fold
-  // and blew up with a context-free `IllegalArgumentException`
-  // (`InvalidSegment`) rather than a named, actionable `list`-level error.
+  // An absolute glob otherwise reaches os-lib's `globRoot` fold and blows up
+  // with a context-free `IllegalArgumentException` (`InvalidSegment`) rather
+  // than a named, actionable `list`-level error.
   test("list rejects an absolute glob with a typed, actionable error"):
     withFs: (fs, _) =>
       val ex = intercept[OrcaFlowException](fs.list("/etc/*.conf"))

--- a/tools/src/test/scala/orca/tools/OsGitHubIntegrationTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitHubIntegrationTest.scala
@@ -30,9 +30,8 @@ class OsGitHubIntegrationTest extends munit.FunSuite:
     assert(result.stdout.contains("\"login\""))
 
   test("readPrComments succeeds against a public issue-or-PR endpoint"):
-    // GitHub's /issues/{n}/comments endpoint is shared between issues and
-    // PRs; Hello-World #1 is stable public data. We assert the call returns
-    // (no exception) and each entry carries a non-empty author.
+    // GitHub's /issues/{n}/comments endpoint is shared between issues and PRs;
+    // Hello-World #1 is stable public data.
     val gh = new OsGitHubTool(OsProcCliRunner)
     val handle = PrHandle("octocat", "Hello-World", 1)
     val comments = gh.readPrComments(handle)

--- a/tools/src/test/scala/orca/tools/OsGitHubToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitHubToolTest.scala
@@ -20,8 +20,7 @@ import scala.jdk.CollectionConverters.*
 class OsGitHubToolTest extends munit.FunSuite:
 
   // Tests exercise gated gh mutators directly; mint the workspace-write token
-  // once for the whole suite (package `orca.tools` can reach
-  // `WorkspaceWrite.unsafe`).
+  // once for the whole suite (package `orca.tools` can reach `WorkspaceWrite.unsafe`).
   private given WorkspaceWrite = WorkspaceWrite.unsafe
 
   private def stubGh(response: CliResult): (StubCliRunner, OsGitHubTool) =
@@ -216,12 +215,11 @@ class OsGitHubToolTest extends munit.FunSuite:
   test(
     "buildStatus reports Pending when a still-running check is mixed with an already-failed one"
   ):
-    // aggregateOutcome checks `states.contains(CheckState.Pending)` before it
-    // ever asks whether any check failed, so one lagging check short-circuits
-    // the whole rollup to Pending even though a sibling check already
-    // resolved to Failure — this is what keeps waitForBuild polling past a
-    // failed check while the others are still running, instead of returning
-    // Failure the instant the first one lands.
+    // aggregateOutcome checks `states.contains(CheckState.Pending)` before
+    // asking whether any check failed, so one lagging check short-circuits the
+    // whole rollup to Pending even when a sibling already resolved to Failure —
+    // this keeps waitForBuild polling while other checks run rather than
+    // returning Failure the instant the first one lands.
     val json =
       """{"statusCheckRollup":[
         | {"status":"IN_PROGRESS","name":"slow-check"},
@@ -240,10 +238,9 @@ class OsGitHubToolTest extends munit.FunSuite:
   test("stateOf maps a legacy EXPECTED status context to Pending"):
     // GitHub's legacy commit-status/GraphQL StatusState `EXPECTED` means "a
     // required external CI context registered but hasn't reported yet" —
-    // distinct from PENDING (running), but equally not-yet-resolved. Before
-    // this classification existed, a present-but-not-pending, present-but-
-    // not-success check fell through to an instant Failure, defeating
-    // waitForBuild's noChecksGrace machinery.
+    // distinct from PENDING (running), but equally not-yet-resolved. Without
+    // this classification such a check falls through to an instant Failure,
+    // defeating waitForBuild's noChecksGrace machinery.
     assertEquals(
       OsGitHubTool.stateOf(GhCheck(state = Some("EXPECTED"))),
       CheckState.Pending
@@ -392,20 +389,16 @@ class OsGitHubToolTest extends munit.FunSuite:
   test(
     "waitForBuild's sticky watermark carries the ON transition forward across later polls"
   ):
-    // Reverse of the transition above: the rollup starts EMPTY (checkCount
-    // 0, not yet seen), then gains a check on the very next poll. `seen`
-    // must flip to true right there and *stay* true on every later poll —
-    // including the ones after the sequenced stub runs out and repeats its
-    // last response — so the NoChecksConfigured fast-path never fires even
-    // once the grace deadline passes; the loop instead falls through to
-    // BuildTimedOut at the (later) timeout. This pins the recursive
-    // `loop(seen)` threading, not a "checkCount vs log.nonEmpty" distinction
-    // — an IN_PROGRESS check renders a non-empty log line too, so this
-    // input can't actually discriminate between the two signals.
+    // Reverse of the transition above: the rollup starts EMPTY (not yet seen),
+    // then gains a check on the next poll. `seen` must flip to true there and
+    // *stay* true on every later poll — including after the sequenced stub runs
+    // out and repeats its last response — so the NoChecksConfigured fast-path
+    // never fires even once the grace deadline passes; the loop falls through
+    // to BuildTimedOut at the (later) timeout. Pins the recursive `loop(seen)`
+    // threading.
     //
-    // Driven by a call-count-sequenced stub rather than a wall-clock race
-    // (a background thread flipping the response after a sleep), so it
-    // can't false-fail under CI scheduling jitter.
+    // Call-count-sequenced rather than a wall-clock race, so it can't
+    // false-fail under CI scheduling jitter.
     val pendingJson =
       """{"statusCheckRollup":[{"status":"IN_PROGRESS","name":"t"}]}"""
     val cli = new SequencedCliRunner(
@@ -473,7 +466,6 @@ class OsGitHubToolTest extends munit.FunSuite:
     )
     val pr = gh.createPr("feat: hi", "hello").orThrow
     assertEquals(pr, samplePr)
-    // Prove the idempotency path went through git rev-parse and gh pr list
     val callArgs = cli.calls.map(_.args)
     assert(
       callArgs.exists(
@@ -496,10 +488,9 @@ class OsGitHubToolTest extends munit.FunSuite:
     )
 
   test("currentBranchGit carries OsGitTool.nonInteractiveEnv"):
-    // The git rev-parse call made during the PR-reuse fallback must carry the
-    // same non-interactive env as every other git invocation
-    // (OsGitTool.nonInteractiveEnv) — otherwise a stalled credential/
-    // passphrase prompt on this one path could hang the flow.
+    // The git rev-parse in the PR-reuse fallback must carry the same
+    // non-interactive env as every other git invocation — otherwise a stalled
+    // credential/passphrase prompt on this path could hang the flow.
     val prListJson =
       """[{"number":42,"url":"https://github.com/acme/widgets/pull/42"}]"""
     val cli = new SequencedCliRunner(

--- a/tools/src/test/scala/orca/tools/OsGitToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitToolTest.scala
@@ -11,8 +11,7 @@ import orca.testkit.TempDirs
 class OsGitToolTest extends munit.FunSuite:
 
   // Tests exercise gated git mutators directly; mint the workspace-write token
-  // once for the whole suite (package `orca.tools` can reach
-  // `WorkspaceWrite.unsafe`).
+  // once for the whole suite (package `orca.tools` can reach `WorkspaceWrite.unsafe`).
   private given WorkspaceWrite = WorkspaceWrite.unsafe
 
   private def withRepo(body: (OsGitTool, os.Path) => Unit): Unit =
@@ -457,10 +456,9 @@ class OsGitToolTest extends munit.FunSuite:
       )
 
   test("commit on a corrupted repo throws with status + fsck diagnostics"):
-    // Integration check that the formatter is actually wired into the commit
-    // path: corrupt the index so `git add -A` fails, then confirm the thrown
-    // message carries the status + fsck blocks (and isn't just the bare
-    // stderr we used to throw before).
+    // Integration check that the formatter is wired into the commit path:
+    // corrupt the index so `git add -A` fails, then confirm the thrown message
+    // carries the status + fsck blocks rather than the bare stderr.
     withRepo: (git, dir) =>
       os.write(dir / "seed.txt", "seed")
       git.commit("seed").orThrow

--- a/tools/src/test/scala/orca/util/JsonSchemaGenTest.scala
+++ b/tools/src/test/scala/orca/util/JsonSchemaGenTest.scala
@@ -72,13 +72,10 @@ class JsonSchemaGenTest extends munit.FunSuite:
     )
 
   test("apply emits no $schema dialect declaration"):
-    // TapirSchemaToJsonSchema stamps `$schema: .../draft/2020-12/schema` on
-    // its output. The claude CLI (observed on 2.1.207) validates the
-    // `--json-schema` value with a validator that has no 2020-12 meta-schema
-    // registered, so a schema DECLARING that dialect is rejected before the
-    // turn starts: `--json-schema is not a valid JSON Schema: no schema with
-    // key or ref "https://json-schema.org/draft/2020-12/schema"`. No consumer
-    // needs the declaration, so `apply` strips it.
+    // TapirSchemaToJsonSchema stamps `$schema: .../draft/2020-12/schema` on its
+    // output, but the claude CLI's `--json-schema` validator has no 2020-12
+    // meta-schema registered and rejects any schema declaring that dialect. No
+    // consumer needs the declaration, so `apply` strips it.
     import sttp.tapir.Schema
     import sttp.tapir.generic.auto.given
     case class Sample(name: String)

--- a/tools/src/test/scala/orcacaps/InStageNegativeTest.scala
+++ b/tools/src/test/scala/orcacaps/InStageNegativeTest.scala
@@ -34,10 +34,8 @@ class InStageNegativeTest extends munit.FunSuite:
   test(
     "a gated git mutation does NOT compile without a WorkspaceWrite in scope"
   ):
-    // The real B2 enforcement, post-0.4 split: with a `GitTool` in scope but NO
-    // `WorkspaceWrite`, `git.commit(...)` must fail to compile, pointing at the
-    // missing capability. Proves the gate works end-to-end — a workspace
-    // mutation is impossible outside a stage.
+    // With a `GitTool` in scope but NO `WorkspaceWrite`, `git.commit(...)` must
+    // fail to compile — a workspace mutation is impossible outside a stage.
     val errors = compileErrors(
       """
       val git: orca.tools.GitTool = ???
@@ -48,12 +46,11 @@ class InStageNegativeTest extends munit.FunSuite:
       errors.nonEmpty,
       "expected a compile error for git.commit without a WorkspaceWrite"
     )
-    // `WorkspaceWrite`'s `@implicitNotFound` makes the error user-facing — it
-    // tells the author to move the call into a `stage(...)` body (not a `fork`
-    // within one), rather than naming the internal `WorkspaceWrite` type. Pin
-    // that message (and that the cryptic default is gone) — and that it is
-    // DISTINCT from the InStage message below, since the two tokens now gate
-    // different effects.
+    // `WorkspaceWrite`'s `@implicitNotFound` tells the author to move the call
+    // into a `stage(...)` body (not a `fork` within one), rather than naming
+    // the internal `WorkspaceWrite` type. Pin that message, and that it is
+    // DISTINCT from the InStage message below — the two tokens gate different
+    // effects.
     assert(
       errors.contains(
         "must be made inside a `stage(...)` body"
@@ -67,10 +64,8 @@ class InStageNegativeTest extends munit.FunSuite:
     )
 
   test("a gated LLM run does NOT compile without an InStage in scope"):
-    // The InStage half of the same enforcement: with an `Agent` in scope but
-    // NO `InStage`, `agent.run(...)` must fail to compile. Proves the
-    // LLM-call gate still works after the split — only a `stage(...)` body can
-    // spend tokens.
+    // With an `Agent` in scope but NO `InStage`, `agent.run(...)` must fail to
+    // compile — only a `stage(...)` body can spend tokens.
     val errors = compileErrors(
       """
       val agent: orca.agents.Agent[orca.agents.BackendTag.ClaudeCode.type] = ???


### PR DESCRIPTION
## Summary

A repo-wide pass over comments and scaladoc: cut accumulated verbosity, historical/migration framing, Scala-mechanics narration, code narration, restatement of nearby comments or the README, and bare plan/finding labels — while keeping the load-bearing content (non-obvious control flow, side-effect/purity notes the signature can't express, the reasoning behind architectural choices, and invariants/gotchas).

**Comments only — no code or behaviour change.** Net ~2,300 comment lines removed across 222 files.

Scope: `.scala` comments/scaladoc only. README.md, AGENTS.md, and the ADRs are intentionally left untouched — the README is the home for general "how Orca works" info, and ADRs are decision records where the history is the point.

## How it was done

38 batches (package-coherent, density-balanced), one agent per batch, each applying the same keep/remove criteria. The only non-comment edit across the whole change is a single behaviour-preserving line-join that scalafmt canonicalizes.

## Verification

- `sbt Test/compile` clean across all modules (zero warnings)
- Full `sbt test` green (all 8 modules)
- `sbt scalafmtCheckAll` clean
- Diff confirmed comment-only (5 non-comment lines total, all benign)
- Hand-reviewed the trims on the highest-risk files (`FlowLifecycle`, `ForkedConversation`, `Session`, `Agent`, `GitTool`): every invariant, side-effect note, and architectural "why" preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)