### PR TITLE
Load the sbt build from a linked git worktree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,10 @@ Extra Scala 3 warnings are enabled (`-Wunused:all`, `-Wvalue-discard`,
 rather than relying on the compiler to block. `sbt ~test` re-runs tests on
 save.
 
+The build also loads from a linked `git worktree`: `build.sbt` enables
+sbt-git's `useReadableConsoleGit`, without which project load dies in JGit
+with `NoWorkTreeException`. Don't remove it.
+
 ## Integration tests (gated)
 
 Some tests shell out to real external tools and skip by default:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,10 @@ save.
 
 The build also loads from a linked `git worktree`: `build.sbt` enables
 sbt-git's `useReadableConsoleGit`, without which project load dies in JGit
-with `NoWorkTreeException`. Don't remove it.
+with `NoWorkTreeException`. Don't remove it. In exchange, project load now
+needs a usable `git` on the PATH — with git missing, or refusing the
+repository (a `safe.directory` complaint under a bind mount, say), sbt fails
+to load rather than carrying on with a fallback version.
 
 ## Integration tests (gated)
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,13 @@ ThisBuild / scalacOptions ++= Seq(
 
 ThisBuild / javacOptions ++= Seq("--release", "21")
 
+// Makes sbt-git answer its read-only queries with the `git` CLI instead of the
+// bundled JGit, which reads a linked worktree's `.git` *file* as a bare repo and
+// aborts project load with NoWorkTreeException — without this, sbt does not
+// start at all inside a `git worktree`. Version derivation is unaffected: it
+// comes from sbt-dynver, which shells out to `git` either way.
+useReadableConsoleGit
+
 // The scala-cli suites link a script against a locally published build, so they
 // need the dynver version the sibling `publishLocal` produced. Forked test JVMs
 // read it from this property (`sys.props`), which keeps the two in step by

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,8 @@ ThisBuild / javacOptions ++= Seq("--release", "21")
 // bundled JGit, which reads a linked worktree's `.git` *file* as a bare repo and
 // aborts project load with NoWorkTreeException — without this, sbt does not
 // start at all inside a `git worktree`. Version derivation is unaffected: it
-// comes from sbt-dynver, which shells out to `git` either way.
+// comes from sbt-dynver (sbt-git's `GitVersioning` is not enabled), which shells
+// out to `git` either way.
 useReadableConsoleGit
 
 // The scala-cli suites link a script against a locally published build, so they


### PR DESCRIPTION
## Problem

`sbt` will not load at all from a linked `git worktree`. sbt-git reads the
repository with its bundled JGit, which treats a linked worktree's `.git`
*file* (rather than directory) as a bare repository:

```
org.eclipse.jgit.errors.NoWorkTreeException: Bare Repository has neither a working tree, nor an index
  at com.github.sbt.git.JGit.hasUncommittedChanges(JGit.scala:92)
  at com.github.sbt.git.SbtGit$.$anonfun$buildSettings$22(GitPlugin.scala:125)
```

`gitUncommittedChanges` is a setting, so it is evaluated during project load —
every task fails, including `compile`. Anyone working in a worktree has had to
invent a local workaround (a throwaway root `.sbt` file, or writing a
`core.worktree` stanza into the repository's git metadata).

## Fix

Enable `useReadableConsoleGit`, sbt-git's documented remedy for exactly this
(its own source comment: *"we allow overriding, since JGit doesn't currently
work with git worktrees"*). It answers the read-only queries with the `git`
CLI instead of JGit.

## Verification

The published version depends on git-derived state, so the setting was A/B'd in
a normal (non-worktree) clone, injected as an untracked `local.sbt` so the
working tree stayed byte-identical between the two runs:

| checkout | `version` without | `version` with |
|---|---|---|
| release tag `v0.1.3` | `0.1.3` | `0.1.3` |
| two commits past the tag | `0.1.3+2-<sha>-SNAPSHOT` | `0.1.3+2-<sha>-SNAPSHOT` |

`isSnapshot`, `dynverGitDescribeOutput`, `scmInfo` and `publishTo` are
identical too, for the root and all nine subprojects. That is expected from the
plugin sources: version derivation is sbt-dynver's, which shells out to `git`
either way, and `GitVersioning` (the plugin that would route the version
through sbt-git) is `noTrigger` and not enabled here.

The setting does change three sbt-git keys that nothing in this build reads —
`gitUncommittedChanges` (the CLI's `git status -s` counts untracked files,
JGit's does not), `gitDescribedVersion` (8- vs 7-character sha abbreviation)
and `gitCurrentBranch` on a detached HEAD (`HEAD` vs the sha).

Project load cost is unchanged within noise: 4.32 / 4.62 / 4.41 s without,
4.81 / 3.91 / 4.01 s with (fresh sbt JVM each run, same clone).

In a linked worktree, `sbt compile` and `sbt scalafmtCheckAll` now both succeed,
with no warnings.

## Tradeoff: `git` on the PATH becomes load-critical

The CLI reader is less forgiving than JGit when git itself is unusable.
`ConsoleGitReadableOnly.branch` and `.remoteOrigin` are the only two of its
methods not `Try`-wrapped, `ConsoleGitRunner` throws on any nonzero exit, and
`GitPlugin` consumes both as `buildSettings` — evaluated eagerly at load, the
same shape as the bug this PR fixes. JGit had no such dependency.

Reproduced with a `git` shim that exits 128 on every call (the shape a
`safe.directory` refusal takes):

| | master | this branch |
|---|---|---|
| project load | succeeds | fails: `Nonzero exit code (128) running git.` |
| `version` | `HEAD+<timestamp>` (dynver fallback) | — |

The realistic trigger is a container: the repository bind-mounted under a
different UID, or an image without git. CI is unaffected — all three jobs run
on bare `ubuntu-latest` with no `container:`, and `fetch-depth: 0`. The
tradeoff is recorded in CONTRIBUTING.md so it is not a surprise later.