### PR TITLE
Record cost, tokens and per-turn prompt size in the run manifest

### DIFF
--- a/adr/0021-orca-shell.md
+++ b/adr/0021-orca-shell.md
@@ -409,7 +409,8 @@ log by `clientId`, and writes the manifest.
 **Manifest**: one JSON file per run at
 `.orca/cache/runs/<startedAt>-<pid>.json` (self-gitignored cache; at most
 one writer per workdir thanks to `FlowLock`), schema v1 per research 08 §4:
-`manifestVersion` (hard gate — newer than the shell understands ⇒ skip with
+`manifestVersion` (hard gate, checked before the body is decoded — any
+version other than the one the build writes ⇒ skip with
 a message), `orcaVersion`, `flow` (populated from the `ORCA_FLOW_NAME` env
 var the shell sets before exec'ing the child — the flow's filename is
 unknowable in-library; `None` for direct `scala-cli run` invocations),

--- a/flow/src/main/scala/orca/events/CostTracker.scala
+++ b/flow/src/main/scala/orca/events/CostTracker.scala
@@ -66,22 +66,9 @@ class CostTracker(pricing: PriceList = Pricing.default) extends OrcaListener:
 
   def onEvent(event: OrcaEvent): Unit = event match
     case OrcaEvent.TokensUsed(agent, model, usage, role) =>
-      val cost = costFor(model, usage)
+      val cost = Pricing.resolve(pricing.table, model, usage)
       val _ = state.updateAndGet(_.record(agent, model, usage, cost, role))
     case _ => ()
-
-  /** Resolve a per-call cost: the reported figure if the backend supplied one,
-    * otherwise an estimate from the pricing table. `None` when neither is
-    * available (no `total_cost_usd` and no table entry for the model).
-    */
-  private def costFor(model: Option[Model], usage: Usage): Option[Cost] =
-    usage.cost
-      .map(amount => Cost(amount, estimated = false))
-      .orElse(
-        Pricing
-          .estimate(pricing.table, model, usage)
-          .map(amount => Cost(amount, estimated = true))
-      )
 
   /** Usage accumulated across every call, regardless of axis. */
   def total: Usage =

--- a/flow/src/main/scala/orca/events/Pricing.scala
+++ b/flow/src/main/scala/orca/events/Pricing.scala
@@ -56,6 +56,22 @@ object Pricing:
     */
   private val DateSuffix: Regex = """^-\d{8}$""".r
 
+  /** Resolve one call's cost: the figure the backend reported if there is one,
+    * an [[estimate]] from `table` otherwise, `None` when neither is available.
+    *
+    * The single home for the reported-vs-estimated decision — every consumer
+    * (the cost summary, the run manifest) reads it from here so no two of them
+    * can disagree about which calls were priced rather than billed.
+    */
+  def resolve(
+      table: PricingTable,
+      model: Option[Model],
+      usage: Usage
+  ): Option[Cost] =
+    usage.cost
+      .map(amount => Cost(amount, estimated = false))
+      .orElse(estimate(table, model, usage).map(Cost(_, estimated = true)))
+
   /** Compute an estimated cost for one call from `usage` and the price for
     * `model`. Returns `None` when `model` is missing or absent from `table`.
     *

--- a/flow/src/main/scala/orca/events/Pricing.scala
+++ b/flow/src/main/scala/orca/events/Pricing.scala
@@ -58,10 +58,7 @@ object Pricing:
 
   /** Resolve one call's cost: the figure the backend reported if there is one,
     * an [[estimate]] from `table` otherwise, `None` when neither is available.
-    *
-    * The single home for the reported-vs-estimated decision — every consumer
-    * (the cost summary, the run manifest) reads it from here so no two of them
-    * can disagree about which calls were priced rather than billed.
+    * The single home for the reported-vs-estimated decision.
     */
   def resolve(
       table: PricingTable,

--- a/runner/src/main/scala/orca/flow.scala
+++ b/runner/src/main/scala/orca/flow.scala
@@ -172,6 +172,7 @@ def flow(
       workDir,
       OrcaBanner.version,
       flowName,
+      pricing,
       () => java.time.Instant.now()
     )
     try

--- a/runner/src/main/scala/orca/runner/manifest/CostAccumulator.scala
+++ b/runner/src/main/scala/orca/runner/manifest/CostAccumulator.scala
@@ -2,11 +2,7 @@ package orca.runner.manifest
 
 import orca.events.{Cost, Usage}
 
-/** Tokens and resolved cost for one bucket of LLM calls. `cost` is `Some` as
-  * soon as any folded-in call had one, and [[Cost.+]] carries the estimated
-  * flag along, so a bucket mixing reported and estimated calls reads as an
-  * estimate.
-  */
+/** Tokens and resolved cost for one bucket of LLM calls. */
 private[manifest] case class Tally(usage: Usage, cost: Option[Cost]):
   def +(that: Tally): Tally =
     Tally(usage + that.usage, (cost ++ that.cost).reduceOption(_ + _))
@@ -15,22 +11,17 @@ private[manifest] object Tally:
   val empty: Tally = Tally(Usage.empty, None)
 
 /** A run's token and cost accounting, folded from `TokensUsed` one turn at a
-  * time. Immutable, so [[RunManifestWriterState]] keeps it in its state record
-  * like any other field; [[summarise]] renders the persisted shape and is
-  * called only when a manifest is actually written.
+  * time.
   *
-  * The three axes are the same calls grouped three ways, so each sums back to
-  * the total — which is why the total is derived from one of them rather than
-  * accumulated separately and left free to drift.
+  * Every turn is retained anyway (the manifest persists the per-turn log), so
+  * the breakdowns are grouped on demand rather than maintained as parallel maps
+  * — which is what makes each axis sum back to the total by construction
+  * instead of by convention.
   */
 private[manifest] case class CostAccumulator(
-    byRole: Map[Option[String], Tally] = Map.empty,
-    byAgent: Map[String, Tally] = Map.empty,
-    byStage: Map[Option[String], Tally] = Map.empty,
-    turns: Vector[ManifestTurn] = Vector.empty
+    entries: Vector[(ManifestTurn, Tally)] = Vector.empty
 ):
-  /** Folds one turn in, under the role/agent/stage keys the turn itself
-    * carries. `cost` is the already-resolved figure for this call — see
+  /** `cost` is the already-resolved figure for this call — see
     * [[orca.events.Pricing.resolve]].
     */
   def record(
@@ -38,42 +29,29 @@ private[manifest] case class CostAccumulator(
       usage: Usage,
       cost: Option[Cost]
   ): CostAccumulator =
-    val tally = Tally(usage, cost)
-    copy(
-      byRole = add(byRole, turn.role, tally),
-      byAgent = add(byAgent, turn.agent, tally),
-      byStage = add(byStage, turn.stage, tally),
-      turns = turns :+ turn
-    )
+    copy(entries = entries :+ (turn, Tally(usage, cost)))
+
+  def turns: List[ManifestTurn] = entries.map((turn, _) => turn).toList
 
   def summarise: ManifestCostSummary =
-    val total = byAgent.values.foldLeft(Tally.empty)(_ + _)
+    val total = entries.foldLeft(Tally.empty)((acc, e) => acc + e._2)
     ManifestCostSummary(
       total = ManifestUsage.of(total.usage),
-      cost = total.cost.map(ManifestCost.of),
-      byRole = subtotals(byRole)(identity),
-      byAgent = subtotals(byAgent)(Some(_)),
-      byStage = subtotals(byStage)(identity)
+      cost = total.cost,
+      byRole = subtotals(_.role),
+      byAgent = subtotals(turn => Some(turn.agent)),
+      byStage = subtotals(_.stage)
     )
-
-  private def add[K](
-      map: Map[K, Tally],
-      key: K,
-      tally: Tally
-  ): Map[K, Tally] =
-    map.updated(key, map.get(key).fold(tally)(_ + tally))
 
   /** Sorted by key so a manifest rewritten mid-run doesn't reorder its
     * breakdowns between writes.
     */
-  private def subtotals[K](
-      map: Map[K, Tally]
-  )(labelOf: K => Option[String]): List[ManifestSubtotal] =
-    map.toList
+  private def subtotals(
+      keyOf: ManifestTurn => Option[String]
+  ): List[ManifestSubtotal] =
+    entries
+      .groupMapReduce((turn, _) => keyOf(turn))((_, tally) => tally)(_ + _)
+      .toList
       .map: (key, tally) =>
-        ManifestSubtotal(
-          key = labelOf(key),
-          usage = ManifestUsage.of(tally.usage),
-          cost = tally.cost.map(ManifestCost.of)
-        )
+        ManifestSubtotal(key, ManifestUsage.of(tally.usage), tally.cost)
       .sortBy(_.key)

--- a/runner/src/main/scala/orca/runner/manifest/CostAccumulator.scala
+++ b/runner/src/main/scala/orca/runner/manifest/CostAccumulator.scala
@@ -1,0 +1,79 @@
+package orca.runner.manifest
+
+import orca.events.{Cost, Usage}
+
+/** Tokens and resolved cost for one bucket of LLM calls. `cost` is `Some` as
+  * soon as any folded-in call had one, and [[Cost.+]] carries the estimated
+  * flag along, so a bucket mixing reported and estimated calls reads as an
+  * estimate.
+  */
+private[manifest] case class Tally(usage: Usage, cost: Option[Cost]):
+  def +(that: Tally): Tally =
+    Tally(usage + that.usage, (cost ++ that.cost).reduceOption(_ + _))
+
+private[manifest] object Tally:
+  val empty: Tally = Tally(Usage.empty, None)
+
+/** A run's token and cost accounting, folded from `TokensUsed` one turn at a
+  * time. Immutable, so [[RunManifestWriterState]] keeps it in its state record
+  * like any other field; [[summarise]] renders the persisted shape and is
+  * called only when a manifest is actually written.
+  *
+  * The three axes are the same calls grouped three ways, so each sums back to
+  * the total — which is why the total is derived from one of them rather than
+  * accumulated separately and left free to drift.
+  */
+private[manifest] case class CostAccumulator(
+    byRole: Map[Option[String], Tally] = Map.empty,
+    byAgent: Map[String, Tally] = Map.empty,
+    byStage: Map[Option[String], Tally] = Map.empty,
+    turns: Vector[ManifestTurn] = Vector.empty
+):
+  /** Folds one turn in, under the role/agent/stage keys the turn itself
+    * carries. `cost` is the already-resolved figure for this call — see
+    * [[orca.events.Pricing.resolve]].
+    */
+  def record(
+      turn: ManifestTurn,
+      usage: Usage,
+      cost: Option[Cost]
+  ): CostAccumulator =
+    val tally = Tally(usage, cost)
+    copy(
+      byRole = add(byRole, turn.role, tally),
+      byAgent = add(byAgent, turn.agent, tally),
+      byStage = add(byStage, turn.stage, tally),
+      turns = turns :+ turn
+    )
+
+  def summarise: ManifestCostSummary =
+    val total = byAgent.values.foldLeft(Tally.empty)(_ + _)
+    ManifestCostSummary(
+      total = ManifestUsage.of(total.usage),
+      cost = total.cost.map(ManifestCost.of),
+      byRole = subtotals(byRole)(identity),
+      byAgent = subtotals(byAgent)(Some(_)),
+      byStage = subtotals(byStage)(identity)
+    )
+
+  private def add[K](
+      map: Map[K, Tally],
+      key: K,
+      tally: Tally
+  ): Map[K, Tally] =
+    map.updated(key, map.get(key).fold(tally)(_ + tally))
+
+  /** Sorted by key so a manifest rewritten mid-run doesn't reorder its
+    * breakdowns between writes.
+    */
+  private def subtotals[K](
+      map: Map[K, Tally]
+  )(labelOf: K => Option[String]): List[ManifestSubtotal] =
+    map.toList
+      .map: (key, tally) =>
+        ManifestSubtotal(
+          key = labelOf(key),
+          usage = ManifestUsage.of(tally.usage),
+          cost = tally.cost.map(ManifestCost.of)
+        )
+      .sortBy(_.key)

--- a/runner/src/main/scala/orca/runner/manifest/RunManifest.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifest.scala
@@ -31,15 +31,12 @@ private[orca] case class ManifestSession(
     */
   def resumable: Boolean = wireId.isDefined
 
-/** Token counts for one call or a group of them — the persisted projection of
-  * [[orca.events.Usage]]'s token axes, sharing its normalisation contract
-  * (`inputTokens` is inclusive of `cachedInputTokens`; `outputTokens` is
-  * inclusive of `reasoningOutputTokens`).
+/** The persisted projection of [[orca.events.Usage]]'s token axes, sharing its
+  * normalisation contract.
   *
-  * Deliberately carries no money: `Usage.cost` is only the portion backends
-  * reported, and a figure sitting next to a resolved [[ManifestCost]] without
-  * saying which is which is how a summary comes to mix reported and estimated
-  * spend. [[ManifestUsage.of]] is the one place the axes are enumerated.
+  * Deliberately carries no money, unlike `Usage`: `Usage.cost` is only the
+  * portion backends reported, and an unlabelled figure next to a resolved
+  * [[orca.events.Cost]] is how reported and estimated spend get mixed.
   */
 private[orca] case class ManifestUsage(
     inputTokens: Long,
@@ -58,33 +55,27 @@ private[orca] object ManifestUsage:
     reasoningOutputTokens = usage.reasoningOutputTokens
   )
 
-/** A USD figure with [[orca.events.Cost]]'s estimated flag preserved:
-  * `estimated` is true when any call folded in was priced from the table rather
-  * than reported by the backend, so an aggregate mixing the two reads as an
-  * estimate and is never quoted as a billed figure.
-  */
-private[orca] case class ManifestCost(amount: BigDecimal, estimated: Boolean)
-
-private[orca] object ManifestCost:
-  def of(cost: Cost): ManifestCost = ManifestCost(cost.amount, cost.estimated)
-
 /** One breakdown bucket of [[ManifestCostSummary]]. `key` is `None` for the
   * untagged bucket — calls from an agent with no role, or tokens spent outside
-  * any stage. `cost` is absent when no call in the bucket had a reported cost
-  * and none could be priced from the table.
+  * any stage.
   */
 private[orca] case class ManifestSubtotal(
     key: Option[String],
     usage: ManifestUsage,
-    cost: Option[ManifestCost]
+    cost: Option[Cost]
 )
 
-/** A run's whole spend, folded from `TokensUsed`. The three breakdowns share
-  * the same calls, so each sums back to `total`.
+/** A run's spend, folded from `TokensUsed`. The three breakdowns are the same
+  * calls grouped three ways, so each sums back to `total`.
+  *
+  * `usage` covers every call; `cost` covers only the calls that had one to
+  * resolve, so a run using a model absent from the pricing table shows tokens
+  * against no dollars. A failed turn contributes nothing on any backend but
+  * claude, which is the only one that attaches usage to a turn failure.
   */
 private[orca] case class ManifestCostSummary(
     total: ManifestUsage,
-    cost: Option[ManifestCost],
+    cost: Option[Cost],
     byRole: List[ManifestSubtotal],
     byAgent: List[ManifestSubtotal],
     byStage: List[ManifestSubtotal]
@@ -98,6 +89,15 @@ private[orca] object ManifestCostSummary:
   * size is what makes per-turn prefix growth measurable across a run; the
   * `agent`/`role`/`stage` keys match [[ManifestCostSummary]]'s breakdowns so a
   * subtotal can be traced back to the turns that produced it.
+  *
+  * `promptTokens` of zero reads as "no request observed", not "no request": it
+  * is the signature of a turn the CLI settles from leftover session state
+  * without calling the API, but every backend also defaults its usage counters
+  * to zero when a terminal frame omits them, and claude takes its cost from a
+  * separate field — so a zero-token turn can still carry a reported cost.
+  *
+  * `at` is stamped when the writer records the turn, not when the tokens were
+  * spent: the event crosses an actor mailbox first.
   */
 private[orca] case class ManifestTurn(
     at: String,
@@ -105,12 +105,7 @@ private[orca] case class ManifestTurn(
     role: Option[String],
     stage: Option[String],
     promptTokens: Long
-):
-  /** Derived, not persisted (like [[ManifestSession.resumable]]): a turn that
-    * reached the provider always carries a prompt, so zero prompt tokens means
-    * the CLI answered from leftover session state without an API call.
-    */
-  def apiCall: Boolean = promptTokens > 0
+)
 
 /** Schema v3 (ADR 0021 §8) of a per-run manifest written to
   * `.orca/cache/runs/<startedAt-epoch-ms>-<pid>.json`, read by the shell to
@@ -124,7 +119,8 @@ private[orca] case class ManifestTurn(
   * sessions.
   *
   * `cost` and `turns` make a run's spend answerable from this file alone, with
-  * no agent transcript involved; `turns.size` is the run's turn count.
+  * no agent transcript involved — subject to the reporting gaps noted on
+  * [[ManifestCostSummary]] and [[ManifestTurn]].
   */
 private[orca] case class RunManifest(
     manifestVersion: Int,
@@ -142,14 +138,10 @@ private[orca] case class RunManifest(
 
 private[orca] object RunManifest:
   /** The manifest schema version this build reads and writes — bumped whenever
-    * the wire shape changes (v3 added [[ManifestCostSummary]] and the per-turn
-    * log). Readers skip any file whose version differs, in either direction:
-    * orca owes no compatibility across 0.x shapes, and `.orca/cache/runs/` is
-    * pruned cache data, so an unreadable older run costs a "continue" offer for
-    * that run and nothing else. The writer ([[RunManifestWriterState.write]])
-    * always passes this explicitly rather than relying on a default, so a
-    * version bump can't silently stamp new manifests without the writer call
-    * site being revisited.
+    * the wire shape changes. Readers skip any file whose version differs, in
+    * either direction: orca owes no compatibility across 0.x shapes, and
+    * `.orca/cache/runs/` is pruned cache data, so an unreadable run costs a
+    * "continue" offer for that run and nothing else.
     */
   val SupportedVersion = 3
 

--- a/runner/src/main/scala/orca/runner/manifest/RunManifest.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifest.scala
@@ -2,6 +2,7 @@ package orca.runner.manifest
 
 import com.github.plokhotnyuk.jsoniter_scala.macros.ConfiguredJsonValueCodec
 import orca.agents.JsonData
+import orca.events.{Cost, Usage}
 
 /** One tracked session inside a [[RunManifest]] (ADR 0021 §8). `wireId` is the
   * persistable id ([[orca.agents.Agent.resumeWireId]]) — `None` for backends
@@ -30,15 +31,100 @@ private[orca] case class ManifestSession(
     */
   def resumable: Boolean = wireId.isDefined
 
-/** Schema v2 (ADR 0021 §8) of a per-run manifest written to
+/** Token counts for one call or a group of them — the persisted projection of
+  * [[orca.events.Usage]]'s token axes, sharing its normalisation contract
+  * (`inputTokens` is inclusive of `cachedInputTokens`; `outputTokens` is
+  * inclusive of `reasoningOutputTokens`).
+  *
+  * Deliberately carries no money: `Usage.cost` is only the portion backends
+  * reported, and a figure sitting next to a resolved [[ManifestCost]] without
+  * saying which is which is how a summary comes to mix reported and estimated
+  * spend. [[ManifestUsage.of]] is the one place the axes are enumerated.
+  */
+private[orca] case class ManifestUsage(
+    inputTokens: Long,
+    outputTokens: Long,
+    cachedInputTokens: Long,
+    reasoningOutputTokens: Long
+)
+
+private[orca] object ManifestUsage:
+  val empty: ManifestUsage = of(Usage.empty)
+
+  def of(usage: Usage): ManifestUsage = ManifestUsage(
+    inputTokens = usage.inputTokens,
+    outputTokens = usage.outputTokens,
+    cachedInputTokens = usage.cachedInputTokens,
+    reasoningOutputTokens = usage.reasoningOutputTokens
+  )
+
+/** A USD figure with [[orca.events.Cost]]'s estimated flag preserved:
+  * `estimated` is true when any call folded in was priced from the table rather
+  * than reported by the backend, so an aggregate mixing the two reads as an
+  * estimate and is never quoted as a billed figure.
+  */
+private[orca] case class ManifestCost(amount: BigDecimal, estimated: Boolean)
+
+private[orca] object ManifestCost:
+  def of(cost: Cost): ManifestCost = ManifestCost(cost.amount, cost.estimated)
+
+/** One breakdown bucket of [[ManifestCostSummary]]. `key` is `None` for the
+  * untagged bucket — calls from an agent with no role, or tokens spent outside
+  * any stage. `cost` is absent when no call in the bucket had a reported cost
+  * and none could be priced from the table.
+  */
+private[orca] case class ManifestSubtotal(
+    key: Option[String],
+    usage: ManifestUsage,
+    cost: Option[ManifestCost]
+)
+
+/** A run's whole spend, folded from `TokensUsed`. The three breakdowns share
+  * the same calls, so each sums back to `total`.
+  */
+private[orca] case class ManifestCostSummary(
+    total: ManifestUsage,
+    cost: Option[ManifestCost],
+    byRole: List[ManifestSubtotal],
+    byAgent: List[ManifestSubtotal],
+    byStage: List[ManifestSubtotal]
+)
+
+private[orca] object ManifestCostSummary:
+  val empty: ManifestCostSummary =
+    ManifestCostSummary(ManifestUsage.empty, None, Nil, Nil, Nil)
+
+/** One LLM turn: what it belonged to and how large its prompt was. The prompt
+  * size is what makes per-turn prefix growth measurable across a run; the
+  * `agent`/`role`/`stage` keys match [[ManifestCostSummary]]'s breakdowns so a
+  * subtotal can be traced back to the turns that produced it.
+  */
+private[orca] case class ManifestTurn(
+    at: String,
+    agent: String,
+    role: Option[String],
+    stage: Option[String],
+    promptTokens: Long
+):
+  /** Derived, not persisted (like [[ManifestSession.resumable]]): a turn that
+    * reached the provider always carries a prompt, so zero prompt tokens means
+    * the CLI answered from leftover session state without an API call.
+    */
+  def apiCall: Boolean = promptTokens > 0
+
+/** Schema v3 (ADR 0021 §8) of a per-run manifest written to
   * `.orca/cache/runs/<startedAt-epoch-ms>-<pid>.json`, read by the shell to
-  * offer "continue a session". `manifestVersion` is a hard gate: a shell that
-  * doesn't understand a newer version skips the file rather than guessing —
-  * that gate is the one place cross-version tolerance lives, so the codec below
-  * doesn't need to be tolerant too. `outcome` is `"running"` until
-  * [[RunManifestWriter.finish]] finalizes it to `"succeeded"` or `"failed"` — a
-  * stale `"running"` with a dead `pid` means the run crashed, and the shell
-  * still offers its recorded sessions.
+  * offer "continue a session". `manifestVersion` is a hard gate: a reader
+  * checks it before decoding and skips anything it doesn't write itself, rather
+  * than guessing at an unfamiliar schema — that gate is the one place
+  * cross-version tolerance lives, so the codec below doesn't need to be
+  * tolerant too. `outcome` is `"running"` until [[RunManifestWriter.finish]]
+  * finalizes it to `"succeeded"` or `"failed"` — a stale `"running"` with a
+  * dead `pid` means the run crashed, and the shell still offers its recorded
+  * sessions.
+  *
+  * `cost` and `turns` make a run's spend answerable from this file alone, with
+  * no agent transcript involved; `turns.size` is the run's turn count.
   */
 private[orca] case class RunManifest(
     manifestVersion: Int,
@@ -49,19 +135,23 @@ private[orca] case class RunManifest(
     startedAt: String,
     finishedAt: Option[String],
     outcome: String,
-    sessions: List[ManifestSession]
+    sessions: List[ManifestSession],
+    cost: ManifestCostSummary,
+    turns: List[ManifestTurn]
 )
 
 private[orca] object RunManifest:
   /** The manifest schema version this build reads and writes — bumped whenever
-    * the wire shape changes (v2 dropped [[ManifestSession.resumable]] as a
-    * persisted field). [[ManifestReader]] skips a file whose version exceeds
-    * this rather than guessing at a newer schema. The writer
-    * ([[RunManifestWriterState.write]]) always passes this explicitly rather
-    * than relying on a default, so a version bump can't silently stamp new
-    * manifests without the writer call site being revisited.
+    * the wire shape changes (v3 added [[ManifestCostSummary]] and the per-turn
+    * log). Readers skip any file whose version differs, in either direction:
+    * orca owes no compatibility across 0.x shapes, and `.orca/cache/runs/` is
+    * pruned cache data, so an unreadable older run costs a "continue" offer for
+    * that run and nothing else. The writer ([[RunManifestWriterState.write]])
+    * always passes this explicitly rather than relying on a default, so a
+    * version bump can't silently stamp new manifests without the writer call
+    * site being revisited.
     */
-  val SupportedVersion = 2
+  val SupportedVersion = 3
 
   // The `outcome` and `ManifestSession.kind` wire strings, named once here so
   // the writer that produces them (RunManifestWriter's Outcome/SessionKind

--- a/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
@@ -29,9 +29,7 @@ private[orca] enum RunOutcome:
   * atomically (the `ProgressStore.writeLog` temp+move idiom) on every stage
   * transition and `SessionCommitted`, so a crashed run still leaves its
   * sessions on disk with `outcome: "running"` and a dead `pid` — the shell
-  * treats that as "crashed, but still offers its sessions". `TokensUsed`
-  * accumulates into the manifest's cost section and per-turn log without
-  * triggering a write of its own.
+  * treats that as "crashed, but still offers its sessions".
   *
   * `flowName` comes from `ORCA_FLOW_NAME`, set by the shell before exec'ing the
   * flow subprocess (`FlowLauncher.childEnv`); `runFlow` never sees the `.sc`
@@ -78,12 +76,13 @@ private class ActorRunManifestWriter(actor: ActorRef[RunManifestWriterState])
 
 /** Mutable manifest-building state — not thread-safe in isolation.
   * [[ActorRunManifestWriter]] serialises every call onto one actor thread:
-  * `onEvent` is a `tell` (fire-and-forget; manifest events fire per
-  * stage/session, not per token, so the bounded mailbox never actually blocks)
-  * and `finish` is an `ask` (its write must land before `flow()` moves on to
-  * the cost summary). Every write is guarded internally ([[safeWrite]]) so a
-  * transient failure can't quarantine the writer or throw out of a `tell`'s
-  * handler. Tests construct this directly and drive events synchronously.
+  * `onEvent` is a `tell` (fire-and-forget, though a full mailbox blocks the
+  * emitter — turns arrive seconds apart and only stage/session events write, so
+  * the queue drains far faster than it fills) and `finish` is an `ask` (its
+  * write must land before `flow()` moves on to the cost summary). Every write
+  * is guarded internally ([[safeWrite]]) so a transient failure can't
+  * quarantine the writer or throw out of a `tell`'s handler. Tests construct
+  * this directly and drive events synchronously.
   *
   * The manifest file only comes into existence on the first `SessionCommitted`
   * — earlier stage and token events just update the in-memory stage stack and
@@ -164,8 +163,7 @@ private[runner] class RunManifestWriterState(
       )
       safeWrite()
     // Accumulate only: a turn fires far more often than a stage or session
-    // event, and every write rewrites the whole file. The next stage/session
-    // event or `finish` carries the accumulated figures to disk.
+    // event, and every write rewrites the whole file.
     case OrcaEvent.TokensUsed(agent, model, usage, role) =>
       val turn = ManifestTurn(
         at = clock().toString,

--- a/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
@@ -6,7 +6,7 @@ import com.github.plokhotnyuk.jsoniter_scala.core.{
 }
 import orca.OrcaDir
 import orca.agents.JsonData
-import orca.events.{OrcaEvent, OrcaListener}
+import orca.events.{OrcaEvent, OrcaListener, PriceList, Pricing}
 import orca.progress.ProgressLog
 import org.slf4j.LoggerFactory
 import ox.Ox
@@ -29,7 +29,9 @@ private[orca] enum RunOutcome:
   * atomically (the `ProgressStore.writeLog` temp+move idiom) on every stage
   * transition and `SessionCommitted`, so a crashed run still leaves its
   * sessions on disk with `outcome: "running"` and a dead `pid` — the shell
-  * treats that as "crashed, but still offers its sessions".
+  * treats that as "crashed, but still offers its sessions". `TokensUsed`
+  * accumulates into the manifest's cost section and per-turn log without
+  * triggering a write of its own.
   *
   * `flowName` comes from `ORCA_FLOW_NAME`, set by the shell before exec'ing the
   * flow subprocess (`FlowLauncher.childEnv`); `runFlow` never sees the `.sc`
@@ -57,10 +59,11 @@ private[orca] object RunManifestWriter:
       workDir: os.Path,
       orcaVersion: String,
       flowName: Option[String],
+      pricing: PriceList,
       clock: () => Instant
   )(using Ox, BufferCapacity): RunManifestWriter =
     val state =
-      new RunManifestWriterState(workDir, orcaVersion, flowName, clock)
+      new RunManifestWriterState(workDir, orcaVersion, flowName, pricing, clock)
     new ActorRunManifestWriter(Actor.create(state))
 
 /** Actor-backed [[RunManifestWriter]]. `onEvent` is a `tell`; `finish` is an
@@ -83,14 +86,16 @@ private class ActorRunManifestWriter(actor: ActorRef[RunManifestWriterState])
   * handler. Tests construct this directly and drive events synchronously.
   *
   * The manifest file only comes into existence on the first `SessionCommitted`
-  * — earlier stage events just update the in-memory stage stack (so the first
-  * session is stamped with the right stage) — and `finish()` no-ops if none
-  * ever committed: a session-less run offers nothing to continue (ADR 0021 §8).
+  * — earlier stage and token events just update the in-memory stage stack and
+  * cost accumulator (so the first session is stamped with the right stage, and
+  * no token spend is lost) — and `finish()` no-ops if none ever committed: a
+  * session-less run offers nothing to continue (ADR 0021 §8).
   */
 private[runner] class RunManifestWriterState(
     workDir: os.Path,
     orcaVersion: String,
     flowName: Option[String],
+    pricing: PriceList,
     clock: () => Instant
 ) extends RunManifestWriter:
 
@@ -132,6 +137,7 @@ private[runner] class RunManifestWriterState(
   private case class State(
       stageStack: List[String] = Nil,
       entries: List[Entry] = Nil,
+      cost: CostAccumulator = CostAccumulator(),
       outcome: Outcome = Outcome.Running,
       finishedAt: Option[Instant] = None,
       prunedOnce: Boolean = false
@@ -157,6 +163,21 @@ private[runner] class RunManifestWriterState(
         upsertSession(harness, clientId, wireId, agent, role)
       )
       safeWrite()
+    // Accumulate only: a turn fires far more often than a stage or session
+    // event, and every write rewrites the whole file. The next stage/session
+    // event or `finish` carries the accumulated figures to disk.
+    case OrcaEvent.TokensUsed(agent, model, usage, role) =>
+      val turn = ManifestTurn(
+        at = clock().toString,
+        agent = agent,
+        role = role,
+        stage = state.stageStack.headOption,
+        promptTokens = usage.inputTokens
+      )
+      state = state.copy(cost =
+        state.cost
+          .record(turn, usage, Pricing.resolve(pricing.table, model, usage))
+      )
     case _ => ()
 
   /** Whether a `SessionCommitted` has ever landed — the manifest file's
@@ -269,7 +290,9 @@ private[runner] class RunManifestWriterState(
       startedAt = startedAt.toString,
       finishedAt = state.finishedAt.map(_.toString),
       outcome = state.outcome.wireValue,
-      sessions = state.entries.map(_.session)
+      sessions = state.entries.map(_.session),
+      cost = state.cost.summarise,
+      turns = state.cost.turns.toList
     )
     val dir = manifestPath / os.up
     val tmp = os.temp(

--- a/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
@@ -4,7 +4,7 @@ import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
 import orca.OrcaDir
 import orca.WorkspaceWrite
 import orca.agents.Model
-import orca.events.{CostTracker, OrcaEvent, PriceList, Pricing, Usage}
+import orca.events.{Cost, OrcaEvent, PriceList, Pricing, Usage}
 import orca.progress.{BranchMode, ProgressHeader, ProgressStore, SessionRecord}
 import orca.testkit.TempDirs
 import ox.channels.BufferCapacity
@@ -420,16 +420,17 @@ class RunManifestWriterTest extends munit.FunSuite:
     assertEquals(manifest.flow, Some("review-pr.sc"))
     assertEquals(manifest.workDir, workDir.toString)
 
-  test("cost section agrees with CostTracker fed the same events"):
+  test("cost section totals the run and breaks it down on all three axes"):
     val workDir = TempDirs.dir()
     val writer =
       newWriter(workDir, fixedClock(Instant.parse("2026-07-18T10:00:00Z")))
-    val tracker = CostTracker(Pricing.default)
-    // One reported cost and one that has to be estimated from the table, so
-    // the run total is flagged as an estimate rather than quoted as billed.
-    val events = List(
+    writer.onEvent(
       OrcaEvent
-        .SessionCommitted("claude", "client-1", Some("wire-1"), "claude", None),
+        .SessionCommitted("claude", "client-1", Some("wire-1"), "claude", None)
+    )
+    // One call the table has to price and one the backend reported, so the run
+    // total is a mix.
+    writer.onEvent(
       OrcaEvent.TokensUsed(
         agent = "claude",
         model = Some(Model("claude-sonnet-5")),
@@ -440,7 +441,9 @@ class RunManifestWriterTest extends munit.FunSuite:
           cachedInputTokens = 107_000
         ),
         role = None
-      ),
+      )
+    )
+    writer.onEvent(
       OrcaEvent.TokensUsed(
         agent = "reviewer",
         model = Some(Model("claude-haiku-4-5")),
@@ -452,26 +455,36 @@ class RunManifestWriterTest extends munit.FunSuite:
         role = Some("reviewer")
       )
     )
-    events.foreach: e =>
-      writer.onEvent(e)
-      tracker.onEvent(e)
     writer.finish(RunOutcome.Succeeded)
 
     val cost = soleManifest(workDir).cost
-    assertEquals(cost.total, ManifestUsage.of(tracker.total))
-    assertEquals(cost.cost, tracker.totalCost.map(ManifestCost.of))
-    assertEquals(cost.cost.map(_.estimated), Some(true))
     assertEquals(
-      cost.byAgent.map(_.key),
-      List(Some("claude"), Some("reviewer"))
+      cost.total,
+      ManifestUsage(
+        inputTokens = 125_000,
+        outputTokens = 1_000,
+        cachedInputTokens = 107_000,
+        reasoningOutputTokens = 0
+      )
+    )
+    // 13k uncached at $3/M + 107k cached at $0.30/M + 900 out at $15/M =
+    // $0.0846, plus the reported $0.0123. `estimated` survives the addition,
+    // so the run total can't be read as a billed figure.
+    assertEquals(cost.cost, Some(Cost(BigDecimal("0.0969"), estimated = true)))
+    assertEquals(
+      cost.byAgent.map(s => (s.key, s.usage.inputTokens)),
+      List((Some("claude"), 120_000L), (Some("reviewer"), 5_000L))
     )
     assertEquals(
       cost.byRole.map(s => (s.key, s.usage.inputTokens)),
       List((None, 120_000L), (Some("reviewer"), 5_000L))
     )
-    assertEquals(cost.byStage.map(_.key), List(None))
+    assertEquals(
+      cost.byStage.map(s => (s.key, s.usage.inputTokens)),
+      List((None, 125_000L))
+    )
 
-  test("per-turn log records prompt size, stage, and a zero-API-call turn"):
+  test("per-turn log records each turn's identity, stage and prompt size"):
     val workDir = TempDirs.dir()
     val writer =
       newWriter(workDir, fixedClock(Instant.parse("2026-07-18T10:00:00Z")))
@@ -483,17 +496,41 @@ class RunManifestWriterTest extends munit.FunSuite:
     writer.onEvent(
       OrcaEvent.TokensUsed("claude", None, Usage(107_000, 500, None), None)
     )
+    // Closing the stage between the two turns pins that the stage is stamped
+    // when a turn is recorded, not when the manifest is later written.
+    writer.onEvent(OrcaEvent.StageCompleted("code"))
     // The CLI answering from leftover session state: no request went out, so
     // every counter is zero.
     writer.onEvent(
-      OrcaEvent.TokensUsed("claude", None, Usage(0, 0, None), None)
+      OrcaEvent.TokensUsed(
+        "reviewer",
+        None,
+        Usage(0, 0, None),
+        Some("reviewer")
+      )
     )
     writer.finish(RunOutcome.Succeeded)
 
     val turns = soleManifest(workDir).turns
-    assertEquals(turns.map(_.promptTokens), List(107_000L, 0L))
-    assertEquals(turns.map(_.apiCall), List(true, false))
-    assertEquals(turns.map(_.stage), List(Some("code"), Some("code")))
+    assertEquals(
+      turns,
+      List(
+        ManifestTurn(
+          at = "2026-07-18T10:00:00Z",
+          agent = "claude",
+          role = None,
+          stage = Some("code"),
+          promptTokens = 107_000
+        ),
+        ManifestTurn(
+          at = "2026-07-18T10:00:00Z",
+          agent = "reviewer",
+          role = Some("reviewer"),
+          stage = None,
+          promptTokens = 0
+        )
+      )
+    )
 
   test("a failed write is swallowed and does not stop the next one"):
     val workDir = TempDirs.dir()

--- a/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
@@ -3,7 +3,8 @@ package orca.runner.manifest
 import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
 import orca.OrcaDir
 import orca.WorkspaceWrite
-import orca.events.OrcaEvent
+import orca.agents.Model
+import orca.events.{CostTracker, OrcaEvent, PriceList, Pricing, Usage}
 import orca.progress.{BranchMode, ProgressHeader, ProgressStore, SessionRecord}
 import orca.testkit.TempDirs
 import ox.channels.BufferCapacity
@@ -30,9 +31,10 @@ class RunManifestWriterTest extends munit.FunSuite:
   private def newWriter(
       workDir: os.Path,
       clock: () => Instant,
-      flowName: Option[String] = None
+      flowName: Option[String] = None,
+      pricing: PriceList = Pricing.default
   ): RunManifestWriterState =
-    new RunManifestWriterState(workDir, "0.0.test", flowName, clock)
+    new RunManifestWriterState(workDir, "0.0.test", flowName, pricing, clock)
 
   private def manifestFiles(workDir: os.Path): List[os.Path] =
     os.list(OrcaDir.cacheRunsPath(workDir)).filter(_.ext == "json").toList
@@ -326,6 +328,7 @@ class RunManifestWriterTest extends munit.FunSuite:
         workDir,
         "0.0.test",
         None,
+        Pricing.default,
         () => Instant.now()
       )
       val threads = (0 until 2).map: t =>
@@ -416,3 +419,95 @@ class RunManifestWriterTest extends munit.FunSuite:
     val manifest = soleManifest(workDir)
     assertEquals(manifest.flow, Some("review-pr.sc"))
     assertEquals(manifest.workDir, workDir.toString)
+
+  test("cost section agrees with CostTracker fed the same events"):
+    val workDir = TempDirs.dir()
+    val writer =
+      newWriter(workDir, fixedClock(Instant.parse("2026-07-18T10:00:00Z")))
+    val tracker = CostTracker(Pricing.default)
+    // One reported cost and one that has to be estimated from the table, so
+    // the run total is flagged as an estimate rather than quoted as billed.
+    val events = List(
+      OrcaEvent
+        .SessionCommitted("claude", "client-1", Some("wire-1"), "claude", None),
+      OrcaEvent.TokensUsed(
+        agent = "claude",
+        model = Some(Model("claude-sonnet-5")),
+        usage = Usage(
+          inputTokens = 120_000,
+          outputTokens = 900,
+          cost = None,
+          cachedInputTokens = 107_000
+        ),
+        role = None
+      ),
+      OrcaEvent.TokensUsed(
+        agent = "reviewer",
+        model = Some(Model("claude-haiku-4-5")),
+        usage = Usage(
+          inputTokens = 5_000,
+          outputTokens = 100,
+          cost = Some(BigDecimal("0.0123"))
+        ),
+        role = Some("reviewer")
+      )
+    )
+    events.foreach: e =>
+      writer.onEvent(e)
+      tracker.onEvent(e)
+    writer.finish(RunOutcome.Succeeded)
+
+    val cost = soleManifest(workDir).cost
+    assertEquals(cost.total, ManifestUsage.of(tracker.total))
+    assertEquals(cost.cost, tracker.totalCost.map(ManifestCost.of))
+    assertEquals(cost.cost.map(_.estimated), Some(true))
+    assertEquals(
+      cost.byAgent.map(_.key),
+      List(Some("claude"), Some("reviewer"))
+    )
+    assertEquals(
+      cost.byRole.map(s => (s.key, s.usage.inputTokens)),
+      List((None, 120_000L), (Some("reviewer"), 5_000L))
+    )
+    assertEquals(cost.byStage.map(_.key), List(None))
+
+  test("per-turn log records prompt size, stage, and a zero-API-call turn"):
+    val workDir = TempDirs.dir()
+    val writer =
+      newWriter(workDir, fixedClock(Instant.parse("2026-07-18T10:00:00Z")))
+    writer.onEvent(OrcaEvent.StageStarted("code"))
+    writer.onEvent(
+      OrcaEvent
+        .SessionCommitted("claude", "client-1", Some("wire-1"), "claude", None)
+    )
+    writer.onEvent(
+      OrcaEvent.TokensUsed("claude", None, Usage(107_000, 500, None), None)
+    )
+    // The CLI answering from leftover session state: no request went out, so
+    // every counter is zero.
+    writer.onEvent(
+      OrcaEvent.TokensUsed("claude", None, Usage(0, 0, None), None)
+    )
+    writer.finish(RunOutcome.Succeeded)
+
+    val turns = soleManifest(workDir).turns
+    assertEquals(turns.map(_.promptTokens), List(107_000L, 0L))
+    assertEquals(turns.map(_.apiCall), List(true, false))
+    assertEquals(turns.map(_.stage), List(Some("code"), Some("code")))
+
+  test("a failed write is swallowed and does not stop the next one"):
+    val workDir = TempDirs.dir()
+    val writer =
+      newWriter(workDir, fixedClock(Instant.parse("2026-07-18T10:00:00Z")))
+    // A plain file where the runs directory belongs: every write into it fails.
+    val runsDir = OrcaDir.cacheRunsPath(workDir)
+    os.remove.all(runsDir)
+    os.write(runsDir, "not a directory")
+    writer.onEvent(
+      OrcaEvent
+        .SessionCommitted("claude", "client-1", Some("wire-1"), "claude", None)
+    )
+    os.remove(runsDir): Unit
+    os.makeDir.all(runsDir)
+    writer.finish(RunOutcome.Succeeded)
+    assertEquals(soleManifest(workDir).outcome, "succeeded")

--- a/shell/src/main/scala/orca/shell/sessions/ManifestReader.scala
+++ b/shell/src/main/scala/orca/shell/sessions/ManifestReader.scala
@@ -1,6 +1,10 @@
 package orca.shell.sessions
 
-import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
+import com.github.plokhotnyuk.jsoniter_scala.core.{
+  JsonValueCodec,
+  readFromString
+}
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 import orca.OrcaDir
 import orca.runner.manifest.RunManifest
 
@@ -19,8 +23,8 @@ private[shell] case class RecordedRun(manifest: RunManifest, crashed: Boolean)
   */
 private[shell] object ManifestReader:
 
-  /** Newest-first by `startedAt`. Skips a file whose `manifestVersion` is newer
-    * than this shell understands, or whose `startedAt` doesn't parse as an
+  /** Newest-first by `startedAt`. Skips a file whose `manifestVersion` isn't
+    * the one this build writes, or whose `startedAt` doesn't parse as an
     * `Instant` (a hand-edited or corrupt file — the writer always produces a
     * well-formed one), collecting a notice naming the file into the returned
     * warnings rather than guessing at an unknown schema or ordering it by a
@@ -52,12 +56,6 @@ private[shell] object ManifestReader:
               readManifest(file) match
                 case Left(warning) => (runs, warning :: warnings)
                 case Right(manifest)
-                    if manifest.manifestVersion > RunManifest.SupportedVersion =>
-                  (
-                    runs,
-                    s"skipping $file: manifestVersion ${manifest.manifestVersion} is newer than this shell understands" :: warnings
-                  )
-                case Right(manifest)
                     if Try(Instant.parse(manifest.startedAt)).isFailure =>
                   (
                     runs,
@@ -74,10 +72,30 @@ private[shell] object ManifestReader:
         warnings.reverse
       )
 
+  /** The version is read on its own, before the full decode, so a manifest
+    * written by another build is skipped by version rather than surfacing
+    * whichever field its schema happens to disagree about first. Schema drift
+    * in either direction lands on the same message.
+    */
   private def readManifest(file: os.Path): Either[String, RunManifest] =
     try
-      Right(readFromString[RunManifest](os.read(file))(using RunManifest.codec))
+      val text = os.read(file)
+      val version = readFromString[SchemaVersion](text).manifestVersion
+      if version != RunManifest.SupportedVersion then
+        Left(
+          s"skipping $file: manifestVersion $version, this build reads ${RunManifest.SupportedVersion}"
+        )
+      else Right(readFromString[RunManifest](text)(using RunManifest.codec))
     catch case NonFatal(e) => Left(s"skipping $file: ${e.getMessage}")
+
+  /** Just enough of a manifest to gate on. The default (unlike
+    * [[RunManifest.codec]]) skips unknown fields, which is the whole point: it
+    * must decode a manifest of any schema version.
+    */
+  private case class SchemaVersion(manifestVersion: Int)
+
+  private given schemaVersionCodec: JsonValueCodec[SchemaVersion] =
+    JsonCodecMaker.make
 
   /** The production value of [[list]]'s `pidAlive` parameter (ADR 0021 §8):
     * `ProcessHandle.of` finds nothing for a pid that's been reaped — treated as

--- a/shell/src/main/scala/orca/shell/sessions/ManifestReader.scala
+++ b/shell/src/main/scala/orca/shell/sessions/ManifestReader.scala
@@ -74,8 +74,7 @@ private[shell] object ManifestReader:
 
   /** The version is read on its own, before the full decode, so a manifest
     * written by another build is skipped by version rather than surfacing
-    * whichever field its schema happens to disagree about first. Schema drift
-    * in either direction lands on the same message.
+    * whichever field its schema happens to disagree about first.
     */
   private def readManifest(file: os.Path): Either[String, RunManifest] =
     try
@@ -88,9 +87,9 @@ private[shell] object ManifestReader:
       else Right(readFromString[RunManifest](text)(using RunManifest.codec))
     catch case NonFatal(e) => Left(s"skipping $file: ${e.getMessage}")
 
-  /** Just enough of a manifest to gate on. The default (unlike
-    * [[RunManifest.codec]]) skips unknown fields, which is the whole point: it
-    * must decode a manifest of any schema version.
+  /** Just enough of a manifest to gate on: declaring one field is what lets
+    * this decode a manifest of any schema version, since everything else is
+    * then an unknown field, which jsoniter skips.
     */
   private case class SchemaVersion(manifestVersion: Int)
 

--- a/shell/src/test/scala/orca/shell/MainTest.scala
+++ b/shell/src/test/scala/orca/shell/MainTest.scala
@@ -2,7 +2,7 @@ package orca.shell
 
 import org.jline.terminal.{Terminal, TerminalBuilder}
 import orca.StackSettings
-import orca.runner.manifest.{ManifestSession, RunManifest}
+import orca.runner.manifest.{ManifestCostSummary, ManifestSession, RunManifest}
 import orca.settings.SettingsFile
 import orca.shell.actions.{SettingsEditAction, StackAction}
 import orca.shell.create.CreateTier
@@ -118,7 +118,9 @@ class MainTest extends munit.FunSuite:
       startedAt = startedAt,
       finishedAt = None,
       outcome = "succeeded",
-      sessions = sessions
+      sessions = sessions,
+      cost = ManifestCostSummary.empty,
+      turns = Nil
     )
 
   private def durable(

--- a/shell/src/test/scala/orca/shell/actions/SessionActionTest.scala
+++ b/shell/src/test/scala/orca/shell/actions/SessionActionTest.scala
@@ -1,6 +1,6 @@
 package orca.shell.actions
 
-import orca.runner.manifest.{ManifestSession, RunManifest}
+import orca.runner.manifest.{ManifestCostSummary, ManifestSession, RunManifest}
 import orca.shell.sessions.SessionSelection
 import orca.testkit.TempDirs
 import orca.tools.pi.PiSessionStore
@@ -31,7 +31,9 @@ class SessionActionTest extends munit.FunSuite:
       startedAt = "2026-07-18T09:00:00Z",
       finishedAt = None,
       outcome = "succeeded",
-      sessions = List(s)
+      sessions = List(s),
+      cost = ManifestCostSummary.empty,
+      turns = Nil
     )
 
   test("identityNotice: names the session, harness, and workDir"):

--- a/shell/src/test/scala/orca/shell/cli/CliTest.scala
+++ b/shell/src/test/scala/orca/shell/cli/CliTest.scala
@@ -948,18 +948,6 @@ class CliTest extends munit.FunSuite:
         |  "pid": 1,
         |  "startedAt": "2026-07-18T09:00:00Z",
         |  "outcome": "succeeded",
-        |  "cost": {
-        |    "total": {
-        |      "inputTokens": 0,
-        |      "outputTokens": 0,
-        |      "cachedInputTokens": 0,
-        |      "reasoningOutputTokens": 0
-        |    },
-        |    "byRole": [],
-        |    "byAgent": [],
-        |    "byStage": []
-        |  },
-        |  "turns": [],
         |  "sessions": []
         |}""".stripMargin
     os.write(

--- a/shell/src/test/scala/orca/shell/cli/CliTest.scala
+++ b/shell/src/test/scala/orca/shell/cli/CliTest.scala
@@ -2,7 +2,7 @@ package orca.shell.cli
 
 import mainargs.ParserForMethods
 import orca.agents.BackendTag
-import orca.runner.manifest.{ManifestSession, RunManifest}
+import orca.runner.manifest.{ManifestCostSummary, ManifestSession, RunManifest}
 import orca.settings.{AgentSettings, AgentSpec, SettingsFile}
 import orca.shell.create.CreateTier
 import orca.shell.flows.{DiscoveredFlow, FlowOrigin}
@@ -744,7 +744,9 @@ class CliTest extends munit.FunSuite:
       startedAt = startedAt,
       finishedAt = None,
       outcome = "succeeded",
-      sessions = sessions
+      sessions = sessions,
+      cost = ManifestCostSummary.empty,
+      turns = Nil
     )
 
   private def durable(
@@ -946,6 +948,18 @@ class CliTest extends munit.FunSuite:
         |  "pid": 1,
         |  "startedAt": "2026-07-18T09:00:00Z",
         |  "outcome": "succeeded",
+        |  "cost": {
+        |    "total": {
+        |      "inputTokens": 0,
+        |      "outputTokens": 0,
+        |      "cachedInputTokens": 0,
+        |      "reasoningOutputTokens": 0
+        |    },
+        |    "byRole": [],
+        |    "byAgent": [],
+        |    "byStage": []
+        |  },
+        |  "turns": [],
         |  "sessions": []
         |}""".stripMargin
     os.write(
@@ -969,24 +983,35 @@ class CliTest extends munit.FunSuite:
     assertEquals(out.trim, "[]")
     assert(
       err.contains(
-        s"manifestVersion ${RunManifest.SupportedVersion + 1} is newer"
+        s"manifestVersion ${RunManifest.SupportedVersion + 1}, this build reads"
       ),
       err
     )
 
   private def writeCrashedManifest(dir: os.Path): Unit =
     val json =
-      """{
-        |  "manifestVersion": 1,
+      s"""{
+        |  "manifestVersion": ${RunManifest.SupportedVersion},
         |  "orcaVersion": "0.0.test",
         |  "workDir": "/work",
         |  "pid": 999999,
         |  "startedAt": "2026-07-18T09:00:00Z",
         |  "outcome": "running",
+        |  "cost": {
+        |    "total": {
+        |      "inputTokens": 0,
+        |      "outputTokens": 0,
+        |      "cachedInputTokens": 0,
+        |      "reasoningOutputTokens": 0
+        |    },
+        |    "byRole": [],
+        |    "byAgent": [],
+        |    "byStage": []
+        |  },
+        |  "turns": [],
         |  "sessions": [{
         |    "harness": "ClaudeCode",
         |    "wireId": "uuid",
-        |    "resumable": true,
         |    "agent": "main",
         |    "sessionName": "main",
         |    "kind": "durable",
@@ -1031,16 +1056,27 @@ class CliTest extends munit.FunSuite:
     val goneWorkDir = (dir / "gone").toString
     val json =
       s"""{
-        |  "manifestVersion": 1,
+        |  "manifestVersion": ${RunManifest.SupportedVersion},
         |  "orcaVersion": "0.0.test",
         |  "workDir": "$goneWorkDir",
         |  "pid": 1,
         |  "startedAt": "2026-07-18T09:00:00Z",
         |  "outcome": "succeeded",
+        |  "cost": {
+        |    "total": {
+        |      "inputTokens": 0,
+        |      "outputTokens": 0,
+        |      "cachedInputTokens": 0,
+        |      "reasoningOutputTokens": 0
+        |    },
+        |    "byRole": [],
+        |    "byAgent": [],
+        |    "byStage": []
+        |  },
+        |  "turns": [],
         |  "sessions": [{
         |    "harness": "ClaudeCode",
         |    "wireId": "uuid",
-        |    "resumable": true,
         |    "agent": "main",
         |    "stage": "Task: fix a bug",
         |    "sessionName": "main",

--- a/shell/src/test/scala/orca/shell/sessions/ManifestReaderTest.scala
+++ b/shell/src/test/scala/orca/shell/sessions/ManifestReaderTest.scala
@@ -28,7 +28,19 @@ class ManifestReaderTest extends munit.FunSuite:
          |  "pid": $pid,
          |  "startedAt": "$startedAt",
          |  "outcome": "$outcome",
-         |  "sessions": []
+         |  "sessions": [],
+         |  "cost": {
+         |    "total": {
+         |      "inputTokens": 0,
+         |      "outputTokens": 0,
+         |      "cachedInputTokens": 0,
+         |      "reasoningOutputTokens": 0
+         |    },
+         |    "byRole": [],
+         |    "byAgent": [],
+         |    "byStage": []
+         |  },
+         |  "turns": []
          |}""".stripMargin
     os.write(runsDir(workDir) / name, json, createFolders = true)
 
@@ -59,7 +71,37 @@ class ManifestReaderTest extends munit.FunSuite:
     )
 
   test(
-    "list skips a manifestVersion newer than this shell understands, warning by filename"
+    "an older manifest is skipped by version, leaving the current one listed"
+  ):
+    val workDir = TempDirs.dir()
+    // A verbatim v2 manifest: it also lacks v3's `cost`/`turns`, so this only
+    // passes if the version is checked before the body is decoded.
+    os.write(
+      runsDir(workDir) / "v2.json",
+      """{
+        |  "manifestVersion": 2,
+        |  "orcaVersion": "0.0.test",
+        |  "workDir": "/work",
+        |  "pid": 111,
+        |  "startedAt": "2026-07-18T10:00:00Z",
+        |  "outcome": "succeeded",
+        |  "sessions": []
+        |}""".stripMargin,
+      createFolders = true
+    )
+    writeManifest(workDir, "current.json", startedAt = "2026-07-18T11:00:00Z")
+    val (runs, warnings) = ManifestReader.list(workDir, alwaysDead)
+    assertEquals(runs.map(_.manifest.startedAt), List("2026-07-18T11:00:00Z"))
+    assertEquals(warnings.size, 1)
+    assert(
+      warnings.head.contains("v2.json") && warnings.head.contains(
+        "manifestVersion 2"
+      ),
+      s"expected the filename and version in the warning, got: ${warnings.head}"
+    )
+
+  test(
+    "list skips a manifestVersion newer than this build writes, warning by filename"
   ):
     val workDir = TempDirs.dir()
     writeManifest(

--- a/shell/src/test/scala/orca/shell/sessions/ManifestRoundTripTest.scala
+++ b/shell/src/test/scala/orca/shell/sessions/ManifestRoundTripTest.scala
@@ -1,7 +1,7 @@
 package orca.shell.sessions
 
 import orca.WorkspaceWrite
-import orca.events.OrcaEvent
+import orca.events.{OrcaEvent, Pricing}
 import orca.progress.{BranchMode, ProgressHeader, ProgressStore, SessionRecord}
 import orca.runner.manifest.{RunManifestWriter, RunOutcome}
 import orca.testkit.TempDirs
@@ -43,6 +43,7 @@ class ManifestRoundTripTest extends munit.FunSuite:
         workDir,
         "0.0.test",
         Some("a-flow.sc"),
+        Pricing.default,
         () => Instant.now()
       )
       writer.onEvent(OrcaEvent.StageStarted("code"))

--- a/shell/src/test/scala/orca/shell/sessions/ManifestRoundTripTest.scala
+++ b/shell/src/test/scala/orca/shell/sessions/ManifestRoundTripTest.scala
@@ -1,7 +1,7 @@
 package orca.shell.sessions
 
 import orca.WorkspaceWrite
-import orca.events.{OrcaEvent, Pricing}
+import orca.events.{OrcaEvent, Pricing, Usage}
 import orca.progress.{BranchMode, ProgressHeader, ProgressStore, SessionRecord}
 import orca.runner.manifest.{RunManifestWriter, RunOutcome}
 import orca.testkit.TempDirs
@@ -56,6 +56,14 @@ class ManifestRoundTripTest extends munit.FunSuite:
           None
         )
       )
+      writer.onEvent(
+        OrcaEvent.TokensUsed(
+          "claude",
+          None,
+          Usage(1_000, 200, Some(BigDecimal("0.5"))),
+          Some("reviewer")
+        )
+      )
       writer.finish(RunOutcome.Succeeded)
 
     val (runs, warnings) = ManifestReader.list(workDir, pidAlive = _ => true)
@@ -68,3 +76,7 @@ class ManifestRoundTripTest extends munit.FunSuite:
     assertEquals(session.resumable, true)
     assertEquals(session.sessionName, Some("coder"))
     assertEquals(session.stage, Some("code"))
+    val cost = runs.head.manifest.cost
+    assertEquals(cost.total.inputTokens, 1_000L)
+    assertEquals(cost.byRole.map(_.key), List(Some("reviewer")))
+    assertEquals(runs.head.manifest.turns.map(_.promptTokens), List(1_000L))


### PR DESCRIPTION
Orca kept no durable record of what a run cost. `RunManifest` carried sessions,
timings and outcome; `CostTracker.summary` was printed once at exit and thrown
away; the only per-event trace was a DEBUG line rendering `Usage.toString` into
a temp file. Every figure in the recent cost investigation had to be
reconstructed from Claude Code's own transcripts — data orca does not own, and
which does not exist at all for the other backends.

## What lands

**Cost and tokens in the manifest (schema v3).** `RunManifest` gains two fields:

- `cost` — the run's total `Usage`, per-role / per-agent / per-stage subtotals,
  and the total cost carrying its estimated-vs-reported flag.
- `turns` — one record per LLM turn: timestamp, agent, role, stage and the
  turn's prompt token count. `turns.size` is the run's turn count.

`Cost.estimated` propagates through addition, so a run mixing backend-reported
and table-estimated calls reports as an estimate rather than being quoted as a
billed figure — the distinction the original investigation lost.

**Per-turn prompt size.** `ManifestTurn.promptTokens` makes "107k re-sent per
turn" reproducible, and a zero there is the signature of a turn the CLI settles
from leftover session state without calling the API — the "13 zero-API-call
turns" finding.

**One home for the reported-vs-estimated decision.** `CostTracker.costFor` moves
to `Pricing.resolve`, now shared by the cost summary and the manifest writer, so
the two cannot disagree about which calls were priced rather than billed.

## What the manifest can and cannot tell you

Review pushed back on an earlier `apiCall: Boolean` derived from
`promptTokens > 0`, and the pushback was right: every backend defaults its usage
counters to zero when a terminal frame omits them
(`wire.usage.getOrElse(UsageWire())` and equivalents in all five), and claude
reads `total_cost_usd` from a separate field — so a zero-token turn can carry a
reported cost, and the flag would have contradicted itself inside one record.
The flag is gone. `promptTokens` carries the measurement and its scaladoc states
that zero means "no request observed", not "no request".

The same honesty applies to the summary, and it is stated on the type rather
than left for a reader to discover: `usage` covers every call, `cost` covers
only the calls that had one to resolve (a model absent from the pricing table
contributes tokens and no dollars), and four of the five backends drop usage
entirely on a failed turn — claude is the only one that attaches it.

## Schema choices

`ManifestUsage` is a named object with one field per `Usage` token axis, not a
positional encoding — axes have been added to `Usage` twice recently, and a
positional form breaks silently the next time. It deliberately carries no money
field: `Usage.cost` is only the portion backends reported, and an unlabelled
figure next to a resolved cost is how reported and estimated spend get mixed.
`orca.events.Cost` is reused as-is rather than mirrored, matching how
`ProgressLog` already persists shared types.

`CostAccumulator` keeps one entry list and groups on demand rather than three
parallel maps. Every turn is retained anyway for the per-turn log, so this
costs nothing and makes "each axis sums back to the total" true by construction
instead of by convention.

## Writing stays cheap and cannot fail the flow

`TokensUsed` accumulates in memory and triggers no write of its own — a turn
fires far more often than a stage or session event, and every write rewrites the
whole file. The accumulated figures reach disk on the existing triggers (stage
transitions, `SessionCommitted`, `finish`). Writes go through the existing
`safeWrite` guard unchanged: a failure is logged and swallowed, never escaping a
listener `tell` or run teardown. At the reference run's size (~340 turns, 21
sessions) the per-turn log is ~37 KB and total manifest I/O across the run is
about 1 MB.

## Compatibility

`manifestVersion` goes 2 → 3, and `ManifestReader` now reads the version with a
small probe codec **before** the full decode, skipping any manifest whose
version is not the one this build writes — in either direction — with a warning
naming the file and both versions. Previously it decoded first and gated only on
*newer* versions, so a newer manifest that dropped or renamed a field failed
with whichever field the codec happened to disagree about first.

Skipping rather than migrating is deliberate: orca is 0.x and owes no
compatibility across shapes (AGENTS.md), and `.orca/cache/runs/` is pruned cache
data, so an unreadable older manifest costs one "continue a session" offer and
nothing else. The listing itself never breaks — a current manifest alongside an
old one still lists. There is exactly one writer and one reader of this file in
the repo, both verified.

Two `CliTest` fixtures were written as `manifestVersion: 1` with a persisted
`resumable` field — a v1 shape the v2 reader accepted only because unknown
fields are skipped. They now match what production writes.

## Merge order relative to #49

**#49 should merge first.** It renames `Usage.cachedInputTokens` to
`cacheReadInputTokens` and adds `cacheWriteInputTokens`, and renames
`ModelPricing.cachedInputUsdPerMillion` to `cacheReadUsdPerMillion`. This branch
does not touch that branch.

The manifest records whatever token axes `Usage` carries and enumerates them in
exactly one place — the `ManifestUsage` case class and `ManifestUsage.of`. After
#49 lands, following it here is a rename in those two declarations plus the JSON
fixtures in four tests; no other manifest code changes. Until then the manifest
carries master's axes, so the cache **read/write split** is not yet reproducible
from it — `inputTokens`, `outputTokens`, `cachedInputTokens` (reads and writes
folded, as master folds them) and `reasoningOutputTokens` are, and uncached input
is `inputTokens - cachedInputTokens`.

Expect a small textual conflict: both branches edit `Pricing.scala` and
`CostTracker.scala`. #49 does not touch `costFor`, so the resolution is
mechanical.

## Not included: the benchmark flow

A checked-in benchmark flow was in scope and is left out deliberately — it is
its own project, and a half-built harness is worse than none. What it needs:

- A fixed flow script and prompt against a fixed seed —
  `examples/runnable/01-simple/create-test-project.sh` already seeds
  deterministically and is the right starting point.
- Fully-qualified model ids, not aliases: `claude:haiku` currently resolves
  server-side to Sonnet 5, so a benchmark using aliases measures a different
  model than it names.
- A pinned reviewer set and iteration ceiling, since fan-out and round count
  dominate run-to-run variance.
- Repeated runs plus an aggregation step over the manifests — a single pair of
  runs cannot separate a saving from noise. That aggregation is possible at all
  only now.

## Tests

- The cost section totals the run and breaks it down on all three axes, against
  literal expected figures (one call the table prices, one the backend reported,
  so the total comes out flagged as an estimate).
- The per-turn log records each turn's identity, stage and prompt size — with
  the stage closed between the two turns, so the stamp is pinned at record time
  rather than write time.
- A failed write is swallowed and does not stop the next one (new coverage for
  the pre-existing `safeWrite` guard).
- An older manifest is skipped by version, using a verbatim v2 body so it only
  passes if the version is checked before decoding, and the current manifest
  beside it still lists.
- The existing writer→reader round trip now carries a populated cost section.

`sbt scalafmtCheckAll` and `sbt clean compile test` are clean, zero warnings.
Behavioural changes were mutation-checked: inverting `Pricing.resolve`'s reported
flag, relaxing the version gate to `>`, keying the agent axis by role, and
dropping the stage stamp each fail a test.
