### PR TITLE
Authoring: compile the flow via the sandbox lint gate

### DIFF
--- a/adr/0021-orca-shell.md
+++ b/adr/0021-orca-shell.md
@@ -552,6 +552,16 @@ included only as a last-resort fallback line.
 > unborn, or the commit fails for any reason — a commit hiccup never fails the
 > authoring result.
 
+> **Amendment (2026-07-28).** The sandbox settings file now sets `lint =
+> scala-cli compile <flow-file>` (format/test stay `off`): the prompt's
+> compile-verify instruction was only agent-honored, so a script the agent
+> never compiled could land committed but broken. The review loop's lint gate
+> makes the check mechanical, and `simple.sc` moved to `maxIterations = 3` so
+> a compile failure found by the gate gets fixed *and re-verified*. The loop's
+> result still isn't a hard gate — a flow that ends with findings ignored
+> still exits Ok and is copied out; accepted, since the sandbox lint is
+> feedback machinery, not an acceptance test.
+
 ### 10. Command-line interface
 
 `orca` with no args starts the interactive shell unchanged (§§3–9); any argv

--- a/flows/simple.sc
+++ b/flows/simple.sc
@@ -1,4 +1,4 @@
-// Implement a task directly — no planning stage — with a single review round.
+// Implement a task directly — no planning stage — with up to three review rounds.
 //> using scala 3.8.4
 //> using dep "org.virtuslab::orca:0.1.1"
 //> using jvm 21
@@ -43,5 +43,5 @@ flow(OrcaArgs(args)):
       reviewers = buildReviewers(reviewAgent, List(review)),
       reviewerSelection = ReviewerSelector.allEveryRound,
       task = userPrompt,
-      maxIterations = 1
+      maxIterations = 3
     )

--- a/shell/src/main/scala/orca/shell/actions/AuthorAction.scala
+++ b/shell/src/main/scala/orca/shell/actions/AuthorAction.scala
@@ -74,7 +74,7 @@ private[shell] object AuthorAction:
       terminal: Terminal,
       launch: FlowLaunch = FlowLauncher.runAnnounced
   ): LaunchResult =
-    val sandbox = AuthoringSandbox.create()
+    val sandbox = AuthoringSandbox.create(params.target.flowPath.last)
     val apiDir = FlowAuthoring.extractApiMaterial(
       OrcaDir.ensureCache(sandbox),
       ShellVersion.value
@@ -104,7 +104,7 @@ private[shell] object AuthorAction:
       terminal: Terminal,
       launch: FlowLaunch = FlowLauncher.runAnnounced
   ): LaunchResult =
-    val sandbox = AuthoringSandbox.create()
+    val sandbox = AuthoringSandbox.create(params.target.flowPath.last)
     val apiDir = FlowAuthoring.extractApiMaterial(
       OrcaDir.ensureCache(sandbox),
       ShellVersion.value

--- a/shell/src/main/scala/orca/shell/create/AuthoringSandbox.scala
+++ b/shell/src/main/scala/orca/shell/create/AuthoringSandbox.scala
@@ -3,22 +3,30 @@ package orca.shell.create
 /** A throwaway git workspace for one authoring run (ADR 0021 §9): the authoring
   * flow runs here instead of in the user's repository, so authoring works from
   * any directory, never stashes or commits the user's tree, and leaves no
-  * branches behind. A pre-committed settings file with every stack key
-  * explicitly `off` counts as "stack configured" (`SettingsFile.hasStackLines`
-  * only sees LIVE lines — a comment would not do) and keeps stack discovery
-  * from ever running — a flow script has no project stack to discover. On
-  * success the authored file is copied out to the real tier and the sandbox
-  * deleted; after a failure it is kept for inspection.
+  * branches behind. A pre-committed settings file counts as "stack configured"
+  * (`SettingsFile.hasStackLines` only sees LIVE lines — a comment would not do)
+  * and keeps stack discovery from ever running. The one mechanical gate a flow
+  * script admits is compiling it, so `lint` is `scala-cli compile <flow-file>`
+  * — the review loop then gets compiler feedback each round — while
+  * `format`/`test` stay off. On success the authored file is copied out to the
+  * real tier and the sandbox deleted; after a failure it is kept for
+  * inspection.
   */
 private[shell] object AuthoringSandbox:
 
-  private[create] val SettingsContents: String =
-    """# orca authoring sandbox — a flow script has no project stack; every
-      |# gate is explicitly disabled.
-      |format = off
-      |lint = off
-      |test = off
-      |""".stripMargin
+  private[create] def settingsContents(flowFileName: String): String =
+    s"""# orca authoring sandbox — compiling the flow script is its only gate;
+       |# there is no project stack to format or test.
+       |format = off
+       |lint = scala-cli compile ${shellQuote(flowFileName)}
+       |test = off
+       |""".stripMargin
+
+  /** Single-quoted for the `bash -c` the lint gate runs under — the filename is
+    * user-entered, so spaces (or a stray quote) must not split the command.
+    */
+  private def shellQuote(name: String): String =
+    "'" + name.replace("'", "'\\''") + "'"
 
   /** Ignores the workspace metadata the coding agent's own `scala-cli compile`
     * (the prompt's verification step) drops beside the flow — kept out of
@@ -33,16 +41,22 @@ private[shell] object AuthoringSandbox:
   /** Creates the sandbox: a fresh temp dir, `git init` with a local identity
     * (no dependence on the user's global git config), and the `.gitignore` +
     * settings file committed as the root commit — so the flow starts on a clean
-    * tree with a commit for its branch machinery to build on.
+    * tree with a commit for its branch machinery to build on. `flowFileName` is
+    * the authored file's basename at the sandbox root
+    * (`AuthorAction.sandboxTarget`), baked into the lint gate's compile
+    * command.
     */
-  def create(): os.Path =
+  def create(flowFileName: String): os.Path =
     val dir = os.temp.dir(prefix = "orca-authoring-")
     git(dir, "init", "--quiet")
     git(dir, "config", "user.name", "orca")
     git(dir, "config", "user.email", "orca@authoring.invalid")
     os.write(dir / ".gitignore", GitignoreContents)
     os.makeDir.all(dir / ".orca")
-    os.write(dir / ".orca" / "settings.properties", SettingsContents)
+    os.write(
+      dir / ".orca" / "settings.properties",
+      settingsContents(flowFileName)
+    )
     git(dir, "add", "-A")
     git(dir, "commit", "--quiet", "-m", "orca authoring sandbox")
     dir

--- a/shell/src/test/scala/orca/shell/actions/AuthorActionTest.scala
+++ b/shell/src/test/scala/orca/shell/actions/AuthorActionTest.scala
@@ -141,7 +141,7 @@ class AuthorActionTest extends munit.FunSuite:
       assert(isGitRepo, "sandbox must be an initialized git repo")
       assert(hasApiMaterial, "API material must be extracted in the sandbox")
       assert(settings.contains("format = off"), settings)
-      assert(settings.contains("lint = off"), settings)
+      assert(settings.contains("lint = scala-cli compile 'new.sc'"), settings)
       assert(settings.contains("test = off"), settings)
 
   test(

--- a/shell/src/test/scala/orca/shell/create/AuthoringSandboxTest.scala
+++ b/shell/src/test/scala/orca/shell/create/AuthoringSandboxTest.scala
@@ -1,14 +1,15 @@
 package orca.shell.create
 
-import orca.StackSettings
 import orca.settings.{SettingsFile, SettingsScope}
 
 class AuthoringSandboxTest extends munit.FunSuite:
 
+  private val flowName = "flow.sc"
+
   test(
     "create: an initialized git repo with a clean tree and a root commit"
   ):
-    val sandbox = AuthoringSandbox.create()
+    val sandbox = AuthoringSandbox.create(flowName)
     try
       assert(os.isDir(sandbox / ".git"))
       val status = os
@@ -26,29 +27,43 @@ class AuthoringSandboxTest extends munit.FunSuite:
     finally AuthoringSandbox.delete(sandbox)
 
   test("create: the settings file suppresses stack discovery"):
-    val sandbox = AuthoringSandbox.create()
+    val sandbox = AuthoringSandbox.create(flowName)
     try
       val settings = os.read(sandbox / ".orca" / "settings.properties")
       assert(
         SettingsFile.hasStackLines(settings),
-        s"live `off` lines must satisfy the discovery trigger:\n$settings"
-      )
-      assertEquals(
-        SettingsFile.parse(settings, SettingsScope.Project).map(_.stack),
-        Right(StackSettings.empty),
-        "off must not parse as a literal command for any gate"
+        s"live stack lines must satisfy the discovery trigger:\n$settings"
       )
     finally AuthoringSandbox.delete(sandbox)
 
+  test("create: lint compiles the flow file; format and test stay off"):
+    val sandbox = AuthoringSandbox.create(flowName)
+    try
+      val settings = os.read(sandbox / ".orca" / "settings.properties")
+      val stack = SettingsFile
+        .parse(settings, SettingsScope.Project)
+        .fold(e => fail(e.message), _.stack)
+      assertEquals(stack.lint, List("scala-cli compile 'flow.sc'"))
+      assertEquals(stack.format, Nil)
+      assertEquals(stack.test, Nil)
+    finally AuthoringSandbox.delete(sandbox)
+
+  test("settingsContents: a quote in the filename survives shell quoting"):
+    val contents = AuthoringSandbox.settingsContents("it's.sc")
+    val stack = SettingsFile
+      .parse(contents, SettingsScope.Project)
+      .fold(e => fail(e.message), _.stack)
+    assertEquals(stack.lint, List("scala-cli compile 'it'\\''s.sc'"))
+
   test("delete removes the sandbox"):
-    val sandbox = AuthoringSandbox.create()
+    val sandbox = AuthoringSandbox.create(flowName)
     AuthoringSandbox.delete(sandbox)
     assert(!os.exists(sandbox))
 
   test(
     "create: scala-cli workspace droppings are ignored — invisible to status"
   ):
-    val sandbox = AuthoringSandbox.create()
+    val sandbox = AuthoringSandbox.create(flowName)
     try
       val tracked = os
         .proc("git", "ls-files")


### PR DESCRIPTION
The authoring prompt tells the agent to run `scala-cli compile` on the written flow, but nothing verified it happened — a script the agent never compiled could land committed but broken.

- `AuthoringSandbox` now writes `lint = scala-cli compile '<flow-file>'` into the sandbox settings (`format`/`test` stay `off`), so `reviewAndFixLoop`'s lint gate runs the compiler mechanically each round; the filename is shell-quoted since it's user-entered.
- `simple.sc` moves to `maxIterations = 3` (upper bound only — the loop still halts when a round is clean), so a compile failure found by the gate gets fixed *and re-verified* instead of a single unchecked fix attempt.
- ADR 0021 §9 amendment records this, including the accepted limitation: the loop result is not a hard gate — a run ending with ignored findings still exits Ok and is copied out.

Tests: `AuthoringSandboxTest` asserts the lint command and quoting; `AuthorActionTest`'s stale `lint = off` assertion updated. `BuiltInFlowsCompileTest`/`FlowAuthoringSmokeTest` fail locally under `sbt --client` on a missing `-Dorca.build.version` — pre-existing (identical on master), unrelated.