### PR TITLE
Write claude's MCP config under .orca/cache so a leftover can't be committed

### DIFF
--- a/adr/0012-mcp-host-bridge.md
+++ b/adr/0012-mcp-host-bridge.md
@@ -45,7 +45,7 @@ the spawned `claude` subprocess via `.mcp.json` + `--mcp-config`.
   the Netty binding.
 
 - **`ClaudeBackend.openConversation`** — builds the bridge + server,
-  writes `.orca-mcp-<port>.json` to `workDir` (port-suffixed so
+  writes `<workDir>/.orca/cache/mcp-<port>.json` (port-suffixed so
   concurrent conversations sharing a workdir don't collide), passes
   `--mcp-config` to claude, and hands the bridge to
   `ClaudeConversation`. Adds the MCP tool name (`mcp__orca__ask_user`)

--- a/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
@@ -2,6 +2,7 @@ package orca.tools.claude
 
 import java.util.concurrent.atomic.AtomicBoolean
 
+import orca.OrcaDir
 import orca.events.OrcaListener
 import orca.agents.{
   AutoApprove,
@@ -156,11 +157,11 @@ private[orca] class ClaudeBackend(
     * for EOF and start producing output.
     *
     * `Interactive` mode wires the MCP `ask_user` tool: stand up an
-    * [[AskUserMcpServer]] on an ephemeral port, write a workDir-local
-    * `.orca-mcp-<port>.json`, point claude at it via `--mcp-config`, and
-    * auto-approve the tool. `Autonomous` skips all of that: those calls have no
-    * renderer to drive the prompt, so exposing the tool would let the agent
-    * deadlock the call.
+    * [[AskUserMcpServer]] on an ephemeral port, write its config at
+    * [[ClaudeBackend.mcpConfigPath]], point claude at it via `--mcp-config`,
+    * and auto-approve the tool. `Autonomous` skips all of that: those calls
+    * have no renderer to drive the prompt, so exposing the tool would let the
+    * agent deadlock the call.
     *
     * The MCP server (when present) is a session resource closed from
     * `onFinalize` after the read loop drains. If anything between resource
@@ -183,7 +184,9 @@ private[orca] class ClaudeBackend(
         AskUserSession.allocate: server =>
           writeMcpConfig(server, workDir)
           List(
-            SubprocessSpawn.deleteFileResource(mcpConfigPath(server, workDir))
+            SubprocessSpawn.deleteFileResource(
+              ClaudeBackend.mcpConfigPath(workDir, server.port)
+            )
           )
     SubprocessSpawn.open("claude stream-json", askUser.toList) {
       val systemPromptFile =
@@ -204,7 +207,8 @@ private[orca] class ClaudeBackend(
         systemPromptFile,
         dispatch = sessions.dispatchFor(session),
         outputSchema,
-        mcpConfig = askUser.map(r => mcpConfigPath(r.server, workDir)),
+        mcpConfig =
+          askUser.map(r => ClaudeBackend.mcpConfigPath(workDir, r.server.port)),
         networkTools = networkTools
       )
       cli.spawnPiped(args, cwd = workDir)
@@ -222,16 +226,7 @@ private[orca] class ClaudeBackend(
       )
     }
 
-  /** Path of the workDir-local MCP config file advertising the host's MCP
-    * server. Named with the bound port so two interactive conversations sharing
-    * a `workDir` don't overwrite each other's config.
-    */
-  private def mcpConfigPath(
-      server: AskUserMcpServer,
-      workDir: os.Path
-  ): os.Path = workDir / s".orca-mcp-${server.port}.json"
-
-  /** Write the MCP config file at [[mcpConfigPath]].
+  /** Write the MCP config file at [[ClaudeBackend.mcpConfigPath]].
     *
     * The `timeout` field extends claude's per-server tool-call timeout from its
     * 60s default to [[AskUserMcpServer.ToolTimeout]]. Without it, claude gives
@@ -246,8 +241,13 @@ private[orca] class ClaudeBackend(
       workDir: os.Path
   ): Unit =
     val timeoutMs = AskUserMcpServer.ToolTimeout.toMillis
-    os.write.over(
-      mcpConfigPath(server, workDir),
+    val path = ClaudeBackend.mcpConfigPath(workDir, server.port)
+    // Recreate rather than overwrite: `os.write` (CREATE_NEW) refuses an
+    // existing symlink at the leaf, which `os.write.over` would follow. The
+    // removal also clears a same-port leftover from an earlier hard kill.
+    val _ = os.remove(path)
+    os.write(
+      path,
       s"""{"mcpServers":{"${AskUserMcpServer.ServerName}":{"type":"http","url":"${server.url}","timeout":$timeoutMs}}}"""
     )
 
@@ -267,6 +267,20 @@ private[orca] class ClaudeBackend(
         os.temp(prefix = "orca-system-prompt-", suffix = ".md", contents = text)
 
 object ClaudeBackend:
+
+  /** Path of the MCP config file advertising the host's `ask_user` server,
+    * ensuring its directory. Named with the bound port so two interactive
+    * conversations sharing a `workDir` don't overwrite each other's config.
+    *
+    * It lives under `.orca/cache/` rather than at the workDir root because a
+    * hard kill skips the deletion resource that removes it, and a leftover at
+    * the root is swept into the next stage's `git add -A` — orca committing its
+    * own scratch file to the user's repository. The cache self-ignores (ADR
+    * 0019), so a leftover there is inert. Still inside the working tree, so a
+    * sandboxed claude that denies reads outside its worktree can read it.
+    */
+  private[claude] def mcpConfigPath(workDir: os.Path, port: Int): os.Path =
+    OrcaDir.ensureCache(workDir) / s"mcp-$port.json"
 
   /** Derives the project-directory slug that claude uses under
     * `~/.claude/projects/`: replaces every `/` in the absolute path with `-`.

--- a/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
@@ -241,10 +241,12 @@ private[orca] class ClaudeBackend(
       workDir: os.Path
   ): Unit =
     val timeoutMs = AskUserMcpServer.ToolTimeout.toMillis
+    val _ = OrcaDir.ensureCache(workDir)
     val path = ClaudeBackend.mcpConfigPath(workDir, server.port)
-    // Recreate rather than overwrite: `os.write` (CREATE_NEW) refuses an
-    // existing symlink at the leaf, which `os.write.over` would follow. The
-    // removal also clears a same-port leftover from an earlier hard kill.
+    // `os.write` is CREATE_NEW — it refuses a leaf symlink, which
+    // `os.write.over` would follow — so a same-port leftover from an earlier
+    // hard kill has to be removed first. `os.remove` unlinks a symlink rather
+    // than following it.
     val _ = os.remove(path)
     os.write(
       path,
@@ -268,19 +270,17 @@ private[orca] class ClaudeBackend(
 
 object ClaudeBackend:
 
-  /** Path of the MCP config file advertising the host's `ask_user` server,
-    * ensuring its directory. Named with the bound port so two interactive
-    * conversations sharing a `workDir` don't overwrite each other's config.
+  /** Path of the MCP config file advertising the host's `ask_user` server.
+    * Named with the bound port so two interactive conversations sharing a
+    * `workDir` don't overwrite each other's config.
     *
-    * It lives under `.orca/cache/` rather than at the workDir root because a
-    * hard kill skips the deletion resource that removes it, and a leftover at
-    * the root is swept into the next stage's `git add -A` — orca committing its
-    * own scratch file to the user's repository. The cache self-ignores (ADR
-    * 0019), so a leftover there is inert. Still inside the working tree, so a
+    * Under the self-ignoring `.orca/cache/` rather than at the workDir root: a
+    * hard kill skips the deletion resource, and a leftover at the root is swept
+    * into the next stage's `git add -A`. Still inside the working tree, so a
     * sandboxed claude that denies reads outside its worktree can read it.
     */
   private[claude] def mcpConfigPath(workDir: os.Path, port: Int): os.Path =
-    OrcaDir.ensureCache(workDir) / s"mcp-$port.json"
+    OrcaDir.cachePath(workDir) / s"mcp-$port.json"
 
   /** Derives the project-directory slug that claude uses under
     * `~/.claude/projects/`: replaces every `/` in the absolute path with `-`.

--- a/claude/src/test/scala/orca/tools/claude/ClaudeBackendTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeBackendTest.scala
@@ -79,9 +79,8 @@ class ClaudeBackendTest extends munit.FunSuite:
       assert(!args.contains("--mcp-config"), args)
 
   test("an MCP config left behind by a hard kill can't reach a commit"):
-    // A hard kill skips the deletion resource, so the file survives into the
-    // next stage's `git add -A`.
     val repo = GitRepo.seeded()
+    val _ = orca.OrcaDir.ensureCache(repo)
     os.write(ClaudeBackend.mcpConfigPath(repo, port = 45123), "{}")
     val _ = os.proc("git", "add", "-A").call(cwd = repo)
     val staged =

--- a/claude/src/test/scala/orca/tools/claude/ClaudeBackendTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeBackendTest.scala
@@ -13,7 +13,7 @@ import orca.agents.{
 import orca.events.OrcaListener
 import orca.{OrcaFlowException}
 import orca.subprocess.{FakePipedCliProcess, SpawnStubCliRunner}
-import orca.testkit.TempDirs
+import orca.testkit.{GitRepo, TempDirs}
 
 class ClaudeBackendTest extends munit.FunSuite:
 
@@ -77,6 +77,19 @@ class ClaudeBackendTest extends munit.FunSuite:
       assert(args.containsSlice(Seq("--output-format", "stream-json")))
       // No ask_user MCP on the autonomous path.
       assert(!args.contains("--mcp-config"), args)
+
+  test("an MCP config left behind by a hard kill can't reach a commit"):
+    // A hard kill skips the deletion resource, so the file survives into the
+    // next stage's `git add -A`.
+    val repo = GitRepo.seeded()
+    os.write(ClaudeBackend.mcpConfigPath(repo, port = 45123), "{}")
+    val _ = os.proc("git", "add", "-A").call(cwd = repo)
+    val staged =
+      os.proc("git", "diff", "--cached", "--name-only")
+        .call(cwd = repo)
+        .out
+        .text()
+    assertEquals(staged, "", "the MCP config must be unstageable")
 
   test("NetworkOnly autonomous call pre-approves the default network tools"):
     val runner = new SpawnStubCliRunner(List(successfulProcess()))

--- a/docs/research/shell/01-global-state.md
+++ b/docs/research/shell/01-global-state.md
@@ -43,7 +43,7 @@ means an exception or hang, never adversarial behaviour.
 | 11 | `opencode serve` subprocess | `opencode/src/main/scala/orca/tools/opencode/OpencodeServer.scala` | Yes (`ctx.close()` tree-destroys it in the body's `finally`) | SAFE |
 | 12 | Per-run instances: `EventDispatcher`, `CostTracker`, `SessionSupport` maps, `StageFrames`, `TerminalOutput`, conversations, `AgentBackend.closedFlag` | various (see §B) | Yes (all die with the run/Ox scope) | SAFE |
 | 13 | Immutable statics: `Pricing.default`, prompt resources, jsoniter codecs, `OrcaBanner`, `OrcaArgs` parser, backend constants | various (see §C) | n/a | SAFE |
-| 14 | Cross-run **on-disk** state: progress log, gemini `settings.json` merge, claude `.orca-mcp-*.json`, opencode global session store | various (see §D) | Mostly; crash leaves documented residue | SAFE / noted |
+| 14 | Cross-run **on-disk** state: progress log, gemini `settings.json` merge, claude `.orca/cache/mcp-*.json`, opencode global session store | various (see §D) | Mostly; crash leaves documented residue | SAFE / noted |
 | 15 | Non-findings: no shutdown hooks (beyond #7), no signal handlers registered by orca, no `System.setProperty`, no `Console`/`System.setOut` redirection, no global executors | — | — | SAFE |
 
 ## A. Process-global mutable state
@@ -386,10 +386,10 @@ concerns:
   ADR 0015); the next run's merge overwrites the entry with its live URL, so
   it self-corrects — but that next run's "restore" then re-instates the
   polluted version. Known, accepted; no worse in a shell.
-- **claude `.orca-mcp-<port>.json`** — `ClaudeBackend.scala:229–232`:
-  workdir-local, port-named (no cross-run collision), deleted via a finalize
-  resource (`ClaudeBackend.scala:184–186`); a crash leaves a harmless
-  untracked file.
+- **claude `.orca/cache/mcp-<port>.json`** — `ClaudeBackend.mcpConfigPath`:
+  in the self-ignoring cache, port-named (no cross-run collision), deleted via
+  a finalize resource; a crash leaves an ignored file that no commit can pick
+  up.
 - **`flow.lock`** — see #4.
 - **opencode global session store** — durable machine-global by design
   (`OpencodeServer.scala` scaladoc, `SessionSupport.durable`); the shell's

--- a/docs/research/shell/05-flow-discovery.md
+++ b/docs/research/shell/05-flow-discovery.md
@@ -20,9 +20,9 @@ All `.orca/` writes route through `tools/src/main/scala/orca/OrcaDir.scala`
 | `.orca/cache/flow.lock` | `runner/.../FlowLock.scala` | no (in cache) |
 | `.orca/cache/lint-*.txt` | `flow/.../review/Lint.scala` (spilled lint output) | no (in cache) |
 
-Not in `.orca/`: claude's transient MCP config is `.orca-mcp-<port>.json` in
-the *workDir root* (`ClaudeBackend`, ClaudeBackend.scala:232), so it is
-irrelevant here. `GitTool`
+Claude's transient MCP config, `.orca/cache/mcp-<port>.json`
+(`ClaudeBackend.mcpConfigPath`), is in the cache, so it is ignored like the
+rest of it. `GitTool`
 excludes `.orca/*` from review diffs via pathspec `:(exclude).orca/*` — a
 flows subdirectory would automatically be excluded from review diffs too,
 which is the right behaviour (a flow script is orchestration bookkeeping, not

--- a/tools/src/main/scala/orca/OrcaDir.scala
+++ b/tools/src/main/scala/orca/OrcaDir.scala
@@ -58,13 +58,19 @@ private[orca] object OrcaDir:
     abortIfOrcaComponentSymlink(workDir, r)
     r.tap(os.makeDir.all(_))
 
+  /** `<workDir>/.orca/cache`, passively — for callers that only need the path
+    * (a file to delete, an argument to hand a subprocess) and must not create
+    * anything. [[ensureCache]] is the write-side counterpart.
+    */
+  def cachePath(workDir: os.Path): os.Path = root(workDir) / "cache"
+
   /** Idempotently ensure `.orca/cache/` exists, writing its self-ignoring
     * `.gitignore` and `CACHEDIR.TAG` before returning so nothing lands in the
     * dir before the exclusion is in place. Markers are written only when
     * absent, so repeated calls do not churn mtimes.
     */
   def ensureCache(workDir: os.Path): os.Path =
-    val cache = root(workDir) / "cache"
+    val cache = cachePath(workDir)
     abortIfOrcaComponentSymlink(workDir, cache)
     os.makeDir.all(cache)
     writeIfAbsent(cache / ".gitignore", gitignoreContents)
@@ -87,7 +93,7 @@ private[orca] object OrcaDir:
     * probe) — only [[ensurePiSessions]] creates.
     */
   def piSessionsPath(workDir: os.Path): os.Path =
-    root(workDir) / "cache" / "pi-sessions"
+    cachePath(workDir) / "pi-sessions"
 
   /** Idempotently ensure `.orca/cache/pi-sessions/` exists and return it, for
     * the write side (spawning pi at a session dir under it).
@@ -102,7 +108,7 @@ private[orca] object OrcaDir:
     * [[cacheRunsPath]] for the shell's manifest listing (ADR 0021 §8), which
     * must not create `.orca` as a side effect of reading it.
     */
-  def runsPath(workDir: os.Path): os.Path = root(workDir) / "cache" / "runs"
+  def runsPath(workDir: os.Path): os.Path = cachePath(workDir) / "runs"
 
   /** `<workDir>/.orca/flows` — project-tier flow scripts (ADR 0021 §5),
     * committed like the rest of `.orca`'s root.

--- a/tools/src/main/scala/orca/backend/mcp/AskUserMcpServer.scala
+++ b/tools/src/main/scala/orca/backend/mcp/AskUserMcpServer.scala
@@ -24,7 +24,7 @@ private[mcp] case class AskUserInput(question: String) derives Codec, Schema
   */
 private[orca] class AskUserMcpServer private[mcp] (
     /** The bound port. Useful when the caller wants to disambiguate per-server
-      * artefacts (e.g. claude's `.orca-mcp-$port.json` config file).
+      * artefacts (e.g. claude's `mcp-$port.json` config file).
       */
     val port: Int,
     stopFn: () => Unit

--- a/tools/src/main/scala/orca/backend/mcp/AskUserSession.scala
+++ b/tools/src/main/scala/orca/backend/mcp/AskUserSession.scala
@@ -7,8 +7,8 @@ import scala.util.control.NonFatal
 
 /** One-conversation ask-user wiring: the host-side [[AskUserBridge]], the
   * Netty-backed [[AskUserMcpServer]], and any backend-specific `extras` (e.g.
-  * claude's `.orca-mcp-<port>.json` config file deletion). The framework closes
-  * it after the read loop drains.
+  * claude's `mcp-<port>.json` config file deletion). The framework closes it
+  * after the read loop drains.
   *
   * Close-order: bridge first (errors any in-flight `ask` so blocked handlers
   * exit before the binding tears down), then server, then extras. Each close is


### PR DESCRIPTION
`ClaudeBackend` wrote its `ask_user` MCP config to `<workDir>/.orca-mcp-<port>.json`
— the project root. Deletion is registered as a resource, so a clean run removes
it, but a hard kill (SIGKILL, power loss, a killed terminal) never runs that
resource. The file then sits untracked in the working tree until the next stage's
`git add -A` sweeps it into the user's repository: orca committing its own scratch
file to someone else's project.

**Fix: write it under `.orca/cache/` instead** — `<workDir>/.orca/cache/mcp-<port>.json`.

Chosen over a startup sweep of stale `.orca-mcp-*.json` files, or teaching git to
ignore the root name, because it makes a leftover *harmless* rather than adding
code that cleans up after one. It is also what orca's own layout already says
(ADR 0019): ephemeral state lives in `.orca/cache/`, which self-ignores via the
`.gitignore` (`*`) and `CACHEDIR.TAG` that `OrcaDir.ensureCache` writes before
anything lands there. `review.Lint` already spills its lint output there for
exactly this reason. The existing deletion resource stays — the file is still
removed on every clean exit.

## What was checked

- **Nothing else depends on the path.** `ClaudeBackend` is the only code that
  computes it; the rest were prose references (ADR 0012 and two scaladocs,
  updated here).
- **The claude CLI can still read it.** `--mcp-config` takes any readable path
  and orca passes an absolute one; the new location is still inside the working
  tree, so a sandboxed claude that denies reads outside its worktree reaches it
  the same way it reaches Lint's spill file.
- **The port in the name still matters** — it is what keeps two interactive
  conversations sharing a `workDir` from overwriting each other's config
  (ADR 0012). It is kept; only the directory changed, and the now-redundant
  `.orca-` prefix was dropped to match the sibling `lint-*.txt` files.
- **`os.write.over` → `os.remove` + `os.write`.** `.over` follows a leaf
  symlink, which AGENTS.md forbids where avoidable; `os.write` is CREATE_NEW
  and refuses one, so a same-port leftover from an earlier kill has to be
  unlinked first (`os.remove` unlinks a symlink rather than following it).
- **`mcpConfigPath` stays a pure accessor.** The cache directory is ensured at
  the one site that writes. `OrcaDir` gains the passive `cachePath` this needs,
  mirroring the `runsPath`/`cacheRunsPath` and `piSessionsPath`/`ensurePiSessions`
  pairs it already has, and the two other places that spelled out
  `.orca/cache` now go through it.

## Test

`ClaudeBackendTest`: write the config at the real computed path in a temp git
repo, run `git add -A`, assert nothing is staged. It fails when the path is
reverted to the workDir root.

`sbt scalafmtCheckAll` clean, `sbt clean compile test` green across all modules,
zero warnings.
