### PR TITLE
Explain agent failures instead of swallowing them

### DIFF
--- a/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
@@ -1,8 +1,7 @@
 package orca.tools.claude
 
 import orca.agents.{AutoApprove, BackendTag, AgentConfig}
-import orca.events.{Usage}
-import orca.{OrcaFlowException}
+import orca.AgentTurnFailed
 import orca.backend.{ApprovalDecision, ConversationEvent}
 import orca.backend.{ForkedConversation, StreamSource}
 import orca.subprocess.PipedCliProcess
@@ -89,7 +88,7 @@ private[claude] class ClaudeConversation(
     case InboundMessage.AssistantTurn(content) => handleAssistantTurn(content)
     case InboundMessage.UserTurn(content)      => handleUserTurn(content)
     case result: InboundMessage.Result =>
-      if result.isError then handleResultError(result.output)
+      if result.isError then handleResultError(result)
       else handleResult(result)
     case InboundMessage.ControlRequest(reqId, body) =>
       handleControlRequest(reqId, body)
@@ -173,12 +172,20 @@ private[claude] class ClaudeConversation(
   private def handleResult(result: InboundMessage.Result): Unit =
     settleSuccess(
       wireId = result.sessionId,
-      output = result.structuredOutput.orElse(result.output).getOrElse(""),
+      output = resultBody(result).getOrElse(""),
       usage = result.usage,
       // Fall back to the model claude announced in system.init when the
       // result message omits it.
       modelId = result.model.orElse(initModel)
     )
+
+  /** The result message's payload: the `--json-schema` validated value when the
+    * session ran structured, else the free-form reply; `None` when the message
+    * carries neither (or only an empty one). Shared by the success and error
+    * paths so the two can't drift on which field is the body.
+    */
+  private def resultBody(result: InboundMessage.Result): Option[String] =
+    result.structuredOutput.orElse(result.output).filter(_.nonEmpty)
 
   /** Claude sets `is_error: true` for out-of-band failures (API errors, rate
     * limits, auth) at the CLI boundary rather than inside a turn. Treat these
@@ -186,15 +193,31 @@ private[claude] class ClaudeConversation(
     * parser, which might otherwise accept a `{"type":"error",...}` payload as
     * valid output. `failWith` carries the full message; the in-stream `Error`
     * event is short if the body already streamed as part of a turn.
+    *
+    * An empty body is the case that most needs diagnosing — a resume that
+    * replays a queued pseudo-turn, an exhausted turn budget — and there the
+    * reason lives only in `subtype`, so it stands in for the message rather
+    * than leaving a bare "claude reported is_error". `AgentTurnFailed` (not a
+    * plain `OrcaFlowException`) because the turn ran and the wire session is
+    * already locked: `awaitResult` would classify it as such anyway, and
+    * settling it here is what lets the failed turn's `usage` reach the cost
+    * summary.
     */
-  private def handleResultError(output: Option[String]): Unit =
-    val message =
-      output.filter(_.nonEmpty).getOrElse("claude reported is_error")
+  private def handleResultError(result: InboundMessage.Result): Unit =
+    val message = resultBody(result).getOrElse(
+      s"claude reported is_error (subtype ${result.subtype})"
+    )
     val displayed =
       if deltasSinceLastFullTurn then "session failed (see message above)"
       else message
     eventQueue.enqueue(ConversationEvent.Error(displayed))
-    failWith(new OrcaFlowException(s"claude session failed: $message"))
+    failWith(
+      new AgentTurnFailed(
+        s"claude session failed (subtype ${result.subtype}, " +
+          s"session ${result.sessionId}): $message",
+        usage = Some(result.usage)
+      )
+    )
 
   private def handleControlRequest(
       requestId: String,

--- a/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
@@ -2,7 +2,7 @@ package orca.tools.claude
 
 import orca.agents.{AutoApprove, AgentConfig}
 import orca.events.{Usage}
-import orca.{OrcaFlowException, OrcaInteractiveCancelled}
+import orca.{AgentTurnFailed, OrcaFlowException, OrcaInteractiveCancelled}
 import orca.backend.{
   ApprovalDecision,
   ConversationEvent,
@@ -120,6 +120,50 @@ class ClaudeConversationTest extends munit.FunSuite:
     ConversationEventConformance.assertGrammar(events, completedNormally = true)
     val failure = intercept[OrcaFlowException](conv.awaitResult())
     assert(failure.getMessage.contains("rate limited"))
+
+  // The empty-body case is where the CLI puts the whole reason in `subtype`
+  // (a resume replaying a queued pseudo-turn, an exhausted turn budget, …), so
+  // it must stand in for the message rather than leaving a bare marker.
+  convTest("is_error with an empty body names the result subtype"):
+    val process = new FakePipedCliProcess()
+    val conv = new ClaudeConversation(process, AgentConfig())
+
+    process.enqueueStdout(
+      """{"type":"result","subtype":"error_max_turns","session_id":"sid-empty","is_error":true}"""
+    )
+    process.closeStdout()
+
+    val errors = conv.events.toList.collect {
+      case ConversationEvent.Error(msg) => msg
+    }
+    assertEquals(
+      errors,
+      List("claude reported is_error (subtype error_max_turns)")
+    )
+    val failure = intercept[OrcaFlowException](conv.awaitResult())
+    assertEquals(
+      failure.getMessage,
+      "claude session failed (subtype error_max_turns, session sid-empty): " +
+        "claude reported is_error (subtype error_max_turns)"
+    )
+
+  // The failing turn's tokens are on the wire in the same `result` frame; the
+  // exception is the only way they can still reach the run's cost summary.
+  convTest("is_error carries the result's usage on the thrown failure"):
+    val process = new FakePipedCliProcess()
+    val conv = new ClaudeConversation(process, AgentConfig())
+
+    process.enqueueStdout(
+      """{"type":"result","subtype":"error_during_execution","session_id":"sid-cost","is_error":true,"usage":{"input_tokens":11,"output_tokens":3,"cache_read_input_tokens":7},"total_cost_usd":0.25}"""
+    )
+    process.closeStdout()
+
+    val _ = conv.events.toList
+    val failure = intercept[AgentTurnFailed](conv.awaitResult())
+    assertEquals(
+      failure.usage,
+      Some(Usage(18L, 3L, Some(BigDecimal("0.25")), 7L))
+    )
 
   convTest(
     "is_error after a tool-only turn (no assistant text) surfaces the full error body"

--- a/flow/src/main/scala/orca/BranchNamingStrategy.scala
+++ b/flow/src/main/scala/orca/BranchNamingStrategy.scala
@@ -80,8 +80,9 @@ object BranchNamingStrategy:
   /** Prompt-shortening strategy: asks `agent.cheap` for a 3–6 word lowercase
     * branch label, then slugs it. Falls back to `slug(userPrompt)` on any
     * failure (LLM throws, empty/blank result) so branch naming can never break
-    * the flow. Non-deterministic — computed once and persisted in the header;
-    * never recomputed on resume.
+    * the flow — `cheapOneShot` announces the fallback rather than hiding it.
+    * Non-deterministic — computed once and persisted in the header; never
+    * recomputed on resume.
     */
   val shortenPrompt: BranchNamingStrategy =
     new BranchNamingStrategy:
@@ -90,7 +91,9 @@ object BranchNamingStrategy:
         // userPrompt fallback both produce a valid ref.
         slug(
           agent.cheapOneShot(
-            s"Reply with ONLY a 3–6 word lowercase branch label (hyphen-separated, no other punctuation) that summarises this task:\n\n$userPrompt",
+            purpose = "branch name",
+            prompt =
+              s"Reply with ONLY a 3–6 word lowercase branch label (hyphen-separated, no other punctuation) that summarises this task:\n\n$userPrompt",
             fallback = userPrompt
           )
         )

--- a/flow/src/main/scala/orca/Flow.scala
+++ b/flow/src/main/scala/orca/Flow.scala
@@ -144,8 +144,9 @@ private def recordAndCommit[T: JsonData](
   * captured before the progress file is force-added, so it reflects only code
   * changes the stage body produced. Falls back to `"stage: <name>"` when the
   * diff is empty, the agent returns blank, or any `NonFatal` is thrown —
-  * committing must never break. Only called when the caller supplied no
-  * explicit `commitMessage`.
+  * committing must never break, though `cheapOneShot` announces the fallback
+  * rather than hiding it. Only called when the caller supplied no explicit
+  * `commitMessage`.
   */
 private def defaultCommitMessage(
     name: String
@@ -160,8 +161,10 @@ private def defaultCommitMessage(
   if diff.isBlank then fallback
   else
     fc.codingAgent.cheapOneShot(
-      s"Write a concise one-line git commit message (imperative mood, ≤72 chars) for this diff:\n\n$diff",
-      fallback
+      purpose = "commit message",
+      prompt =
+        s"Write a concise one-line git commit message (imperative mood, ≤72 chars) for this diff:\n\n$diff",
+      fallback = fallback
     )
 
 private def formatMalformedOutput(

--- a/tools/src/main/scala/orca/OrcaFlowException.scala
+++ b/tools/src/main/scala/orca/OrcaFlowException.scala
@@ -41,7 +41,16 @@ class OrcaInteractiveCancelled(
   * `cause` is optional so `getCause` still reaches the original exception
   * (stack trace, exact type) for `--verbose`/debug inspection rather than being
   * flattened into the message string.
+  *
+  * `usage` carries what the turn spent before failing, when the backend reports
+  * it on the terminal error frame (claude's `result` message does). Without it
+  * a failed turn's tokens would never reach `OrcaEvent.TokensUsed` — the
+  * success path is the only other emitter — and the run's cost summary would
+  * understate spend. `None` for backends whose failure frame carries no usage.
   */
-class AgentTurnFailed(message: String, cause: Throwable | Null = null)
-    extends OrcaFlowException(message):
+class AgentTurnFailed(
+    message: String,
+    cause: Throwable | Null = null,
+    val usage: Option[orca.events.Usage] = None
+) extends OrcaFlowException(message):
   if cause != null then initCause(cause): Unit

--- a/tools/src/main/scala/orca/agents/Agent.scala
+++ b/tools/src/main/scala/orca/agents/Agent.scala
@@ -1,8 +1,13 @@
 package orca.agents
 
 import orca.InStage
+import orca.events.OrcaEvent
+import orca.util.TextUtil
+import org.slf4j.LoggerFactory
 
 import scala.util.control.NonFatal
+
+private val log = LoggerFactory.getLogger("orca.agents")
 
 /** An LLM adapter usable from flow scripts — the handle you call from a
   * `flow(...)` block (`claude`, `codex`, etc.). Three rungs, by how long the
@@ -143,19 +148,59 @@ trait Agent[B <: BackendTag]:
     * incidental text (branch naming, default commit messages). Never throws — a
     * failure here must not break a flow, so any non-fatal error yields
     * `fallback`.
+    *
+    * Falling back is always announced, never silent: `purpose` is the noun
+    * phrase naming what this one-shot was for ("commit message", "branch name")
+    * and appears both in the WARN log line and in the `Step` event that tells
+    * the user orca carried on with the default.
     */
-  private[orca] def cheapOneShot(prompt: String, fallback: => String)(using
-      InStage
-  ): String =
+  private[orca] def cheapOneShot(
+      purpose: String,
+      prompt: String,
+      fallback: => String
+  )(using InStage): String =
     try
-      val text = cheap.withReadOnly.quietTextTurn(prompt)
-      val firstLine = text.linesIterator
-        .map(_.trim)
-        .filterNot(_.startsWith("```"))
-        .find(_.nonEmpty)
-        .getOrElse("")
-      if firstLine.isBlank then fallback else firstLine
-    catch case NonFatal(_) => fallback
+      val line = Agent.payloadLine(cheap.withReadOnly.quietTextTurn(prompt))
+      if line.isBlank then
+        reportFallback(
+          purpose = purpose,
+          reason = "the model replied with nothing usable",
+          cause = None
+        )
+        fallback
+      else line
+    catch
+      case NonFatal(e) =>
+        reportFallback(
+          purpose = purpose,
+          reason = TextUtil.throwableMessage(e, firstLineOnly = true),
+          cause = Some(e)
+        )
+        fallback
+
+  /** Announce a [[cheapOneShot]] fallback on both channels: WARN in the log
+    * (with the throwable, when there is one, so the stack survives) and a
+    * `Step` for the user, so the default value never appears unexplained.
+    */
+  private def reportFallback(
+      purpose: String,
+      reason: String,
+      cause: Option[Throwable]
+  ): Unit =
+    cause match
+      case Some(e) => log.warn(s"$purpose one-shot failed: $reason", e)
+      case None    => log.warn("{} one-shot failed: {}", purpose, reason)
+    emitEvent(
+      OrcaEvent.Step(
+        s"$purpose agent failed ($reason) — using the default $purpose instead"
+      )
+    )
+
+  /** Publish an event on this agent's sink. No-op by default (tools without a
+    * backend have no sink); `BaseAgent` routes it to the run's listener, which
+    * is what makes [[cheapOneShot]]'s fallback visible to the user.
+    */
+  private[orca] def emitEvent(event: OrcaEvent): Unit = ()
 
   /** One autonomous text turn with the streaming display suppressed: no `▸`
     * prompt echo and — on `BaseAgent`-derived tools, which override this — no
@@ -249,6 +294,26 @@ trait Agent[B <: BackendTag]:
     * no-op default. The runtime calls this from `DefaultFlowContext.close()`.
     */
   private[orca] def close(): Unit = ()
+
+private[orca] object Agent:
+
+  /** The single line to use from a cheap model's reply to a [[cheapOneShot]]
+    * prompt. A fenced block, when the reply has one, wins over the surrounding
+    * prose: cheap models routinely narrate first ("Looking at this diff, the
+    * main changes are:") and put the actual answer inside the fence, so reading
+    * top-down would take the narration. Falls back to the first non-empty,
+    * non-fence line, and to `""` when the reply holds neither.
+    */
+  def payloadLine(text: String): String =
+    val lines = text.linesIterator.map(_.trim).toList
+    val fenced = lines
+      .dropWhile(!_.startsWith("```"))
+      .drop(1)
+      .takeWhile(!_.startsWith("```"))
+    fenced
+      .find(_.nonEmpty)
+      .orElse(lines.find(l => l.nonEmpty && !l.startsWith("```")))
+      .getOrElse("")
 
 /** Bare `claude` runs Opus with the 1M-token context window (the long-lived
   * implementer); the accessors below pin a specific tier, e.g.

--- a/tools/src/main/scala/orca/agents/AgentCall.scala
+++ b/tools/src/main/scala/orca/agents/AgentCall.scala
@@ -222,13 +222,31 @@ class DefaultAgentCall[B <: BackendTag, O](
           if emitPrompt then events.onEvent(OrcaEvent.UserPrompt(corrective))
           corrective
         case None => initialPrompt
-      val result = backend.runAutonomous(
-        promptText,
-        session,
-        effective,
-        events,
-        outputSchema = Some(outputSchema)
-      )
+      val result =
+        try
+          backend.runAutonomous(
+            promptText,
+            session,
+            effective,
+            events,
+            outputSchema = Some(outputSchema)
+          )
+        catch
+          // A turn that failed after the model ran still spent tokens; the
+          // success path below is the only other emitter, so without this they
+          // never reach the cost summary. Fires at most once per call —
+          // `AgentTurnFailed` is never retried.
+          case e: AgentTurnFailed =>
+            e.usage.foreach: usage =>
+              events.onEvent(
+                OrcaEvent.TokensUsed(
+                  agentName,
+                  effective.model,
+                  usage,
+                  agentRole
+                )
+              )
+            throw e
       // Fire as soon as the backend drain commits — before the fallible
       // parse below — so a session that later exhausts its retries (parse
       // keeps failing) or throws on a subsequent attempt still gets
@@ -274,7 +292,8 @@ class DefaultAgentCall[B <: BackendTag, O](
         throw new AgentTurnFailed(
           s"agent '$agentName' turn failed " +
             s"(this turn's input ≈${serialized.length} chars): ${e.getMessage}",
-          e
+          e,
+          e.usage
         )
 
   /** Interactive variant. No retry: the user is steering the session and a

--- a/tools/src/main/scala/orca/agents/BaseAgent.scala
+++ b/tools/src/main/scala/orca/agents/BaseAgent.scala
@@ -1,6 +1,6 @@
 package orca.agents
 
-import orca.OrcaFlowException
+import orca.{AgentTurnFailed, OrcaFlowException}
 import orca.backend.{Interaction, AgentBackend, AgentResult}
 import orca.events.{OrcaEvent, OrcaListener}
 
@@ -72,6 +72,9 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
 
   override private[orca] def backendTag: Option[BackendTag] = Some(backend.tag)
 
+  override private[orca] def emitEvent(event: OrcaEvent): Unit =
+    events.onEvent(event)
+
   override private[orca] def configuredModel: Option[Model] = config.model
 
   override private[orca] def backendIdentity: Option[AnyRef] = Some(
@@ -107,7 +110,8 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
         val effective = effectiveConfig(callConfig)
         if emitPrompt then events.onEvent(OrcaEvent.UserPrompt(prompt))
         val result =
-          backend.runAutonomous(prompt, session, effective, events)
+          runAccountingForFailure(effective):
+            backend.runAutonomous(prompt, session, effective, events)
         emitTokens(effective, result)
         emitSessionCommitted(session)
         result.output
@@ -127,7 +131,13 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
         case _: OrcaEvent.AssistantMessage | _: OrcaEvent.ToolUse => ()
         case other => events.onEvent(other)
     val result =
-      backend.runAutonomous(prompt, SessionId.fresh[B], effective, quietEvents)
+      runAccountingForFailure(effective):
+        backend.runAutonomous(
+          prompt,
+          SessionId.fresh[B],
+          effective,
+          quietEvents
+        )
     emitTokens(effective, result)
     result.output
 
@@ -142,6 +152,24 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
       agentName = name,
       agentRole = role
     )
+
+  /** Run a backend turn, emitting the spend of a turn that fails after the
+    * model already ran ([[AgentTurnFailed.usage]]) before re-raising —
+    * otherwise only the success path reports tokens and a failed turn is
+    * invisible in the cost summary. The failure frame carries no model id, so
+    * the bucket key is whatever the caller pinned.
+    */
+  private def runAccountingForFailure(
+      effective: AgentConfig
+  )(turn: => AgentResult[B]): AgentResult[B] =
+    try turn
+    catch
+      case e: AgentTurnFailed =>
+        e.usage.foreach: usage =>
+          events.onEvent(
+            OrcaEvent.TokensUsed(name, effective.model, usage, role)
+          )
+        throw e
 
   /** `model` prefers the response-reported model (most precise), falling back
     * to whatever the caller pinned in config, `None` when neither is known.

--- a/tools/src/test/scala/orca/agents/BaseAgentTest.scala
+++ b/tools/src/test/scala/orca/agents/BaseAgentTest.scala
@@ -105,7 +105,11 @@ class BaseAgentTest extends munit.FunSuite:
       new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
     val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
     val tool = new StubTool(new NoisyBackend, listener = listener)
-    val reply = tool.cheapOneShot("name this branch", fallback = "fb")
+    val reply = tool.cheapOneShot(
+      purpose = "branch name",
+      prompt = "name this branch",
+      fallback = "fb"
+    )
     assertEquals(reply, "short-label")
     val events = seen.get()
     assert(
@@ -123,6 +127,68 @@ class BaseAgentTest extends munit.FunSuite:
     assert(
       events.exists(_.isInstanceOf[OrcaEvent.TokensUsed]),
       s"cost accounting must still flow on a quiet turn: $events"
+    )
+
+  // A one-shot that fails is best-effort by design, but the fallback must not
+  // be silent: the user needs to know which incidental agent failed, why, and
+  // that orca carried on with the default.
+  test("a failing cheapOneShot returns its fallback and reports the purpose"):
+    val seen =
+      new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
+    val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
+    val tool = new StubTool(
+      new FailingBackend(new RuntimeException("Prompt is too long")),
+      listener = listener
+    )
+    val reply = tool.cheapOneShot(
+      purpose = "commit message",
+      prompt = "summarise this diff",
+      fallback = "stage: build"
+    )
+    assertEquals(reply, "stage: build")
+    val steps = seen.get().collect { case OrcaEvent.Step(m) => m }
+    assertEquals(
+      steps,
+      List(
+        "commit message agent failed (Prompt is too long) — " +
+          "using the default commit message instead"
+      )
+    )
+
+  // Cheap models routinely narrate before answering and fence the answer; the
+  // narration line must not become the commit message / branch label.
+  test("cheapOneShot prefers a fenced answer over the narration above it"):
+    val tool = new StubTool(
+      new ScriptedDrainBackend(
+        "Looking at this diff, the main changes are:\n\n```\nShow branch in menu\n```\n"
+      ),
+      prompts = DefaultPrompts
+    )
+    val reply = tool.cheapOneShot(
+      purpose = "commit message",
+      prompt = "summarise this diff",
+      fallback = "stage: build"
+    )
+    assertEquals(reply, "Show branch in menu")
+
+  // A turn that failed after the model ran still spent tokens; the success path
+  // is the only other TokensUsed emitter, so without this the failed turn is
+  // invisible in the run's cost summary.
+  test("a turn failing with reported usage still emits TokensUsed"):
+    val seen =
+      new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
+    val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
+    val spent = Usage(120L, 8L, Some(BigDecimal("0.0031")))
+    val tool = new StubTool(
+      new FailingBackend(
+        new orca.AgentTurnFailed("claude session failed", usage = Some(spent))
+      ),
+      listener = listener
+    )
+    val _ = intercept[orca.AgentTurnFailed](tool.run("prompt"))
+    assertEquals(
+      seen.get().collect { case t: OrcaEvent.TokensUsed => t.usage },
+      List(spent)
     )
 
   // The manifest writer (ADR 0021 §8) needs the wire id known after the
@@ -388,6 +454,35 @@ class BaseAgentTest extends munit.FunSuite:
         "out",
         Usage.empty
       )
+    def runInteractive(
+        prompt: String,
+        session: SessionId[BackendTag.Pi.type],
+        displayPrompt: String,
+        config: AgentConfig,
+        outputSchema: Option[String]
+    )(using ox.Ox): Conversation[BackendTag.Pi.type] =
+      throw new UnsupportedOperationException
+    val sessions: SessionSupport[BackendTag.Pi.type] =
+      SessionSupport.ephemeral(IdScheme.ClientClaimed)
+    val tag: BackendTag.Pi.type = BackendTag.Pi
+    def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
+      Enforcement.Ignored
+    def structuredOutputMode: StructuredOutputMode =
+      StructuredOutputMode.RawText
+
+  /** Fails every turn with `error`, so the fallback/accounting paths around a
+    * failed `runAutonomous` can be exercised without a live backend.
+    */
+  private class FailingBackend(error: Throwable)
+      extends AgentBackend[BackendTag.Pi.type]:
+    val workDir: os.Path = os.pwd
+    def runAutonomous(
+        prompt: String,
+        session: SessionId[BackendTag.Pi.type],
+        config: AgentConfig,
+        events: OrcaListener,
+        outputSchema: Option[String]
+    ): AgentResult[BackendTag.Pi.type] = throw error
     def runInteractive(
         prompt: String,
         session: SessionId[BackendTag.Pi.type],


### PR DESCRIPTION
During flow runs the log showed a bare `✖ claude reported is_error` and the run
carried on with no explanation. Three separate defects fed that; all three are
fixed here.

## What changed

**1. `Agent.cheapOneShot` no longer swallows failures.** It caught `NonFatal`
and returned the fallback, discarding the exception entirely — nothing in the
log connected a fallback commit message to a failed turn. It now takes a
`purpose` label, threaded from the two call sites (`Flow.defaultCommitMessage`
→ `"commit message"`, `BranchNamingStrategy.shortenPrompt` → `"branch name"`),
logs the exception at WARN via slf4j and emits an `OrcaEvent.Step`. The blank
reply case (also a silent fallback) is reported the same way. The fallback
behaviour itself is unchanged — these calls are best-effort by design.

Emission needs a sink the `Agent` trait doesn't have, so it goes through a new
`private[orca] emitEvent` hook: no-op by default, routed to the run's listener
by `BaseAgent`, following the trait's existing "safe default, `BaseAgent`
overrides" pattern.

**2. `handleResultError` gets the whole `Result`.** It received only
`result.output`, dropping `subtype`, `sessionId`, `usage`, `model` and
`structuredOutput`. An empty body — precisely when the reason lives in
`subtype` — degraded to a useless literal. It also never consulted
`structuredOutput`, though `handleResult` did; both now read the body through
one `resultBody` accessor so the success and error paths can't drift.

It now settles with `AgentTurnFailed` rather than a plain `OrcaFlowException`.
No behaviour change — `awaitResult` already reclassified it as exactly that,
and codex/opencode already settle this way — but it is what lets the usage
travel with the failure.

**3. A failed turn's cost is accounted for.** On the is_error path
`settleSuccess` was never reached, so no `TokensUsed` was emitted and the
turn's tokens were invisible in the cost summary, even though `usage` and
`total_cost_usd` were already parsed off the wire. `AgentTurnFailed` now
carries `usage: Option[Usage]`, and both emission sites (`BaseAgent` for
free-text/quiet turns, `DefaultAgentCall` for structured ones) report it before
re-raising. Fires at most once per call — `AgentTurnFailed` is never retried.
`None` for backends whose failure frame carries no usage, so nothing changes
for them.

**4. Reply extraction (from the root-cause investigation, see below).**
`cheapOneShot` took the first non-empty non-fence line. Cheap models routinely
narrate first and put the answer inside a fence, so a fenced block now wins
over the prose above it.

## Before / after

```
# 1 — cheap one-shot failure (previously: nothing at all in the log)
∙ commit message agent failed (Prompt is too long) — using the default commit message instead

# 2 — claude is_error with an empty body
- ✖ claude reported is_error
+ ✖ claude reported is_error (subtype error_max_turns)

#     and the thrown failure
- claude session failed: claude reported is_error
+ claude session failed (subtype error_max_turns, session sid-empty): claude reported is_error (subtype error_max_turns)

# 3 — cost summary, failed turn
- By agent:
-   main: 0 in, 0 out            # the failed turn contributed nothing
+ By agent:
+   main: 42.2K in, 1.2K out ($0.0031)

# 4 — commit message from a narrating cheap model
- git commit -m "Looking at this diff, the main changes are:"
+ git commit -m "Show branch in menu and detect conflicting orca runs"
```

A non-empty error body renders exactly as before.

## Root cause of the `is_error` failures

**The cheap one-shot was not the thing failing.** Evidence from two real flow
logs (`/tmp/orca-10886735498265082441.log`,
`/tmp/orca-647206953960863837.log`) and the matching transcripts under
`~/.claude/projects/-home-adamw-orca/`:

- All 13 `is_error` events across both runs were preceded, within 1–2 s, by a
  `--model opus … --resume <main-session-uuid>` spawn. All four `cheapOneShot`
  turns in those same runs **succeeded**.
- Each failure ran ~1.1 s for **0 input / 0 output tokens** — no API call
  happened.
- The main session's transcript shows why: on `--resume`, the CLI replays
  leftover session state — a `Continue from where you left off.` pseudo-turn
  and/or orphaned background-task notifications from the previous process. It
  answers instantly with `No response requested.` and emits a `result` with
  `is_error: true` and an **empty body**, before orca's real prompt (written to
  stdin ~70 ms later) is ever processed. Orca settles the turn on that first
  `result`. The structured-call retry re-spawns ~1.5 s later and succeeds,
  which is why the flow survived and only the `✖` remained.

So the hypotheses in the brief are all contradicted by the data: not rate
limiting (no API round trip, and 5–7 concurrent opus reviewer forks in the same
runs never produced `is_error`); not max-turns (orca never passes
`--max-turns`); not auth (the identical argv succeeds 1.5 s later); not a
disallowed tool call (the cheap sessions contain no `tool_use` block at all).

This PR does not attempt to fix the resume replay — suppressing an is_error
result that arrives before orca's own prompt was answered is a subtle change to
the settle protocol and wants its own investigation. What it does is make the
condition self-diagnosing: the failure now reads `claude reported is_error
(subtype …)` instead of a bare marker, which is exactly the information that
was missing while diagnosing this.

The investigation did surface a real, evidenced `cheapOneShot` defect, fixed
here as item 4. From transcript
`c4f16ef5-d0c2-4e2b-9605-5f30821941d3.jsonl`, haiku replied with `Looking at
this diff, the main changes are:` … then the actual message inside a fenced
block. The old first-line rule took the narration, and the run really did
`git commit -m "Looking at this diff, the main changes are:"`.

## Deliberately left out

- **The resume-replay fix**, for the reason above.
- **No truncation of the commit-message diff.** `Flow.defaultCommitMessage`
  inlines `fc.git.diff()` raw and `GitTool.diff` is `git diff HEAD` with no cap.
  Measured inputs in the observed runs were 31K–42K tokens, well under haiku's
  window, so this is a latent risk rather than an observed failure — but a large
  stage would fail with `Prompt is too long`. It is now at least *visible*
  (item 1) rather than silently swallowed. Worth capping separately.
- **The interactive path's `TokensUsed`** is untouched; only the autonomous
  paths account for a failed turn.

## Tests

`ClaudeConversationTest`: empty-body is_error names the subtype (event + thrown
message with subtype and session id); the failure carries the result's usage.
The existing non-empty-body cases pin that their text is unchanged.
`BaseAgentTest`: a failing `cheapOneShot` still returns its fallback but now
emits a purpose-naming `Step`; a fenced reply beats the narration above it; a
turn failing with reported usage emits `TokensUsed`.

`sbt test` — all modules green, zero warnings.
