### PR TITLE
Unbreak master: align the manifest cost schema with the split cache axes

### DIFF
--- a/runner/src/main/scala/orca/runner/manifest/RunManifest.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifest.scala
@@ -32,7 +32,13 @@ private[orca] case class ManifestSession(
   def resumable: Boolean = wireId.isDefined
 
 /** The persisted projection of [[orca.events.Usage]]'s token axes, sharing its
-  * normalisation contract.
+  * normalisation contract — including that cache reads and cache writes are
+  * disjoint sub-portions of `inputTokens`, carried separately because they bill
+  * at opposite ends of base input.
+  *
+  * The field names are `Usage`'s, verbatim, and so are the JSON keys: every
+  * axis persisted here has to be traceable to the one it mirrors, or the two
+  * drift and a reader silently reports the wrong money.
   *
   * Deliberately carries no money, unlike `Usage`: `Usage.cost` is only the
   * portion backends reported, and an unlabelled figure next to a resolved
@@ -41,7 +47,8 @@ private[orca] case class ManifestSession(
 private[orca] case class ManifestUsage(
     inputTokens: Long,
     outputTokens: Long,
-    cachedInputTokens: Long,
+    cacheReadInputTokens: Long,
+    cacheWriteInputTokens: Long,
     reasoningOutputTokens: Long
 )
 
@@ -51,7 +58,8 @@ private[orca] object ManifestUsage:
   def of(usage: Usage): ManifestUsage = ManifestUsage(
     inputTokens = usage.inputTokens,
     outputTokens = usage.outputTokens,
-    cachedInputTokens = usage.cachedInputTokens,
+    cacheReadInputTokens = usage.cacheReadInputTokens,
+    cacheWriteInputTokens = usage.cacheWriteInputTokens,
     reasoningOutputTokens = usage.reasoningOutputTokens
   )
 

--- a/runner/src/test/scala/orca/runner/manifest/RunManifestTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/RunManifestTest.scala
@@ -1,0 +1,18 @@
+package orca.runner.manifest
+
+import orca.events.Usage
+
+class RunManifestTest extends munit.FunSuite:
+
+  // Guards the invariant ManifestUsage's scaladoc states: it mirrors every one
+  // of Usage's token axes. Without this, an axis ADDED to Usage leaves
+  // `ManifestUsage.of` compiling untouched and the manifest silently
+  // under-records spend — which is exactly how the cache-write axis went
+  // missing. Only the rename that came with it turned that into a compile
+  // error; a plain addition would have shipped.
+  test("ManifestUsage mirrors every token axis of Usage"):
+    assertEquals(
+      ManifestUsage.empty.productElementNames.toSet,
+      // `cost` is Usage's one non-token field, deliberately not persisted.
+      Usage.empty.productElementNames.toSet - "cost"
+    )

--- a/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
@@ -429,7 +429,10 @@ class RunManifestWriterTest extends munit.FunSuite:
         .SessionCommitted("claude", "client-1", Some("wire-1"), "claude", None)
     )
     // One call the table has to price and one the backend reported, so the run
-    // total is a mix.
+    // total is a mix. The priced call's cache-read and cache-write figures are
+    // deliberately non-zero and unequal: they are what pins that both axes
+    // survive the ManifestUsage projection, and that a write is billed at the
+    // write rate rather than folded into base input.
     writer.onEvent(
       OrcaEvent.TokensUsed(
         agent = "claude",

--- a/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
@@ -438,7 +438,8 @@ class RunManifestWriterTest extends munit.FunSuite:
           inputTokens = 120_000,
           outputTokens = 900,
           cost = None,
-          cachedInputTokens = 107_000
+          cacheReadInputTokens = 107_000,
+          cacheWriteInputTokens = 8_000
         ),
         role = None
       )
@@ -463,14 +464,15 @@ class RunManifestWriterTest extends munit.FunSuite:
       ManifestUsage(
         inputTokens = 125_000,
         outputTokens = 1_000,
-        cachedInputTokens = 107_000,
+        cacheReadInputTokens = 107_000,
+        cacheWriteInputTokens = 8_000,
         reasoningOutputTokens = 0
       )
     )
-    // 13k uncached at $3/M + 107k cached at $0.30/M + 900 out at $15/M =
-    // $0.0846, plus the reported $0.0123. `estimated` survives the addition,
-    // so the run total can't be read as a billed figure.
-    assertEquals(cost.cost, Some(Cost(BigDecimal("0.0969"), estimated = true)))
+    // 5k fresh at $3/M + 107k cache-read at $0.30/M + 8k cache-write at $6/M +
+    // 900 out at $15/M = $0.1086, plus the reported $0.0123. `estimated`
+    // survives the addition, so the run total can't be read as a billed figure.
+    assertEquals(cost.cost, Some(Cost(BigDecimal("0.1209"), estimated = true)))
     assertEquals(
       cost.byAgent.map(s => (s.key, s.usage.inputTokens)),
       List((Some("claude"), 120_000L), (Some("reviewer"), 5_000L))

--- a/shell/src/test/scala/orca/shell/cli/CliTest.scala
+++ b/shell/src/test/scala/orca/shell/cli/CliTest.scala
@@ -989,7 +989,8 @@ class CliTest extends munit.FunSuite:
         |    "total": {
         |      "inputTokens": 0,
         |      "outputTokens": 0,
-        |      "cachedInputTokens": 0,
+        |      "cacheReadInputTokens": 0,
+        |      "cacheWriteInputTokens": 0,
         |      "reasoningOutputTokens": 0
         |    },
         |    "byRole": [],
@@ -1054,7 +1055,8 @@ class CliTest extends munit.FunSuite:
         |    "total": {
         |      "inputTokens": 0,
         |      "outputTokens": 0,
-        |      "cachedInputTokens": 0,
+        |      "cacheReadInputTokens": 0,
+        |      "cacheWriteInputTokens": 0,
         |      "reasoningOutputTokens": 0
         |    },
         |    "byRole": [],

--- a/shell/src/test/scala/orca/shell/sessions/ManifestReaderTest.scala
+++ b/shell/src/test/scala/orca/shell/sessions/ManifestReaderTest.scala
@@ -33,7 +33,8 @@ class ManifestReaderTest extends munit.FunSuite:
          |    "total": {
          |      "inputTokens": 0,
          |      "outputTokens": 0,
-         |      "cachedInputTokens": 0,
+         |      "cacheReadInputTokens": 0,
+         |      "cacheWriteInputTokens": 0,
          |      "reasoningOutputTokens": 0
          |    },
          |    "byRole": [],


### PR DESCRIPTION
Master is red. `sbt compile` fails with:

```
runner/src/main/scala/orca/runner/manifest/RunManifest.scala:54:30
value cachedInputTokens is not a member of orca.events.Usage
- did you mean usage.cacheReadInputTokens?
```

## What happened

Two merged PRs that never textually conflicted:

- **#49** (`9ec755bb`) renamed `Usage.cachedInputTokens` to `cacheReadInputTokens` (and `ModelPricing.cachedInputUsdPerMillion` to `cacheReadUsdPerMillion`), and split the one cached axis into two disjoint ones: `cacheReadInputTokens` (served *from* cache) and `cacheWriteInputTokens` (written *into* it). They bill at opposite ends of base input.
- **#61** (`59fd204b`) added the manifest cost schema off a branch that predated the rename.

They touched different files, so mergeability checks saw nothing to flag.

## The substantive half

The compile error is only what surfaced this. `ManifestUsage` was a projection of the *pre-split* `Usage`, so it had no cache-write field at all — a manifest recorded the read axis and **silently dropped the write figure**. That is not a rounding detail: cache writes were 46% of spend in the run this schema was built to measure. Mechanically renaming the field would have compiled, gone green, and left the hole.

So `ManifestUsage` now carries both axes. Nothing upstream needed changing: `CostAccumulator` folds `Usage` values, which already carry both — only the final projection was lossy.

**And note how narrowly this was caught.** `ManifestUsage.of` maps axes by name, so if #49 had merely *added* `cacheWriteInputTokens` without also renaming `cachedInputTokens`, the projection would have compiled untouched and under-recorded spend in silence. The compile error was luck, not design. `RunManifestTest` now pins the mirror structurally, so the next axis added to `Usage` fails a test instead of quietly vanishing from the manifest.

## The on-disk key rename, deliberately

`ManifestUsage`'s fields *are* the JSON keys of manifest schema v3, so this renames `cachedInputTokens` to `cacheReadInputTokens` on disk and adds `cacheWriteInputTokens`.

Taking that rename rather than keeping the old key: **the persisted key should match the `Usage` axis it mirrors, so the two cannot drift again.** A manifest key spelled `cachedInputTokens` next to a `Usage` axis spelled `cacheReadInputTokens` is exactly the ambiguity that hid the missing write axis — one name that reads like "all cached tokens" while holding only the read portion.

The migration cost is nil, not merely small:

- v3 was introduced by #61, which landed *after* the last release (0.1.3, `f44c6d37`), so no released build ever wrote a v3 manifest (`git tag --contains 59fd204b` is empty).
- Master has not compiled since #61, so no build from master wrote one either.
- Nothing reads `manifest.cost` or `manifest.turns` yet — the cost section is write-only today.
- `manifestVersion` is a hard gate — the reader skips any manifest whose version it does not itself write — and `ManifestReader.readManifest` catches decode failures and skips with a warning regardless. `.orca/cache/runs/` is pruned cache data; the worst case is losing one "continue a session" offer.

`SupportedVersion` therefore stays at 3: there is no shipped v3 shape to be compatible with. The one residual case is a local dev box that built #61's branch pre-merge — those files pass the version gate, then fail the strict decode and are skipped with a warning. Bounded, and self-clearing via the existing prune.

## Verification

- `sbt scalafmtCheckAll` — clean
- `sbt clean compile test` — green, **zero warnings**, 1788 tests across 9 modules

The writer test now runs non-zero and unequal cache-read/cache-write figures end to end, so both axes are pinned rather than merely present; its expected cost moves from $0.0969 to $0.1209 (5k fresh @ $3/M + 107k read @ $0.30/M + 8k write @ $6/M + 900 out @ $15/M, plus the reported $0.0123). The hand-written JSON fixtures in `CliTest` and `ManifestReaderTest` carry both keys — being literal, they are what pins the on-disk spelling, since the writer test round-trips through the same codec and cannot see a rename.
