### PR TITLE
Trim flows and README to user-relevant content

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,8 @@ backend's model accessors and backend-specific extras:
 
 The runtime owns git: every write-capable agent turn is told not to commit,
 push, or switch branches — it edits the working tree, and the flow
-commits/branches/pushes via `git.*`. This keeps `reviewAndFixLoop`'s diff-based
-reviewer selection working (a self-committing agent would leave an empty
-`git.reviewDiff()`). Opt out per-tool with `claude.withSelfManagedGit` (mirrors
-`withReadOnly`).
+commits/branches/pushes via `git.*`. Opt out per-tool with
+`claude.withSelfManagedGit`.
 
 For the LLM interfaces, `resultAs[O]` defines the shape of the structured
 output. The `O` type needs a `JsonData[O]` (provided by `derives JsonData` on a
@@ -194,8 +192,7 @@ case class) for schema generation and deserialization. Additionally, you might
 define an `Announce[O]` so that a friendly summary is printed in the event log,
 instead of a raw json.
 
-A minimal Pi-backed flow looks the same; Pi reads your normal Pi configuration
-and is driven through RPC mode under the hood:
+A minimal Pi-backed flow looks the same; Pi reads your normal Pi configuration:
 
 ```scala
 flow(OrcaArgs(args)):
@@ -232,10 +229,8 @@ which tools exist at all:
 val reviewer = claude.withReadOnly
 
 // NetworkOnly — reads plus read-only network (web + GitHub), for planners that
-// must read an issue/PR. Hard no-edit on claude (command-scoped `--allowedTools`,
-// configurable via `claude.withNetworkTools(...)`), gemini (scoped `web_fetch`),
-// and opencode (web); on pi/codex network needs a writable shell, so there the
-// no-edit guarantee is prompt-only. See ADR 0016.
+// must read an issue/PR. The no-edit guarantee is hard on claude, gemini and
+// opencode, prompt-only on pi/codex (ADR 0016).
 val planner = claude.withNetworkOnly
 
 // Full (the default) — write-capable.
@@ -322,12 +317,10 @@ Each `flow(...)` run is bound to exactly one feature branch and one progress log
   untracked files (e.g. plan files left by a planning harness) stay in place for
   the flow, and get swept into the first stage's commit. Resuming a
   `--skip-branch` run still auto-stashes, same as normal mode.
-- **Resume:** the progress log lives at a branch-independent, prompt-derived
-  path, so recovery finds it before any checkout. Its header is validated as
-  untrusted input (branch must match orca naming rules, prompt hash must match),
-  then the run resumes from the first incomplete stage. A corrupt or truncated
-  progress log is detected at startup — orca warns and starts fresh (previous
-  stages re-run) rather than silently mis-resuming.
+- **Resume:** a re-run with the same prompt finds the progress log and resumes
+  from the first incomplete stage. A corrupt or truncated progress log is
+  detected at startup — orca warns and starts fresh (previous stages re-run)
+  rather than silently mis-resuming.
 - **Success teardown:** remove the progress-log file in a final commit. A
   throwaway feature branch (no substantive changes vs the starting branch) is
   deleted and HEAD returns to the starting branch. Otherwise the feature branch
@@ -346,10 +339,8 @@ Two files, both plain `key = value` lines, parsed once per run before setup:
   settings: the stack commands (`format`/`lint`/`test`) and, per role, which
   agent to use.
 - **`$XDG_CONFIG_HOME/orca/settings.properties`**, defaulting to
-  `~/.config/orca/settings.properties` (the XDG Base Directory spec — the
-  `gh`/`git` CLI convention, followed on macOS too) — a per-user default, agent
-  keys only. A relative or unset `XDG_CONFIG_HOME` falls back to `~/.config`; an
-  absent global file is simply skipped.
+  `~/.config/orca/settings.properties` (also on macOS) — a per-user default,
+  agent keys only. An absent global file is simply skipped.
 
 Precedence, code always winning over files:
 
@@ -371,11 +362,8 @@ appends — the task's commands run in file order, so a multi-stack repo lists o
 line per stack half. A key's value may also be the literal `off`, which
 explicitly disables that task; a missing key has the same runtime effect (the
 gate is skipped) but, unlike `off`, does not count as "configured" — see
-Auto-discovery below. A `#` line is a comment and carries no meaning to the
-parser: discovery places each command's evidence (or, for a disabled task, its
-reason) as its own `#` line directly above the `key = value` line, but a comment
-is purely informative — commenting out a line is the same as deleting it. A
-typical discovered project file:
+Auto-discovery below. `#` lines are comments; commenting out a line is the same
+as deleting it. A typical discovered project file:
 
 ```properties
 # orca settings — edit freely, commit with the project.
@@ -412,17 +400,10 @@ resolved roles and where each came from:
 agents: planning=claude:claude-opus-5[1m] (default), coding=codex:gpt-5-mini (project), review=codex (global)
 ```
 
-(A role without a pin of its own shows the wired default's model when one exists
-— bare `claude` resolves to Opus — and stays bare where the harness's own
-configuration decides, as for `codex`.)
-
-**Auto-discovery.** Discovery runs when the project file is absent, or when it
-exists but has no LIVE stack line — a hand-written file containing only agent
-keys (or only commented-out stack examples) still triggers it, appending the
-discovered stack entries below the existing content rather than overwriting it,
-so agent lines are never touched. Delete the stack lines (or the whole file) to
-re-run discovery. When it runs (and no `flow(stackSettings = ...)` override is
-passed), the first run spends one cheap-model, read-only agent call inspecting
+**Auto-discovery.** Discovery runs when the project file is absent or has no
+stack line; discovered entries are appended below any existing content, so
+agent lines are never touched. Delete the stack lines (or the whole file) to
+re-run it. Discovery spends one cheap-model, read-only agent call inspecting
 the repo, then writes the file and announces every guess in the event log:
 
 ```text
@@ -478,14 +459,11 @@ exists only on the ephemeral rungs — a live human steering a turn can't be
 replayed from a seed, so durable interactive sessions don't exist by
 construction.
 
-- **Durable — `agent.session(name, seed)`.** A get-or-create keyed by `name`
-  (plus occurrence, to disambiguate duplicates of the same name), recorded in
-  the progress log with no LLM call, returning a `FlowSession` handle that
-  survives crash/resume. The same `name` resumes the same session; reordering
-  *other* `session(...)` calls between runs doesn't re-key it. On resume the
-  recorded session is reused — with a warning if this call's seed differs,
-  rather than silently resuming the wrong one. Callable only outside a stage
-  (the compiler rejects an in-stage mint); its runs happen inside stages, on the
+- **Durable — `agent.session(name, seed)`.** A get-or-create keyed by `name`,
+  returning a `FlowSession` handle that survives crash/resume: the same `name`
+  resumes the same session (with a warning if this call's seed differs, rather
+  than silently resuming the wrong one). Callable only outside a stage (the
+  compiler rejects an in-stage mint); its runs happen inside stages, on the
   flow thread.
 - **Ephemeral — `agent.chat()`.** A `Chat` handle continuing one conversation
   across `.run` calls *within this run only* — no seeding, no persistence. Runs
@@ -506,25 +484,20 @@ val chats = Par.mapUnordered(4)(reviewers): r =>
 ```
 
 The `seed` is the essential context to rebuild the agent — typically the **plan
-brief**, or the issue body when there is no brief. `FlowSession.run` (and
-`resultAs[O].run`) primes a fresh session with it on first use, and re-seeds if
-the backend lost the conversation on resume (with a warning: history is gone,
-only the seed plus a progress preamble naming completed stages are rebuilt); a
-live session just continues with its full history. Opencode sessions survive a
-process restart — opencode keeps them in its own on-disk store — but the uniform
-fallback (re-seed) covers any backend whose store isn't reachable.
+brief**, or the issue body when there is no brief. A fresh session is primed
+with it on first use; if the backend lost the conversation on resume, the
+session is re-seeded (with a warning: history is gone, only the seed plus a
+preamble naming completed stages are rebuilt), while a live session just
+continues with its full history.
 
 `agent.cheap` returns the backend's cheap/fast variant (claude → haiku, codex →
 mini, gemini → flash, opencode → anthropicHaiku, others → self) — used by the
 runtime for branch naming and default commit messages.
 
-**Backend swaps across runs.** A recorded session is tagged with the backend
-that minted it. If a settings edit changes a role's agent between runs (e.g.
-`codingAgent = codex` becomes `codingAgent = claude`), the next run finds a
-session recorded under the old backend: rather than resume it against the new,
-unrelated backend, orca mints a fresh session and warns (`warning: session
-'<name>' #<n> was minted on <old>; this agent is <new> — minting fresh`) — the
-same re-seed fallback that already covers a lost backend conversation.
+**Backend swaps across runs.** If a settings edit changes a role's agent
+between runs (e.g. `codingAgent = codex` becomes `codingAgent = claude`), a
+session recorded under the old backend isn't resumed against the new one —
+orca mints a fresh session from the seed and warns.
 
 ## Authoring rules
 
@@ -635,13 +608,11 @@ splits `autonomous` / `interactive`:
 
 Every cell returns `Sessioned[B, <result>]` — the result paired with the
 (ephemeral) `Chat` that produced it. Continue that conversation in-run
-(`chat.run(task)` — the planning turn ran restricted, but the chat is bound to
-the base agent, so continuations have write access), or `.value` it and get a
+(`chat.run(task)`; continuations have write access), or `.value` it and start a
 fresh, durable implementer session via `agent.session("implementer", seed =
 plan.brief)` — the chat does not survive a crash/resume, so every shipped
-example takes `.value`. Destructure positionally when you want both: `val
-Sessioned(chat, plan) = Plan.autonomous.from(...)` — `chat` here is the
-ephemeral one (in-run only), not a durable session.
+example takes `.value`. Destructure when you want both: `val Sessioned(chat,
+plan) = Plan.autonomous.from(...)`.
 
 From a `Sessioned[B, Plan]`, an optional `.reviewed(agent)` step refines the
 plan before implementing — the planner critiques its own draft, producing an

--- a/flows/implement-enhanced.sc
+++ b/flows/implement-enhanced.sc
@@ -6,88 +6,56 @@
 /** Autonomous planning + coding flow that lands the work on its own branch and
   * opens a pull request.
   *
-  * Same backbone as `implement.sc` (autonomous planning → per-task implement
-  * + review-and-fix loop), enhanced with a self-review pass on the plan:
-  *
-  *   1. **`.reviewed(planningAgent)`** — the planner critiques its own draft and
-  *      returns an improved plan (missing/duplicated tasks, ordering, vague
-  *      descriptions, steps that don't fit the code). Runs read-only on the
-  *      planning session; no extra exploration cost.
-  *
-  * In addition, the plan always carries a `brief` — a codebase summary the
-  * planner writes as part of its structured output. It seeds the implementer
-  * session so the cold-starting coding agents don't re-discover what the
-  * planner already learned.
-  *
-  * The flow runtime handles the feature branch automatically: it creates a
-  * branch from the prompt, commits progress to the stage log, and returns to
-  * the starting branch on success. Resume is stage-log based — a re-run with
-  * the same prompt continues from the first incomplete stage.
+  * Same backbone as `implement.sc` (autonomous planning → per-task implement +
+  * review-and-fix loop), with a self-review pass on the plan: the planner
+  * critiques its own draft and returns an improved one (missing or duplicated
+  * tasks, ordering, vague descriptions, steps that don't fit the code).
   *
   * On success the flow:
   *
   *   1. Updates the project's docs (README, doc-comments) from what the tasks
   *      changed, as its own stage and commit — so the docs land in the PR.
   *   1. Pushes the feature branch.
-  *   1. Opens a PR with a haiku-generated title + description from the full
-  *      branch diff. A human picks the PR up from there.
+  *   1. Opens a PR with a cheap-model-generated title + description from the
+  *      full branch diff. A human picks the PR up from there.
   *
   * ```bash
   * scala-cli run implement-enhanced.sc -- "Add a multiply function to the calculator crate"
   * ```
   *
-  * The review loop's format and lint commands come from
-  * `.orca/settings.properties`, auto-discovered on first run — the script
-  * itself stays stack-agnostic.
-  *
-  * Requires `claude` logged in, `cargo` on PATH, and `gh` authenticated.
+  * Requires the configured role agents logged in (`claude` by default) and
+  * `gh` authenticated.
   */
 
 import orca.{*, given}
 
 // Opens a PR at the end, so return to the starting branch afterward (the
-// default is to stay on the feature branch, for no-PR flows like implement.sc).
-// Roles come from settings.properties, default claude for everything.
+// default is to stay on the feature branch, for no-PR flows).
 flow(OrcaArgs(args), returnToStartBranch = true):
-  // Plan → review, all on one read-only planner session. The Plan structured
-  // output always includes a brief, which seeds the implementer session below.
   val plan = stage("Plan"):
     Plan.autonomous
       .from(userPrompt, planningAgent)
       .reviewed(planningAgent)
       .value
 
-  // Get-or-create the implementer session on the coding role, seeded with the
-  // plan brief so the agent has codebase context from the start (replayed on
-  // resume if lost).
   val session = codingAgent.session("implementer", seed = plan.brief)
 
   for task <- plan.tasks do
-    stage(s"Task: ${task.title}"):      // skipped on resume if already done
-      // The session seed already carries the brief, so send only the task
-      // description here — session.run re-prepends the seed on first use / resume.
+    stage(s"Task: ${task.title}"):
       session.run(task.description)
-      // reviewerSelection defaults to agentDriven(reviewAgent.cheap); format
-      // and lint default to the project's stack settings
-      // (`.orca/settings.properties`).
       reviewAndFixLoop(
         coderSession = session,
         reviewers = allReviewers(reviewAgent),
         task = task.title.value
       )
-      // one commit per task: code + progress entry
 
   // Docs pass on the implementer session — it already carries the brief and
-  // every task's context. A separate stage from the task loop, so it commits on
-  // its own and the push below stays a LATER stage than the edits it pushes
-  // (ADR 0018 §3.2 R8).
+  // every task's context. Its own stage, so the docs commit exists before the
+  // push below.
   stage("Update documentation"):
     session.run(
       "All tasks done. Update project docs (README, doc-comments) based " +
         "on the changes made. Only update what's affected — no new sections."
     )
 
-  // Push the branch and open the PR from the full branch diff. openPrFromBranch
-  // is the push → summarise → create tail as three resume-safe stages;
-  // gh.createPr is idempotent by head branch (R24), so a re-run reuses the PR.
   openPrFromBranch(summarisingAgent = codingAgent.cheap)

--- a/flows/implement-interactive.sc
+++ b/flows/implement-interactive.sc
@@ -7,14 +7,11 @@
   *
   * Same shape as `implement.sc`, but the planner can drive a conversation: on
   * an underspecified prompt it calls the `ask_user` tool to clarify before
-  * producing the plan. Progress and resume work identically — the stage log
-  * (`.orca/progress-<hash>.json`) is the sole resume mechanism. An interactive
-  * planning stage that already completed is replayed from its recorded result
-  * without re-prompting on a re-run.
+  * producing the plan. A planning stage that already completed is not
+  * re-prompted on a re-run.
   *
-  * `examples/runnable/02-interactive/create-test-project.sh` seeds the
-  * calculator crate into a temp dir and copies this script alongside it;
-  * from there:
+  * `examples/runnable/02-interactive/create-test-project.sh` seeds a calculator
+  * crate into a temp dir and copies this script alongside it; from there:
   *
   * ```bash
   * scala-cli run implement-interactive.sc -- "Add a new arithmetic operation to the calculator crate. Ask the user which."
@@ -23,39 +20,25 @@
   * The trailing "Ask the user which." pushes the planner to call `ask_user`
   * rather than guessing.
   *
-  * The review loop's format and lint commands come from
-  * `.orca/settings.properties`, auto-discovered on first run — the script
-  * itself stays stack-agnostic.
-  *
-  * Requires `claude` logged in and `cargo` on PATH.
+  * Requires the configured role agents logged in (`claude` by default); the
+  * seeded calculator example also needs `cargo` on PATH.
   */
 
 import orca.{*, given}
 
 flow(OrcaArgs(args)):
   val plan = stage("Plan"):
-    // `.value` drops the planner's session; the implementer mints its own
-    // below. Interactive planning follows the configured planning role too —
-    // `ask_user` works on every backend, so no concrete accessor is needed
-    // here.
     Plan.interactive.from(userPrompt, planningAgent).value
 
-  // Stable autonomous session on the coding role, shared by implementer and
-  // fixer (ask_user was only needed for planning), seeded with the plan
-  // brief; primed on first use and replayed if the backend session is lost
-  // on resume.
+  // One autonomous session for implementing and fixing alike — ask_user was
+  // only needed while planning.
   val session = codingAgent.session("implementer", seed = plan.brief)
 
   for task <- plan.tasks do
-    stage(s"Task: ${task.title}"):      // skipped on resume if already done
+    stage(s"Task: ${task.title}"):
       session.run(task.description)
       reviewAndFixLoop(
         coderSession = session,
         reviewers = allReviewers(reviewAgent),
-        // reviewerSelection defaults to agentDriven(reviewAgent.cheap); pass
-        // `ReviewerSelector.allEveryRound` to run every reviewer instead.
-        // Format and lint default to the project's stack settings
-        // (`.orca/settings.properties`).
         task = task.title.value
       )
-      // one commit per task: code + progress entry

--- a/flows/implement.sc
+++ b/flows/implement.sc
@@ -3,30 +3,20 @@
 //> using dep "org.virtuslab::orca:0.1.0"
 //> using jvm 21
 
-/** Autonomous planning + coding flow.
+/** Autonomous planning + coding flow — the README example.
   *
-  * Mirrors the README example. The planner breaks the prompt into tasks; the
-  * task list and implementation progress are tracked in the stage log
-  * (`.orca/progress-<hash>.json`), committed on the branch after every stage. A
-  * re-run with the same prompt resumes from the first incomplete stage — no
-  * plan file, no checkbox state to keep in sync.
+  * The planner breaks the prompt into tasks; each task is implemented on the
+  * run's feature branch and taken through a review-and-fix loop.
   *
-  * Each task is implemented on a single feature branch (auto-created from the
-  * prompt) with a review-and-fix loop; code + the updated progress entry are
-  * committed together. The branch is auto-deleted if no code landed.
-  *
-  * `examples/runnable/01-simple/create-test-project.sh` seeds the calculator
+  * `examples/runnable/01-simple/create-test-project.sh` seeds a calculator
   * crate into a temp dir and copies this script alongside it; from there:
   *
   * ```bash
   * scala-cli run implement.sc -- "Add a multiply function to the calculator crate"
   * ```
   *
-  * The review loop's format and lint commands come from
-  * `.orca/settings.properties`, auto-discovered on first run — the script
-  * itself stays stack-agnostic.
-  *
-  * Requires `claude` logged in and `cargo` on PATH.
+  * Requires the configured role agents logged in (`claude` by default); the
+  * seeded calculator example also needs `cargo` on PATH.
   *
   * For the variant where the planner can ask clarifying questions, see
   * `implement-interactive.sc`.
@@ -34,30 +24,17 @@
 
 import orca.{*, given}
 
-// Roles (planning / coding / review) come from settings.properties —
-// per-project `.orca/settings.properties`, else ~/.config/orca/settings.properties,
-// else claude for everything. Bodies can still name a concrete harness
-// (`claude`, `codex.mini`, …) where a flow wants one.
 flow(OrcaArgs(args)):
   val plan = stage("Plan"):
     Plan.autonomous.from(userPrompt, planningAgent).value
 
-  // Get-or-create the implementer session on the coding role, seeded with the
-  // plan brief (primed on first use, replayed if the backend session is lost
-  // on resume).
   val session = codingAgent.session("implementer", seed = plan.brief)
 
   for task <- plan.tasks do
-    stage(s"Task: ${task.title}"): // skipped on resume if already done
+    stage(s"Task: ${task.title}"):
       session.run(task.description)
-      reviewAndFixLoop( // runs under this stage
+      reviewAndFixLoop(
         coderSession = session,
         reviewers = allReviewers(reviewAgent),
-        // reviewerSelection defaults to agentDriven(reviewAgent.cheap); pass
-        // `ReviewerSelector.allEveryRound` to run every reviewer instead.
-        // Format and lint default to the project's stack settings
-        // (`.orca/settings.properties`); pass `Configured.Off`/`.Use(...)`
-        // to opt out or override per call.
         task = task.title.value
       )
-      // one commit per task: code + progress entry

--- a/flows/issue-pr-bugfix.sc
+++ b/flows/issue-pr-bugfix.sc
@@ -17,30 +17,24 @@
   *
   * Given a `<owner>/<repo>#<number>` reference to an issue, the flow:
   *
-  *   1. Reads the issue from GitHub (pure read, outside any stage).
+  *   1. Reads the issue from GitHub.
   *   1. Triages: actually a bug? can a unit test reproduce it?
-  *      - Not a bug → posts the verdict on the issue. The throwaway branch (no
-  *        code committed) is auto-deleted by the runtime on exit.
+  *      - Not a bug → posts the verdict on the issue.
   *      - Bug, but not testable → posts reproduction steps on the issue and
-  *        stops (no PR for docs-only repros). Same branch cleanup.
-  *   1. For a testable bug:
-  *      a. "Write failing test" stage: writes and commits the test. b. "Push +
-  *         open tentative PR" stage: pushes the committed test, then opens a PR
-  *         (`gh.createPr` is idempotent by branch). These are two separate
-  *         stages because a stage commits only on completion — a push in the
-  *         same stage as the edit would push nothing (ADR 0018 §3.2 R8).
-  *   1. Waits for CI to go red (pure polling read, outside a stage). Fails
-  *      loudly on green — the reproduction is wrong.
+  *        stops (no PR for docs-only repros).
+  *   1. For a testable bug: writes and commits the failing test, then pushes
+  *      it and opens a tentative PR.
+  *   1. Waits for CI to go red. Fails loudly on green — the reproduction is
+  *      wrong.
   *   1. Confirms the failure matches the report.
-  *   1. Plans + implements the fix on the same branch (each task a stage).
-  *   1. "Push fix + finalise PR" stage: pushes the fix and regenerates the PR
-  *      title + description from the full branch diff.
+  *   1. Plans + implements the fix on the same branch.
+  *   1. Pushes the fix and regenerates the PR title + description from the
+  *      full branch diff.
   *
   * The feature branch is named deterministically from the issue number
   * (`fix/issue-<n>`), so a re-run after a crash lands on the same branch.
-  * Resume is stage-log based — each completed stage is skipped on a re-run.
   *
-  * The flow reads top-to-bottom below; the per-step helper methods it calls
+  * The flow reads top-to-bottom below; the per-step helpers
   * (`confirmReproductionMatches`, `planAndImplementFix`, `prSummary`) are
   * defined at the bottom of the file.
   *
@@ -50,8 +44,8 @@
   * scala-cli run issue-pr-bugfix.sc -- "acme/widgets#42"
   * ```
   *
-  * Requires `gh` authenticated, and the backend the settings name for the
-  * planning/coding/review roles logged in (`claude` unless changed).
+  * Requires `gh` authenticated, and the configured role agents logged in
+  * (`claude` by default).
   *
   * The target repo must have a CI workflow that runs its test suite: a red
   * build is what confirms the reproduction.
@@ -67,14 +61,12 @@ val issueHandle = IssueHandle.parseOrThrow(orcaArgs.userPrompt)
 
 val CiTimeout = 30.minutes
 
-// Opens a PR, so return to the starting branch afterward (the default is to
-// stay on the feature branch, for no-PR flows).
+// Opens a PR, so return to the starting branch afterward.
 flow(
   orcaArgs,
   branchNaming = Some(BranchNamingStrategy.issue(issueHandle)),
   returnToStartBranch = true
 ):
-  // Pure read — outside any stage (reads don't need InStage).
   val issue = gh.readIssue(issueHandle)
 
   val issuePayload =
@@ -83,14 +75,10 @@ flow(
        |
        |${issue.body}""".stripMargin
 
-  // Get-or-create the implementer session on the coding role before the
-  // triage stage (pure: reserves the session id, no LLM call). The seed
-  // primes it on first use and is replayed if the backend session is lost on
-  // resume.
   val session = codingAgent.session("fixer", seed = issue.body)
 
   val triage: Triage = stage("Triage"):
-    // Autonomous triage, read-only (read/grep to verify the report).
+    // Read-only: the triager reads/greps to verify the report, changes nothing.
     Plan.autonomous.triage(issuePayload, planningAgent).value
 
   triage match
@@ -113,7 +101,6 @@ flow(
         )
 
     case Triage.Testable(summary, _, failingTestPath) =>
-      // Write failing test: committed by the stage.
       stage("Write failing test"):
         session.run(
           s"""Write the failing unit test at `$failingTestPath`. It MUST
@@ -122,14 +109,9 @@ flow(
              |verify.""".stripMargin
         )
 
-      // Push + open PR: a SEPARATE stage from the edit above.
-      // Authoring rule (ADR 0018 §3.2 R8): a stage commits only on completion,
-      // so a push in the same stage as the edit would push nothing — the push
-      // must be in a later stage than the code that produced it.
+      // A later stage than the edit above, so the test commit exists to push.
       val pr = stage("Push + open tentative PR"):
         git.push().orThrow
-        // gh.createPr is idempotent by head branch (R24): if the branch already
-        // has an open PR, the existing handle is returned.
         gh.createPr(
           title = summary,
           body = s"""Failing test only — fix pending.
@@ -137,7 +119,6 @@ flow(
                     |Closes ${issueHandle.shortRef}.""".stripMargin
         ).orThrow
 
-      // `waitForBuild` is a pure polling read — outside any stage.
       if gh.waitForBuild(pr, CiTimeout).orThrow.outcome == BuildOutcome.Success
       then
         fail(
@@ -148,7 +129,7 @@ flow(
       confirmReproductionMatches(pr, issue)
       planAndImplementFix(session)
 
-      // Push fix + update PR: again a LATER stage than the task edits above.
+      // Again later than the task edits above, so the fix commits exist.
       stage("Push fix + finalise PR"):
         git.push().orThrow
         val finalSum = prSummary(
@@ -165,10 +146,6 @@ flow(
         )
 
 // ============================ pipeline helpers ============================
-// One def per step of the testable-bug pipeline; the `Testable` branch above
-// reads as their sequence. Defined below the flow so the high-level logic comes
-// first; each takes a `using` flow capability plus the `issue` / `session` it
-// needs.
 
 /** PR title + body from the full branch diff, with issue context and a
   * phase-specific `note`. Used for both the tentative (test-only) and final
@@ -236,14 +213,10 @@ def confirmReproductionMatches(pr: PrHandle, issue: Issue)(using
     if !verdict.matches then
       fail(s"Reproduction doesn't match the report: ${verdict.explanation}")
 
-/** Plan + implement the fix on the same branch. The plan always carries a
-  * brief (no separate `.briefed` step); `taskPrompt` prepends it to each task.
-  * Implementation reuses the triage `session`.
+/** Plan + implement the fix on the same branch, reusing the triage `session`.
   *
-  * `[B <: BackendTag]` carries the coding agent's backend so the `session`
-  * threads through the reviewers and `session.run`; it's read off the
-  * `session` argument, letting the helper accept a session for whichever
-  * backend the settings named.
+  * `[B <: BackendTag]` is read off the `session` argument, so the helper
+  * accepts a session for whichever backend the settings named.
   */
 def planAndImplementFix[B <: BackendTag](
     session: FlowSession[B]
@@ -260,7 +233,7 @@ def planAndImplementFix[B <: BackendTag](
       .value
 
   for task <- fixPlan.tasks do
-    stage(s"Task: ${task.title}"): // skipped on resume if already done
+    stage(s"Task: ${task.title}"):
       session.run(fixPlan.taskPrompt(task))
       // Don't gate this loop on the tests: the branch carries a deliberately
       // failing one until the last fix task lands.
@@ -269,4 +242,3 @@ def planAndImplementFix[B <: BackendTag](
         reviewers = allReviewers(reviewAgent),
         task = task.title.value
       )
-      // one commit per task: code + progress entry

--- a/flows/issue-pr.sc
+++ b/flows/issue-pr.sc
@@ -15,17 +15,13 @@
   *
   * Given a `<owner>/<repo>#<number>` reference (the user's prompt), the flow:
   *
-  *   1. Reads the issue from GitHub (title, body, author) — outside any stage,
-  *      since it is a pure read.
+  *   1. Reads the issue from GitHub.
   *   1. Skeptically assesses the report against the repo (claims, missing
   *      detail, duplicates, scope) and either proceeds with a plan or rejects.
-  *   1. On rejection: posts the agent's reply on the issue. The throwaway
-  *      branch (no code committed) is auto-deleted by the runtime on exit.
-  *   1. On proceed: runs the per-task implement + review-and-fix loop. The
-  *      task list and progress live in the stage log; a re-run resumes from
-  *      the first incomplete stage.
-  *   1. Pushes the branch, folds the diff into a PR title + description via
-  *      haiku (`summarisePr`), and opens the PR via `gh` (idempotent by branch).
+  *   1. On rejection: posts the agent's reply on the issue.
+  *   1. On proceed: runs the per-task implement + review-and-fix loop.
+  *   1. Pushes the branch and opens a PR with a cheap-model-generated title
+  *      and description.
   *
   * The feature branch is named deterministically from the issue number
   * (`fix/issue-<n>`), so a re-run after a crash lands on the same branch.
@@ -36,8 +32,8 @@
   * scala-cli run issue-pr.sc -- "acme/widgets#42"
   * ```
   *
-  * Requires `gh` authenticated, and the backend the settings name for the
-  * planning/coding/review roles logged in (`claude` unless changed).
+  * Requires `gh` authenticated, and the configured role agents logged in
+  * (`claude` by default).
   */
 
 import orca.{*, given}
@@ -47,15 +43,12 @@ import orca.{*, given}
 val orcaArgs = OrcaArgs(args)
 val issueHandle = IssueHandle.parseOrThrow(orcaArgs.userPrompt)
 
-// returnToStartBranch: this flow opens a PR, so switch back to the starting
-// branch afterward (ready for the next task) rather than staying on the feature
-// branch — which is the default for no-PR flows like implement.sc.
+// Opens a PR, so return to the starting branch afterward.
 flow(
   orcaArgs,
   branchNaming = Some(BranchNamingStrategy.issue(issueHandle)),
   returnToStartBranch = true
 ):
-  // Pure read — outside any stage (reads don't need InStage).
   val issue = gh.readIssue(issueHandle)
 
   val issuePayload =
@@ -82,23 +75,17 @@ flow(
       )
 
   maybePlan.foreach: plan =>
-    // Get-or-create the implementer session on the coding role, seeded with
-    // the plan brief (replayed on resume if the session is lost).
     val session = codingAgent.session("implementer", seed = plan.brief)
 
     for task <- plan.tasks do
-      stage(s"Task: ${task.title}"):    // skipped on resume if already done
+      stage(s"Task: ${task.title}"):
         session.run(task.description)
         reviewAndFixLoop(
           coderSession = session,
           reviewers = allReviewers(reviewAgent),
           task = task.title.value
         )
-        // one commit per task: code + progress entry
 
-    // Push → summarise → create, as three resume-safe stages. The summariser
-    // sees the branch-vs-base diff (git.diff() vs HEAD would be empty here,
-    // since every task is already committed); the body appends the issue closer.
     openPrFromBranch(
       summarisingAgent = codingAgent.cheap,
       body = summary =>

--- a/flows/review.sc
+++ b/flows/review.sc
@@ -35,8 +35,8 @@
   * git diff | orca run review.sc
   * ```
   *
-  * Requires the backend the settings name for the review role logged in
-  * (`claude` unless changed), and `gh` authenticated when the target is a PR.
+  * Requires the configured role agents logged in (`claude` by default), and
+  * `gh` authenticated when the target is a PR.
   */
 
 import orca.{*, given}

--- a/flows/simple.sc
+++ b/flows/simple.sc
@@ -10,18 +10,11 @@
   * flow file, a one-line fix) where splitting into a plan first is pure
   * overhead.
   *
-  * The session is seeded with `userPrompt` rather than run with it, so the task
-  * survives a lost/resumed backend conversation even if a later prompt (e.g. a
-  * fix-loop turn) doesn't restate it — see `FlowSession`'s replay semantics.
-  *
   * ```bash
   * scala-cli run simple.sc -- "Add a .gitignore entry for build artifacts"
   * ```
   *
-  * The review loop's format and lint commands come from
-  * `.orca/settings.properties`, auto-discovered on first run.
-  *
-  * Requires `claude` logged in.
+  * Requires the configured role agents logged in (`claude` by default).
   */
 
 import orca.{*, given}
@@ -40,6 +33,8 @@ val review = Reviewer(
 )
 
 flow(OrcaArgs(args)):
+  // Seeded with the prompt (rather than run with it), so the task survives a
+  // resume even when a later fix-loop turn doesn't restate it.
   val session = codingAgent.session("implementer", seed = userPrompt)
   stage("Implement"):
     session.run("Implement the task from the seed prompt above.")


### PR DESCRIPTION
A relevancy pass over all seven flow scripts and the README, applying the rule from the recent comment reviews: **a comment may only state facts specific to the file it's in** — platform behavior belongs in the platform's docs, once.

## Flows (−150 lines of comments, no code changes except none)

What was cut from every script where it appeared:
- the `.orca/settings.properties` format/lint paragraphs (the Settings section covers resolution),
- `reviewerSelection`/format/lint default explanations at `reviewAndFixLoop` call sites,
- stage/resume mechanics: `skipped on resume`, `one commit per task`, `Pure read — outside any stage`, stage-log paths,
- session-seed replay semantics on every `session(...)` mint,
- `gh.createPr` idempotency and ADR rule citations (the Authoring rules section covers them).

What each flow keeps: its shape, its possible outcomes, usage, prerequisites, and the genuinely local facts (e.g. bugfix's "don't gate this loop on tests — the branch carries a deliberately failing one", the two-stage verdict/comment split in `issue-pr.sc`).

Prerequisites are now uniform — "the configured role agents logged in (`claude` by default)" — instead of naming `claude`, and `cargo` is tied to the seeded calculator examples rather than claimed as a flow requirement. `issue-pr.sc`'s scaladoc also said the PR description came "via haiku", which has been wrong since it moved to `codingAgent.cheap` — now "cheap-model-generated".

## README (−50 lines)

Internals removed from user-facing prose (reference tables untouched):
- progress-log header validation details under Resume,
- session occurrence-keying, the verbatim backend-swap warning text, opencode's on-disk session store,
- XDG fallback rules and spec citations,
- discovery's evidence-comment placement mechanics and the trigger's edge-case enumeration,
- per-backend `NetworkOnly` enforcement mechanics — now one line + the ADR 0016 pointer,
- `reviewAndFixLoop` rationale inside "The runtime owns git".

## Verified

`BuiltInFlowsCompileTest` against a fresh `publishLocal`: 7/7 flows compile.