### PR TITLE
Stop stripMargin mangling wizard input in the authoring prompts

### DIFF
--- a/shell/src/main/scala/orca/shell/create/FlowAuthoring.scala
+++ b/shell/src/main/scala/orca/shell/create/FlowAuthoring.scala
@@ -106,6 +106,8 @@ private[shell] object FlowAuthoring:
     * [[sanitizeSlug]] has the best chance of a clean answer to sanitize.
     */
   def slugPrompt(goal: String): String =
+    // No `stripMargin` over `goal`: it is the user's typed text, whose
+    // `|`-leading lines it would eat.
     s"""Suggest a short lowercase-kebab-case filename (letters, digits, and
        |hyphens only, no file extension, no explanation) for a script whose
        |goal is:""".stripMargin + "\n" + goal +
@@ -125,6 +127,8 @@ private[shell] object FlowAuthoring:
       changes: String
   ): String =
     val description = sourceDescription.getOrElse("(no description)")
+    // No `stripMargin` over `changes`: it is the user's typed text, whose
+    // `|`-leading lines it would eat.
     s"""Suggest a short lowercase-kebab-case descriptor (1-3 words; letters,
        |digits, and hyphens only; no file extension, no explanation) for the
        |change a fork makes to an existing script. The descriptor will be
@@ -499,8 +503,10 @@ private[shell] object FlowAuthoring:
     // indented as its own block rather than trailing "Goal: " on one line —
     // keeps a multi-paragraph goal visually distinct from the rest of the
     // prompt instead of running the first line on with the label.
-    s"Write a new Orca flow at $targetPath.\n\nGoal:\n" + indentBlock(goal) +
-      "\n\n" +
+    s"""Write a new Orca flow at $targetPath.
+       |
+       |Goal:""".stripMargin +
+      "\n" + indentBlock(goal) + "\n\n" +
       s"""Start the file with this exact header (the pinned version matches the
          |orca release this flow was launched from):
          |${versionPinLines(orcaVersion)}
@@ -621,10 +627,10 @@ private[shell] object FlowAuthoring:
       s"""Create the Orca flow at $targetPath by copying $sourcePath and
          |applying these changes:""".stripMargin +
         "\n" + indentBlock(changes) + "\n\n" +
-        """Keep the copied file's existing version-pinned header (`//> using
-         |scala`/`//> using dep`/`//> using jvm`) and its line-1 `//`
-         |one-line-description convention — update the description line only if
-         |the fork's behavior changes enough to make the original one wrong.""".stripMargin
+        s"""Keep the copied file's existing version-pinned header (`//> using
+           |scala`/`//> using dep`/`//> using jvm`) and its line-1 `//`
+           |one-line-description convention — update the description line only if
+           |the fork's behavior changes enough to make the original one wrong.""".stripMargin
     changePrompt(opening, targetPath, apiDir, orcaVersion)
 
   /** The authoring task for edit-by-agent (ADR 0021 §6/§9 amendment):
@@ -646,10 +652,10 @@ private[shell] object FlowAuthoring:
       s"""Edit the Orca flow: apply these changes to $targetPath, which is a
          |copy of $sourcePath:""".stripMargin +
         "\n" + indentBlock(changes) + "\n\n" +
-        """Keep the file's existing version-pinned header (`//> using
-         |scala`/`//> using dep`/`//> using jvm`) and its line-1 `//`
-         |one-line-description convention — update the description line only if
-         |these changes make the original one wrong.""".stripMargin
+        s"""Keep the file's existing version-pinned header (`//> using
+           |scala`/`//> using dep`/`//> using jvm`) and its line-1 `//`
+           |one-line-description convention — update the description line only if
+           |these changes make the original one wrong.""".stripMargin
     changePrompt(opening, targetPath, apiDir, orcaVersion)
 
   /** A hand-authored flow's starting point (ADR 0021 §9 amendment,

--- a/shell/src/main/scala/orca/shell/create/FlowAuthoring.scala
+++ b/shell/src/main/scala/orca/shell/create/FlowAuthoring.scala
@@ -108,10 +108,8 @@ private[shell] object FlowAuthoring:
   def slugPrompt(goal: String): String =
     s"""Suggest a short lowercase-kebab-case filename (letters, digits, and
        |hyphens only, no file extension, no explanation) for a script whose
-       |goal is:
-       |$goal
-       |
-       |Reply with ONLY the filename, nothing else.""".stripMargin
+       |goal is:""".stripMargin + "\n" + goal +
+      "\n\nReply with ONLY the filename, nothing else."
 
   /** [[slugPrompt]]'s fork counterpart: the same bare-filename ask, grounded in
     * the source flow's name and one-line description plus the user's described
@@ -135,10 +133,8 @@ private[shell] object FlowAuthoring:
        |Source script: $sourceName
        |Source description: $description
        |
-       |Changes made in the fork:
-       |$changes
-       |
-       |Reply with ONLY the descriptor, nothing else.""".stripMargin
+       |Changes made in the fork:""".stripMargin + "\n" + changes +
+      "\n\nReply with ONLY the descriptor, nothing else."
 
   private val maxSlugLength = 50
 
@@ -503,40 +499,38 @@ private[shell] object FlowAuthoring:
     // indented as its own block rather than trailing "Goal: " on one line —
     // keeps a multi-paragraph goal visually distinct from the rest of the
     // prompt instead of running the first line on with the label.
-    val indentedGoal = indentBlock(goal)
-    s"""Write a new Orca flow at $targetPath.
-       |
-       |Goal:
-       |$indentedGoal
-       |
-       |Start the file with this exact header (the pinned version matches the
-       |orca release this flow was launched from):
-       |${versionPinLines(orcaVersion)}
-       |
-       |Line 1 of the file must be a `//` comment giving a one-line description
-       |of the flow — the shell's flow listing uses it as the description.
-       |
-       |The Orca API reference is at $readme — read it before writing the
-       |flow. Two example flows are at $example1 and $example2; start from
-       |whichever is closer to the goal.
-       |
-       |After writing the file, verify it with `scala-cli compile $targetPath`
-       |and fix errors until it compiles.
-       |
-       |Caveat: some authoring rules (fork-boundary captures, stage
-       |push-after-commit ordering, no concurrent stages) are enforced at runtime,
-       |not by the compiler — a script can compile and still violate them.
-       |Follow the README's Authoring rules section beyond what the compiler
-       |catches.
-       |
-       |Last resort, only if the local README above is somehow missing: the
-       |tag-pinned reference is at
-       |https://raw.githubusercontent.com/VirtusLab/orca/v$orcaVersion/README.md
-       |""".stripMargin
+    s"Write a new Orca flow at $targetPath.\n\nGoal:\n" + indentBlock(goal) +
+      "\n\n" +
+      s"""Start the file with this exact header (the pinned version matches the
+         |orca release this flow was launched from):
+         |${versionPinLines(orcaVersion)}
+         |
+         |Line 1 of the file must be a `//` comment giving a one-line description
+         |of the flow — the shell's flow listing uses it as the description.
+         |
+         |The Orca API reference is at $readme — read it before writing the
+         |flow. Two example flows are at $example1 and $example2; start from
+         |whichever is closer to the goal.
+         |
+         |After writing the file, verify it with `scala-cli compile $targetPath`
+         |and fix errors until it compiles.
+         |
+         |Caveat: some authoring rules (fork-boundary captures, stage
+         |push-after-commit ordering, no concurrent stages) are enforced at runtime,
+         |not by the compiler — a script can compile and still violate them.
+         |Follow the README's Authoring rules section beyond what the compiler
+         |catches.
+         |
+         |Last resort, only if the local README above is somehow missing: the
+         |tag-pinned reference is at
+         |https://raw.githubusercontent.com/VirtusLab/orca/v$orcaVersion/README.md
+         |""".stripMargin
 
   /** Two-space-indents every line of `text` — the shared block-quoting used by
     * [[initialPrompt]]'s goal and [[forkPrompt]]'s change description, both of
-    * which come from `inputMultiline` and so may be several lines long.
+    * which come from `inputMultiline` and so may be several lines long. Callers
+    * concatenate the result: interpolating it into a `stripMargin` block would
+    * eat the leading `|` of a table or margin block the user typed.
     */
   private def indentBlock(text: String): String =
     text.linesIterator.map(line => s"  $line").mkString("\n")
@@ -587,25 +581,26 @@ private[shell] object FlowAuthoring:
     val readme = apiDir / "README.md"
     val example1 = apiDir / "implement.sc"
     val example2 = apiDir / "implement-interactive.sc"
-    s"""$opening
-       |
-       |The Orca API reference is at $readme — read it if the changes need API
-       |surface the source doesn't already use. Two example flows are at
-       |$example1 and $example2.
-       |
-       |After writing the file, verify it with `scala-cli compile $targetPath`
-       |and fix errors until it compiles.
-       |
-       |Caveat: some authoring rules (fork-boundary captures, stage
-       |push-after-commit ordering, no concurrent stages) are enforced at runtime,
-       |not by the compiler — a script can compile and still violate them.
-       |Follow the README's Authoring rules section beyond what the compiler
-       |catches.
-       |
-       |Last resort, only if the local README above is somehow missing: the
-       |tag-pinned reference is at
-       |https://raw.githubusercontent.com/VirtusLab/orca/v$orcaVersion/README.md
-       |""".stripMargin
+    // `opening` already carries the user's typed changes: interpolating it here
+    // would run a second `stripMargin` pass over that text.
+    opening + "\n\n" +
+      s"""The Orca API reference is at $readme — read it if the changes need API
+         |surface the source doesn't already use. Two example flows are at
+         |$example1 and $example2.
+         |
+         |After writing the file, verify it with `scala-cli compile $targetPath`
+         |and fix errors until it compiles.
+         |
+         |Caveat: some authoring rules (fork-boundary captures, stage
+         |push-after-commit ordering, no concurrent stages) are enforced at runtime,
+         |not by the compiler — a script can compile and still violate them.
+         |Follow the README's Authoring rules section beyond what the compiler
+         |catches.
+         |
+         |Last resort, only if the local README above is somehow missing: the
+         |tag-pinned reference is at
+         |https://raw.githubusercontent.com/VirtusLab/orca/v$orcaVersion/README.md
+         |""".stripMargin
 
   /** The authoring task for a fork (ADR 0021 §9): states the source path and
     * the described changes as one indivisible step (create the target by
@@ -622,13 +617,11 @@ private[shell] object FlowAuthoring:
       apiDir: os.Path,
       orcaVersion: String
   ): String =
-    val indentedChanges = indentBlock(changes)
     val opening =
       s"""Create the Orca flow at $targetPath by copying $sourcePath and
-         |applying these changes:
-         |$indentedChanges
-         |
-         |Keep the copied file's existing version-pinned header (`//> using
+         |applying these changes:""".stripMargin +
+        "\n" + indentBlock(changes) + "\n\n" +
+        """Keep the copied file's existing version-pinned header (`//> using
          |scala`/`//> using dep`/`//> using jvm`) and its line-1 `//`
          |one-line-description convention — update the description line only if
          |the fork's behavior changes enough to make the original one wrong.""".stripMargin
@@ -649,13 +642,11 @@ private[shell] object FlowAuthoring:
       apiDir: os.Path,
       orcaVersion: String
   ): String =
-    val indentedChanges = indentBlock(changes)
     val opening =
       s"""Edit the Orca flow: apply these changes to $targetPath, which is a
-         |copy of $sourcePath:
-         |$indentedChanges
-         |
-         |Keep the file's existing version-pinned header (`//> using
+         |copy of $sourcePath:""".stripMargin +
+        "\n" + indentBlock(changes) + "\n\n" +
+        """Keep the file's existing version-pinned header (`//> using
          |scala`/`//> using dep`/`//> using jvm`) and its line-1 `//`
          |one-line-description convention — update the description line only if
          |these changes make the original one wrong.""".stripMargin

--- a/shell/src/test/scala/orca/shell/create/FlowAuthoringTest.scala
+++ b/shell/src/test/scala/orca/shell/create/FlowAuthoringTest.scala
@@ -79,6 +79,15 @@ class FlowAuthoringTest extends munit.FunSuite:
     assert(text.contains("  sync issues nightly"))
     assert(text.contains("  and also close stale ones"))
 
+  test("initialPrompt keeps a goal line that starts with `|`"):
+    val text = FlowAuthoring.initialPrompt(
+      "compare the modes:\n| mode | effect |",
+      targetPath,
+      apiDir,
+      "0.0.18"
+    )
+    assert(text.contains("\n  | mode | effect |"), text)
+
   test("initialPrompt states the verbatim version-pinned header"):
     assert(prompt.contains("//> using scala 3.8.4"))
     assert(prompt.contains("""//> using dep "org.virtuslab::orca:0.0.18""""))
@@ -204,6 +213,10 @@ class FlowAuthoringTest extends munit.FunSuite:
     assert(text.contains("sync issues nightly"))
     assert(text.contains("Reply with ONLY the filename"))
 
+  test("slugPrompt keeps a goal line that starts with `|`"):
+    val text = FlowAuthoring.slugPrompt("compare:\n| mode | effect |")
+    assert(text.contains("\n| mode | effect |"), text)
+
   // --- sanitizeSlug ---
 
   test("sanitizeSlug kebab-cases junk (mixed case, punctuation, spaces)"):
@@ -301,6 +314,11 @@ class FlowAuthoringTest extends munit.FunSuite:
   ):
     val text = FlowAuthoring.forkSlugPrompt("implement.sc", None, "add logging")
     assert(text.contains("(no description)"))
+
+  test("forkSlugPrompt keeps a changes line that starts with `|`"):
+    val text =
+      FlowAuthoring.forkSlugPrompt("implement.sc", None, "cover:\n| a | b |")
+    assert(text.contains("\n| a | b |"), text)
 
   // --- suggestFilenameForFork ---
 
@@ -496,6 +514,16 @@ class FlowAuthoringTest extends munit.FunSuite:
     assert(text.contains("  add a rate limit"))
     assert(text.contains("  and log rejected requests"))
 
+  test("forkPrompt keeps a changes line that starts with `|`"):
+    val text = FlowAuthoring.forkPrompt(
+      "reword the header to:\n  |//> using jvm 21",
+      targetPath / os.up / "implement.sc",
+      targetPath,
+      apiDir,
+      "0.0.18"
+    )
+    assert(text.contains("\n    |//> using jvm 21"), text)
+
   // --- editPrompt (edit-by-agent's task — same tail as forkPrompt, distinct
   // opening: worded as an edit, since that's the action the user picked) ---
 
@@ -542,6 +570,16 @@ class FlowAuthoringTest extends munit.FunSuite:
     )
     assert(text.contains("  add a rate limit"))
     assert(text.contains("  and log rejected requests"))
+
+  test("editPrompt keeps a changes line that starts with `|`"):
+    val text = FlowAuthoring.editPrompt(
+      "cover these cases:\n| input | expected |",
+      targetPath / os.up / "implement.sc",
+      targetPath,
+      apiDir,
+      "0.0.18"
+    )
+    assert(text.contains("\n  | input | expected |"), text)
 
   // --- resolveTarget / prepareTarget ---
 

--- a/shell/src/test/scala/orca/shell/create/FlowAuthoringTest.scala
+++ b/shell/src/test/scala/orca/shell/create/FlowAuthoringTest.scala
@@ -581,6 +581,19 @@ class FlowAuthoringTest extends munit.FunSuite:
     )
     assert(text.contains("\n  | input | expected |"), text)
 
+  test("no wizard prompt leaks a `|` margin gutter from its static text"):
+    // Each prompt now assembles from several literals, so a misplaced
+    // `.stripMargin` would ship the markers to the authoring agent. None of
+    // these fixtures' inputs contain a `|`, so any `|`-leading line is a leak.
+    List(
+      prompt,
+      fork,
+      edit,
+      FlowAuthoring.slugPrompt("sync issues nightly"),
+      FlowAuthoring.forkSlugPrompt("implement.sc", None, "add logging")
+    ).foreach: text =>
+      assert(!text.linesIterator.exists(_.trim.startsWith("|")), text)
+
   // --- resolveTarget / prepareTarget ---
 
   test("prepareAutoTarget: a free name is used as-is"):


### PR DESCRIPTION
`stripMargin` runs over the *interpolated* result, not the literal, so only the
first interpolated line is protected by the literal's own margin marker. Every
later line of injected text that begins with optional whitespace followed by `|`
loses that `|`.

The flow-authoring wizard's input is free prose typed into `inputMultiline`, and
`indentBlock` prefixes each line with two spaces — exactly the "optional
whitespace then `|`" shape `stripMargin` strips. A pasted markdown table, a
quoted Scala margin block, or any `|`-leading line reached the authoring agent
mangled.

Same fix as #46 and #54: plain concatenation wherever the user's text is
injected.

## Sites

| Site | Injected |
|---|---|
| `initialPrompt` | the goal block |
| `forkPrompt` / `editPrompt` | the change-description block |
| `changePrompt` | the already-assembled `opening` |
| `slugPrompt` / `forkSlugPrompt` | the same goal / changes text |

`changePrompt` was not a pure concatenation swap. It took the `opening` that
`forkPrompt`/`editPrompt` had already assembled — user text included — and
interpolated it into a *second* `stripMargin` block, so that text was stripped
twice. Restructured so the assembly happens exactly once: each opening is built
from a static head (`stripMargin` over the literal only), the indented user
block, and a static tail, and `changePrompt` concatenates that opening instead
of re-interpolating it.

`slugPrompt`/`forkSlugPrompt` were found while reviewing this change: the same
goal/changes text reaches the cheap filename-suggestion call. Lower stakes — the
reply only has to survive `sanitizeSlug` — but the same defect, and leaving them
would mean two answers in one file.

No margin pass runs over user text or over an assembled prompt any more. The
static templates still use `stripMargin` over their own literals, including the
`versionPinLines` block interpolated into `initialPrompt` and `skeletonFlow` —
harmless, since those lines start `//>`.

## Byte-identity

The produced prompts are byte-identical to before for input containing no `|`.
This was verified by inspection, not by a test: the base and head expressions
were extracted into a standalone program and run side by side over multi-line,
single-line, empty, already-indented and tab-bearing inputs, with distinct
sentinel values for every path and version parameter, against both the release
and dev version branches — zero differences. Deliberately not regression-guarded:
a snapshot of the full prompt text would need rewriting on every wording change,
for no defect the tests below don't already catch.

`indentBlock`'s scaladoc states the concatenate-don't-interpolate rule for
callers that use it; the two slug prompts, which don't, carry the per-site
`// No stripMargin` note used elsewhere in the repo.

## Tests

One per fixed site in `FlowAuthoringTest`, each asserting a `|`-leading line —
a markdown table row, a `//> using` margin block — survives into the prompt.
Against the pre-fix source exactly those five fail. Reverting only
`changePrompt` fails the fork and edit ones, so the second pass is covered on
its own rather than only in combination.

Plus one invariant test: no prompt may contain a `|`-leading line when its input
has none, which catches a `.stripMargin` lost or misplaced among the static
templates. Without it, deleting `.stripMargin` from all of them left the whole
suite green — every other assertion is a `contains` of a mid-line fragment,
which a leading `|` gutter doesn't break.

`sbt scalafmtCheckAll` clean, `sbt clean compile test` green across all modules,
zero warnings.

Closes #60.

