### PR TITLE
Drop the Scala-skill mandate from CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,8 +328,7 @@ Orca is 0.x: no backwards compatibility is owed anywhere.
   first. The check is lstat/no-follow and runs at the earliest `.orca` touch
   (`FlowLock.acquireWorkdir` → `ensureCache`), ahead of any mutation.
 
-The `direct-style-scala` plugin codifies the Scala-style bullets; re-reading
-its chapters before a non-trivial change is recommended.
+The Scala-style bullets are distilled from the `direct-style-scala` plugin.
 
 ## Publishing and local testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,3 @@
 Read [AGENTS.md](AGENTS.md) for internals, architecture, and coding
 conventions, and [CONTRIBUTING.md](CONTRIBUTING.md) for build/test commands
 and the local-testing recipes.
-
-Before writing, modifying, or reviewing any Scala code in this repository,
-invoke the `direct-style-scala` skill (via the Skill tool). This applies to
-subagents dispatched to implement or review a task: load the skill first,
-then start the work.


### PR DESCRIPTION
CLAUDE.md instructed every agent — and every subagent dispatched to implement or review a task — to invoke the `direct-style-scala` skill before touching Scala. That is a tool's configuration, not repo policy: which skill a coding agent loads should be up to the coding agent.

It also costs real tokens. The skill is ~18k characters, and the mandate applied it indiscriminately — including to reviewers that never write Scala (readability, simplicity) and to the lint summariser — riding in the fixed per-session preamble.

## Changes

**CLAUDE.md** — removed the mandate paragraph. What remains is the pointer to `AGENTS.md` and `CONTRIBUTING.md` it already was. The file stays (rather than being folded into AGENTS.md) because it is the only instruction file Claude Code auto-loads, and the markdown-link form is the cheap shim: `@AGENTS.md` would inline the whole conventions document into the preamble, working against this PR's own rationale.

**AGENTS.md** — the Scala-conventions section ended with:

> The `direct-style-scala` plugin codifies the Scala-style bullets; re-reading its chapters before a non-trivial change is recommended.

That sentence carried two different things. The provenance half (these bullets are distilled from a published convention, not invented here) belongs and stays. The second half is the same tool-use direction just deleted from CLAUDE.md, only softer, sitting in the file agents are pointed at — so the repo would have said in one file that skill-loading is the agent's business and in another that it should be doing it. Trimmed to the provenance:

> The Scala-style bullets are distilled from the `direct-style-scala` plugin.

Revert that one line if you'd rather keep the recommendation.

## What depended on the mandate

Nothing programmatic. Searched the repo case-insensitively across `.md`, `.scala`, `.sc`, `.json`, `.yml`, `.sh`, every prompt resource under `*/src/main/resources/orca/`, `flows/*.sc`, `.github/`, `install.sh` and `build.sbt`:

- Orca never reads `CLAUDE.md` at runtime — the Claude backend composes its system prompt from `config.systemPrompt` into a temp file (`ClaudeBackend`, `--append-system-prompt-file`). No prompt resource, flow script, CI job or Scala source mentions the skill or the file.
- `flow/src/main/resources/orca/review/prompts/reviewers/scala-fp.md` spells the direct-style conventions out itself rather than deferring to the skill, so the review path enforces them independently.
- Four documents restate the guidance in prose: the two `docs/superpowers/plans/` records and two `docs/research/run-cost/` planning notes. All are historical records of work, left alone.
- The conventions themselves are unaffected — braceless syntax, explicit return types, no class-level `var`s, opaque types, `Either[E, T]` all live in AGENTS.md's "Conventions" section.

## Deliberate, not a no-op

The removed paragraph said "must invoke … before writing, modifying, **or reviewing** any Scala code" and explicitly propagated to dispatched subagents. Nothing surviving carries that propagation. That is the intended policy change, not an oversight.
