### PR TITLE
Send claude's haiku alias fully qualified, so `claude:haiku` runs Haiku

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,9 @@ files, single-valued (a repeated agent key is an error). Value grammar:
 `harness` is one of `claude`, `codex`, `opencode`, `pi`, `gemini` (an
 unrecognised name is an error naming the valid set). The model part is passed
 **verbatim** to the harness's `withModel` — orca does not normalise or validate
-model ids — for example:
+model ids, except that claude's bare `haiku` alias is sent as
+`claude-haiku-4-5`, since the CLI serves Sonnet for the alias on the read-only
+turns reviewers use. For example:
 
 ```properties
 planningAgent = claude:opus

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -43,12 +43,30 @@ private[claude] object ClaudeArgs:
       "--verbose",
       "--include-partial-messages"
     ) ++
-      CliArgs.modelArgs(config) ++
+      modelArgs(config) ++
       systemPromptFileArgs(systemPromptFile) ++
       sessionArgs(dispatch) ++
       autoApproveArgs(config, networkTools) ++
       jsonSchemaArgs(jsonSchema) ++
       mcpConfigArgs(mcpConfig)
+
+  /** `--model`, with the bare `haiku` alias replaced by its fully-qualified id.
+    *
+    * Under `--permission-mode plan` (every read-only turn — see
+    * `autoApproveArgs`) the CLI serves `claude-sonnet-5` for `--model haiku`,
+    * 3x the intended rate for a `claude:haiku` role pin. Its init line still
+    * names haiku, so re-checking this means reading the model off the assistant
+    * messages or the result's `modelUsage`, not off the init line. It honours
+    * `claude-haiku-4-5` in the same mode; verified against claude 2.1.220.
+    *
+    * Only `haiku` is rewritten — the CLI resolves `sonnet`/`opus`/`fable`
+    * correctly in plan mode, and leaving those bare keeps them tracking the
+    * latest model in their tier.
+    */
+  private def modelArgs(config: AgentConfig): Seq[String] =
+    CliArgs.flag("--model", config.model): model =>
+      if model.name == "haiku" then DefaultClaudeAgent.Haiku.name
+      else model.name
 
   private def systemPromptFileArgs(file: Option[os.Path]): Seq[String] =
     CliArgs.flag("--append-system-prompt-file", file)(_.toString)

--- a/claude/src/main/scala/orca/tools/claude/DefaultClaudeAgent.scala
+++ b/claude/src/main/scala/orca/tools/claude/DefaultClaudeAgent.scala
@@ -27,7 +27,7 @@ private[orca] class DefaultClaudeAgent(
     )
     with ClaudeAgent:
 
-  def haiku: ClaudeAgent = withModel(Model("claude-haiku-4-5"))
+  def haiku: ClaudeAgent = withModel(DefaultClaudeAgent.Haiku)
   def sonnet: ClaudeAgent = withModel(Model("claude-sonnet-5"))
   def opus: ClaudeAgent = withModel(DefaultClaudeAgent.Opus1M)
   def fable: ClaudeAgent = withModel(DefaultClaudeAgent.Fable)
@@ -64,6 +64,13 @@ private[orca] class DefaultClaudeAgent(
     )
 
 private[orca] object DefaultClaudeAgent:
+  /** The cheap tier. Spelled out rather than the `haiku` alias, which plan mode
+    * mis-resolves — see `ClaudeArgs.modelArgs`. That rewrite covers a
+    * `claude:haiku` pin too, so neither spelling tracks a new haiku generation:
+    * this constant is the one place to bump when one ships.
+    */
+  val Haiku: Model = Model("claude-haiku-4-5")
+
   /** The default coding model: Opus with the 1M-token context window, via the
     * `[1m]` model-alias suffix. The main implementer session is long-lived and
     * accumulates context across tasks, so 1M keeps it from overflowing ("Prompt

--- a/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
@@ -44,6 +44,17 @@ class ClaudeArgsTest extends munit.FunSuite:
   test("model flag is absent when AgentConfig.model is None"):
     assert(!streamJson(AgentConfig()).contains("--model"))
 
+  test("the `haiku` alias — what `claude:haiku` pins — is sent qualified"):
+    // Plan mode serves claude-sonnet-5 for the bare alias — see
+    // ClaudeArgs.modelArgs.
+    val args = streamJson(AgentConfig(model = Some(Model("haiku"))))
+    assert(args.containsSlice(Seq("--model", "claude-haiku-4-5")), args)
+
+  test("the `sonnet` alias is left bare"):
+    // Guards against generalising the rewrite to aliases the CLI resolves fine.
+    val args = streamJson(AgentConfig(model = Some(Model("sonnet"))))
+    assert(args.containsSlice(Seq("--model", "sonnet")), args)
+
   test("system-prompt-file flag is emitted when a file is supplied"):
     val file = os.temp(contents = "content")
     val args = ClaudeArgs.streamJson(

--- a/tools/src/main/scala/orca/backend/CliArgs.scala
+++ b/tools/src/main/scala/orca/backend/CliArgs.scala
@@ -15,9 +15,9 @@ private[orca] object CliArgs:
   def flag[A](name: String, opt: Option[A])(render: A => String): Seq[String] =
     opt.toSeq.flatMap(v => Seq(name, render(v)))
 
-  /** `--model <name>` when `config.model` is set, empty otherwise. Both
-    * supported backends spell the flag the same way; if a future backend
-    * differs, render the model name elsewhere and don't use this helper.
+  /** `--model <name>` when `config.model` is set, empty otherwise. Codex,
+    * gemini and pi spell the flag the same way; claude renders its own because
+    * it rewrites one alias (see `ClaudeArgs.modelArgs`).
     */
   def modelArgs(config: AgentConfig): Seq[String] =
     flag("--model", config.model)(_.name)


### PR DESCRIPTION
A settings pin of `reviewAgent = claude:haiku` was running Sonnet 5, at 3x the
intended rate. This sends the alias fully qualified so it runs Haiku.

## The bug

The claude CLI's plan mode has a model-capability floor. Given a **bare alias**
below that floor it silently substitutes a stronger model; given a
**fully-qualified id** it honours the request. `haiku` is the only alias below
the floor.

orca passes `--permission-mode plan` for every `ToolSet.ReadOnly` and
`ToolSet.NetworkOnly` turn (`ClaudeArgs.autoApproveArgs`), and every reviewer
runs `.withReadOnly` — so every reviewer turn is a plan-mode turn.

Measured against claude CLI 2.1.220, using orca's own spawn shape
(`--print --input-format stream-json --output-format stream-json --verbose`):

| flags | model that answered |
|---|---|
| `--permission-mode plan --model haiku` | `claude-sonnet-5` ❌ |
| `--permission-mode plan --model claude-haiku-4-5` | `claude-haiku-4-5-20251001` ✅ |
| `--permission-mode plan --model sonnet` / `opus` / `fable` | own family ✅ |
| `--model haiku` (no plan mode) | `claude-haiku-4-5-20251001` ✅ |

5/5 reproductions of the failing row. Isolated by bisecting orca's flags:
`--permission-mode plan` is the trigger; `--include-partial-messages` and
`--session-id` are not.

The mis-resolution is easy to miss because **the CLI's `system.init` line still
announces haiku** — only the assistant messages and the result's `modelUsage`
report `claude-sonnet-5`.

The affected path is the settings string only:

- `reviewAgent = claude:haiku` → `AgentSpec` → `RoleAgents` →
  `withModel(Model("haiku"))` → `--model haiku` — **affected**
- the Scala accessor `claude.haiku` already produced `claude-haiku-4-5` —
  never affected

## The fix

Resolve the bare `haiku` alias to `claude-haiku-4-5` in `ClaudeArgs`, claude's
single `--model` choke point (`ClaudeBackend` has one spawn, and the autonomous
and interactive paths share this one arg builder). `AgentConfig.cheapModel` and
`Agent.cheap` funnel through the same point, so a `withCheapModel(Model("haiku"))`
pin is covered too.

`DefaultClaudeAgent.Haiku` now holds the id once, shared by the `haiku` accessor
and the arg builder.

### Why only `haiku`

The other three aliases demonstrably resolve correctly in plan mode, and a bare
alias earns something real: it tracks the latest model in its tier without a
code change. Pinning `sonnet`/`opus`/`fable` would trade that live benefit for a
maintenance burden on three ids, to guard a floor move that has not happened.
For `haiku` the tracking benefit is already worthless — the alias does not work
under plan mode at all — so qualifying it costs nothing that currently works.

Mapping every alias would also collide with orca's own vocabulary: the `opus`
accessor deliberately means `claude-opus-5[1m]` (1M context), not plain
`claude-opus-5`, so a settings-level `opus` entry would give the codebase two
different meanings of "opus".

### Staleness

The rewrite freezes both `claude:haiku` and `claude.haiku` on 4-5 — there is no
longer a "latest haiku" spelling. That is a real cost, stated in
`DefaultClaudeAgent.Haiku`'s scaladoc, which names itself as the one place to
bump when a new haiku ships. It adds no new maintenance point: that constant
already had to be updated on a new generation.

The scaladoc records the CLI version verified against, and — because the init
line lies — which field to re-check it on.

## Other backends

Checked all four for the same class of bug; **none fixed, none demonstrated**.

- **codex** — no alias vocabulary reaches the wire (`mini` is already the
  qualified `gpt-5.4-mini`). Verified: under `--sandbox read-only` the
  qualified id is echoed back unchanged, and a bare `mini` is *rejected loudly*
  rather than silently substituted.
- **opencode** — the CLI requires `provider/model`; every accessor is already
  qualified. The bare-alias precondition cannot arise.
- **gemini** — uses `--approval-mode plan`, the closest structural analogue, but
  `flash`/`pro` are already qualified ids. **Not authenticated in this
  environment, so untested** — unknown, not claimed safe.
- **pi** — forwards the model verbatim and does its own pattern/fuzzy matching,
  making it the strongest structural candidate; but its restricted tier is a
  `--tools` allowlist, not an approval mode. **Not authenticated, so untested.**

## Interaction with #49 (`cost-split-cache-writes`) — needs reconciling at merge

**Not touched by this PR.** #49 adds a `claude-haiku-4-5-20251001` pricing row
priced at *Sonnet 5* rates, because that id's traffic really was Sonnet.

I independently confirmed the mechanism behind that row: orca attributes cost
via `ClaudeConversation`'s `result.model.orElse(initModel)`, the result message
carries no `model` field, so orca falls back to the **init** line — which
reports `claude-haiku-4-5-20251001` while the turn bills at Sonnet rates.
Exactly what #49 observed.

This PR changes that row's justification. Once orca stops sending the bare
alias, nothing it spawns reports `claude-haiku-4-5-20251001` any more — a
qualified request reports the undated `claude-haiku-4-5` and prices on the
existing Haiku row. So on merge that row is either dead or, if it is ever hit
again, denotes *genuine* Haiku traffic that Sonnet pricing would over-charge 3x.
It should be dropped or re-priced at Haiku rates. #49's own comment anticipates
this ("Revisit when the alias resolves to Haiku again"); the trigger is now
"orca no longer asks for the alias".

## Tests

Two, both mutation-checked:

- the `haiku` alias is sent as `claude-haiku-4-5` — fails when the rewrite is
  removed
- the `sonnet` alias is left bare — fails when the rewrite is generalised to
  other aliases

Neither sets `ToolSet.ReadOnly`: the rewrite is unconditional, and gating on
plan mode would imply a conditional that does not exist.

Also verified empirically that `--model Haiku` (mixed case) resolves to Haiku
correctly, so the exact-lowercase match is right and case-insensitivity would
be wrong.

`sbt scalafmtCheckAll` and `sbt clean compile test` pass with zero warnings.
