### PR TITLE
Tear down the agent's whole process tree on turn teardown

### DIFF
--- a/tools/src/main/scala/orca/backend/ForkedConversation.scala
+++ b/tools/src/main/scala/orca/backend/ForkedConversation.scala
@@ -269,7 +269,8 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
       if !isSettled then onCancelRequested()
       // Escalation: SIGINT the agent process, then the forcible backstop, which
       // for a subprocess source kills the whole process tree — so work the agent
-      // spawned doesn't outlive the turn. The two are back-to-back, with no
+      // spawned, unless it detached itself, doesn't outlive the turn. The two
+      // are back-to-back, with no
       // grace window for the SIGINT: this same path runs in the routine
       // `finally` of every turn, where the process has already exited.
       // The destroy also unblocks a reader stuck on a pipe a descendant still

--- a/tools/src/main/scala/orca/backend/ForkedConversation.scala
+++ b/tools/src/main/scala/orca/backend/ForkedConversation.scala
@@ -267,10 +267,13 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
       // interrupt/destroy below always runs regardless (idle teardown is
       // harmless there).
       if !isSettled then onCancelRequested()
-      // Graceful SIGINT first, then the forcible backstop, so the
-      // non-interruptible reader's `source.lines` always reaches EOF and the
-      // scope join never hangs. Both are no-ops on the happy path. The
-      // `finalized` guard means the reader, if it got there first, isn't re-run.
+      // Escalation: a graceful SIGINT to the agent process itself, giving it
+      // the chance to flush its session, then the forcible backstop, which for
+      // a subprocess source kills the whole process tree. So the
+      // non-interruptible reader's `source.lines` always reaches EOF, the scope
+      // join never hangs, and work the agent spawned doesn't outlive the turn.
+      // Both are no-ops on the happy path. The `finalized` guard means the
+      // reader, if it got there first, isn't re-run.
       source.interrupt()
       source.destroyForcibly()
       runFinalize()

--- a/tools/src/main/scala/orca/backend/ForkedConversation.scala
+++ b/tools/src/main/scala/orca/backend/ForkedConversation.scala
@@ -267,11 +267,15 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
       // interrupt/destroy below always runs regardless (idle teardown is
       // harmless there).
       if !isSettled then onCancelRequested()
-      // Escalation: a graceful SIGINT to the agent process itself, giving it
-      // the chance to flush its session, then the forcible backstop, which for
-      // a subprocess source kills the whole process tree. So the
-      // non-interruptible reader's `source.lines` always reaches EOF, the scope
-      // join never hangs, and work the agent spawned doesn't outlive the turn.
+      // Escalation: SIGINT the agent process, then the forcible backstop, which
+      // for a subprocess source kills the whole process tree — so work the agent
+      // spawned doesn't outlive the turn. The two are back-to-back, with no
+      // grace window for the SIGINT: this same path runs in the routine
+      // `finally` of every turn, where the process has already exited.
+      // The destroy also unblocks a reader stuck on a pipe a descendant still
+      // holds open, but only where cancel runs CONCURRENTLY with that reader (a
+      // Ctrl-C at an interactive prompt); the autonomous drain calls cancel only
+      // after the reader has already finished.
       // Both are no-ops on the happy path. The `finalized` guard means the
       // reader, if it got there first, isn't re-run.
       source.interrupt()

--- a/tools/src/main/scala/orca/backend/StderrPipeline.scala
+++ b/tools/src/main/scala/orca/backend/StderrPipeline.scala
@@ -58,9 +58,14 @@ private[orca] trait StderrPipeline[B <: BackendTag]
     val _ = stderrBuffer.updateAndGet(appendBounded(_, line))
 
   /** Wait for the stderr drain so trailing lines reach the queue before the
-    * failure outcome is computed. No timeout needed: `destroyForcibly` (and a
-    * real process's exit) always EOFs the stderr stream, so the drain fork
-    * terminates. `None` means workers never started (nothing to wait for).
+    * failure outcome is computed. `None` means workers never started (nothing
+    * to wait for).
+    *
+    * The join is unbounded and ends only at stderr EOF, which needs every
+    * inherited write-end closed — including any the agent's own descendants
+    * hold. The tree kill that closes those runs in the conversation's
+    * `cancel()`, which on the autonomous path is downstream of this finalize,
+    * so it cannot rescue a stall here.
     */
   override protected def onFinalize(): Unit =
     stderrDrainFork.foreach(_.join())

--- a/tools/src/main/scala/orca/backend/StreamSource.scala
+++ b/tools/src/main/scala/orca/backend/StreamSource.scala
@@ -56,7 +56,8 @@ private[orca] object StreamSource:
       def interrupt(): Unit = process.sendSigInt()
       // Tree, not PID: a coding-agent CLI spawns its own children (shell tool
       // calls, MCP servers, a build it backgrounded), which inherit the stdout
-      // pipe write-end. A root-only kill would both orphan that work into the
-      // next stage and leave the pipe un-EOF'd for the reader.
+      // pipe write-end. A root-only kill would orphan that work into the next
+      // stage and can leave the reader waiting for EOF. Work the agent
+      // deliberately detached stays out of reach either way.
       override def destroyForcibly(): Unit = process.destroyForciblyTree()
       def tryExitCode: Option[Int] = process.tryExitCode

--- a/tools/src/main/scala/orca/backend/StreamSource.scala
+++ b/tools/src/main/scala/orca/backend/StreamSource.scala
@@ -31,11 +31,12 @@ private[orca] trait StreamSource:
     */
   def interrupt(): Unit
 
-  /** Guaranteed backstop after [[interrupt]]: SIGKILL the subprocess / close
-    * the connection so [[lines]] always terminates even if the graceful
-    * interrupt didn't take. Default delegates to [[interrupt]] (sufficient for
-    * sources whose interrupt already hard-closes); the subprocess source
-    * overrides it. Must tolerate calls from any thread and more than once.
+  /** Guaranteed backstop after [[interrupt]]: SIGKILL the subprocess and every
+    * descendant it left running / close the connection, so [[lines]] always
+    * terminates even if the graceful interrupt didn't take. Default delegates
+    * to [[interrupt]] (sufficient for sources whose interrupt already
+    * hard-closes); the subprocess source overrides it. Must tolerate calls from
+    * any thread and more than once.
     */
   def destroyForcibly(): Unit = interrupt()
 
@@ -53,5 +54,9 @@ private[orca] object StreamSource:
       def lines: Iterator[String] = process.stdoutLines
       def errorLines: Iterator[String] = process.stderrLines
       def interrupt(): Unit = process.sendSigInt()
-      override def destroyForcibly(): Unit = process.destroyForcibly()
+      // Tree, not PID: a coding-agent CLI spawns its own children (shell tool
+      // calls, MCP servers, a build it backgrounded), which inherit the stdout
+      // pipe write-end. A root-only kill would both orphan that work into the
+      // next stage and leave the pipe un-EOF'd for the reader.
+      override def destroyForcibly(): Unit = process.destroyForciblyTree()
       def tryExitCode: Option[Int] = process.tryExitCode

--- a/tools/src/main/scala/orca/subprocess/CliProcess.scala
+++ b/tools/src/main/scala/orca/subprocess/CliProcess.scala
@@ -13,12 +13,14 @@ trait CliProcess:
     */
   def destroyForcibly(): Unit
 
-  /** Forcibly terminate this process AND any descendants — the teardown every
-    * caller driving a real, spawned process wants. Two reasons a single-PID
-    * kill isn't enough: a surviving descendant holds the inherited
-    * stdout/stderr pipe write-ends, so a reader blocked on the pipe never sees
-    * EOF; and it keeps running after the turn that started it, free to hold a
-    * build lock or write into the working tree the flow is about to commit.
+  /** Forcibly terminate this process AND every descendant still reachable from
+    * it — the teardown every caller driving a real, spawned process wants. Two
+    * reasons a single-PID kill isn't enough: a surviving descendant holds the
+    * inherited stdout/stderr pipe write-ends, so a reader blocked on the pipe
+    * can be left waiting for EOF; and it keeps running after the turn that
+    * started it, free to hold a build lock or write into the working tree the
+    * flow is about to commit. A descendant that detached itself into its own
+    * session is out of reach — see the OS-backed implementation.
     *
     * Defaults to just this process, which is what fakes with no real children
     * want. Same call-anywhere / idempotent contract as [[destroyForcibly]].

--- a/tools/src/main/scala/orca/subprocess/CliProcess.scala
+++ b/tools/src/main/scala/orca/subprocess/CliProcess.scala
@@ -13,12 +13,15 @@ trait CliProcess:
     */
   def destroyForcibly(): Unit
 
-  /** Forcibly terminate this process AND any descendants. Defaults to just this
-    * process; override where a launch wrapper (e.g. `ollama launch opencode`)
-    * forks the real process, which inherits the stdout/stderr pipe fds: a
-    * single-PID kill would orphan it, leaving those write-ends open so a reader
-    * blocked on the pipe never sees EOF. Same call-anywhere / idempotent
-    * contract as [[destroyForcibly]].
+  /** Forcibly terminate this process AND any descendants — the teardown every
+    * caller driving a real, spawned process wants. Two reasons a single-PID
+    * kill isn't enough: a surviving descendant holds the inherited
+    * stdout/stderr pipe write-ends, so a reader blocked on the pipe never sees
+    * EOF; and it keeps running after the turn that started it, free to hold a
+    * build lock or write into the working tree the flow is about to commit.
+    *
+    * Defaults to just this process, which is what fakes with no real children
+    * want. Same call-anywhere / idempotent contract as [[destroyForcibly]].
     */
   def destroyForciblyTree(): Unit = destroyForcibly()
 

--- a/tools/src/main/scala/orca/subprocess/OsProcCliRunner.scala
+++ b/tools/src/main/scala/orca/subprocess/OsProcCliRunner.scala
@@ -1,6 +1,7 @@
 package orca.subprocess
 
 import org.slf4j.LoggerFactory
+import ox.discard
 
 import java.util.concurrent.atomic.AtomicReference
 import scala.jdk.CollectionConverters.given
@@ -77,17 +78,35 @@ private final class OsPipedSubProcess(
     * remembered `ProcessHandle` cannot hit an unrelated process that recycled
     * the pid: the JDK signals only if the pid still has the start time the
     * handle was taken with.
+    *
+    * The snapshot only ever fills when orca signals a root that is still alive
+    * — a turn that settles, or a cancel. A root that exited on its own (an
+    * agent crash, a clean exit with no terminal message) was never signalled,
+    * so nothing was recorded and a descendant that redirected its own stdio
+    * survives. Covering that too needs a process group established at spawn,
+    * not parent→child links.
     */
-  private val signalledDescendants =
-    new AtomicReference[List[ProcessHandle]](Nil)
+  private val signalledDescendants: AtomicReference[List[ProcessHandle]] =
+    new AtomicReference(Nil)
 
   // Signals the root PID only, deliberately: a spawned child inherits the JVM's
   // process group (`ProcessBuilder` does not setsid), so `kill -INT -<pgid>`
   // would signal orca itself. Descendants are covered by `destroyForciblyTree`,
   // which walks parent→child links instead of the group.
   def sendSigInt(): Unit =
-    val _ = signalledDescendants.updateAndGet(_ ++ liveDescendants())
-    val _ = QuietProc.call(Seq("kill", "-INT", sub.wrapped.pid.toString))
+    // Walked outside the CAS: `updateAndGet` may retry its function, and an OS
+    // process walk is neither cheap nor idempotent enough to re-run.
+    val toRemember = liveDescendants()
+    signalledDescendants
+      .updateAndGet(prev => (prev ++ toRemember).distinct)
+      .discard
+    // Narrows (does not close) the window where the pid has been recycled by an
+    // unrelated process — unlike the ProcessHandle path, a shelled-out `kill`
+    // has no start-time check to protect it. SIGINT rather than
+    // `ProcessHandle.destroy`'s SIGTERM because that is the signal agent CLIs
+    // treat as "user interrupted me".
+    if sub.isAlive() then
+      QuietProc.call(Seq("kill", "-INT", sub.wrapped.pid.toString)).discard
 
   def isAlive: Boolean = sub.isAlive()
 
@@ -97,17 +116,25 @@ private final class OsPipedSubProcess(
   override def destroyForciblyTree(): Unit =
     // Descendants first, then the root: a child that outlives its parent holds
     // the inherited stdout/stderr pipe write-ends, so killing only the root PID
-    // would never EOF a blocked drain.
-    // Reachability is best-effort — an already-orphaned process that double-
-    // forked and got reparented to init (`nohup … &`, `setsid`) appears in
-    // neither the walk nor the snapshot, and would need a dedicated process
-    // group at spawn to catch.
-    (liveDescendants() ++ signalledDescendants.get())
-      .foreach(h => { val _ = h.destroyForcibly() })
-    val _ = sub.wrapped.toHandle.destroyForcibly()
+    // can leave a drain still waiting for EOF (the JDK closes our read end when
+    // the root exits, but that runs under the stream's own monitor, which a
+    // reader blocked mid-read may hold).
+    // Remembered handles are re-expanded rather than killed flat: by now the
+    // root is usually gone, so they are the only reachable branch of the tree,
+    // and each may have spawned children since the snapshot was taken.
+    // Reachability is best-effort throughout — a process that double-forked and
+    // got reparented to init (`nohup … &`, `setsid`) appears in neither the walk
+    // nor the snapshot, and would need a dedicated process group at spawn.
+    val remembered =
+      signalledDescendants.get().flatMap(h => h +: descendantsOf(h))
+    (liveDescendants() ++ remembered).foreach(_.destroyForcibly().discard)
+    sub.wrapped.toHandle.destroyForcibly().discard
 
   private def liveDescendants(): List[ProcessHandle] =
-    sub.wrapped.toHandle.descendants().toList.asScala.toList
+    descendantsOf(sub.wrapped.toHandle)
+
+  private def descendantsOf(handle: ProcessHandle): List[ProcessHandle] =
+    handle.descendants().iterator().asScala.toList
 
   def waitForExit(): Int =
     val _ = sub.join()

--- a/tools/src/main/scala/orca/subprocess/OsProcCliRunner.scala
+++ b/tools/src/main/scala/orca/subprocess/OsProcCliRunner.scala
@@ -83,8 +83,7 @@ private final class OsPipedSubProcess(
     * — a turn that settles, or a cancel. A root that exited on its own (an
     * agent crash, a clean exit with no terminal message) was never signalled,
     * so nothing was recorded and a descendant that redirected its own stdio
-    * survives. Covering that too needs a process group established at spawn,
-    * not parent→child links.
+    * survives.
     */
   private val signalledDescendants: AtomicReference[List[ProcessHandle]] =
     new AtomicReference(Nil)
@@ -122,9 +121,14 @@ private final class OsPipedSubProcess(
     // Remembered handles are re-expanded rather than killed flat: by now the
     // root is usually gone, so they are the only reachable branch of the tree,
     // and each may have spawned children since the snapshot was taken.
-    // Reachability is best-effort throughout — a process that double-forked and
-    // got reparented to init (`nohup … &`, `setsid`) appears in neither the walk
-    // nor the snapshot, and would need a dedicated process group at spawn.
+    // Reachability is best-effort throughout — a process that detached itself
+    // (`nohup … &`, `setsid`) appears in neither the walk nor the snapshot. A
+    // process group established here would not extend to it either: every agent
+    // CLI runs its tool calls in a session of their own, so orca's group never
+    // contains them (measured: a claude bash tool call's session id is its own
+    // pid). Reaching a detached process needs a marker it carries — e.g. a
+    // per-turn cookie injected into the environment and swept at teardown — or
+    // an OS-level container such as a cgroup scope.
     val remembered =
       signalledDescendants.get().flatMap(h => h +: descendantsOf(h))
     (liveDescendants() ++ remembered).foreach(_.destroyForcibly().discard)

--- a/tools/src/main/scala/orca/subprocess/OsProcCliRunner.scala
+++ b/tools/src/main/scala/orca/subprocess/OsProcCliRunner.scala
@@ -2,6 +2,7 @@ package orca.subprocess
 
 import org.slf4j.LoggerFactory
 
+import java.util.concurrent.atomic.AtomicReference
 import scala.jdk.CollectionConverters.given
 
 /** Runs external commands via os-lib. `check = false` is intentional — callers
@@ -69,7 +70,23 @@ private final class OsPipedSubProcess(
     if stderrPiped then sub.stderr.buffered.lines().iterator().asScala
     else Iterator.empty
 
+  /** Descendants that were alive when the root was signalled. Signalling the
+    * root can make it exit, at which point its children are reparented to init
+    * and drop out of the root's `descendants()` walk — so a later tree kill
+    * would silently miss exactly the processes it exists to reap. Killing a
+    * remembered `ProcessHandle` cannot hit an unrelated process that recycled
+    * the pid: the JDK signals only if the pid still has the start time the
+    * handle was taken with.
+    */
+  private val signalledDescendants =
+    new AtomicReference[List[ProcessHandle]](Nil)
+
+  // Signals the root PID only, deliberately: a spawned child inherits the JVM's
+  // process group (`ProcessBuilder` does not setsid), so `kill -INT -<pgid>`
+  // would signal orca itself. Descendants are covered by `destroyForciblyTree`,
+  // which walks parent→child links instead of the group.
   def sendSigInt(): Unit =
+    val _ = signalledDescendants.updateAndGet(_ ++ liveDescendants())
     val _ = QuietProc.call(Seq("kill", "-INT", sub.wrapped.pid.toString))
 
   def isAlive: Boolean = sub.isAlive()
@@ -78,17 +95,19 @@ private final class OsPipedSubProcess(
     val _ = sub.wrapped.destroyForcibly()
 
   override def destroyForciblyTree(): Unit =
-    // Descendants first, then the root: a launch wrapper that forked the real
-    // child leaves it holding the inherited stdout/stderr pipe write-ends, so
-    // killing only the root PID would never EOF a blocked drain.
-    // `descendants()` is a best-effort snapshot of live parent→child linkage; it
-    // catches a wrapper that stays alive as the worker's parent (the `ollama
-    // launch` case), but NOT one that double-forks and exits, reparenting the
-    // worker to init — that would need a process-group kill or a recorded worker
-    // PID. No current launcher does that.
-    val handle = sub.wrapped.toHandle
-    handle.descendants().forEach(h => { val _ = h.destroyForcibly() })
-    val _ = handle.destroyForcibly()
+    // Descendants first, then the root: a child that outlives its parent holds
+    // the inherited stdout/stderr pipe write-ends, so killing only the root PID
+    // would never EOF a blocked drain.
+    // Reachability is best-effort — an already-orphaned process that double-
+    // forked and got reparented to init (`nohup … &`, `setsid`) appears in
+    // neither the walk nor the snapshot, and would need a dedicated process
+    // group at spawn to catch.
+    (liveDescendants() ++ signalledDescendants.get())
+      .foreach(h => { val _ = h.destroyForcibly() })
+    val _ = sub.wrapped.toHandle.destroyForcibly()
+
+  private def liveDescendants(): List[ProcessHandle] =
+    sub.wrapped.toHandle.descendants().toList.asScala.toList
 
   def waitForExit(): Int =
     val _ = sub.join()

--- a/tools/src/test/scala/orca/backend/ConversationTeardownTest.scala
+++ b/tools/src/test/scala/orca/backend/ConversationTeardownTest.scala
@@ -28,8 +28,10 @@ class ConversationTeardownTest extends munit.FunSuite:
   test("cancel kills work the agent process spawned, not just its own PID"):
     supervised:
       // Stands in for an agent that backgrounded a build: the `sleep` inherits
-      // the stdout pipe and outlives nothing but its parent, which `wait` keeps
-      // alive so the descendant is reachable at kill time.
+      // the stdout pipe, and `wait` keeps the shell alive until the SIGINT, so
+      // the descendant is recorded by the signal-time snapshot. It is normally
+      // NOT reachable by the time the forcible step runs — the shell dies within
+      // milliseconds of the signal and the `sleep` is reparented to init.
       val process = OsProcCliRunner.spawnPiped(
         Seq("bash", "-c", "sleep 30 & echo $!; wait"),
         env = Map.empty,

--- a/tools/src/test/scala/orca/backend/ConversationTeardownTest.scala
+++ b/tools/src/test/scala/orca/backend/ConversationTeardownTest.scala
@@ -1,0 +1,62 @@
+package orca.backend
+
+import orca.agents.BackendTag
+import orca.subprocess.OsProcCliRunner
+import orca.testkit.ProcessProbe.{alive, awaitDead}
+
+import ox.supervised
+
+/** End-to-end teardown of a cancelled turn against a REAL agent process, which
+  * is the only way to exercise the tree kill — every fake process has no
+  * descendants, so the `destroyForciblyTree` default hides the wiring.
+  */
+class ConversationTeardownTest extends munit.FunSuite:
+
+  /** Minimal driver that republishes each stdout line, so the test can read the
+    * process's output through the conversation surface (the reader fork owns
+    * the pipe, so nothing else may read it).
+    */
+  private class LineEchoingConversation(source: StreamSource)
+      extends ForkedConversation[BackendTag.ClaudeCode.type](
+        source = source,
+        backendName = "fake"
+      ):
+    val outputSchema: Option[String] = None
+    protected def handleLine(line: String): Unit =
+      eventQueue.enqueue(ConversationEvent.AssistantTextDelta(line))
+
+  test("cancel kills work the agent process spawned, not just its own PID"):
+    supervised:
+      // Stands in for an agent that backgrounded a build: the `sleep` inherits
+      // the stdout pipe and outlives nothing but its parent, which `wait` keeps
+      // alive so the descendant is reachable at kill time.
+      val process = OsProcCliRunner.spawnPiped(
+        Seq("bash", "-c", "sleep 30 & echo $!; wait"),
+        env = Map.empty,
+        cwd = os.pwd,
+        pipeStderr = true
+      )
+      var spawnedPid = 0L
+      try
+        val conv =
+          new LineEchoingConversation(StreamSource.fromProcess(process))
+        spawnedPid = conv.events.next() match
+          case ConversationEvent.AssistantTextDelta(pid) => pid.trim.toLong
+          case other => fail(s"expected the spawned PID, got: $other")
+        assert(alive(spawnedPid), "the spawned work should be running")
+
+        conv.cancel()
+
+        assert(
+          awaitDead(spawnedPid),
+          "a cancelled turn must leave no surviving descendant"
+        )
+      finally
+        // A descendant this test failed to reap still holds the stdout pipe
+        // open, so without an unconditional kill the scope join would deadlock
+        // on the reader instead of reporting the failed assertion.
+        process.destroyForciblyTree()
+        if spawnedPid > 0 then
+          ProcessHandle
+            .of(spawnedPid)
+            .ifPresent(h => { val _ = h.destroyForcibly() })

--- a/tools/src/test/scala/orca/subprocess/OsProcCliRunnerTest.scala
+++ b/tools/src/test/scala/orca/subprocess/OsProcCliRunnerTest.scala
@@ -1,15 +1,8 @@
 package orca.subprocess
 
+import orca.testkit.ProcessProbe.{alive, awaitDead}
+
 class OsProcCliRunnerTest extends munit.FunSuite:
-
-  private def alive(pid: Long): Boolean =
-    val h = ProcessHandle.of(pid)
-    h.isPresent && h.get.isAlive
-
-  private def awaitDead(pid: Long): Boolean =
-    val deadline = System.currentTimeMillis + 3000
-    while alive(pid) && System.currentTimeMillis < deadline do Thread.sleep(20)
-    !alive(pid)
 
   /** A launch wrapper forks a worker that inherits the stdout/stderr pipes, so
     * killing only the wrapper PID would orphan it and leave a drain reader
@@ -33,4 +26,26 @@ class OsProcCliRunnerTest extends munit.FunSuite:
     assert(
       awaitDead(childPid),
       "tree kill must terminate the forked descendant"
+    )
+
+  /** Teardown runs unconditionally in a `finally`, so on the happy path it hits
+    * a process that already exited — and `descendants()` on a dead handle is an
+    * empty stream, not a failure.
+    */
+  test("destroyForciblyTree on an already-exited process is a no-op"):
+    val proc = OsProcCliRunner.spawnPiped(
+      Seq("bash", "-c", "exit 0"),
+      env = Map.empty,
+      cwd = os.pwd,
+      pipeStderr = true
+    )
+    assertEquals(proc.waitForExit(), 0)
+
+    proc.destroyForciblyTree()
+    proc.destroyForciblyTree()
+
+    assertEquals(
+      proc.tryExitCode,
+      Some(0),
+      "the recorded exit code must survive a post-exit tree kill"
     )

--- a/tools/src/test/scala/orca/subprocess/OsProcCliRunnerTest.scala
+++ b/tools/src/test/scala/orca/subprocess/OsProcCliRunnerTest.scala
@@ -1,32 +1,121 @@
 package orca.subprocess
 
-import orca.testkit.ProcessProbe.{alive, awaitDead}
+import orca.testkit.ProcessProbe.{alive, awaitDead, awaitTrue}
+import orca.testkit.TempDirs
+import ox.discard
 
 class OsProcCliRunnerTest extends munit.FunSuite:
 
-  /** A launch wrapper forks a worker that inherits the stdout/stderr pipes, so
-    * killing only the wrapper PID would orphan it and leave a drain reader
-    * blocked on a never-EOF'd pipe. `destroyForciblyTree` must reap the
-    * descendant too, unlike the PID-only `destroyForcibly`.
+  private def killPid(pid: Long): Unit =
+    if pid > 0 then ProcessHandle.of(pid).ifPresent(_.destroyForcibly().discard)
+
+  /** Spawns a shell that backgrounds a `sleep` and stays alive as its parent,
+    * yields the backgrounded PID, and tree-kills whatever is left afterwards so
+    * a failing assertion can't leak either process. `$!` is the backgrounded
+    * job's PID; `wait` is what keeps the shell running.
     */
-  test("destroyForciblyTree reaps a forked descendant"):
-    // `$!` is the backgrounded sleep's PID; `wait` keeps bash alive as its
-    // parent so it is reachable via `descendants()` at kill time.
+  private def withBackgroundedChild(
+      body: (PipedCliProcess, Long) => Unit
+  ): Unit =
     val proc = OsProcCliRunner.spawnPiped(
       Seq("bash", "-c", "sleep 30 & echo $!; wait"),
       env = Map.empty,
       cwd = os.pwd,
       pipeStderr = true
     )
-    val childPid = proc.stdoutLines.next().trim.toLong
-    assert(alive(childPid), "the forked descendant should be running")
+    var childPid = 0L
+    try
+      childPid = proc.stdoutLines.next().trim.toLong
+      body(proc, childPid)
+    finally
+      proc.destroyForciblyTree()
+      killPid(childPid)
 
-    proc.destroyForciblyTree()
+  /** A launch wrapper forks a worker that inherits the stdout/stderr pipes, so
+    * killing only the wrapper PID would orphan it and leave a drain reader
+    * blocked on a never-EOF'd pipe. `destroyForciblyTree` must reap the
+    * descendant too, unlike the PID-only `destroyForcibly`.
+    */
+  test("destroyForciblyTree reaps a live descendant"):
+    withBackgroundedChild: (proc, childPid) =>
+      assert(alive(childPid), "the forked descendant should be running")
 
-    assert(
-      awaitDead(childPid),
-      "tree kill must terminate the forked descendant"
+      proc.destroyForciblyTree()
+
+      assert(
+        awaitDead(childPid),
+        "tree kill must terminate the forked descendant"
+      )
+
+  /** The case the signal-time snapshot exists for, made deterministic by
+    * letting the root exit first: a `&`-backgrounded job in a non-interactive
+    * shell inherits SIGINT as ignored, so it survives the signal that kills its
+    * parent and is reparented to init — off the root's `descendants()` walk
+    * entirely by the time the forcible step runs.
+    */
+  test("destroyForciblyTree reaps a descendant the SIGINT orphaned"):
+    withBackgroundedChild: (proc, childPid) =>
+      proc.sendSigInt()
+      assert(awaitTrue(!proc.isAlive), "the SIGINT should end the root shell")
+      assert(alive(childPid), "the orphan should have survived the SIGINT")
+
+      proc.destroyForciblyTree()
+
+      assert(
+        awaitDead(childPid),
+        "the signal-time snapshot must still reach an orphaned descendant"
+      )
+
+  /** A remembered handle is a branch of the tree, not a leaf: the orphan can
+    * spawn children of its own after the snapshot was taken, and with the root
+    * already dead nothing else can reach them.
+    *
+    * Sequenced through the filesystem, not stdout: once the root exits, the JDK
+    * reaper drains and closes our read end of the pipe
+    * (`ProcessPipeInputStream.processExited`), so nothing the orphan writes
+    * afterwards is readable. The orphan spawns its child only when the test
+    * creates the trigger, which it does after the snapshot has been taken.
+    */
+  test("destroyForciblyTree re-expands a remembered orphan's own children"):
+    val dir = TempDirs.dir()
+    val trigger = dir / "spawn-now"
+    val pidFile = dir / "grandchild.pid"
+    // Single-quoted so the inner shell expands `$TRIGGER`/`$PIDFILE` and its own
+    // `$!`; the outer `$!` is the inner shell's PID.
+    val script =
+      """bash -c 'while [ ! -e "$TRIGGER" ]; do sleep 0.02; done""" +
+        """; sleep 30 & echo $! > "$PIDFILE"; wait' & echo $!; wait"""
+    val proc = OsProcCliRunner.spawnPiped(
+      Seq("bash", "-c", script),
+      env = Map("TRIGGER" -> trigger.toString, "PIDFILE" -> pidFile.toString),
+      cwd = os.pwd,
+      pipeStderr = true
     )
+    var orphanPid = 0L
+    var grandchildPid = 0L
+    try
+      orphanPid = proc.stdoutLines.next().trim.toLong
+      proc.sendSigInt()
+      assert(awaitTrue(!proc.isAlive), "the SIGINT should end the root shell")
+
+      os.write(trigger, "")
+      assert(
+        awaitTrue(os.exists(pidFile) && os.read(pidFile).trim.nonEmpty),
+        "the orphan should have spawned its child on the trigger"
+      )
+      grandchildPid = os.read(pidFile).trim.toLong
+      assert(alive(grandchildPid), "the late grandchild should be running")
+
+      proc.destroyForciblyTree()
+
+      assert(
+        awaitDead(grandchildPid),
+        "a remembered orphan's later children must be reaped too"
+      )
+    finally
+      proc.destroyForciblyTree()
+      killPid(grandchildPid)
+      killPid(orphanPid)
 
   /** Teardown runs unconditionally in a `finally`, so on the happy path it hits
     * a process that already exited — and `descendants()` on a dead handle is an

--- a/tools/src/test/scala/orca/testkit/ProcessProbe.scala
+++ b/tools/src/test/scala/orca/testkit/ProcessProbe.scala
@@ -9,12 +9,15 @@ object ProcessProbe:
     val handle = ProcessHandle.of(pid)
     handle.isPresent && handle.get.isAlive
 
-  /** Polls until `pid` is gone, up to `timeoutMillis`; returns whether it died.
-    * A kill is asynchronous — the signal is delivered before the process is
-    * reaped — so a same-instant `alive` check would be flaky in either
-    * direction.
+  /** Polls `condition` until it holds, up to `timeoutMillis`; returns whether
+    * it ever did. Process teardown is asynchronous — a signal is delivered
+    * before the process is reaped — so a same-instant check would be flaky in
+    * either direction.
     */
-  def awaitDead(pid: Long, timeoutMillis: Long = 5000): Boolean =
+  def awaitTrue(condition: => Boolean, timeoutMillis: Long = 5000): Boolean =
     val deadline = System.currentTimeMillis + timeoutMillis
-    while alive(pid) && System.currentTimeMillis < deadline do Thread.sleep(20)
-    !alive(pid)
+    while !condition && System.currentTimeMillis < deadline do Thread.sleep(20)
+    condition
+
+  def awaitDead(pid: Long, timeoutMillis: Long = 5000): Boolean =
+    awaitTrue(!alive(pid), timeoutMillis)

--- a/tools/src/test/scala/orca/testkit/ProcessProbe.scala
+++ b/tools/src/test/scala/orca/testkit/ProcessProbe.scala
@@ -1,0 +1,20 @@
+package orca.testkit
+
+/** Liveness probes for a PID a test spawned, for asserting that teardown
+  * actually reaped a process rather than sleeping and hoping.
+  */
+object ProcessProbe:
+
+  def alive(pid: Long): Boolean =
+    val handle = ProcessHandle.of(pid)
+    handle.isPresent && handle.get.isAlive
+
+  /** Polls until `pid` is gone, up to `timeoutMillis`; returns whether it died.
+    * A kill is asynchronous — the signal is delivered before the process is
+    * reaped — so a same-instant `alive` check would be flaky in either
+    * direction.
+    */
+  def awaitDead(pid: Long, timeoutMillis: Long = 5000): Boolean =
+    val deadline = System.currentTimeMillis + timeoutMillis
+    while alive(pid) && System.currentTimeMillis < deadline do Thread.sleep(20)
+    !alive(pid)


### PR DESCRIPTION
## The leak

When a turn ends, `ForkedConversation.cancel` escalates `source.interrupt()` →
`source.destroyForcibly()`. For a subprocess source the forcible step was
`Process.destroyForcibly()` on the root PID alone, so anything the agent had
spawned — a backgrounded build, a shell tool call still running — was
**orphaned, not killed**. The orphan outlives the stage that started it: it can
hold a build lock the next stage then blocks on, or race the flow's own
`git add -A` by writing build output into the tree mid-commit.

`destroyForciblyTree()` — descendants first, then the root — already existed
with exactly this rationale in its scaladoc, wired only to `OpencodeServer`.

## Scope: non-detached descendants only

This reaps processes reachable from the agent process by parent→child links. A
process that deliberately detaches — `nohup … &`, `setsid`, any double-fork that
reparents it to init — is in neither the live walk nor the snapshot and
survives. Both cases were exercised against a real flow:

- An agent told to background work *without* detaching spawned a heartbeat
  writer that stopped dead at turn teardown; the run exited seconds later with
  nothing surviving.
- An agent asked simply to "background a heartbeat" reached for
  `nohup bash -c '…' &` unprompted. It had PPID 1 the instant the run exited,
  survived three further stages and the JVM exit, and had to be killed by hand.

So background work is killed in the common case and escapes when the agent
detaches it.

**Covering the detached case is not a matter of establishing a process group at
spawn — that cannot work.** Every agent CLI already runs its own tool calls in a
fresh session, so no group orca establishes on the agent process is an ancestor
group of anything a tool call spawns. Measured here against claude: the bash
tool call's session id equals its own PID (it `setsid`'d away from the agent),
and a `nohup … &` started inside it lands with PPID 1 in *that* session — so
`kill -- -<pgid>` from orca reaches neither. This is universal, not
claude-specific: codex calls `setsid()` in a pre-exec hook, and gemini, opencode
and pi all pass node's `detached: true`, which is the same call. All four
`killpg` their own tool-call group, but only on timeout/abort — a `nohup … &`
returns immediately, so the tool call *succeeds*, no killpg fires, and the
process is left in a session orca can never name. Retrofitting a group from the
parent is ruled out too: `setpgid` on a child that has already exec'd fails with
EACCES (measured: errno 13), as POSIX requires.

What does reach a detached process is a marker it carries: inject a per-turn
cookie into the environment at spawn and sweep processes whose environment
carries it at teardown (Jenkins' ProcessTreeKiller does exactly this for daemons
that cannot be tracked by the regular ancestor/descendant relationship), or
confine the agent to a cgroup v2 scope on Linux+systemd. Neither is in this PR.
The prompt rule in the in-flight prompt PR is the primary mitigation; this PR is
the backstop for the non-detached case.

## The fix

`StreamSource.fromProcess` now routes its forcible backstop through
`destroyForciblyTree()`. The graceful `interrupt()` (SIGINT to the root) is
unchanged.

That alone did not work, and the first version of the test is what caught it:
**SIGINT to the root can make it exit and reparent its children to init before
the tree walk runs**, so `descendants()` returns nothing. (Near-deterministic,
not theoretical: a `&`-backgrounded job in a non-interactive shell inherits
SIGINT as ignored, so it reliably outlives the parent the signal kills.)
`sendSigInt` therefore snapshots the descendants alive at signal time, and
`destroyForciblyTree` kills that snapshot — **re-expanded transitively**, since
the root is normally already gone by then, making those handles the only
reachable branch of the tree, and each may have spawned children since. Killing
a remembered `ProcessHandle` is safe against pid reuse: `destroy0(pid,
startTime, force)` is documented as signalling "only if its start time matches
the known start time".

Teardown is now uniform rather than cancel-specific: `cancel()` also runs as the
routine `finally` after a turn that completed normally, so reachable
agent-spawned work is reaped at the end of *every* turn, not only a cancelled
one. That is the intended semantics — nothing an agent spawns (short of
detaching it) should outlive the turn that spawned it.

## The four questions

**Why did the tree variant exist but reach only opencode?** It was a targeted
regression fix, not a policy decision. `destroyForciblyTree` was added in
"fix(opencode): tree-kill the serve process on shutdown" because the
`ollama launch opencode -- serve` wrapper forks the real serve child and a
PID-only kill hung the drain forks' join; the follow-up commit deleted the
sibling `sendSigIntTree` as dead and added a test. Neither revisited the
conversation path, and nothing in the code, comments, ADRs or history argues it
should stay root-only. The scaladoc framed the method around the launch-wrapper
case specifically, which is probably why it never read as generally applicable;
it is broadened here to state both reasons a PID-only kill is wrong.

**Should SIGINT become a group signal?** No — it would signal orca itself.
`ProcessBuilder` does not `setsid`, so a spawned child inherits the JVM's own
process group (verified: JVM, child and grandchild all share one pgid), and
`kill -INT -<pgid>` would deliver to the whole group, JVM included. Group
signalling would first require spawning every agent through `setsid`, a change
to how every backend is launched — and, per the Scope section, it would still
not reach anything a tool call spawns, since the CLIs open their own sessions.

Escalation is the right shape and is what the code does: SIGINT to the root,
then a forced kill of the whole tree. The two steps are back-to-back with no
grace window, deliberately — this path runs in the routine `finally` of every
turn, where the process has already exited, so a wait-for-exit window would add
latency to the common path for a few milliseconds of flush time on the rare one.
The comment no longer claims a graceful flush that a back-to-back escalation
does not deliver.

**An already-exited process, and platforms without the tree walk?** Both degrade
to a no-op, never an error. `descendants()` on a dead handle is an empty stream;
`ProcessHandle.destroyForcibly()` on an exited process returns `false` and throws
nothing. Pinned by a test that tree-kills an exited process twice and asserts the
recorded exit code survives. Where the OS cannot enumerate children,
`descendants()` returns what it can — possibly nothing — so behaviour falls back
to today's root-only kill rather than failing. The shelled-out `kill -INT` is now
guarded on liveness: unlike the ProcessHandle path it has no start-time check, so
an unguarded signal to a recycled pid could hit an unrelated process.

**Does the teardown ordering hold?** Yes, and it is unchanged here. Both drivers
destroy from the scope body's own `finally`, ahead of the join:
`Conversations.runAutonomous` and `AgentCall.runInteractiveOnce`. Nothing in the
repo registers a process teardown with `releaseAfterScope`/`useInScope` — there
are no call sites at all — and the three places where the sequencing is
load-bearing already say so (`flow.scala`, `AgentBackend.close`,
`OpencodeServer`). This change alters only *what* the destroy step reaps.

## Known limits, now stated in the code

- **The tree kill cannot rescue the autonomous path's reader.**
  `runAutonomous` is `try drainAndCommit finally conv.cancel()`, and the drain
  returns only once the reader has finished — so if the reader is stalled,
  `cancel()` never runs. The tree kill unblocks a stalled reader only where
  cancel runs *concurrently* with it, i.e. a Ctrl-C at an interactive prompt.
  Same for `StderrPipeline.onFinalize`'s unbounded join, whose comment claimed
  "no timeout needed" because a destroy always EOFs stderr — false on that path,
  since the finalize is upstream of `cancel()`. Both comments are corrected.
  Bounding that join is a real fix but changes the diagnostics contract of three
  backends and wants its own test, so it is deliberately left to a follow-up;
  the behaviour is pre-existing and not a regression from this PR.
- **The snapshot only fills when orca signals a still-alive root.** A root that
  exited on its own (agent crash, clean exit with no terminal message) was never
  signalled, so nothing was recorded and a descendant that redirected its own
  stdio survives. Documented at the field; inherent to parent-link reachability.
- **A lost-update window** exists between a settle-time snapshot write on the
  reader thread and a concurrent cancel's tree kill on the driving thread; the
  losing descendants are missed. Reachable only on the interactive path, and the
  worst case equals pre-PR behaviour. An `AtomicReference` cannot close it — the
  *pair* would need to be atomic. The alternative that does close it (kill
  descendants inside `interrupt()`, before signalling the root, while the root is
  guaranteed alive) turns the documented-graceful `interrupt()` into a SIGKILL
  for every caller including the per-turn settle path; that is a contract change
  for a window that is not a regression, so it is not taken here.
- **EOF nuance, verified against the JDK source.** "A surviving descendant holds
  the write-end so the reader never sees EOF" is narrower than it sounds:
  `ProcessPipeInputStream.processExited` drains and closes *our* read end when
  the root exits. But it is `synchronized` on the stream, so a reader blocked
  mid-read can hold that monitor and prevent the close — which is why the
  original opencode hang was real. The comment now says "can leave a drain still
  waiting for EOF", not "would never EOF".

## Testing

- `ConversationTeardownTest` (new): a real spawned process backgrounds a child
  that inherits its stdout pipe; the turn is cancelled through the actual
  `ForkedConversation` surface and the test polls until the descendant's PID is
  gone. Non-vacuous — reverted to `destroyForcibly()` and it fails in 5s with
  "a cancelled turn must leave no surviving descendant".
- `OsProcCliRunnerTest`: three cases beside the existing live-descendant one —
  a descendant orphaned by the SIGINT (the root is confirmed dead before the
  forcible step, so only the snapshot can reach it: fails in 5.1s without the
  snapshot); a grandchild spawned *after* the snapshot (fails in 5.1s without
  the transitive re-expansion); and the already-exited no-op. All spawns now go
  through a helper that tree-kills in a `finally`, so a failing assertion cannot
  leak a `sleep 30`.
- Fakes are unaffected: `CliProcess.destroyForciblyTree` still defaults to
  `destroyForcibly`, so no fake-driven test changes meaning.
- Opencode teardown is untouched and still covered by `OpencodeServerTest`.
- `sbt scalafmtCheckAll` clean; `sbt clean compile test` green across all
  modules, zero compiler warnings.
- Separately exercised end to end on a real flow: 11 turns, four concurrent
  reviewer forks, a durable session resumed across stages, five commits, a
  branch switch and delete — exit 0, no hang, no premature kill, no truncated
  stream.

## Coordination

`SystemPromptComposer`'s prompt rule about backgrounded work lives in another
in-flight PR, not in master, so this branch cannot correct it. Once both land,
the honest wording is that non-detached background work is killed at turn end
while a deliberately detached process survives — the two probes above are the
evidence.

Not addressed here: `SubprocessSpawn.open`'s build-failure path still sends only
a SIGINT (no forcible backstop) to a just-spawned process. Separate path, no
test coverage; flagged rather than folded in.
