### PR TITLE
Bump os-lib to 0.11.8

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 object Dependencies {
   object V {
     val scala = "3.8.4"
-    val osLib = "0.11.4"
+    val osLib = "0.11.8"
     val jsoniter = "2.38.17"
     val tapir = "1.13.25"
     val sttpApispec = "0.11.10"

--- a/shell/src/main/scala/orca/shell/create/FlowAuthoring.scala
+++ b/shell/src/main/scala/orca/shell/create/FlowAuthoring.scala
@@ -299,22 +299,12 @@ private[shell] object FlowAuthoring:
         if proc.waitFor(timeoutMillis) && proc.exitCode() == 0 then
           Some(proc.stdout.text())
         else None
-      finally if proc.isAlive() then destroyQuietly(proc)
+      finally
+        // `shutdownGracePeriod = 0` is the non-deprecated spelling of
+        // `destroyForcibly()`; os-lib's destroy is recursive, so the agent
+        // CLI's own children go with it.
+        if proc.isAlive() then proc.destroy(shutdownGracePeriod = 0)
     catch case NonFatal(_) => None
-
-  /** Force-kills `proc` (`destroy(shutdownGracePeriod = 0)` — the
-    * non-deprecated spelling of `destroyForcibly()`), with stdout muted for the
-    * call itself. os-lib 0.11.4's `SubProcess.destroy` unconditionally
-    * `println`s `"wrapped.destroyForcibly()"` to the real stdout right before
-    * actually forcibly killing (an upstream debug leftover, not gated behind
-    * any flag) — on this timeout path that noise would otherwise land on the
-    * user's terminal mid-prompt. The subprocess's own stdout was captured via
-    * `os.Pipe` above, not `Console.out`, so muting it here can't drop any of
-    * its output.
-    */
-  private def destroyQuietly(proc: os.SubProcess): Unit =
-    val mutedOut = java.io.PrintStream(java.io.OutputStream.nullOutputStream())
-    Console.withOut(mutedOut)(proc.destroy(shutdownGracePeriod = 0))
 
   /** The directory associated with `tier` (see [[CreateTier]]'s scaladoc):
     * `workDir` for Project, `globalFlows`'s parent for Global. Shared by

--- a/shell/src/main/scala/orca/shell/create/FlowAuthoring.scala
+++ b/shell/src/main/scala/orca/shell/create/FlowAuthoring.scala
@@ -284,9 +284,11 @@ private[shell] object FlowAuthoring:
       case None    => forkFilenameDefault(sourceName)
 
   /** Runs `argv` to completion within `timeoutMillis`, returning its stdout on
-    * a zero exit; `None` on a timeout (the process is killed rather than left
-    * running), a non-zero exit, or any failure to even start (a missing binary
-    * throws from `os.proc`'s spawn). [[suggestFilename]]'s production runner.
+    * a zero exit; `None` on a timeout (the process tree is killed — os-lib's
+    * `destroy` recurses into `children()`, so the agent CLI's own subprocesses
+    * go with it — rather than left running), a non-zero exit, or any failure to
+    * even start (a missing binary throws from `os.proc`'s spawn).
+    * [[suggestFilename]]'s production runner.
     */
   private def runSlugProc(
       argv: Seq[String],
@@ -299,11 +301,7 @@ private[shell] object FlowAuthoring:
         if proc.waitFor(timeoutMillis) && proc.exitCode() == 0 then
           Some(proc.stdout.text())
         else None
-      finally
-        // `shutdownGracePeriod = 0` is the non-deprecated spelling of
-        // `destroyForcibly()`; os-lib's destroy is recursive, so the agent
-        // CLI's own children go with it.
-        if proc.isAlive() then proc.destroy(shutdownGracePeriod = 0)
+      finally if proc.isAlive() then proc.destroy(shutdownGracePeriod = 0)
     catch case NonFatal(_) => None
 
   /** The directory associated with `tier` (see [[CreateTier]]'s scaladoc):


### PR DESCRIPTION
Orca pinned os-lib 0.11.4. Latest stable on Maven Central is 0.11.8 (`<release>` is `0.11.9-M8`, a milestone, skipped).

## What actually changed for orca

**1. `SubProcess.destroy` recurses into `children()`.** In 0.11.4 it killed only the root pid; since 0.11.5 it walks `ProcessHandle.children()`, destroying each parent before its children. Exactly one orca call site invokes os-lib's own `destroy`:

- `FlowAuthoring.runSlugProc` — the filename-slug helper that spawns a coding-agent CLI with a timeout and force-kills it on expiry. It now takes that CLI's subprocesses with it. Best-effort, not guaranteed: with `shutdownGracePeriod = 0` the parent is signalled but not waited on before `children()` is enumerated, so a child reparented in that window still escapes. Strictly better than the old root-only kill either way, and no call site relied on the narrower behaviour.

Every *other* kill path in orca goes through `java.lang.Process` / `ProcessHandle` directly (`OsPipedSubProcess.destroyForcibly`, `destroyForciblyTree`, `OpencodeServer`) and is untouched.

`OsProcCliRunner.destroyForciblyTree` is now *duplicated* by the library, but deliberately kept: it walks descendants-first (documented there — a launch wrapper's child holds the inherited pipe write-ends, so killing the root first can leave a drain blocked), and sends SIGKILL only, where os-lib goes parent-first with SIGTERM-then-SIGKILL. Not a drop-in swap, and `OsProcCliRunnerTest` pins the current behaviour.

**2. `proc.call` now forwards `destroyOnExit` and `shutdownGracePeriod` to `spawn`.** In 0.11.4 `proc.call` passed seven positional arguments to `spawn`; per SLS 6.26.3 the compiler prefers applicable alternatives that need no default arguments, so that bound to a bincompat forwarder hardcoding `destroyOnExit = false` — `proc.call`'s own `destroyOnExit = true` default never reached the process. Consequence for orca: a `QuietProc.call` child got **no** JVM shutdown hook at all.

After the bump, each such child is registered for destruction at JVM exit, and that destroy is recursive. A git, lint or `gh` subprocess is no longer orphaned when orca exits mid-call.

Two costs, both accepted:

- os-lib starts one platform thread per call (`subprocess-shutdown-hook-monitor`) that polls `isAlive` at 1 ms until the child exits, then deregisters the hook. For `QuietProc.call` children that is the length of a git invocation. It is *not* bounded that way at the three `os.proc(...).call` sites with long-lived tty-inherited children — `FlowEditor.edit` (the user's `$EDITOR`), `SessionAction`'s resumed agent session, and `FlowLauncher.spawnInherited` (the flow-runner JVM) — where a sleeping platform thread now lives for the whole child's lifetime.
- Those same three children are now killed at shell exit rather than orphaned. Ctrl-C does not trigger this: `ChildTerminal.withChild` installs a no-op SIGINT handler for the bracket's duration, so the shell JVM does not exit and the hooks never run. On SIGTERM they do.

`spawn` call sites are unaffected — `OsProcCliRunner.spawnPiped` and `runSlugProc` both use named arguments, so they already bound to the full overload with `destroyOnExit = true`.

**3. The stray debug `println` is gone.** 0.11.4's `destroy` unconditionally printed `wrapped.destroyForcibly()` to stdout before force-killing. `FlowAuthoring` carried a `Console.withOut(nullOutputStream)` wrapper purely to keep that off the user's terminal mid-prompt. Removed; the kill is a plain `proc.destroy(shutdownGracePeriod = 0)`.

**4. Stdin pumping no longer throws out of its thread.** `ProcessInput`'s pump wraps `writeBytesTo` in `try/catch` with `finally stdin.close()`. `OsProcCliRunner.run` passes the prompt as a `String`, so every agent CLI invocation goes through it. Previously a child that exited before draining stdin produced an uncaught broken-pipe stack trace on the real stderr — the renderer-tearing output `QuietProc` exists to prevent — and left the child's stdin open, so a child waiting for EOF hung. The trade: a partially written prompt is now swallowed silently rather than surfacing.

## Reviewed and not relevant

- `os.list` / `os.walk` / two-arg `os.exists` gained `Checker#onRead` calls; `hardlink`/`symlink` reclassified their destination as a read. Orca installs no `os.Checker`, and its `os.exists` calls bind to the single-arg overload, which did not change. `ProgressScan`, `PiSessionStore`, `RunManifestWriter`, `FlowCatalog`, `FsTool` unaffected.
- `os.Path` routes `toString`/`toIO`/`toNIO` and construction through a new `@experimental` `pathSerializer` whose default is the previous behaviour verbatim. Those three methods are *not* themselves annotated and orca has no `import os.*` wildcard, so no experimental-mode requirement reaches orca's compilation. `toURI`/`toURL` are additive. `ProcessOps` went from `private[os]` to `@experimental` public; orca has zero references.
- `os.temp` unchanged. `os.zip` internals moved out of `ZipOps` (orca does not use zip). `require()` messages improved. `StatOps` gained `isReadable`/`isWritable`/`isExecutable`. The package object absorbed `ResourceApi`; orca does not use `os.resource`.
- os-lib leaves `addShutdownHook` unguarded, so a `.call` issued *during* JVM shutdown would newly throw `IllegalStateException`. Orca registers no shutdown hooks of its own, and both `System.exit` sites run after teardown, so no subprocess is launched during shutdown.
- No test depends on the old process-kill behaviour. `DepOverrideCanaryTest`'s `0.8.1`/`0.9.1` pins are scala-cli dependency-override fixtures, unrelated to the build's own version. No test is added: the change pins a *library* guarantee, `runSlugProc` is private and every existing test stubs its `runner` seam, and `OsProcCliRunnerTest` already covers descendant reaping.
- `flows/*.sc` pin a released orca, so the bump reaches flow scripts at the next release.

## Verification

`sbt scalafmtCheckAll` clean; `sbt clean compile test` green (1763 tests) with zero warnings. Resolved classpath confirmed as `os-lib_3-0.11.8.jar`.
