### PR TITLE
Pass --head explicitly to gh pr create

### DIFF
--- a/tools/src/main/scala/orca/tools/GitHubTool.scala
+++ b/tools/src/main/scala/orca/tools/GitHubTool.scala
@@ -103,7 +103,19 @@ final class PrAlreadyExists
 
 final class NoCommitsToPr
     extends PrCreateFailed(
-      "no commits to open a pull request from — push the branch first"
+      "no commits between the base branch and the pushed branch — nothing to " +
+        "open a pull request from"
+    )
+
+/** gh refused because it does not consider the current branch pushed. With
+  * `--head` passed explicitly by [[GitHubTool.createPr]] this should not occur;
+  * kept distinct from [[NoCommitsToPr]] so the diagnostic stays truthful — the
+  * branch may well be pushed, just with local-only commits on top.
+  */
+final class BranchNotPushed
+    extends PrCreateFailed(
+      "gh does not consider the current branch pushed — push the branch " +
+        "(including any local-only commits) first"
     )
 
 /** Common parent for recoverable [[GitHubTool.waitForBuild]] failure modes:
@@ -246,7 +258,26 @@ private[orca] class OsGitHubTool(
     // already has a PR" / "no commits to push" cases from genuine system
     // failures, so this uses `runGhResult` (raw result) rather than
     // `ghRead`/`ghMutate` (which abort on non-zero exit).
-    val result = runGhResult("pr", "create", "--title", title, "--body", body)
+    //
+    // `--head` is passed explicitly: gh's own head detection only accepts a
+    // remote tracking ref whose hash equals local HEAD's, and non-interactive
+    // gh aborts when none matches. A flow stage that pushes and then commits
+    // its progress log leaves HEAD ahead of the pushed ref, so detection would
+    // wrongly conclude the branch isn't pushed. Naming the branch creates the
+    // PR from the pushed ref regardless of local-only commits on top. Bare
+    // branch name (no `owner:` prefix) — like [[findOpenPr]], this assumes the
+    // head branch lives in the same repo the PR targets, not a fork.
+    val head = currentBranchGit()
+    val result = runGhResult(
+      "pr",
+      "create",
+      "--title",
+      title,
+      "--body",
+      body,
+      "--head",
+      head
+    )
     if result.exitCode == 0 then
       val output = result.stdout.trim
       PrUrlPattern.findFirstMatchIn(output) match
@@ -263,13 +294,15 @@ private[orca] class OsGitHubTool(
       if OsGitHubTool.isPrAlreadyExists(combined) then
         // Look up the existing open PR rather than failing — crash-safe for
         // flows that may re-enter a "push + open PR" stage.
-        findOpenPr(currentBranchGit()) match
+        findOpenPr(head) match
           case Some(pr) =>
             events.onEvent(OrcaEvent.Step(s"Reusing existing PR: ${pr.url}"))
             Right(pr)
           case None => Left(new PrAlreadyExists)
       else if OsGitHubTool.isNoCommitsToPr(combined) then
         Left(new NoCommitsToPr)
+      else if OsGitHubTool.isBranchNotPushed(combined) then
+        Left(new BranchNotPushed)
       else fail("gh pr create", result)
 
   /** Resolve the current branch name via `git rev-parse --abbrev-ref HEAD`.
@@ -564,12 +597,18 @@ private[orca] object OsGitHubTool:
   private[tools] def isPrAlreadyExists(combined: String): Boolean =
     combined.toLowerCase.contains("already exists")
 
-  /** True when `gh pr create` reported there is nothing to open a PR from (no
-    * commits ahead of base, or branch not pushed).
+  /** True when `gh pr create` reported no commits between the base and head
+    * branches — the pushed branch has nothing on top of base.
     */
   private[tools] def isNoCommitsToPr(combined: String): Boolean =
-    val lower = combined.toLowerCase
-    lower.contains("no commits") || lower.contains("must first push")
+    combined.toLowerCase.contains("no commits")
+
+  /** True when non-interactive `gh pr create` aborted because it does not
+    * consider the current branch pushed — it found no remote tracking ref whose
+    * hash matches local HEAD.
+    */
+  private[tools] def isBranchNotPushed(combined: String): Boolean =
+    combined.toLowerCase.contains("must first push")
 
   private val StatusCompleted = "COMPLETED"
   private val SuccessfulConclusions = Set("SUCCESS", "NEUTRAL", "SKIPPED")

--- a/tools/src/main/scala/orca/tools/GitHubTool.scala
+++ b/tools/src/main/scala/orca/tools/GitHubTool.scala
@@ -107,15 +107,14 @@ final class NoCommitsToPr
         "open a pull request from"
     )
 
-/** gh refused because it does not consider the current branch pushed. With
-  * `--head` passed explicitly by [[GitHubTool.createPr]] this should not occur;
-  * kept distinct from [[NoCommitsToPr]] so the diagnostic stays truthful — the
-  * branch may well be pushed, just with local-only commits on top.
+/** gh refused to create the PR because the head branch is not on the remote —
+  * e.g. a resumed flow that skipped its already-recorded push stage. Distinct
+  * from [[NoCommitsToPr]], where the branch is pushed but carries nothing on
+  * top of base.
   */
 final class BranchNotPushed
     extends PrCreateFailed(
-      "gh does not consider the current branch pushed — push the branch " +
-        "(including any local-only commits) first"
+      "the head branch is not on the remote — push the branch first"
     )
 
 /** Common parent for recoverable [[GitHubTool.waitForBuild]] failure modes:
@@ -147,6 +146,12 @@ final class NoChecksConfigured(grace: FiniteDuration)
   * writes PR comments, and polls GitHub's check-run status.
   */
 trait GitHubTool:
+  /** Open a PR for the current branch, named explicitly as the head and assumed
+    * to live in the repo the PR targets (fork clones are unsupported). gh
+    * refusals with a recovery path come back as `Left`s; throws when the
+    * current branch cannot be resolved (detached HEAD) and on system failures
+    * (auth, network).
+    */
   def createPr(title: String, body: String)(using
       WorkspaceWrite
   ): Either[PrCreateFailed, PrHandle]
@@ -254,20 +259,17 @@ private[orca] class OsGitHubTool(
   def createPr(title: String, body: String)(using
       WorkspaceWrite
   ): Either[PrCreateFailed, PrHandle] =
-    // Inspect exit code + stderr ourselves to split the recoverable "branch
-    // already has a PR" / "no commits to push" cases from genuine system
-    // failures, so this uses `runGhResult` (raw result) rather than
-    // `ghRead`/`ghMutate` (which abort on non-zero exit).
+    // Inspect exit code + stderr ourselves to split the recoverable failures
+    // (the `PrCreateFailed` cases) from genuine system failures, so this uses
+    // `runGhResult` (raw result) rather than `ghRead`/`ghMutate` (which abort
+    // on non-zero exit).
     //
-    // `--head` is passed explicitly: gh's own head detection only accepts a
-    // remote tracking ref whose hash equals local HEAD's, and non-interactive
-    // gh aborts when none matches. A flow stage that pushes and then commits
-    // its progress log leaves HEAD ahead of the pushed ref, so detection would
-    // wrongly conclude the branch isn't pushed. Naming the branch creates the
-    // PR from the pushed ref regardless of local-only commits on top. Bare
-    // branch name (no `owner:` prefix) — like [[findOpenPr]], this assumes the
-    // head branch lives in the same repo the PR targets, not a fork.
-    val head = currentBranchGit()
+    // `--head` is passed explicitly: gh's own detection requires a remote ref
+    // whose hash equals local HEAD's, so a stage that pushes and then commits
+    // its progress log would be misread as "branch not pushed". Bare branch
+    // name, no `owner:` prefix — like `findOpenPr`, this assumes the head
+    // branch lives in the repo the PR targets, not a fork.
+    val head = headBranchForPr()
     val result = runGhResult(
       "pr",
       "create",
@@ -299,11 +301,25 @@ private[orca] class OsGitHubTool(
             events.onEvent(OrcaEvent.Step(s"Reusing existing PR: ${pr.url}"))
             Right(pr)
           case None => Left(new PrAlreadyExists)
-      else if OsGitHubTool.isNoCommitsToPr(combined) then
-        Left(new NoCommitsToPr)
+      // The missing-head-branch 422 also contains "no commits", so
+      // isBranchNotPushed must be tested before isNoCommitsToPr.
       else if OsGitHubTool.isBranchNotPushed(combined) then
         Left(new BranchNotPushed)
+      else if OsGitHubTool.isNoCommitsToPr(combined) then
+        Left(new NoCommitsToPr)
       else fail("gh pr create", result)
+
+  /** The current branch name for `--head`. Throws on detached HEAD (rev-parse
+    * yields the literal `HEAD`) or a blank name — passing `--head ""` would
+    * silently re-enable gh's own head detection.
+    */
+  private def headBranchForPr(): String =
+    val head = currentBranchGit()
+    if head.isEmpty || head == "HEAD" then
+      throw OrcaFlowException(
+        s"cannot open a PR: not on a branch (git rev-parse gave '$head')"
+      )
+    head
 
   /** Resolve the current branch name via `git rev-parse --abbrev-ref HEAD`.
     * Carries [[OsGitTool.nonInteractiveEnv]] so an ssh/credential prompt can't
@@ -552,8 +568,8 @@ private[orca] class OsGitHubTool(
     result.stdout
 
   /** Abort with a uniform message for an unrecoverable CLI failure. Callers
-    * handle the expected non-zero exits (PR already exists, no commits) as
-    * `Left`s before reaching here.
+    * handle the expected non-zero exits (PR already exists, branch not pushed,
+    * no commits) as `Left`s before reaching here.
     */
   private def fail(label: String, result: CliResult): Nothing =
     throw OrcaFlowException(
@@ -603,12 +619,17 @@ private[orca] object OsGitHubTool:
   private[tools] def isNoCommitsToPr(combined: String): Boolean =
     combined.toLowerCase.contains("no commits")
 
-  /** True when non-interactive `gh pr create` aborted because it does not
-    * consider the current branch pushed — it found no remote tracking ref whose
-    * hash matches local HEAD.
+  /** True when `gh pr create` failed because the head branch is not on the
+    * remote: the API 422 for a `--head` naming a branch GitHub doesn't have, or
+    * gh's own abort when its head detection finds no pushed ref. The 422 text
+    * also contains "no commits", so callers must test this predicate before
+    * [[isNoCommitsToPr]].
     */
   private[tools] def isBranchNotPushed(combined: String): Boolean =
-    combined.toLowerCase.contains("must first push")
+    val lower = combined.toLowerCase
+    lower.contains("head ref must be a branch") ||
+    lower.contains("head sha can't be blank") ||
+    lower.contains("must first push")
 
   private val StatusCompleted = "COMPLETED"
   private val SuccessfulConclusions = Set("SUCCESS", "NEUTRAL", "SKIPPED")

--- a/tools/src/main/scala/orca/tools/GitHubTool.scala
+++ b/tools/src/main/scala/orca/tools/GitHubTool.scala
@@ -107,14 +107,14 @@ final class NoCommitsToPr
         "open a pull request from"
     )
 
-/** gh refused to create the PR because the head branch is not on the remote —
-  * e.g. a resumed flow that skipped its already-recorded push stage. Distinct
-  * from [[NoCommitsToPr]], where the branch is pushed but carries nothing on
-  * top of base.
+/** The head branch is not on the remote — e.g. a resumed flow that skipped its
+  * already-recorded push stage. Distinct from [[NoCommitsToPr]], where the
+  * branch is pushed but carries nothing on top of base.
   */
 final class BranchNotPushed
     extends PrCreateFailed(
-      "the head branch is not on the remote — push the branch first"
+      "the head branch is not on the remote — push the branch first (fork " +
+        "clones are unsupported)"
     )
 
 /** Common parent for recoverable [[GitHubTool.waitForBuild]] failure modes:
@@ -146,10 +146,11 @@ final class NoChecksConfigured(grace: FiniteDuration)
   * writes PR comments, and polls GitHub's check-run status.
   */
 trait GitHubTool:
-  /** Open a PR for the current branch, named explicitly as the head and assumed
-    * to live in the repo the PR targets (fork clones are unsupported). gh
-    * refusals with a recovery path come back as `Left`s; throws when the
-    * current branch cannot be resolved (detached HEAD) and on system failures
+  /** Open a PR from the current branch as it exists on the remote: the branch
+    * must already be pushed to the repo the PR targets (fork clones are
+    * unsupported), and commits made locally after the last push are not
+    * included. Refusals with a recovery path come back as `Left`s; throws on
+    * detached HEAD, on gh output carrying no PR URL, and on system failures
     * (auth, network).
     */
   def createPr(title: String, body: String)(using
@@ -267,8 +268,7 @@ private[orca] class OsGitHubTool(
     // `--head` is passed explicitly: gh's own detection requires a remote ref
     // whose hash equals local HEAD's, so a stage that pushes and then commits
     // its progress log would be misread as "branch not pushed". Bare branch
-    // name, no `owner:` prefix — like `findOpenPr`, this assumes the head
-    // branch lives in the repo the PR targets, not a fork.
+    // name, no `owner:` prefix, matching `findOpenPr`.
     val head = headBranchForPr()
     val result = runGhResult(
       "pr",
@@ -301,38 +301,31 @@ private[orca] class OsGitHubTool(
             events.onEvent(OrcaEvent.Step(s"Reusing existing PR: ${pr.url}"))
             Right(pr)
           case None => Left(new PrAlreadyExists)
-      // The missing-head-branch 422 also contains "no commits", so
-      // isBranchNotPushed must be tested before isNoCommitsToPr.
       else if OsGitHubTool.isBranchNotPushed(combined) then
         Left(new BranchNotPushed)
       else if OsGitHubTool.isNoCommitsToPr(combined) then
         Left(new NoCommitsToPr)
       else fail("gh pr create", result)
 
-  /** The current branch name for `--head`. Throws on detached HEAD (rev-parse
-    * yields the literal `HEAD`) or a blank name — passing `--head ""` would
-    * silently re-enable gh's own head detection.
+  /** The current branch name for `--head`, via `git rev-parse --abbrev-ref
+    * HEAD` (carrying [[OsGitTool.nonInteractiveEnv]] so an ssh/credential
+    * prompt can't hang a flow). Throws on detached HEAD (rev-parse yields the
+    * literal `HEAD`) and on a blank name, which would silently re-enable gh's
+    * own head detection.
     */
   private def headBranchForPr(): String =
-    val head = currentBranchGit()
-    if head.isEmpty || head == "HEAD" then
-      throw OrcaFlowException(
-        s"cannot open a PR: not on a branch (git rev-parse gave '$head')"
-      )
-    head
-
-  /** Resolve the current branch name via `git rev-parse --abbrev-ref HEAD`.
-    * Carries [[OsGitTool.nonInteractiveEnv]] so an ssh/credential prompt can't
-    * hang a flow.
-    */
-  private def currentBranchGit(): String =
     val result = cli.run(
       Seq("git", "rev-parse", "--abbrev-ref", "HEAD"),
       env = OsGitTool.nonInteractiveEnv,
       cwd = workDir
     )
-    if result.exitCode == 0 then result.stdout.trim
-    else fail("git rev-parse", result)
+    if result.exitCode != 0 then fail("git rev-parse", result)
+    val head = result.stdout.trim
+    if head.isEmpty || head == "HEAD" then
+      throw OrcaFlowException(
+        s"cannot open a PR: not on a branch (git rev-parse gave '$head')"
+      )
+    head
 
   /** Find the first open PR whose head branch matches `head`, or `None`.
     * Head-only matching suffices: a branch has at most one open PR per base,
@@ -614,22 +607,22 @@ private[orca] object OsGitHubTool:
     combined.toLowerCase.contains("already exists")
 
   /** True when `gh pr create` reported no commits between the base and head
-    * branches — the pushed branch has nothing on top of base.
+    * branches — the branch is pushed but carries nothing on top of base.
+    * Excludes the missing-head-branch validation error, whose text also says
+    * "no commits", so the two predicates stay disjoint.
     */
   private[tools] def isNoCommitsToPr(combined: String): Boolean =
-    combined.toLowerCase.contains("no commits")
+    combined.toLowerCase.contains("no commits") && !isBranchNotPushed(combined)
 
   /** True when `gh pr create` failed because the head branch is not on the
-    * remote: the API 422 for a `--head` naming a branch GitHub doesn't have, or
-    * gh's own abort when its head detection finds no pushed ref. The 422 text
-    * also contains "no commits", so callers must test this predicate before
-    * [[isNoCommitsToPr]].
+    * remote: GitHub's createPullRequest validation error for a `--head` naming
+    * a branch it doesn't have. Both fragments come from the same error — either
+    * suffices; two are kept as insurance against upstream rewording.
     */
   private[tools] def isBranchNotPushed(combined: String): Boolean =
     val lower = combined.toLowerCase
     lower.contains("head ref must be a branch") ||
-    lower.contains("head sha can't be blank") ||
-    lower.contains("must first push")
+    lower.contains("head sha can't be blank")
 
   private val StatusCompleted = "COMPLETED"
   private val SuccessfulConclusions = Set("SUCCESS", "NEUTRAL", "SKIPPED")

--- a/tools/src/test/scala/orca/tools/CliFailurePredicatesTest.scala
+++ b/tools/src/test/scala/orca/tools/CliFailurePredicatesTest.scala
@@ -82,6 +82,18 @@ class CliFailurePredicatesTest extends munit.FunSuite:
     assert(OsGitHubTool.isBranchNotPushed(combined))
     assert(!OsGitHubTool.isNoCommitsToPr(combined))
 
+  test(
+    "isBranchNotPushed matches the 422 for a --head branch missing remotely"
+  ):
+    // Verbatim GitHub API response when `--head` names a branch that was never
+    // pushed. It also contains "no commits" — which is why createPr must test
+    // isBranchNotPushed before isNoCommitsToPr.
+    val combined =
+      "pull request create failed: GraphQL: Head sha can't be blank, " +
+        "Base sha can't be blank, No commits between main and feat, " +
+        "Head ref must be a branch (createPullRequest)"
+    assert(OsGitHubTool.isBranchNotPushed(combined))
+
   test("the gh predicates do not match an unrelated failure"):
     val combined = "error: could not resolve to a repository"
     assert(!OsGitHubTool.isPrAlreadyExists(combined))

--- a/tools/src/test/scala/orca/tools/CliFailurePredicatesTest.scala
+++ b/tools/src/test/scala/orca/tools/CliFailurePredicatesTest.scala
@@ -73,26 +73,17 @@ class CliFailurePredicatesTest extends munit.FunSuite:
       )
     )
 
-  test("isBranchNotPushed matches the must-first-push abort"):
-    // Verbatim non-interactive gh output when it doesn't consider the current
-    // branch pushed (no remote tracking ref whose hash matches local HEAD).
-    val combined =
-      "aborted: you must first push the current branch to a remote, " +
-        "or use the --head flag"
-    assert(OsGitHubTool.isBranchNotPushed(combined))
-    assert(!OsGitHubTool.isNoCommitsToPr(combined))
-
   test(
-    "isBranchNotPushed matches the 422 for a --head branch missing remotely"
+    "isBranchNotPushed matches the validation error for a missing --head branch"
   ):
-    // Verbatim GitHub API response when `--head` names a branch that was never
-    // pushed. It also contains "no commits" — which is why createPr must test
-    // isBranchNotPushed before isNoCommitsToPr.
+    // Verbatim GitHub API response (HTTP 422) when `--head` names a branch
+    // that was never pushed.
     val combined =
       "pull request create failed: GraphQL: Head sha can't be blank, " +
         "Base sha can't be blank, No commits between main and feat, " +
         "Head ref must be a branch (createPullRequest)"
     assert(OsGitHubTool.isBranchNotPushed(combined))
+    assert(!OsGitHubTool.isNoCommitsToPr(combined))
 
   test("the gh predicates do not match an unrelated failure"):
     val combined = "error: could not resolve to a repository"

--- a/tools/src/test/scala/orca/tools/CliFailurePredicatesTest.scala
+++ b/tools/src/test/scala/orca/tools/CliFailurePredicatesTest.scala
@@ -73,14 +73,17 @@ class CliFailurePredicatesTest extends munit.FunSuite:
       )
     )
 
-  test("isNoCommitsToPr matches the must-first-push message"):
-    assert(
-      OsGitHubTool.isNoCommitsToPr(
-        "Must first push the current branch to a remote"
-      )
-    )
+  test("isBranchNotPushed matches the must-first-push abort"):
+    // Verbatim non-interactive gh output when it doesn't consider the current
+    // branch pushed (no remote tracking ref whose hash matches local HEAD).
+    val combined =
+      "aborted: you must first push the current branch to a remote, " +
+        "or use the --head flag"
+    assert(OsGitHubTool.isBranchNotPushed(combined))
+    assert(!OsGitHubTool.isNoCommitsToPr(combined))
 
   test("the gh predicates do not match an unrelated failure"):
     val combined = "error: could not resolve to a repository"
     assert(!OsGitHubTool.isPrAlreadyExists(combined))
     assert(!OsGitHubTool.isNoCommitsToPr(combined))
+    assert(!OsGitHubTool.isBranchNotPushed(combined))

--- a/tools/src/test/scala/orca/tools/OsGitHubToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitHubToolTest.scala
@@ -67,20 +67,34 @@ class OsGitHubToolTest extends munit.FunSuite:
 
   private val samplePr = PrHandle("acme", "widgets", 42)
 
-  test("createPr parses the PR URL returned by gh"):
-    val (cli, gh) = stubGh(
+  /** Responses for a `createPr` call: the leading `git rev-parse` resolving the
+    * head branch (`feat`), then the given `gh pr create` result, then any
+    * further responses (e.g. `gh pr list` on the already-exists path).
+    */
+  private def createPrRunner(
+      createResult: CliResult,
+      rest: CliResult*
+  ): SequencedCliRunner =
+    new SequencedCliRunner(
+      CliResult(0, "feat\n", "") +: createResult +: rest.toList
+    )
+
+  test("createPr passes the current branch as --head and parses the PR URL"):
+    val cli = createPrRunner(
       CliResult(0, "https://github.com/acme/widgets/pull/42\n", "")
     )
+    val gh = new OsGitHubTool(cli)
     val pr = gh.createPr("feat: hi", "hello").orThrow
     assertEquals(pr, samplePr)
-    val args = cli.lastCall.getOrElse(fail("expected a call")).args
+    val args = cli.calls.last.args
     assert(args.containsSlice(Seq("gh", "pr", "create")))
     assert(args.containsSlice(Seq("--title", "feat: hi")))
     assert(args.containsSlice(Seq("--body", "hello")))
+    assert(args.containsSlice(Seq("--head", "feat")))
 
   test("createPr emits a Step event with the opened PR URL"):
     val listener = new CapturingListener
-    val cli = new StubCliRunner(
+    val cli = createPrRunner(
       CliResult(0, "https://github.com/acme/widgets/pull/42\n", "")
     )
     val gh = new OsGitHubTool(cli, events = listener)
@@ -91,31 +105,48 @@ class OsGitHubToolTest extends munit.FunSuite:
     )
 
   test("createPr throws when gh output does not contain a PR URL"):
-    val (_, gh) = stubGh(CliResult(0, "no url here", ""))
+    val gh = new OsGitHubTool(createPrRunner(CliResult(0, "no url here", "")))
     val _ = intercept[OrcaFlowException](gh.createPr("t", "b"))
 
   test(
     "createPr returns Left(PrAlreadyExists) when gh reports a duplicate and no open PR is found"
   ):
-    // gh pr create reports duplicate; git rev-parse gives branch name; gh pr list
-    // returns empty → fallback Left(PrAlreadyExists).
-    val cli = new SequencedCliRunner(
-      List(
-        CliResult(1, "", "a pull request for branch 'feat' already exists"),
-        CliResult(0, "feat\n", ""), // git rev-parse
-        CliResult(0, "[]", "") // gh pr list — no open PR
-      )
+    // git rev-parse gives the branch name; gh pr create reports duplicate;
+    // gh pr list returns empty → fallback Left(PrAlreadyExists).
+    val cli = createPrRunner(
+      CliResult(1, "", "a pull request for branch 'feat' already exists"),
+      CliResult(0, "[]", "") // gh pr list — no open PR
     )
     val gh = new OsGitHubTool(cli, readRetry = Schedule.immediate)
     assert(gh.createPr("t", "b").left.exists(_.isInstanceOf[PrAlreadyExists]))
 
   test(
-    "createPr returns Left(NoCommitsToPr) when the branch has nothing to push"
+    "createPr returns Left(NoCommitsToPr) when the pushed branch has no commits vs base"
   ):
-    val (_, gh) = stubGh(
-      CliResult(1, "", "must first push the current branch")
+    val gh = new OsGitHubTool(
+      createPrRunner(
+        CliResult(
+          1,
+          "",
+          "pull request create failed: No commits between main and feat"
+        )
+      )
     )
     assert(gh.createPr("t", "b").left.exists(_.isInstanceOf[NoCommitsToPr]))
+
+  test(
+    "createPr returns Left(BranchNotPushed) when gh does not consider the branch pushed"
+  ):
+    val gh = new OsGitHubTool(
+      createPrRunner(
+        CliResult(
+          1,
+          "",
+          "aborted: you must first push the current branch to a remote"
+        )
+      )
+    )
+    assert(gh.createPr("t", "b").left.exists(_.isInstanceOf[BranchNotPushed]))
 
   test("readPrComments maps gh api JSON into Comment values"):
     val json =
@@ -446,18 +477,15 @@ class OsGitHubToolTest extends munit.FunSuite:
   test(
     "createPr returns Right(existing PR) and emits 'Reusing existing PR' when gh reports 'already exists'"
   ):
-    // Call 1: gh pr create exits 1 with "already exists"
-    // Call 2: git rev-parse to get the current branch name
+    // Call 1: git rev-parse to get the current branch name
+    // Call 2: gh pr create exits 1 with "already exists"
     // Call 3: gh pr list returns JSON with the existing PR
     val prListJson =
       """[{"number":42,"url":"https://github.com/acme/widgets/pull/42"}]"""
     val listener = new CapturingListener
-    val cli = new SequencedCliRunner(
-      List(
-        CliResult(1, "", "a pull request for branch 'feat' already exists"),
-        CliResult(0, "feat\n", ""), // git rev-parse
-        CliResult(0, prListJson, "") // gh pr list
-      )
+    val cli = createPrRunner(
+      CliResult(1, "", "a pull request for branch 'feat' already exists"),
+      CliResult(0, prListJson, "") // gh pr list
     )
     val gh = new OsGitHubTool(
       cli,
@@ -493,12 +521,9 @@ class OsGitHubToolTest extends munit.FunSuite:
     // credential/passphrase prompt on this path could hang the flow.
     val prListJson =
       """[{"number":42,"url":"https://github.com/acme/widgets/pull/42"}]"""
-    val cli = new SequencedCliRunner(
-      List(
-        CliResult(1, "", "a pull request for branch 'feat' already exists"),
-        CliResult(0, "feat\n", ""), // git rev-parse
-        CliResult(0, prListJson, "") // gh pr list
-      )
+    val cli = createPrRunner(
+      CliResult(1, "", "a pull request for branch 'feat' already exists"),
+      CliResult(0, prListJson, "") // gh pr list
     )
     val gh = new OsGitHubTool(
       cli,

--- a/tools/src/test/scala/orca/tools/OsGitHubToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitHubToolTest.scala
@@ -79,18 +79,28 @@ class OsGitHubToolTest extends munit.FunSuite:
       CliResult(0, "feat\n", "") +: createResult +: rest.toList
     )
 
-  test("createPr passes the current branch as --head and parses the PR URL"):
+  test("createPr resolves the current branch and passes it as --head"):
     val cli = createPrRunner(
       CliResult(0, "https://github.com/acme/widgets/pull/42\n", "")
     )
     val gh = new OsGitHubTool(cli)
-    val pr = gh.createPr("feat: hi", "hello").orThrow
-    assertEquals(pr, samplePr)
-    val args = cli.calls.last.args
-    assert(args.containsSlice(Seq("gh", "pr", "create")))
+    val _ = gh.createPr("feat: hi", "hello").orThrow
+    // The whole fix rests on rev-parse running before gh, so pin the order.
+    assertEquals(
+      cli.calls.map(_.args.take(2)),
+      List(Seq("git", "rev-parse"), Seq("gh", "pr"))
+    )
+    val args = cli.calls.lastOption.getOrElse(fail("expected a call")).args
     assert(args.containsSlice(Seq("--title", "feat: hi")))
     assert(args.containsSlice(Seq("--body", "hello")))
     assert(args.containsSlice(Seq("--head", "feat")))
+
+  test("createPr parses the PR URL returned by gh"):
+    val cli = createPrRunner(
+      CliResult(0, "https://github.com/acme/widgets/pull/42\n", "")
+    )
+    val gh = new OsGitHubTool(cli)
+    assertEquals(gh.createPr("feat: hi", "hello").orThrow, samplePr)
 
   test("createPr emits a Step event with the opened PR URL"):
     val listener = new CapturingListener
@@ -135,18 +145,30 @@ class OsGitHubToolTest extends munit.FunSuite:
     assert(gh.createPr("t", "b").left.exists(_.isInstanceOf[NoCommitsToPr]))
 
   test(
-    "createPr returns Left(BranchNotPushed) when gh does not consider the branch pushed"
+    "createPr returns Left(BranchNotPushed) — not NoCommitsToPr — when the head branch is missing remotely"
   ):
+    // The 422 for an unpushed --head branch also contains "no commits"; this
+    // pins the classification order in createPr.
     val gh = new OsGitHubTool(
       createPrRunner(
         CliResult(
           1,
           "",
-          "aborted: you must first push the current branch to a remote"
+          "GraphQL: Head sha can't be blank, No commits between main and feat, " +
+            "Head ref must be a branch (createPullRequest)"
         )
       )
     )
     assert(gh.createPr("t", "b").left.exists(_.isInstanceOf[BranchNotPushed]))
+
+  test("createPr throws when not on a branch (detached HEAD)"):
+    // rev-parse prints the literal "HEAD" when detached. It must not reach
+    // --head — nor may a blank value, which would silently re-enable gh's own
+    // head detection and reinstate the local-commits-ahead bug.
+    val cli = new SequencedCliRunner(List(CliResult(0, "HEAD\n", "")))
+    val gh = new OsGitHubTool(cli)
+    val e = intercept[OrcaFlowException](gh.createPr("t", "b"))
+    assert(e.getMessage.contains("not on a branch"), e.getMessage)
 
   test("readPrComments maps gh api JSON into Comment values"):
     val json =
@@ -496,12 +518,6 @@ class OsGitHubToolTest extends munit.FunSuite:
     assertEquals(pr, samplePr)
     val callArgs = cli.calls.map(_.args)
     assert(
-      callArgs.exists(
-        _.containsSlice(Seq("git", "rev-parse", "--abbrev-ref", "HEAD"))
-      ),
-      s"expected git rev-parse in calls but got: $callArgs"
-    )
-    assert(
       callArgs.exists(a =>
         a.containsSlice(
           Seq("gh", "pr", "list", "--head", "feat", "--state", "open")
@@ -516,25 +532,16 @@ class OsGitHubToolTest extends munit.FunSuite:
     )
 
   test("currentBranchGit carries OsGitTool.nonInteractiveEnv"):
-    // The git rev-parse in the PR-reuse fallback must carry the same
-    // non-interactive env as every other git invocation — otherwise a stalled
-    // credential/passphrase prompt on this path could hang the flow.
-    val prListJson =
-      """[{"number":42,"url":"https://github.com/acme/widgets/pull/42"}]"""
+    // The git rev-parse resolving --head must carry the same non-interactive
+    // env as every other git invocation — otherwise a stalled
+    // credential/passphrase prompt could hang the flow.
     val cli = createPrRunner(
-      CliResult(1, "", "a pull request for branch 'feat' already exists"),
-      CliResult(0, prListJson, "") // gh pr list
+      CliResult(0, "https://github.com/acme/widgets/pull/42\n", "")
     )
-    val gh = new OsGitHubTool(
-      cli,
-      readRetry = Schedule.immediate
-    )
+    val gh = new OsGitHubTool(cli)
     val _ = gh.createPr("feat: hi", "hello").orThrow
-    val revParseCall = cli.calls
-      .find(
-        _.args.containsSlice(Seq("git", "rev-parse", "--abbrev-ref", "HEAD"))
-      )
-      .getOrElse(fail("expected a git rev-parse call"))
+    val revParseCall =
+      cli.calls.headOption.getOrElse(fail("expected a git rev-parse call"))
     assertEquals(revParseCall.env.get("GIT_TERMINAL_PROMPT"), Some("0"))
     assert(
       revParseCall.env

--- a/tools/src/test/scala/orca/tools/OsGitHubToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitHubToolTest.scala
@@ -85,12 +85,13 @@ class OsGitHubToolTest extends munit.FunSuite:
     )
     val gh = new OsGitHubTool(cli)
     val _ = gh.createPr("feat: hi", "hello").orThrow
-    // The whole fix rests on rev-parse running before gh, so pin the order.
+    // gh must be given the branch rev-parse resolved, so pin the order.
     assertEquals(
       cli.calls.map(_.args.take(2)),
       List(Seq("git", "rev-parse"), Seq("gh", "pr"))
     )
-    val args = cli.calls.lastOption.getOrElse(fail("expected a call")).args
+    val args = cli.calls.last.args
+    assert(args.containsSlice(Seq("gh", "pr", "create")))
     assert(args.containsSlice(Seq("--title", "feat: hi")))
     assert(args.containsSlice(Seq("--body", "hello")))
     assert(args.containsSlice(Seq("--head", "feat")))
@@ -147,8 +148,8 @@ class OsGitHubToolTest extends munit.FunSuite:
   test(
     "createPr returns Left(BranchNotPushed) — not NoCommitsToPr — when the head branch is missing remotely"
   ):
-    // The 422 for an unpushed --head branch also contains "no commits"; this
-    // pins the classification order in createPr.
+    // GitHub's validation error for an unpushed --head branch also contains
+    // "no commits"; it must classify as the missing branch, not an empty diff.
     val gh = new OsGitHubTool(
       createPrRunner(
         CliResult(
@@ -162,9 +163,9 @@ class OsGitHubToolTest extends munit.FunSuite:
     assert(gh.createPr("t", "b").left.exists(_.isInstanceOf[BranchNotPushed]))
 
   test("createPr throws when not on a branch (detached HEAD)"):
-    // rev-parse prints the literal "HEAD" when detached. It must not reach
-    // --head — nor may a blank value, which would silently re-enable gh's own
-    // head detection and reinstate the local-commits-ahead bug.
+    // rev-parse prints the literal "HEAD" when detached; the guard rejects it
+    // rather than passing it to --head (it also rejects a blank name, which
+    // would silently re-enable gh's own head detection).
     val cli = new SequencedCliRunner(List(CliResult(0, "HEAD\n", "")))
     val gh = new OsGitHubTool(cli)
     val e = intercept[OrcaFlowException](gh.createPr("t", "b"))
@@ -531,7 +532,7 @@ class OsGitHubToolTest extends munit.FunSuite:
         case _                   => false
     )
 
-  test("currentBranchGit carries OsGitTool.nonInteractiveEnv"):
+  test("the --head rev-parse carries OsGitTool.nonInteractiveEnv"):
     // The git rev-parse resolving --head must carry the same non-interactive
     // env as every other git invocation — otherwise a stalled
     // credential/passphrase prompt could hang the flow.


### PR DESCRIPTION
## Problem

The `issue-pr` flow failed at the **Open PR** stage with `no commits to open a pull request from — push the branch first`, even though the branch had just been pushed (observed on the run for #28 / PR #35).

Root cause: a pushing stage commits its progress-log bookkeeping *after* the push, so local HEAD ends up ahead of the pushed ref (`stage: Push branch`, then `stage: Generate PR title and description`). `gh pr create`'s head detection ([`determineTrackingBranch`](https://github.com/cli/cli/blob/v2.46.0/pkg/cmd/pr/create/create.go)) only accepts a remote tracking ref whose hash **equals** local HEAD's, so non-interactive gh concluded the branch wasn't pushed and aborted with `must first push the current branch`. `isNoCommitsToPr` matched that text and surfaced the misleading `NoCommitsToPr` message. The failure also wedged resume: a re-run replays the push stage from the recorded result without pushing, so Open PR failed identically every time.

## Fix

- `createPr` now passes `--head <current branch>` so gh creates the PR from the pushed ref regardless of local-only bookkeeping commits on top. This also unwedges re-runs. Bare branch name, same-repo assumption (fork clones unsupported, documented on `GitHubTool.createPr`).
- The resolved head branch is guarded: detached HEAD or a blank name throws instead of reaching `--head` (an empty value would silently re-enable gh's own head detection).
- Split the error mapping into two disjoint predicates: `isNoCommitsToPr` matches only the genuine "no commits between base and head" case, explicitly excluding GitHub's validation error for a missing `--head` branch (`Head sha can't be blank … Head ref must be a branch`, whose text also contains "no commits") — that case maps to a new `BranchNotPushed` failure. gh's own `must first push` abort is unreachable with a non-blank `--head` and intentionally unmapped; if it ever occurs, the generic failure path prints gh's verbatim stderr.

Not included (possible follow-up): a final non-stage `git.push()` after the Open PR stage in `openPrFromBranch`, so the bookkeeping commits also land on origin and the local branch doesn't drift.

## Tests

- `createPr` argv asserted to include `--head` and to run `rev-parse` before gh; the validation-error-vs-no-commits classification and the detached-HEAD guard are pinned; predicate tests carry the verbatim gh/API texts and assert the predicates are disjoint.
- Full unit suite green (`sbt test`).