### PR TITLE
Drop sbt hardcodes from issue-pr-bugfix.sc; state both issue flows' outcomes

### DIFF
--- a/flows/issue-pr-bugfix.sc
+++ b/flows/issue-pr-bugfix.sc
@@ -1,14 +1,19 @@
-// Bug report (owner/repo#N) → reproduce with a failing test, fix, PR.
+// Bug report (owner/repo#N) → repro test, fix, PR — or a triage comment.
 //> using scala 3.8.4
 //> using dep "org.virtuslab::orca:0.1.0"
 //> using jvm 21
 
-/** Bug-report → fix flow, autonomous and stack-agnostic.
+/** Bug-report → fix flow, autonomous.
   *
   * The bug-report counterpart of `issue-pr.sc`: where that flow assesses an
   * issue and plans straight into an implementation, this one insists on a
   * reproduction first — a failing test that CI confirms is red — and only then
   * fixes it.
+  *
+  * Three outcomes, decided by triage: a comment saying it isn't a bug; a
+  * comment with reproduction steps when it is one but no test can show it; or
+  * a PR carrying the failing test and the fix that makes it pass. Only the
+  * third writes any code.
   *
   * Given a `<owner>/<repo>#<number>` reference to an issue, the flow:
   *
@@ -46,8 +51,7 @@
   * ```
   *
   * The review loop's format and lint commands come from
-  * `.orca/settings.properties`, auto-discovered on first run — the script
-  * itself stays stack-agnostic.
+  * `.orca/settings.properties`, auto-discovered on first run.
   *
   * Requires `claude` and `gh` authenticated; the target repo must have a CI
   * workflow that runs its test suite, since a red build is what confirms the

--- a/flows/issue-pr-bugfix.sc
+++ b/flows/issue-pr-bugfix.sc
@@ -1,12 +1,16 @@
-// Triage a Scala bug report; reproduce with a failing test, fix, open a PR.
+// Bug report (owner/repo#N) → reproduce with a failing test, fix, PR.
 //> using scala 3.8.4
 //> using dep "org.virtuslab::orca:0.1.0"
 //> using jvm 21
 
-/** Bug-report → fix flow for Scala projects, autonomous.
+/** Bug-report → fix flow, autonomous and stack-agnostic.
   *
-  * Given a `<owner>/<repo>#<number>` reference to a Scala-project issue, the
-  * flow:
+  * The bug-report counterpart of `issue-pr.sc`: where that flow assesses an
+  * issue and plans straight into an implementation, this one insists on a
+  * reproduction first — a failing test that CI confirms is red — and only then
+  * fixes it.
+  *
+  * Given a `<owner>/<repo>#<number>` reference to an issue, the flow:
   *
   *   1. Reads the issue from GitHub (pure read, outside any stage).
   *   1. Triages: actually a bug? can a unit test reproduce it?
@@ -41,12 +45,13 @@
   * scala-cli run issue-pr-bugfix.sc -- "acme/widgets#42"
   * ```
   *
-  * The review loop's format commands come from `.orca/settings.properties`,
-  * auto-discovered on first run; the lint gate is pinned explicitly below to
-  * demonstrate the per-call override.
+  * The review loop's format and lint commands come from
+  * `.orca/settings.properties`, auto-discovered on first run — the script
+  * itself stays stack-agnostic.
   *
-  * Requires `claude` and `gh` authenticated; target repo must have a CI
-  * workflow that runs `sbt test`.
+  * Requires `claude` and `gh` authenticated; the target repo must have a CI
+  * workflow that runs its test suite, since a red build is what confirms the
+  * reproduction.
   */
 
 import orca.{*, given}
@@ -110,7 +115,8 @@ flow(
         session.run(
           s"""Write the failing unit test at `$failingTestPath`. It MUST
              |fail on the current code — that's how we confirm the bug.
-             |Run `sbt test` locally if you can to verify.""".stripMargin
+             |Run the project's test suite locally if you can to
+             |verify.""".stripMargin
         )
 
       // Push + open PR: a SEPARATE stage from the edit above.
@@ -251,15 +257,16 @@ def planAndImplementFix[B <: BackendTag](
     stage(s"Task: ${task.title}"): // skipped on resume if already done
       session.run(fixPlan.taskPrompt(task))
       // reviewerSelection defaults to agentDriven — a picker LLM on
-      // reviewAgent's cheap tier. Format defaults to the project's stack
-      // settings (`.orca/settings.properties`).
+      // reviewAgent's cheap tier. Format and lint default to the project's
+      // stack settings (`.orca/settings.properties`). Don't override lint with
+      // the test command here: until the last fix task lands, the branch
+      // carries a deliberately failing test, so a test-running gate would fail
+      // every round. A discovered lint command never runs tests (ADR 0019),
+      // which is exactly the cheap sanity check this flow wants — the failing
+      // test runs in CI, and correctness is the reviewers' job.
       reviewAndFixLoop(
         coderSession = session,
         reviewers = allReviewers(reviewAgent),
-        task = task.title.value,
-        // An explicit override beats the settings file: pin the lint gate to
-        // a compile (main + test) — a cheap sanity check; the failing test
-        // runs in CI and correctness is the reviewers' job.
-        lint = Configured.Use(Lint(List("sbt Test/compile"), codingAgent.cheap))
+        task = task.title.value
       )
       // one commit per task: code + progress entry

--- a/flows/issue-pr-bugfix.sc
+++ b/flows/issue-pr-bugfix.sc
@@ -50,9 +50,6 @@
   * scala-cli run issue-pr-bugfix.sc -- "acme/widgets#42"
   * ```
   *
-  * The review loop's format and lint commands come from
-  * `.orca/settings.properties`, auto-discovered on first run.
-  *
   * Requires `gh` authenticated, and the backend the settings name for the
   * planning/coding/review roles logged in (`claude` unless changed).
   *
@@ -265,14 +262,8 @@ def planAndImplementFix[B <: BackendTag](
   for task <- fixPlan.tasks do
     stage(s"Task: ${task.title}"): // skipped on resume if already done
       session.run(fixPlan.taskPrompt(task))
-      // reviewerSelection defaults to agentDriven — a picker LLM on
-      // reviewAgent's cheap tier. Format and lint default to the project's
-      // stack settings (`.orca/settings.properties`). Don't override lint with
-      // the test command here: until the last fix task lands, the branch
-      // carries a deliberately failing test, so a test-running gate would fail
-      // every round. A discovered lint command never runs tests (ADR 0019),
-      // which is exactly the cheap sanity check this flow wants — the failing
-      // test runs in CI, and correctness is the reviewers' job.
+      // Don't gate this loop on the tests: the branch carries a deliberately
+      // failing one until the last fix task lands.
       reviewAndFixLoop(
         coderSession = session,
         reviewers = allReviewers(reviewAgent),

--- a/flows/issue-pr-bugfix.sc
+++ b/flows/issue-pr-bugfix.sc
@@ -53,9 +53,12 @@
   * The review loop's format and lint commands come from
   * `.orca/settings.properties`, auto-discovered on first run.
   *
-  * Requires `claude` and `gh` authenticated; the target repo must have a CI
-  * workflow that runs its test suite, since a red build is what confirms the
-  * reproduction.
+  * Requires `gh` authenticated, and the backend the settings name for the
+  * planning/coding/review roles logged in — plus `claude` whatever they say,
+  * since the reproduction checks below pin `claude.sonnet`.
+  *
+  * The target repo must have a CI workflow that runs its test suite: a red
+  * build is what confirms the reproduction.
   */
 
 import orca.{*, given}

--- a/flows/issue-pr-bugfix.sc
+++ b/flows/issue-pr-bugfix.sc
@@ -54,8 +54,7 @@
   * `.orca/settings.properties`, auto-discovered on first run.
   *
   * Requires `gh` authenticated, and the backend the settings name for the
-  * planning/coding/review roles logged in — plus `claude` whatever they say,
-  * since the reproduction checks below pin `claude.sonnet`.
+  * planning/coding/review roles logged in (`claude` unless changed).
   *
   * The target repo must have a CI workflow that runs its test suite: a red
   * build is what confirms the reproduction.
@@ -194,14 +193,17 @@ def prSummary(note: String, issue: Issue)(using
     )
   )
 
-/** Confirm the CI failure matches the original report. Each sub-stage is a
-  * one-shot sonnet call — fresh session, no seed needed.
+/** Confirm the CI failure matches the original report. Both sub-stages are
+  * one-shot calls on the coding role — fresh session, no seed needed. The
+  * excerpt-picking is cheap-tier work; the verdict is not, since a wrong
+  * "matches" lets a bogus reproduction through and a wrong "doesn't" aborts a
+  * sound one.
   */
 def confirmReproductionMatches(pr: PrHandle, issue: Issue)(using
     FlowControl
 ): Unit =
   stage("Post focused failure comment"):
-    val failureSummary = claude.sonnet.run(
+    val failureSummary = codingAgent.cheap.run(
       s"""CI went red on PR ${pr.shortRef} (${pr.url}). Inspect the
          |failed run via `gh` — start with:
          |
@@ -221,7 +223,7 @@ def confirmReproductionMatches(pr: PrHandle, issue: Issue)(using
 
   stage("Verify failure matches the report"):
     val verdict =
-      claude.sonnet
+      codingAgent
         .resultAs[BugReportMatch]
         .autonomous
         .run(

--- a/flows/issue-pr.sc
+++ b/flows/issue-pr.sc
@@ -1,4 +1,4 @@
-// GitHub issue (owner/repo#N) → assess, plan, implement, open a PR.
+// GitHub issue (owner/repo#N) → assess, plan, implement, PR — or reject.
 //> using scala 3.8.4
 //> using dep "org.virtuslab::orca:0.1.0"
 //> using jvm 21
@@ -8,6 +8,10 @@
   * Takes any issue — a feature request, a change, a bug — and goes straight
   * from assessment to a plan. For a bug report where a reproduction should come
   * first, `issue-pr-bugfix.sc` writes a CI-verified failing test before fixing.
+  *
+  * Two outcomes, decided by the assessment: a comment on the issue explaining
+  * why it was rejected, or a PR implementing it. Only the second writes any
+  * code.
   *
   * Given a `<owner>/<repo>#<number>` reference (the user's prompt), the flow:
   *
@@ -33,8 +37,7 @@
   * ```
   *
   * The review loop's format and lint commands come from
-  * `.orca/settings.properties`, auto-discovered on first run — the script
-  * itself stays stack-agnostic.
+  * `.orca/settings.properties`, auto-discovered on first run.
   *
   * Requires `claude` and `gh` both authenticated.
   */

--- a/flows/issue-pr.sc
+++ b/flows/issue-pr.sc
@@ -36,9 +36,6 @@
   * scala-cli run issue-pr.sc -- "acme/widgets#42"
   * ```
   *
-  * The review loop's format and lint commands come from
-  * `.orca/settings.properties`, auto-discovered on first run.
-  *
   * Requires `gh` authenticated, and the backend the settings name for the
   * planning/coding/review roles logged in (`claude` unless changed).
   */
@@ -92,10 +89,6 @@ flow(
     for task <- plan.tasks do
       stage(s"Task: ${task.title}"):    // skipped on resume if already done
         session.run(task.description)
-        // reviewerSelection defaults to agentDriven(reviewAgent.cheap); pass
-        // `ReviewerSelector.allEveryRound` to run every reviewer instead.
-        // Format and lint default to the project's stack settings
-        // (`.orca/settings.properties`).
         reviewAndFixLoop(
           coderSession = session,
           reviewers = allReviewers(reviewAgent),

--- a/flows/issue-pr.sc
+++ b/flows/issue-pr.sc
@@ -1,9 +1,13 @@
-// Turn a GitHub issue (owner/repo#N) into an implemented, opened PR.
+// GitHub issue (owner/repo#N) → assess, plan, implement, open a PR.
 //> using scala 3.8.4
 //> using dep "org.virtuslab::orca:0.1.0"
 //> using jvm 21
 
 /** GitHub-issue → PR flow, fully autonomous.
+  *
+  * Takes any issue — a feature request, a change, a bug — and goes straight
+  * from assessment to a plan. For a bug report where a reproduction should come
+  * first, `issue-pr-bugfix.sc` writes a CI-verified failing test before fixing.
   *
   * Given a `<owner>/<repo>#<number>` reference (the user's prompt), the flow:
   *

--- a/flows/issue-pr.sc
+++ b/flows/issue-pr.sc
@@ -39,7 +39,8 @@
   * The review loop's format and lint commands come from
   * `.orca/settings.properties`, auto-discovered on first run.
   *
-  * Requires `claude` and `gh` both authenticated.
+  * Requires `gh` authenticated, and the backend the settings name for the
+  * planning/coding/review roles logged in (`claude` unless changed).
   */
 
 import orca.{*, given}


### PR DESCRIPTION
Two changes to the issue flows.

**`issue-pr-bugfix.sc` no longer hardcodes sbt.** It pinned `sbt Test/compile` as the lint gate, told the agent to run `sbt test` when writing the failing test, and required a CI workflow running `sbt test`. Lint now comes from `.orca/settings.properties` like every other flow, and the prompts name the project's test suite rather than a command.

Dropping the lint override preserves the behaviour rather than changing it: a discovered lint command is by definition a compile/typecheck that never runs tests (ADR 0019), which is what the pinned `sbt Test/compile` was doing by hand. That distinction matters more here than elsewhere — the branch deliberately carries a failing test until the fix lands, so a test-running gate would fail every review round. The comment now explains why lint is *not* overridden.

**Both flows now say what they can end in.** Neither always produces a PR, which the old one-liners implied:

    issue-pr.sc         // GitHub issue (owner/repo#N) → assess, plan, implement, PR — or reject.
    issue-pr-bugfix.sc  // Bug report (owner/repo#N) → repro test, fix, PR — or a triage comment.

`issue-pr.sc` has two outcomes: a rejection comment on the issue, or a PR. `issue-pr-bugfix.sc` has three: a not-a-bug verdict, reproduction steps when it's a real bug no test can show, or a PR carrying the failing test plus the fix. Each scaladoc now states its outcomes up front, and points at the other flow.

Verified with `scala-cli compile` on both flows.
