### PR TITLE
T1.4 findings: one CLI process per durable session — NO-GO

### DIFF
--- a/docs/research/run-cost/07-persistent-cli-session.md
+++ b/docs/research/run-cost/07-persistent-cli-session.md
@@ -7,7 +7,11 @@ durable session, instead of today's fresh process per turn with stdin closed.
 
 1. The primary shipped flow **cannot run** on a held-open claude process —
    `--json-schema` is argv-side and a durable session alternates between
-   schema'd and un-schema'd turns (§2).
+   schema'd and un-schema'd turns (§2). **[V]** for the argv encoding and the
+   alternation; **[U]** for "cannot", which holds only if `--json-schema`
+   also cannot be varied per message over claude's control channel. That
+   sub-question is unresolved (§2), and §6.1 calls settling it a ~30-minute
+   experiment that decides the ADR. Ground 1 is contingent on its answer.
 2. The headline cost benefit is **not supported by measurement** (§1), so the
    change would be bought on reliability grounds alone — and its reliability
    benefit shares a mechanism with a deadlock already documented in the code (§3).
@@ -56,9 +60,14 @@ argument, not a measurement. The honest position is **"not supported", not
 "refuted"**, and the experiment that would settle it is in §6.
 
 Either way this points the same direction as the plan's existing conclusion: the
-levers are **prefix size and turn count**, not process lifetime. It also closes
-T1.5 to the extent that per-turn teardown is *not* the cause of the 2.0M
-cache-creation figure.
+levers are **prefix size and turn count**, not process lifetime.
+
+It does **not** close T1.5. T1.5 asks what forces 2.0M tokens of cache creation,
+and names per-turn teardown as the likely cause; the regime that produced that
+figure is the implementer at a 213k prefix with real tool calls, which is
+precisely the regime the paragraph above says these probes cannot reach. Ruling
+teardown out there would be reasserting in the regime this section has just
+excluded. T1.5 stays open on the same experiment (§6.2).
 
 ---
 
@@ -116,8 +125,9 @@ latches** are the real problem.
   `failWith` end in `source.interrupt()` (`ForkedConversation.scala:295-329`) and
   `StreamSource.fromProcess.interrupt()` is `process.sendSigInt()`
   (`StreamSource.scala:68`). But `interrupt()` is a **per-source policy**
-  (`StreamSource.scala:28-33`) and the class already contemplates a source that
-  outlives a turn (`:290-294`, the SSE case), so this is a new `StreamSource`
+  (`StreamSource.scala:28-33`) and the codebase already contemplates a source
+  that outlives a turn (`ForkedConversation.scala:290-294`, the SSE case — not
+  `StreamSource.scala`, which is 76 lines), so this is a new `StreamSource`
   implementation, not a rewrite. **[V]**
 - **`FlowSession` has no lexical span.** It must be minted *outside* any stage
   (`OutsideStage`, `Session.scala:28-30`, runtime throw at `:180-185`) and closed
@@ -152,8 +162,13 @@ latches** are the real problem.
   accommodation (`StreamSource.scala:52-59`). **[V]**
 - **PR #47's shipped system-prompt rule becomes false.** The composed prompt
   tells agents the harness is torn down each turn and long commands must run in
-  the foreground. It and its four string-pinning assertions in
-  `SystemPromptComposerTest` would have to be retracted in the same change. **[V]**
+  the foreground. The rule's *text* would have to be retracted in the same
+  change; the tests would not fight it. `SystemPromptComposerTest` asserts on
+  `BackgroundWorkAbandonedAtTurnEnd` in **six** of its seven tests, but through
+  the symbol, so what they pin is composition — which turns get the rule, and in
+  what order it joins the others — not its wording. Rewording the rule breaks
+  none of them; dropping it from read-only or write-capable turns breaks
+  several. **[V]**
 - **Ox is pinned at 1.0.5** (`project/Dependencies.scala:10`);
   `abandonOnInterruptReads` needs ≥ 1.0.6. A one-line bump, but today
   destroy-then-EOF is the only mitigation and this change removes it from the
@@ -314,11 +329,28 @@ Only under all of these:
 - **`ProgressLog.scala:75-76`** says pi's sessions live in a `deleteOnExit` temp
   dir so a resumed run always re-seeds; `PiBackend.scala:67-68` and ADR 0018's
   2026-07-28 amendment say pi is durable. **[V]**
-- **Latent write-after-close.** `ClaudeBackend.scala:221` closes stdin;
-  `ClaudeConversation.scala:284-285` later writes a `control_response` to it, and
-  `OsProcCliRunner.scala:159-163` writes to the closed stream. Reachable on the
-  autonomous path — `Conversations.scala:105-116` responds `Deny` to
-  `ApproveTool`. Unit tests cannot catch it: the fake is lenient about writes
-  after close (`FakePipedCliProcessTest.scala:65-69`). Not verified live. **[I]**
+- **Latent write-after-close.** `ClaudeBackend.scala:221` closes stdin
+  immediately after writing the opening turn; `ClaudeConversation.respond`
+  (`:278-285`) later writes a `control_response` to it, and
+  `OsProcCliRunner.scala:159-163` writes to the closed stream. The defect is
+  real, but **the trigger first named for it was wrong**, and it is worth being
+  precise about which path reaches it:
+  - Not the `Deny` branch. `Conversations.scala:105-116` responds `Deny` to
+    `ApproveTool`, but that event is only enqueued when
+    `ClaudeConversation.autoApproves(name)` is false (`:243-252`), which under
+    the shipped `AutoApprove.All` (`AgentConfig.scala:21`) it never is. No orca
+    call site sets `AutoApprove.Only`, so the branch is dead in shipped
+    configuration. **[V]**
+  - The live path is the `Allow()` reply at `:244`, which writes to the same
+    closed stdin.
+  - Either way, nothing gets that far: stdin is closed before any
+    `control_request` could arrive, so orca cannot deliver *any* decision. No
+    `control_request` frame appears in any of the baseline run's ten reviewer
+    transcripts. **[M]**
+
+  So the write-after-close is unreachable-in-practice rather than latent-and-
+  waiting, and the code that would exercise it is code that cannot work at all.
+  Unit tests cannot catch it: the fake is lenient about writes after close
+  (`FakePipedCliProcessTest.scala:65-69`). Not verified live. **[V]/[I]**
 - **`StderrPipeline.onFinalize`'s unbounded join** (`:60-71`) is a real
   mis-sequencing today for codex/gemini/pi, independent of this proposal.

--- a/docs/research/run-cost/07-persistent-cli-session.md
+++ b/docs/research/run-cost/07-persistent-cli-session.md
@@ -30,8 +30,8 @@ inferred, **[U]** unknown.
 
 ## 1. The cost benefit is not supported
 
-This was the load-bearing justification (cache writes were 46% of the baseline
-run), so it was measured rather than argued.
+This was the main justification (cache writes were 46% of the baseline run), so
+it was measured rather than argued.
 
 **Controlled comparison.** Two arms, three turns each, **distinct** ~79k-token
 content per arm, `--resume` arm run first so it could not inherit the other's
@@ -56,7 +56,7 @@ reproduce intra-turn growth. **[M]/[U]**
 
 No mechanism has been identified by which a held-open process would write less in
 that regime — tool results grow the prefix identically either way — but that is an
-argument, not a measurement. The honest position is **"not supported", not
+argument, not a measurement. So this is recorded as **"not supported", not
 "refuted"**, and the experiment that would settle it is in §6.
 
 Either way this points the same direction as the plan's existing conclusion: the
@@ -64,10 +64,10 @@ levers are **prefix size and turn count**, not process lifetime.
 
 It does **not** close T1.5. T1.5 asks what forces 2.0M tokens of cache creation,
 and names per-turn teardown as the likely cause; the regime that produced that
-figure is the implementer at a 213k prefix with real tool calls, which is
-precisely the regime the paragraph above says these probes cannot reach. Ruling
-teardown out there would be reasserting in the regime this section has just
-excluded. T1.5 stays open on the same experiment (§6.2).
+figure is the implementer at a 213k prefix with real tool calls, which is the
+regime the paragraph above says these probes cannot reach. Ruling teardown out
+there would be a claim about a regime this section has just excluded. T1.5 stays
+open on the same experiment (§6.2).
 
 ---
 
@@ -99,8 +99,7 @@ equivalent. **[U]** This is the single question that gates any revival (§6.1).
 
 ## 3. Structural cost in orca's runtime
 
-The reader machinery generalises better than first assumed; the **one-shot
-latches** are the real problem.
+The reader machinery generalises; the **one-shot latches** are the problem.
 
 - **`settledOutcome` is a single-write `Option`** with a first-write-wins
   invariant (`ForkedConversation.scala:105-121`). Under N turns on one stream, a
@@ -115,12 +114,12 @@ latches** are the real problem.
   bindings"* — this change redefines "the conversation" as "the whole flow". **[V]**
 - **`StderrPipeline.onFinalize` joins the stderr fork unboundedly**, and its own
   comment records that the tree kill which would unblock it runs *downstream* of
-  the finalize (`StderrPipeline.scala:60-71`). **[V]** Today the blast radius is
-  one turn's descendants; under this change it is every descendant accumulated
-  over the session — i.e. **exactly the background work the proposal exists to
-  keep alive**. Benefit (a) and this deadlock are the same mechanism. This is the
-  hazard the direct-style-scala subprocess chapter is about, already live in the
-  repo, made structural by the change.
+  the finalize (`StderrPipeline.scala:60-71`). **[V]** Today this reaches one
+  turn's descendants; under this change it reaches every descendant accumulated
+  over the session — **exactly the background work the proposal exists to keep
+  alive**. Benefit (a) and this deadlock are the same mechanism. The
+  direct-style-scala subprocess chapter covers this hazard; it is already live in
+  the repo, and this change makes it structural.
 - **Every successful turn currently SIGINTs the process** — `succeedWith` and
   `failWith` end in `source.interrupt()` (`ForkedConversation.scala:295-329`) and
   `StreamSource.fromProcess.interrupt()` is `process.sendSigInt()`
@@ -211,8 +210,8 @@ conversations are ephemeral by construction — `agent.chat()` mints a **fresh**
 `SessionId` (`Agent.scala:77`), used by the unbounded
 `CheckedPar.mapParUnordered(tasks.size)` fan-out over 8 reviewers plus lint
 (`ReviewLoop.scala:429, 510`; `Reviewers.scala:78-87`) — so they were never
-candidates. Scoping to `FlowSession` and excluding `Chat` is a clean boundary,
-not an inconsistency.
+candidates. Scoping to `FlowSession` and excluding `Chat` is therefore a clean
+boundary.
 
 ---
 
@@ -333,8 +332,7 @@ Only under all of these:
   immediately after writing the opening turn; `ClaudeConversation.respond`
   (`:278-285`) later writes a `control_response` to it, and
   `OsProcCliRunner.scala:159-163` writes to the closed stream. The defect is
-  real, but **the trigger first named for it was wrong**, and it is worth being
-  precise about which path reaches it:
+  real, but **the trigger first named for it was wrong**. Which path reaches it:
   - Not the `Deny` branch. `Conversations.scala:105-116` responds `Deny` to
     `ApproveTool`, but that event is only enqueued when
     `ClaudeConversation.autoApproves(name)` is false (`:243-252`), which under
@@ -348,8 +346,8 @@ Only under all of these:
     `control_request` frame appears in any of the baseline run's ten reviewer
     transcripts. **[M]**
 
-  So the write-after-close is unreachable-in-practice rather than latent-and-
-  waiting, and the code that would exercise it is code that cannot work at all.
+  So the write-after-close is unreachable in practice rather than latent, and
+  the code that would exercise it cannot work at all.
   Unit tests cannot catch it: the fake is lenient about writes after close
   (`FakePipedCliProcessTest.scala:65-69`). Not verified live. **[V]/[I]**
 - **`StderrPipeline.onFinalize`'s unbounded join** (`:60-71`) is a real

--- a/docs/research/run-cost/07-persistent-cli-session.md
+++ b/docs/research/run-cost/07-persistent-cli-session.md
@@ -1,0 +1,324 @@
+# One CLI process per durable session — findings (T1.4)
+
+Investigation of holding a single agent CLI process open across the turns of a
+durable session, instead of today's fresh process per turn with stdin closed.
+
+**Recommendation: NO-GO as proposed**, on two independent grounds:
+
+1. The primary shipped flow **cannot run** on a held-open claude process —
+   `--json-schema` is argv-side and a durable session alternates between
+   schema'd and un-schema'd turns (§2).
+2. The headline cost benefit is **not supported by measurement** (§1), so the
+   change would be bought on reliability grounds alone — and its reliability
+   benefit shares a mechanism with a deadlock already documented in the code (§3).
+
+T1.4's own declared gate, T1.3, is also still open, and a persistent process
+makes T1.3's failure mode the *normal* case on every turn boundary (§4).
+
+Method: two independent researchers over the codebase, a skeptic round against
+their findings, and live probes against the installed CLIs (claude 2.1.220).
+Where the researchers and the skeptic disagreed, §7 records who was taken and why.
+
+Evidence tags: **[V]** read in the code, **[M]** measured by probe, **[I]**
+inferred, **[U]** unknown.
+
+---
+
+## 1. The cost benefit is not supported
+
+This was the load-bearing justification (cache writes were 46% of the baseline
+run), so it was measured rather than argued.
+
+**Controlled comparison.** Two arms, three turns each, **distinct** ~79k-token
+content per arm, `--resume` arm run first so it could not inherit the other's
+cache: **[M]**
+
+| arm | turn 1 `cache_creation` | turn 2 | turn 3 | **total** |
+|---|---|---|---|---|
+| per-turn spawn + `--resume` (orca today) | 57,426 | 239 | 125 | **57,790** |
+| one held-open process | 56,646 | 430 | 12 | **57,088** |
+
+A 1.2% difference. The cold-start write is the same in both arms, and the
+marginal per-turn write is small in both. The mechanism is that `--resume`
+re-sends the same prefix and the cache is *read*, not re-created.
+
+**What this does and does not establish.** It establishes that for cache writes
+driven by **conversation growth**, process lifetime is irrelevant. It does **not**
+cover the regime the baseline actually ran in: the implementer averaged 213k
+tokens and ~5,900 cache-write tokens per turn, and much of that growth happens
+*inside* a turn as tool results land (`Conversations.scala:138-143` notes tool
+output volume is unbounded). Every probe here has **zero tool use**, so it cannot
+reproduce intra-turn growth. **[M]/[U]**
+
+No mechanism has been identified by which a held-open process would write less in
+that regime — tool results grow the prefix identically either way — but that is an
+argument, not a measurement. The honest position is **"not supported", not
+"refuted"**, and the experiment that would settle it is in §6.
+
+Either way this points the same direction as the plan's existing conclusion: the
+levers are **prefix size and turn count**, not process lifetime. It also closes
+T1.5 to the extent that per-turn teardown is *not* the cause of the 2.0M
+cache-creation figure.
+
+---
+
+## 2. The blocker: per-turn config is argv, and the primary flow varies it
+
+`ClaudeArgs.streamJson` (`claude/.../ClaudeArgs.scala:28-51`) encodes **model,
+permission-mode/toolset, auto-approve, `--json-schema`, `--mcp-config` and
+`--append-system-prompt-file`** in argv — all therefore frozen at spawn for the
+life of a held-open process. **[V]**
+
+That would be tolerable if a durable session used one shape throughout. It does
+not. In every shipped implement-style flow the coder's durable session alternates
+between:
+
+- free-form turns — `flows/implement.sc:35` → `session.run(task.description)`,
+  no schema; and
+- structured turns — `ReviewLoop.scala:610-611` →
+  `coderSession.resultAs[FixOutcome]`, which adds `--json-schema`. **[V]**
+
+`reviewAndFixLoop` receives that same `coderSession` (`ReviewLoop.scala:221`,
+`:306`), so this is the primary code path, not a corner case.
+
+Some of these *may* be settable over claude's control channel — the repo already
+speaks that protocol (`ClaudeConversation.scala:278-285`) — but `--json-schema`,
+`--mcp-config` and `--append-system-prompt-file` have no documented per-message
+equivalent. **[U]** This is the single question that gates any revival (§6.1).
+
+---
+
+## 3. Structural cost in orca's runtime
+
+The reader machinery generalises better than first assumed; the **one-shot
+latches** are the real problem.
+
+- **`settledOutcome` is a single-write `Option`** with a first-write-wins
+  invariant (`ForkedConversation.scala:105-121`). Under N turns on one stream, a
+  stray or misattributed `result` frame settles the **session**, not just the
+  turn. This is where §4's T1.3 hazard bites. **[V]**
+- **`runFinalize` is one-shot**, guarded by an `AtomicBoolean`
+  (`ForkedConversation.scala:487-494`). Every per-turn resource released there
+  becomes session-lifetime: the `--append-system-prompt-file` temp file
+  (`ClaudeConversation.scala:86-91`) and the `ask_user` MCP bundle (`:494`).
+  `ClaudeBackend.scala:41-43` states the MCP server's *"lifetime tracks the
+  conversation … so a long flow with many interactive calls doesn't leak Netty
+  bindings"* — this change redefines "the conversation" as "the whole flow". **[V]**
+- **`StderrPipeline.onFinalize` joins the stderr fork unboundedly**, and its own
+  comment records that the tree kill which would unblock it runs *downstream* of
+  the finalize (`StderrPipeline.scala:60-71`). **[V]** Today the blast radius is
+  one turn's descendants; under this change it is every descendant accumulated
+  over the session — i.e. **exactly the background work the proposal exists to
+  keep alive**. Benefit (a) and this deadlock are the same mechanism. This is the
+  hazard the direct-style-scala subprocess chapter is about, already live in the
+  repo, made structural by the change.
+- **Every successful turn currently SIGINTs the process** — `succeedWith` and
+  `failWith` end in `source.interrupt()` (`ForkedConversation.scala:295-329`) and
+  `StreamSource.fromProcess.interrupt()` is `process.sendSigInt()`
+  (`StreamSource.scala:68`). But `interrupt()` is a **per-source policy**
+  (`StreamSource.scala:28-33`) and the class already contemplates a source that
+  outlives a turn (`:290-294`, the SSE case), so this is a new `StreamSource`
+  implementation, not a rewrite. **[V]**
+- **`FlowSession` has no lexical span.** It must be minted *outside* any stage
+  (`OutsideStage`, `Session.scala:28-30`, runtime throw at `:180-185`) and closed
+  over into arbitrarily many later stages (`:50-54`). There is therefore no
+  lexical region corresponding to "the session" in which to put the `supervised`
+  block the chapter requires. The chapter's prescribed shape —
+  `run(...)(use: Handle => T)` — would change the signature of
+  `agent.session(name, seed)` and every user flow script. **[V]**
+- **Concurrent access is not excluded by the owner-thread assert.**
+  `FlowSession.run` asserts owner-thread (`Session.scala:84, 129`), but
+  `Session.scala:44-48` documents the deliberate escape hatch:
+  `agent.chat(session.id)` adopts the same session id from inside a fork.
+  `Agent.scala:79-85` adds *"One live continuation at a time: concurrent turns
+  against the same backend conversation fail."* Today that spawns a second
+  `--resume` process; with an always-live process it collides on stdin. **[V]**
+- **`Dispatch` cannot express "live in this process"** — it is `Fresh | Resume`
+  only (`SessionSupport.scala:20-23`) — and `willContinue` (`:153-161`) means
+  "a transcript exists on disk" (claude's probe is `os.exists(...)`,
+  `ClaudeBackend.scala:103-110`), which is not liveness. With a live process,
+  `willContinue` returns `true` for a session whose process has died, and
+  `Session.effectivePrompt` (`:319-343`) then skips re-seeding into a corpse. **[V]**
+- **Cost accounting would break silently.** The reported figure is preferred
+  (`InboundMessage.scala:90` → `Pricing.resolve`) and `CostTracker` **sums** it
+  (`flow/.../CostTracker.scala:63, 80-81`) **[V]**; on a held-open process
+  claude's `total_cost_usd` is **cumulative for the session** (0.02138 → 0.02560
+  → 0.02882, increments matching per-process figures) **[M]**. Left alone this
+  over-counts quadratically — corrupting the measurements Epic 0 exists to
+  produce.
+- **`EnvCookieSweep.afterTurn`** is keyed on the per-spawn cookie
+  (`Conversations.scala:194`); a per-session process makes the per-turn leak
+  report name the agent's own live process. opencode already needed this
+  accommodation (`StreamSource.scala:52-59`). **[V]**
+- **PR #47's shipped system-prompt rule becomes false.** The composed prompt
+  tells agents the harness is torn down each turn and long commands must run in
+  the foreground. It and its four string-pinning assertions in
+  `SystemPromptComposerTest` would have to be retracted in the same change. **[V]**
+- **Ox is pinned at 1.0.5** (`project/Dependencies.scala:10`);
+  `abandonOnInterruptReads` needs ≥ 1.0.6. A one-line bump, but today
+  destroy-then-EOF is the only mitigation and this change removes it from the
+  turn boundary. **[V]**
+
+---
+
+## 4. The declared gate, T1.3, is unmet — and this change makes it worse
+
+`01-development-plan.md:133, 423` — *"Depends on T1.3"*, *"T1.3 gates T1.4."*
+T1.3 is still `[TODO]`: on `--resume` the CLI emits a `result` with
+`is_error: true` ~70 ms **before** orca's prompt reaches stdin, and orca settles
+on it.
+
+Under a persistent process, "which `result` belongs to which prompt" stops being
+a `--resume` edge case and becomes the **normal question at every turn
+boundary** — against a `settledOutcome` that can only be written once (§3).
+Attribution must be solved before, not after.
+
+---
+
+## 5. Backend coverage and the fan-out
+
+| Backend | Transport | Multi-turn on one process? |
+|---|---|---|
+| claude | `--print --input-format stream-json` | **yes** — verified **[M]** |
+| pi | `--mode rpc`; orca already holds stdin open *within* a turn under a lock (`PiConversation.scala:60-74, 153-156`) | plausible; the RPC loop survived two prompts, credentials blocked confirming context carry-over **[M]/[U]** |
+| codex | prompt on argv, stdin closed (`CodexBackend.scala:201-204`) | **no** — ADR 0007:51-56, `codex exec --help` **[V]** |
+| gemini | prompt on argv (`GeminiBackend.scala:161-169`); `-o stream-json` is output-only | **no** on the path orca uses; `--acp` exists, unused **[V]** |
+| opencode | HTTP + SSE against a per-run `opencode serve` | **already has the property** **[V]** |
+
+Claude probe detail: two user messages 25 s apart on one held-open stdin were
+both answered, sharing one `session_id`, with context carried ("BANANA" recalled
+on turns 2 and 3), the first `result` arriving 4.79 s in **with stdin still
+open**. **[M]**
+
+**The fan-out cannot share a process, and need not.** Two messages 0.2 s apart on
+one stdin are **serialised** by the CLI, not interleaved. **[M]** But reviewer
+conversations are ephemeral by construction — `agent.chat()` mints a **fresh**
+`SessionId` (`Agent.scala:77`), used by the unbounded
+`CheckedPar.mapParUnordered(tasks.size)` fan-out over 8 reviewers plus lint
+(`ReviewLoop.scala:429, 510`; `Reviewers.scala:78-87`) — so they were never
+candidates. Scoping to `FlowSession` and excluding `Chat` is a clean boundary,
+not an inconsistency.
+
+---
+
+## 6. What remains unknown, and the experiment for each
+
+1. **Can `--json-schema` / model / permission-mode be varied per message over the
+   control channel?** Gates everything (§2). *Experiment:* drive one held-open
+   `claude --print --input-format stream-json` and attempt each override. ~30
+   minutes, and it decides the ADR. If `--json-schema` cannot change, this is
+   dead for claude as proposed.
+2. **Does the cache result hold at 213k with tool use?** (§1.) *Experiment:*
+   distinct freshly-generated content per arm, randomised interleaved arm order,
+   ≥3 replicates, ≥200k prefix, **real tool calls producing multi-KB results**,
+   plus a >1h-gap arm; report `usage` with `Option` presence distinguished from
+   zero. Success criterion: does the per-turn difference approach the baseline's
+   ~5,900 tokens/turn? Better still, skip the synthetic probe — T0.2's per-turn
+   prompt-size record over a T0.3 benchmark flow answers this on real traffic.
+3. **Does claude's stream-json input have a per-turn abort that leaves the
+   process alive?** Nothing bounds a turn today — no timeout anywhere in
+   `agents/` or `backend/` **[V]**, and `OpencodeBackend.scala:51-54` says so
+   outright. Today the backstop is process exit: EOF ends the reader and
+   `outcomeFromExit` produces an outcome. A persistent process never EOFs.
+   *Experiment:* start a long tool call, send a candidate control frame, observe
+   whether the turn aborts and the process survives.
+4. **Does the session-teardown deadlock in §3 actually fire?** *Experiment:* hold
+   a claude process open, have it spawn a non-detached background child holding
+   the stderr write-end, tear the session down, and see whether
+   `StderrPipeline.onFinalize`'s unbounded join hangs.
+5. **Can a second message be written while a turn is in flight?** All probes
+   waited for `result`. *Experiment:* write message 2 ~1 s after message 1.
+6. **Does pi accept a second `prompt` after `agent_end`, with context carried?**
+   *Experiment:* re-run the two-prompt RPC probe with a pi provider key.
+7. **Do 9 persistent processes with growing contexts change the memory /
+   rate-limit profile?** *Experiment:* measure RSS and rate-limit headers across a
+   full `reviewAndFixLoop` round.
+
+---
+
+## 7. Where the researchers and the skeptic disagreed
+
+- **"The cache benefit is refuted" vs "unpowered null."** Skeptic taken,
+  partially. The first probes (~30k, writes of 18–430) were indeed too small to
+  detect a ~5,900/turn effect. The controlled 79k run answers that objection for
+  growth-driven writes, but the skeptic's deeper point — zero tool use, so no
+  intra-turn growth — stands. Recorded as **not supported** rather than refuted,
+  with the experiment named. The recommendation does not depend on it: §2 is an
+  independent blocker.
+- **"`runReader` needs a rewrite" vs "a new `StreamSource` suffices."** Skeptic
+  taken. `interrupt()` is per-source policy and the class already documents an
+  SSE source outliving a turn (`ForkedConversation.scala:290-294`). The genuine
+  structural items are `settledOutcome`'s single write and `runFinalize`'s
+  one-shot guard — which the research missed and the skeptic found.
+- **"Background work already survives, so benefit (a) is hollow."** Skeptic
+  taken. Detached work (`nohup`/`setsid`) escapes today — that is why PR #62
+  exists — but the default an agent writes, `cmd &`, is a non-detached descendant
+  that `destroyForciblyTree()` does kill (`StreamSource.scala:74`). Benefit (a)
+  is real. The correct objection is §3's: the mechanism that lets that work
+  survive is the same one that hangs the stderr join at session end.
+- **"Ctrl-C would orphan a long-lived agent."** Skeptic taken; the research
+  overstated it. `ChildTerminal.scala:22-41` documents that there is **no
+  `setsid` anywhere in the launch chain**, so the agent CLI shares the shell's
+  foreground process group and Ctrl-C reaches it directly. The orphan window is
+  SIGKILL/SIGTERM only.
+- **Cross-process cache sharing.** Neither side settled it. An uncontrolled run
+  showed a fresh `--resume` process paying `cache_creation = 0` for a 128k prefix
+  a prior process had just written, but the skeptic correctly noted the arithmetic
+  is equally consistent with other explanations. Dropped — the controlled run in
+  §1 does not rely on it.
+
+---
+
+## 8. If it is ever revisited
+
+Only under all of these:
+
+1. **§6.1 resolves favourably.** Otherwise stop.
+2. **T1.3 is answered first** — turn attribution is a prerequisite, not a
+   follow-up (§4).
+3. **Justified on reliability, never on cost**, unless §6.2 overturns §1.
+4. **Scoped to `FlowSession` on claude only**, leaving `Chat`, the reviewer
+   fan-out, codex and gemini on process-per-turn; opencode needs nothing.
+5. **`--resume` retained as the recovery path**, with `resumeWireId` still
+   persisted every turn — a live process cannot survive an orca restart, so this
+   change converts `--resume` from the steady-state path to the cold-start path
+   rather than removing it.
+6. **These land first, each independently useful:** a per-turn timeout; a
+   `CostTracker` that does not sum cumulative cost fields; Ox ≥ 1.0.6; and a fix
+   for `StderrPipeline.onFinalize`'s unbounded join.
+7. **Modelled on `OpencodeServer`**, which already solves this shape correctly:
+   lazily-spawned, run-scoped, idempotent `shutdown()`, drains in the flow scope,
+   teardown in the flow body's `finally` before the join
+   (`OpencodeServer.scala:14-27, 63-80`; `flow.scala:326-337`).
+
+### ADR-worthy decisions, if it proceeds
+
+- **Process lifetime** — per `FlowSession`, spawned lazily on first turn, closed
+  at flow teardown via the `ctx.close()` seam.
+- **Cancellation** — a per-turn abort distinct from session teardown; today
+  `succeedWith`'s `source.interrupt()` conflates them.
+- **Crash recovery** — unchanged: `--resume` from the persisted `resumeWireId`.
+  A live process is an optimisation over that path, never a replacement.
+- **A turn that never ends** — an explicit per-turn deadline, and a defined answer
+  for whether a timed-out turn kills the session or only the turn.
+
+---
+
+## 9. Corrections to make regardless of this proposal's fate
+
+- **Stale claim, twice.** `ClaudeBackend.scala:154-157` and the
+  `PipedCliProcess` trait contract at `CliProcess.scala:34-38` both state that
+  claude needs stdin EOF before it produces output. Measured false at 2.1.220
+  (first `result` at 4.79 s, stdin open) **[M]**, and already contradicted in
+  passing by ADR 0007:51-56. The SPI docs are the more important of the two.
+- **`ProgressLog.scala:75-76`** says pi's sessions live in a `deleteOnExit` temp
+  dir so a resumed run always re-seeds; `PiBackend.scala:67-68` and ADR 0018's
+  2026-07-28 amendment say pi is durable. **[V]**
+- **Latent write-after-close.** `ClaudeBackend.scala:221` closes stdin;
+  `ClaudeConversation.scala:284-285` later writes a `control_response` to it, and
+  `OsProcCliRunner.scala:159-163` writes to the closed stream. Reachable on the
+  autonomous path — `Conversations.scala:105-116` responds `Deny` to
+  `ApproveTool`. Unit tests cannot catch it: the fake is lenient about writes
+  after close (`FakePipedCliProcessTest.scala:65-69`). Not verified live. **[I]**
+- **`StderrPipeline.onFinalize`'s unbounded join** (`:60-71`) is a real
+  mis-sequencing today for codex/gemini/pi, independent of this proposal.

--- a/docs/research/run-cost/08-re-review-payload.md
+++ b/docs/research/run-cost/08-re-review-payload.md
@@ -1,0 +1,302 @@
+# T2.5 — Should the re-review prompt carry more payload?
+
+Investigates whether `re-review.md` should carry the fixer's `FixOutcome`, a
+diff, or anything else beyond the eight lines it sends today. Read-only: no code
+changed.
+
+The short answer: **send the fixer's `ignored` list, not its `fixed` list, and
+prioritise a diff over both.** The reasoning, and the measurement behind it,
+follow.
+
+## 1. What the re-review prompt carries today
+
+`ReviewLoopPrompts.ReReview` (`ReviewLoopPrompts.scala:75-76`) is
+`PromptResource.load`, not `render` — the resource has no placeholders and
+nothing is interpolated into it. The whole payload is:
+
+> Fixes have been applied to the working tree based on your earlier review.
+> Re-review the current state — focus on whether your earlier findings were
+> addressed and on any new issues introduced by the fix. Stay scoped to the same
+> changes you reviewed initially; do not expand to unrelated files. If nothing in
+> your scope still applies, report no issues.
+>
+> The confidence contract from the initial prompt still applies: the probability
+> the finding is real, on the evidence you gathered — not deference to the plan.
+
+`resumeReview` (`ReviewLoop.scala:415-419`) sends exactly that text plus the
+structured-output schema preamble. No diff, no issue list, no fix outcome, no
+list of files touched.
+
+### The resumed reviewer receives no diff at all — including after #59
+
+This is the finding that reframes the rest. `runReviewersAndLint` samples the
+diff only when some active reviewer has no session yet:
+
+```scala
+val needsDiff = active.exists(e => storedFor(e).isEmpty)   // ReviewLoop.scala:477
+val currentDiff = if needsDiff then sampleDiff() else ""   // ReviewLoop.scala:478
+```
+
+Under every shipped selector, `needsDiff` is false from round 2 onward:
+
+- `agentDriven` computes its pick once and returns the constant arrow
+  `_ => active` (`ReviewerSelector.scala:178`);
+- `narrowingAcrossRounds` only *filters* that pick, and its floor falls back to
+  the same pick rather than to the roster (`ReviewerSelector.scala:203-221`);
+- `allEveryRound` returns `all` every round (`ReviewerSelector.scala:67`).
+
+So the active set at round N is always a subset of round 1's, every member of
+which already holds a session. The re-sampled diff never reaches anybody.
+
+The consequence for this task: **#59 changed round 1 and left follow-up rounds
+untouched.** The scaladoc's "a reviewer joining the active set on iteration N
+sees the earlier fixes too" (`ReviewLoop.scala:262-266`, `:374-376`) describes a
+path only a custom selector can reach. The premise the T2.5 hypothesis was built
+on — reviewers rediscovering the change set by hand every round — is still
+exactly true from round 2 on.
+
+Two smaller observations while in the prompt resources:
+
+- `initial-review.md:7` still labels its payload "Diff (working tree vs HEAD at
+  the start of the review loop)". #59 made that false: the diff is now
+  stage-base-relative. T2.2's done-when asked for this line and it is unfixed.
+- `select-reviewers.md:8` still tells the picker to try `git diff HEAD`, which
+  is the sampling decision #59 abandoned.
+
+## 2. Is the fix outcome absent, or merely implicit?
+
+Genuinely absent. Traced end to end:
+
+- produced at `ReviewLoop.scala:606-612` (`coderSession.resultAs[FixOutcome]`);
+- consumed in `run()` only as `outcome.fixed.size` / `outcome.ignored` for the
+  display line and the accumulated `IgnoredIssues` (`ReviewLoop.scala:698-711`),
+  and by `unaccountedFor` at the halt exit (`:633-644`);
+- `fixLoop`'s state-free variant does the same (`:92-99`).
+
+No prompt resource interpolates it — `fix.md` is the fixer's own brief, not
+anything a reviewer sees. A grep for `FixOutcome` across `flow/src/main` returns
+only these sites plus the type's own definition.
+
+The only trace that escapes the loop is `orca.display("Fixed N, ignored M")` —
+counts, no titles — and that goes to the event log, not into any agent's prompt.
+Reviewer sessions are minted with a bare `e.agent.withRole(...).chat()`
+(`ReviewLoop.scala:429`), with no seed and no progress preamble, so nothing
+reaches them by that route either.
+
+## 3. What the resumed session can be relied on to hold
+
+It is a `--resume` of the reviewer's own CLI session, so it holds:
+
+- its system prompt (the reviewer's identity);
+- the round-1 `initial-review` prompt **including the round-1 diff**;
+- every tool call and result it made in earlier rounds;
+- its own earlier findings, verbatim, as structured output.
+
+It does **not** hold, and cannot derive without spending tool calls:
+
+- what the fixer did, or claimed to do, about any finding;
+- the fixer's reason for declining a finding — not recoverable from the tree at
+  any price;
+- which files changed since its last round.
+
+Two reliability caveats on "session memory", both observed:
+
+- **Context compaction.** Not observed in the baseline (zero compaction events
+  across the ten reviewer sessions), but those loops ran 3–5 rounds. The shipped
+  `maxIterations = 10` permits 11 rounds on an Opus session already carrying
+  ~400k tokens of prefix; at compaction the round-1 diff becomes a summary.
+- **Resume leftovers.** `No response requested.` appears 30 times across the ten
+  reviewer transcripts — the T1.3 pre-prompt `result` defect, live inside
+  reviewer sessions specifically.
+
+## 4. What a follow-up round costs
+
+**No post-change measurement exists.** Every manifest under `.orca/cache/runs/`
+is `manifestVersion: 2`; #61's schema v3 has not been exercised by a run yet, so
+there is no per-turn record for the current code. Nothing below measures today.
+
+What follows is the baseline run of 2026-08-01 (`outcome: failed`), reconstructed
+from the ten reviewer transcripts it produced — two tasks, ten reviewer sessions,
+40 review rounds — under the pre-#59/#48 regime. Counts are deduped by assistant
+message id: the CLI writes one transcript line per content block and repeats the
+same `usage` on each, so a naive sum roughly triples the tokens.
+
+| | n | tool calls (mean / median) | LLM messages | cache write | cache read | output | est. $/reviewer |
+|---|---|---|---|---|---|---|---|
+| round 1 (initial) | 10 | 11.3 / 9.5 | 10.3 | 37.3k | 399k | 7.2k | 0.75 |
+| round 2 (first re-review) | 10 | 10.3 / 10.5 | 10.3 | 63.2k | 576k | 8.9k | 1.14 |
+| rounds ≥3 | 20 | 4.35 / 4.0 | 4.7 | 9.1k | 397k | 2.8k | 0.36 |
+
+Dollar figures are estimates at the shipped `claude-opus-5` card
+(`Pricing.scala:159-164`; write $10/M, read $0.50/M, output $25/M) — the CLI's
+own `total_cost_usd` is not recorded per assistant message. The three rows sum to
+~$26 across these ten sessions against a $44.64 run, which is the sanity check
+that the reconstruction is in the right range.
+
+**What the calls are spent on** — every `Bash` command, classified:
+
+| | git status/diff/log/show | read & search (rg, grep, sed, …) |
+|---|---|---|
+| round 1 | 39 | 35 |
+| round 2 | 21 | 41 |
+| rounds ≥3 | **38** | 15 |
+
+Round 2 is dominated by reading code. Rounds ≥3 invert: **68% of shell calls are
+reconstructing what changed**, at ~1.9 git calls per round out of 4.35 tool calls
+— one of which is the mandatory `StructuredOutput` call. The floor for a round
+that verifies nothing is 2 calls; the observed minimum is 2.
+
+A representative round in full (the `performance` reviewer, round 3 of task 1):
+
+```
+Bash  git status --porcelain=v1 && echo "---" && git diff HEAD --stat
+Bash  git diff HEAD -- runner/.../FlowLifecycle.scala flow/.../ProgressScan.scala
+TEXT  "Re-reviewed the current working tree. The only change since my last pass
+       is in FlowLifecycle: busyBranchHeader became busyBranchLog …"
+StructuredOutput  {"issues": []}
+```
+
+Two of three calls reconstruct a delta orca already knows, and the reviewer's own
+words name what it wanted: *the change since its last pass*.
+
+## 5. Does the original 9.3-vs-4.2 evidence survive?
+
+**It reproduces, and it survives — for the wrong reason — but it is
+mis-grouped.**
+
+- *Reproduces.* Round 1's median of 9.5 tool calls and rounds ≥3's mean of 4.35
+  match the 9.3/4.2 figures closely enough that they are plainly the same
+  measurement.
+- *Mis-grouped.* Splitting "follow-up" at round 2 hides that round 2 is the most
+  expensive round in the loop — 10.3 tool calls and, because it re-reads the
+  fixer's edits into a grown prefix, ~$1.14 per reviewer against round 1's ~$0.75.
+  "Follow-up rounds are cheap" is true only from round 3.
+- *Survives #59.* The brief expected it not to. But #59 cannot reach a resumed
+  reviewer (§1), so the rounds-≥3 figure describes today's code as well as it
+  described the baseline. Round 1 should fall — it now gets a real diff instead
+  of `(no diff captured)` — and round 2 may fall a little, since the round-1 diff
+  is now in session. Round 3 onward should not move at all.
+- *Survives #48, with a caveat.* Narrowing changes *how many* reviewers run in
+  later rounds, not what each one does. The per-reviewer figure stands; the
+  per-round aggregate falls by whatever fraction goes quiet. In the baseline's
+  first task, all five reviewers ran all five rounds; under narrowing that set
+  would have shrunk.
+
+So: treat 4.2 tool calls per reviewer per follow-up round as still live. Treat
+any *aggregate* extrapolated from it as stale.
+
+## 6. Recommendation
+
+**(a) Do not send the `fixed` titles.** Three reasons, in order of weight:
+
+1. It answers the question the round exists to ask. A reviewer told "your finding
+   was fixed" is being handed the conclusion it was convened to reach
+   independently. `initial-review.md:35-40` already has a section — "The plan is
+   not evidence" — establishing that a claim about the code is not evidence about
+   the code. A fixer's `fixed` list is the same class of claim, from an agent
+   with an interest in the answer.
+2. It endangers the two properties ADR 0011 depends on. The confidence gate wants
+   "your estimated probability … judged only on the evidence you gathered by
+   reading the code"; a prior from the fixer corrupts that number in a way the
+   gate cannot detect, because a confident rubber stamp and a confident
+   verification are the same float. And the shipped selector's rationale — "it's
+   the reviewer that reported which has to check the fix it triggered"
+   (`ReviewerSelector.scala:52-53`) — is precisely the check being softened.
+3. It saves nothing measurable. The reviewer must open the code either way; a
+   title tells it neither which file to open nor what changed. It removes zero of
+   the 1.9 git calls per round.
+
+**(b) Do send the `ignored` titles with their reasons.** This is the opposite
+case on every axis. It is small (typically 0–3 entries, ~50–150 tokens), and it
+is the one thing in the loop that is **not recoverable from the tree at any
+price**: no amount of reading tells a reviewer that the fixer considered a
+finding a deliberate trade-off. Today the reviewer re-reports the finding, the
+fixer re-declines it, and the round is spent — and because the loop keeps
+iterating while `fixed` is non-empty, that exchange can repeat for the life of
+the loop. Frame it as the fixer's position, not a verdict: *"the fixer declined
+these, with its stated reason; if you still think the finding is real, report it
+again and say why the reason is wrong."* That keeps the disagreement possible,
+which is what makes it safe.
+
+**(c) The larger lever is a diff, not the fix outcome.** Hand the resumed
+reviewer the change since its own previous round. That is what 38 of 56 late-round
+shell calls reconstruct by hand, and what the exemplar round spends two of three
+calls on. Unlike `fixed`, a diff is evidence rather than a claim, so it does not
+touch the confidence gate at all — it is the same kind of payload round 1
+already gets.
+
+It also closes a live correctness hole, not just a cost one. A resumed reviewer
+falls back to its own `git diff HEAD`, which is **empty the moment the fixer
+commits** — the exact failure #59 removed from round 1 and left standing on the
+follow-up path. `RuntimeOwnsGit` (`SystemPromptComposer.scala:31-32`) tells the
+fixer not to commit and was in force during the baseline, where the work was
+committed anyway. A reviewer whose `git diff HEAD` comes back empty concludes
+nothing changed and reports clean; nothing downstream can tell that apart from a
+real all-clear.
+
+Mechanism note, unverified: `reviewDiff(since)` already accepts any commit-ish
+and already splices untracked file contents (`GitTool.scala:573-574`), so the
+missing piece is a per-round snapshot to diff against. A tree object written
+through a throwaway index (`GIT_INDEX_FILE=<tmp> git add -A && git write-tree`)
+gives one without touching HEAD, the real index, or the working tree, and
+`reviewDiff(Some(previousTree))` then reads as "everything that changed since
+your last round". Whether ignore rules make that snapshot agree with
+`untrackedPaths()` was not checked.
+
+**Ordering.** (b) is a prompt-and-plumbing change of a few lines and can ship on
+its own. (c) needs a `GitTool` addition and touches `ReviewLoopState`, so it
+belongs with Epic 2's remaining work — and it must not ship before T2.4 decides
+the diff-size policy, since an uncapped per-round delta can cost more than the
+two tool calls it removes.
+
+## 7. The risk to review quality, stated plainly
+
+- **Rubber-stamping** is the real risk, and it is why (a) is a refusal rather
+  than a "measure it first". A reviewer that clears a finding because it was told
+  the finding was fixed produces the same output as one that verified — the loop
+  cannot distinguish them, and the failure mode is silent approval of unfixed
+  code. That is the outcome the baseline run already reached by another route
+  (agents reporting "fixed" on builds they never saw, per Epic 1).
+- **Attention narrowing** is the risk in (c). A reviewer handed "here is what
+  changed since your last round" may stop checking whether its *earlier* finding
+  is still open somewhere the delta does not touch. Mitigation is wording, not
+  mechanism: the delta is additional context, the round-1 diff stays in session,
+  and the prompt should say earlier findings stand until the reviewer can see
+  they were addressed.
+- **Token cost** in (c) is unbounded today, exactly as T2.4 records for the
+  initial diff. A fixer that reformats a file sends a delta larger than the round
+  it was meant to shrink.
+- **(b)'s risk is mild but real**: a reviewer may treat the fixer's reason as
+  settling the matter. The wording above is what keeps it from doing so, and
+  unlike (a) the underlying fact is one the reviewer could not have obtained by
+  working harder.
+
+## 8. What would settle the rest
+
+Nothing here measures the current code, and nothing can until T0.3's checked-in
+benchmark flow exists — run-to-run variance in a real task exceeds every effect
+in this document. With that flow and a v3 manifest, one experiment settles all
+three questions at once:
+
+**Three arms over the same seeded flow**, identical in everything but
+`re-review.md`: control · `+ignored`-with-reasons · `+delta-diff`.
+
+- *Cost*, from the manifest alone: per-reviewer follow-up-round turn count and
+  `promptTokens`, split at round 2 versus rounds ≥3 (the split this document
+  shows the earlier figures blurred). Predicted: the delta arm removes ~2 tool
+  calls per reviewer from rounds ≥3 and nothing from round 2.
+- *Convergence*, for the `ignored` arm: rounds to termination, and the count of
+  findings re-reported after being declined. If the reasons work, both fall.
+- *The harm*, which is the measurement that actually matters and is the reason
+  to add a fourth `+fixed` arm even though §6(a) recommends against shipping it:
+  count how often a reviewer clears one of its own findings **in a round where
+  the file it named did not change**. That is a rubber stamp with no innocent
+  explanation, it is computable from the delta diff plus the round's issue lists,
+  and it is the only signal that separates a cheaper loop from a blinder one. If
+  the `+fixed` arm's rate rises above control's, the refusal in §6(a) is
+  confirmed rather than merely argued.
+
+Two things the experiment will not settle, and that need judgement instead: how
+large a real fixer delta is in a repo like this one (a T2.4 input), and whether
+compaction ever eats the round-1 diff in a loop that runs to the shipped
+`maxIterations = 10`.

--- a/docs/research/run-cost/08-re-review-payload.md
+++ b/docs/research/run-cost/08-re-review-payload.md
@@ -4,9 +4,17 @@ Investigates whether `re-review.md` should carry the fixer's `FixOutcome`, a
 diff, or anything else beyond the eight lines it sends today. Read-only: no code
 changed.
 
+Source read at `59597ca5`. Every measurement below is over the baseline run of
+2026-08-01 (`.orca/cache/runs/1785572076039-880497.json`) and the ten non-lint
+reviewer transcripts it produced.
+
 The short answer: **send the fixer's `ignored` list, not its `fixed` list, and
 prioritise a diff over both.** The reasoning, and the measurement behind it,
 follow.
+
+**Open PRs this document is written against.** #72 (resumed-reviewer diff) is
+open and changes the ground under §1, §5 and §6(c); the markers below say what
+becomes stale if it lands first, and are correct whichever order is taken.
 
 ## 1. What the re-review prompt carries today
 
@@ -28,6 +36,12 @@ structured-output schema preamble. No diff, no issue list, no fix outcome, no
 list of files touched.
 
 ### The resumed reviewer receives no diff at all — including after #59
+
+> **Stale if #72 lands first.** This whole section describes `59597ca5`. PR #72
+> makes `runReviewersAndLint` sample whenever any reviewer runs and passes the
+> result to `resumeReview`, so the defect below is fixed and §1 becomes a record
+> of what was true before it. Read §1 as history from that point on; §2, §3, §4
+> and §7 are unaffected.
 
 This is the finding that reframes the rest. `runReviewersAndLint` samples the
 diff only when some active reviewer has no session yet:
@@ -62,6 +76,8 @@ Two smaller observations while in the prompt resources:
   stage-base-relative. T2.2's done-when asked for this line and it is unfixed.
 - `select-reviewers.md:8` still tells the picker to try `git diff HEAD`, which
   is the sampling decision #59 abandoned.
+
+> Both are corrected by #72; if it lands first, these two bullets are done.
 
 ## 2. Is the fix outcome absent, or merely implicit?
 
@@ -99,12 +115,23 @@ It does **not** hold, and cannot derive without spending tool calls:
   any price;
 - which files changed since its last round.
 
+> The third item is what #72 supplies, for the whole change set rather than the
+> per-reviewer increment. The first two are unaffected by it.
+
 Two reliability caveats on "session memory", both observed:
 
 - **Context compaction.** Not observed in the baseline (zero compaction events
-  across the ten reviewer sessions), but those loops ran 3–5 rounds. The shipped
-  `maxIterations = 10` permits 11 rounds on an Opus session already carrying
-  ~400k tokens of prefix; at compaction the round-1 diff becomes a summary.
+  across the ten reviewer sessions), but those loops ran 3–5 rounds. Nothing in
+  the baseline came close to the window: the largest single reviewer prompt
+  measured **123,615** tokens, at round 5 of the longest loop, against a 200k
+  window. (The 399k in §4's round-1 row is the *sum* of cache reads across that
+  round's ~10 API messages, not a context size — per-message prefix in round 1
+  averaged 47.0k. It is not evidence about compaction.) The shipped
+  `maxIterations = 10` permits 11 rounds, and per-message prefix grew
+  monotonically across the observed rounds (47.0k → 68.7k → 96.7k mean), so a
+  full-length loop plausibly reaches the window — but that is an extrapolation
+  from five rounds, not an observation, and at compaction the round-1 diff
+  becomes a summary.
 - **Resume leftovers.** `No response requested.` appears 30 times across the ten
   reviewer transcripts — the T1.3 pre-prompt `result` defect, live inside
   reviewer sessions specifically.
@@ -117,9 +144,21 @@ there is no per-turn record for the current code. Nothing below measures today.
 
 What follows is the baseline run of 2026-08-01 (`outcome: failed`), reconstructed
 from the ten reviewer transcripts it produced — two tasks, ten reviewer sessions,
-40 review rounds — under the pre-#59/#48 regime. Counts are deduped by assistant
-message id: the CLI writes one transcript line per content block and repeats the
-same `usage` on each, so a naive sum roughly triples the tokens.
+40 review rounds — under the pre-#59/#48 regime.
+
+**Two different dedup keys, one per column kind.** The CLI writes one transcript
+line per content block and repeats the same `usage` on each, so the two axes
+cannot share a key:
+
+- **Tool calls** are unique `tool_use` **block ids**, `StructuredOutput`
+  included. Block ids are unique — 303 raw blocks, 303 distinct ids — so this is
+  a plain count. Deduplicating tool calls by assistant *message* id instead
+  yields 52, because the streaming partials that share a message id carry
+  different content and all but the first are dropped.
+- **Token columns** are deduplicated by assistant **message id**, keeping one
+  `usage` per message: 300 distinct assistant messages, of which 270 carry a
+  non-zero prompt (the other 30 are the `No response requested.` records
+  below). Summing per block would roughly triple the totals.
 
 | | n | tool calls (mean / median) | LLM messages | cache write | cache read | output | est. $/reviewer |
 |---|---|---|---|---|---|---|---|
@@ -131,20 +170,38 @@ Dollar figures are estimates at the shipped `claude-opus-5` card
 (`Pricing.scala:159-164`; write $10/M, read $0.50/M, output $25/M) — the CLI's
 own `total_cost_usd` is not recorded per assistant message. The three rows sum to
 ~$26 across these ten sessions against a $44.64 run, which is the sanity check
-that the reconstruction is in the right range.
+that the reconstruction is in the right range. It is a sanity check and not a
+reconciliation: an estimate at card rates and the CLI's own billed total are not
+the same quantity.
 
-**What the calls are spent on** — every `Bash` command, classified:
+### Reconciliation with T2.4 (#73)
 
-| | git status/diff/log/show | read & search (rg, grep, sed, …) |
-|---|---|---|
-| round 1 | 39 | 35 |
-| round 2 | 21 | 41 |
-| rounds ≥3 | **38** | 15 |
+**These tables do not disagree.** #73 §3 reports the same three rounds as 10.3 /
+9.3 / 3.35 tool calls — exactly 1.00 below each row here, in all three rounds.
+The reason is inclusion, not measurement: both count unique `tool_use` block
+ids over the same 40 rounds, and this document includes the mandatory
+`StructuredOutput` call while #73 excludes it. The rows here sum to **303**
+blocks (199 `Bash`, 63 `Read`, 40 `StructuredOutput`, 1 `Skill`); #73's sum to
+**263** = 303 − 40, one `StructuredOutput` per round. Either convention is
+defensible; they are the same measurement.
+
+**What the calls are spent on.** Every `Bash` command in the round, sorted into
+the two categories that matter for this question. The columns are **not
+exhaustive** — they name git-reconstruction and code-reading, and leave out
+what falls in neither, so they sum to 189 of the 199 `Bash` calls. Round totals
+are given so the percentages below have a stated denominator.
+
+| | git status/diff/log/show | read & search (rg, grep, sed, …) | all `Bash` calls |
+|---|---|---|---|
+| round 1 | 39 | 35 | 76 |
+| round 2 | 21 | 41 | 67 |
+| rounds ≥3 | **38** | 15 | 56 |
 
 Round 2 is dominated by reading code. Rounds ≥3 invert: **68% of shell calls are
-reconstructing what changed**, at ~1.9 git calls per round out of 4.35 tool calls
-— one of which is the mandatory `StructuredOutput` call. The floor for a round
-that verifies nothing is 2 calls; the observed minimum is 2.
+reconstructing what changed** — 38 of the round's 56 `Bash` calls — at ~1.9 git
+calls per round out of 4.35 tool calls, one of which is the mandatory
+`StructuredOutput` call. The floor for a round that verifies nothing is 2 calls;
+the observed minimum is 2.
 
 A representative round in full (the `performance` reviewer, round 3 of task 1):
 
@@ -176,18 +233,28 @@ mis-grouped.**
   described the baseline. Round 1 should fall — it now gets a real diff instead
   of `(no diff captured)` — and round 2 may fall a little, since the round-1 diff
   is now in session. Round 3 onward should not move at all.
+  > **Stale if #72 lands first.** This bullet holds only while the resumed
+  > reviewer gets no diff. #72 gives it one every round it changed, which is the
+  > intervention the rounds-≥3 figure measures the absence of, so that figure
+  > then describes the pre-#72 code and has to be re-measured. Nothing else in
+  > §5 depends on it.
 - *Survives #48, with a caveat.* Narrowing changes *how many* reviewers run in
   later rounds, not what each one does. The per-reviewer figure stands; the
   per-round aggregate falls by whatever fraction goes quiet. In the baseline's
   first task, all five reviewers ran all five rounds; under narrowing that set
   would have shrunk.
 
-So: treat 4.2 tool calls per reviewer per follow-up round as still live. Treat
-any *aggregate* extrapolated from it as stale.
+So: treat 4.2 tool calls per reviewer per follow-up round as still live — *until
+#72 lands*, at which point it becomes a pre-#72 figure and needs re-measuring.
+Treat any *aggregate* extrapolated from it as stale either way.
 
 ## 6. Recommendation
 
-**(a) Do not send the `fixed` titles.** Three reasons, in order of weight:
+**(a) Do not send the `fixed` titles — as the default, not as a settled
+refusal.** The argument below is a design argument, and the experiment that
+would test it is §8's `+fixed` arm. Nothing here measures rubber-stamping; the
+recommendation is what to ship *pending* that measurement, and it should be
+revisited if the arm comes back clean. Three reasons, in order of weight:
 
 1. It answers the question the round exists to ask. A reviewer told "your finding
    was fixed" is being handed the conclusion it was convened to reach
@@ -195,13 +262,18 @@ any *aggregate* extrapolated from it as stale.
    not evidence" — establishing that a claim about the code is not evidence about
    the code. A fixer's `fixed` list is the same class of claim, from an agent
    with an interest in the answer.
-2. It endangers the two properties ADR 0011 depends on. The confidence gate wants
-   "your estimated probability … judged only on the evidence you gathered by
-   reading the code"; a prior from the fixer corrupts that number in a way the
-   gate cannot detect, because a confident rubber stamp and a confident
-   verification are the same float. And the shipped selector's rationale — "it's
-   the reviewer that reported which has to check the fix it triggered"
-   (`ReviewerSelector.scala:52-53`) — is precisely the check being softened.
+2. It endangers two properties the loop depends on. The confidence contract —
+   stated in `initial-review.md:17-22` and pinned schema-side at
+   `ReviewIssue.scala:23-32` — asks for "your estimated probability … judged
+   only on the evidence you gathered by reading the code and tracing its
+   behaviour". A prior from the fixer corrupts that number in a way
+   `ConfidenceGate` cannot detect, because a confident rubber stamp and a
+   confident verification are the same float. And the shipped selector's
+   rationale — "it's the reviewer that reported which has to check the fix it
+   triggered" (`ReviewerSelector.scala:52-53`) — is precisely the check being
+   softened. (ADR 0011 is the *roster* decision and says nothing about the
+   confidence contract; an earlier draft of this section cited it and was
+   wrong.)
 3. It saves nothing measurable. The reviewer must open the code either way; a
    title tells it neither which file to open nor what changed. It removes zero of
    the 1.9 git calls per round.
@@ -224,6 +296,15 @@ shell calls reconstruct by hand, and what the exemplar round spends two of three
 calls on. Unlike `fixed`, a diff is evidence rather than a claim, so it does not
 touch the confidence gate at all — it is the same kind of payload round 1
 already gets.
+
+> **Partly shipped by #72, in the coarser shape.** #72 sends the resumed
+> reviewer the whole re-sampled change set rather than the per-reviewer
+> increment, classified against what that reviewer was last sent
+> (`AlreadySeen` → nothing, `TooLarge` → paths only above 16 KiB, otherwise the
+> diff inline). That takes the correctness half of (c) and most of the cost
+> half. What remains open is the increment itself, which is strictly smaller and
+> which #72 explicitly defers. Note also that #72's arrival re-orders this
+> document against the rule stated under **Ordering** below.
 
 It also closes a live correctness hole, not just a cost one. A resumed reviewer
 falls back to its own `git diff HEAD`, which is **empty the moment the fixer
@@ -249,14 +330,28 @@ belongs with Epic 2's remaining work — and it must not ship before T2.4 decide
 the diff-size policy, since an uncapped per-round delta can cost more than the
 two tool calls it removes.
 
+> **This rule is in tension with the open PRs, and the tension is unresolved
+> here.** #72 ships the round-≥2 change set before T2.4 (#73) is merged, which
+> is the order this paragraph says not to take. The mitigation #72 carries is
+> its own 16 KiB `TooLarge` threshold, which bounds the per-round payload
+> without settling the general policy — and #72 says so, leaving the initial
+> diff uncapped. Whether that is enough is a call for whoever merges, not
+> something this document should decide retroactively: recorded as a conflict
+> rather than silently resolved.
+
 ## 7. The risk to review quality, stated plainly
 
-- **Rubber-stamping** is the real risk, and it is why (a) is a refusal rather
-  than a "measure it first". A reviewer that clears a finding because it was told
-  the finding was fixed produces the same output as one that verified — the loop
+- **Rubber-stamping** is the real risk, and it is why (a) is a default rather
+  than a coin flip. A reviewer that clears a finding because it was told the
+  finding was fixed produces the same output as one that verified — the loop
   cannot distinguish them, and the failure mode is silent approval of unfixed
-  code. That is the outcome the baseline run already reached by another route
-  (agents reporting "fixed" on builds they never saw, per Epic 1).
+  code. **This risk is argued, not measured**; §8's `+fixed` arm is what would
+  measure it. Epic 1's "agents reporting 'fixed' on builds they never saw" is
+  *not* an instance of it: that is the fixer, not a reviewer, and the cause is
+  the turn boundary killing its backgrounded build, not a claim it was handed.
+  It shows the loop cannot detect an unverified "fixed" — which is why the risk
+  matters — but it is not evidence that telling a reviewer about `fixed` titles
+  produces one.
 - **Attention narrowing** is the risk in (c). A reviewer handed "here is what
   changed since your last round" may stop checking whether its *earlier* finding
   is still open somewhere the delta does not touch. Mitigation is wording, not
@@ -287,8 +382,9 @@ three questions at once:
   calls per reviewer from rounds ≥3 and nothing from round 2.
 - *Convergence*, for the `ignored` arm: rounds to termination, and the count of
   findings re-reported after being declined. If the reasons work, both fall.
-- *The harm*, which is the measurement that actually matters and is the reason
-  to add a fourth `+fixed` arm even though §6(a) recommends against shipping it:
+- *The harm*, which is the measurement that actually matters and is what §6(a)
+  is pending — hence the fourth `+fixed` arm, even though §6(a)'s default is
+  against shipping it:
   count how often a reviewer clears one of its own findings **in a round where
   the file it named did not change**. That is a rubber stamp with no innocent
   explanation, it is computable from the delta diff plus the round's issue lists,

--- a/docs/research/run-cost/08-re-review-payload.md
+++ b/docs/research/run-cost/08-re-review-payload.md
@@ -9,8 +9,7 @@ Source read at `59597ca5`. Every measurement below is over the baseline run of
 reviewer transcripts it produced.
 
 The short answer: **send the fixer's `ignored` list, not its `fixed` list, and
-prioritise a diff over both.** The reasoning, and the measurement behind it,
-follow.
+prioritise a diff over both.**
 
 **Open PRs this document is written against.** #72 (resumed-reviewer diff) is
 open and changes the ground under §1, §5 and §6(c); the markers below say what
@@ -43,8 +42,8 @@ list of files touched.
 > of what was true before it. Read §1 as history from that point on; §2, §3, §4
 > and §7 are unaffected.
 
-This is the finding that reframes the rest. `runReviewersAndLint` samples the
-diff only when some active reviewer has no session yet:
+`runReviewersAndLint` samples the diff only when some active reviewer has no
+session yet:
 
 ```scala
 val needsDiff = active.exists(e => storedFor(e).isEmpty)   // ReviewLoop.scala:477
@@ -69,7 +68,7 @@ path only a custom selector can reach. The premise the T2.5 hypothesis was built
 on — reviewers rediscovering the change set by hand every round — is still
 exactly true from round 2 on.
 
-Two smaller observations while in the prompt resources:
+Two smaller observations on the prompt resources:
 
 - `initial-review.md:7` still labels its payload "Diff (working tree vs HEAD at
   the start of the review loop)". #59 made that false: the diff is now
@@ -169,10 +168,10 @@ cannot share a key:
 Dollar figures are estimates at the shipped `claude-opus-5` card
 (`Pricing.scala:159-164`; write $10/M, read $0.50/M, output $25/M) — the CLI's
 own `total_cost_usd` is not recorded per assistant message. The three rows sum to
-~$26 across these ten sessions against a $44.64 run, which is the sanity check
-that the reconstruction is in the right range. It is a sanity check and not a
-reconciliation: an estimate at card rates and the CLI's own billed total are not
-the same quantity.
+~$26 across these ten sessions against a $44.64 run, which puts the
+reconstruction in the right range. That is a sanity check, not a reconciliation:
+an estimate at card rates and the CLI's own billed total are not the same
+quantity.
 
 ### Reconciliation with T2.4 (#73)
 
@@ -183,7 +182,7 @@ ids over the same 40 rounds, and this document includes the mandatory
 `StructuredOutput` call while #73 excludes it. The rows here sum to **303**
 blocks (199 `Bash`, 63 `Read`, 40 `StructuredOutput`, 1 `Skill`); #73's sum to
 **263** = 303 − 40, one `StructuredOutput` per round. Either convention is
-defensible; they are the same measurement.
+defensible.
 
 **What the calls are spent on.** Every `Bash` command in the round, sorted into
 the two categories that matter for this question. The columns are **not
@@ -213,12 +212,12 @@ TEXT  "Re-reviewed the current working tree. The only change since my last pass
 StructuredOutput  {"issues": []}
 ```
 
-Two of three calls reconstruct a delta orca already knows, and the reviewer's own
-words name what it wanted: *the change since its last pass*.
+Two of three calls reconstruct a change orca already knows, and the reviewer says
+what it wanted: *the change since its last pass*.
 
 ## 5. Does the original 9.3-vs-4.2 evidence survive?
 
-**It reproduces, and it survives — for the wrong reason — but it is
+**It reproduces and it survives, though not for the expected reason, and it is
 mis-grouped.**
 
 - *Reproduces.* Round 1's median of 9.5 tool calls and rounds ≥3's mean of 4.35
@@ -257,8 +256,8 @@ recommendation is what to ship *pending* that measurement, and it should be
 revisited if the arm comes back clean. Three reasons, in order of weight:
 
 1. It answers the question the round exists to ask. A reviewer told "your finding
-   was fixed" is being handed the conclusion it was convened to reach
-   independently. `initial-review.md:35-40` already has a section — "The plan is
+   was fixed" is handed the conclusion it was asked to reach on its own.
+   `initial-review.md:35-40` already has a section — "The plan is
    not evidence" — establishing that a claim about the code is not evidence about
    the code. A fixer's `fixed` list is the same class of claim, from an agent
    with an interest in the answer.
@@ -278,8 +277,8 @@ revisited if the arm comes back clean. Three reasons, in order of weight:
    title tells it neither which file to open nor what changed. It removes zero of
    the 1.9 git calls per round.
 
-**(b) Do send the `ignored` titles with their reasons.** This is the opposite
-case on every axis. It is small (typically 0–3 entries, ~50–150 tokens), and it
+**(b) Do send the `ignored` titles with their reasons.** The case here is the
+reverse. It is small (typically 0–3 entries, ~50–150 tokens), and it
 is the one thing in the loop that is **not recoverable from the tree at any
 price**: no amount of reading tells a reviewer that the fixer considered a
 finding a deliberate trade-off. Today the reviewer re-reports the finding, the
@@ -287,8 +286,8 @@ fixer re-declines it, and the round is spent — and because the loop keeps
 iterating while `fixed` is non-empty, that exchange can repeat for the life of
 the loop. Frame it as the fixer's position, not a verdict: *"the fixer declined
 these, with its stated reason; if you still think the finding is real, report it
-again and say why the reason is wrong."* That keeps the disagreement possible,
-which is what makes it safe.
+again and say why the reason is wrong."* That keeps disagreement possible, which
+is what makes it safe.
 
 **(c) The larger lever is a diff, not the fix outcome.** Hand the resumed
 reviewer the change since its own previous round. That is what 38 of 56 late-round
@@ -330,7 +329,7 @@ belongs with Epic 2's remaining work — and it must not ship before T2.4 decide
 the diff-size policy, since an uncapped per-round delta can cost more than the
 two tool calls it removes.
 
-> **This rule is in tension with the open PRs, and the tension is unresolved
+> **This rule conflicts with the open PRs, and the conflict is not resolved
 > here.** #72 ships the round-≥2 change set before T2.4 (#73) is merged, which
 > is the order this paragraph says not to take. The mitigation #72 carries is
 > its own 16 KiB `TooLarge` threshold, which bounds the per-round payload
@@ -339,10 +338,10 @@ two tool calls it removes.
 > something this document should decide retroactively: recorded as a conflict
 > rather than silently resolved.
 
-## 7. The risk to review quality, stated plainly
+## 7. The risk to review quality
 
-- **Rubber-stamping** is the real risk, and it is why (a) is a default rather
-  than a coin flip. A reviewer that clears a finding because it was told the
+- **Rubber-stamping** is the real risk, and it is why (a) is a default. A
+  reviewer that clears a finding because it was told the
   finding was fixed produces the same output as one that verified — the loop
   cannot distinguish them, and the failure mode is silent approval of unfixed
   code. **This risk is argued, not measured**; §8's `+fixed` arm is what would
@@ -382,9 +381,8 @@ three questions at once:
   calls per reviewer from rounds ≥3 and nothing from round 2.
 - *Convergence*, for the `ignored` arm: rounds to termination, and the count of
   findings re-reported after being declined. If the reasons work, both fall.
-- *The harm*, which is the measurement that actually matters and is what §6(a)
-  is pending — hence the fourth `+fixed` arm, even though §6(a)'s default is
-  against shipping it:
+- *The harm* — the measurement §6(a) is pending, and the reason for a fourth
+  `+fixed` arm even though §6(a)'s default is against shipping it:
   count how often a reviewer clears one of its own findings **in a round where
   the file it named did not change**. That is a rubber stamp with no innocent
   explanation, it is computable from the delta diff plus the round's issue lists,


### PR DESCRIPTION
T1.4: should orca hold one agent CLI process open across the turns of a durable
session, instead of today's fresh process per turn with stdin closed?

Investigation only (`[investigate, ADR-sized]`). One new file under
`docs/research/run-cost/`; no code change. Stacked on #65, whose file this
branch also carries byte-identically — #65 lands first.

## The answer: NO-GO as proposed

Two independent grounds.

1. **The primary shipped flow cannot run on a held-open claude process** —
   *contingent, see below*. `--json-schema` is argv-side
   (`ClaudeArgs.scala:28-51`) and so frozen at spawn, but a durable session
   alternates between un-schema'd turns (`flows/implement.sc:35` →
   `session.run`) and schema'd ones (`ReviewLoop.scala:610-611` →
   `coderSession.resultAs[FixOutcome]`). `reviewAndFixLoop` is handed that same
   session, so this is the main path, not a corner. The argv encoding and the
   alternation are **[V]**; "cannot" is **[U]**, because it holds only if
   `--json-schema` also cannot be varied per message over claude's control
   channel. That is the ~30-minute experiment in §6.1 that decides the ADR.
2. **The headline cost benefit is not supported by measurement.** Controlled
   comparison, distinct ~79k-token content per arm, `--resume` arm first: total
   cache-creation **57,790** (per-turn `--resume`, i.e. today) vs **57,088**
   (held-open) — a 1.2% difference. Not called noise: n=1 per arm and no noise
   floor was established, so 1.2% is a point difference with no dispersion
   behind it. What the probes do establish is that for growth-driven cache
   writes the two arms are close; the regime that matters (213k prefix, real
   tool calls) was not reached, which is why §1 records this as **not supported
   rather than refuted**.

T1.4's declared gate, T1.3, is also still open — and a persistent process turns
T1.3's "which `result` belongs to which prompt" into the normal question at
every turn boundary, against a `settledOutcome` that can only be written once.

## Evidence

Two independent researchers over the codebase, a skeptic round against their
findings, and live probes against claude 2.1.220. §7 of the file records each
disagreement and which side was taken. Every claim carries an evidence tag:
**[V]** read in the code, **[M]** measured, **[I]** inferred, **[U]** unknown.

Supporting findings:

- **Multi-turn over held-open stdin already works on claude** — verified by
  probe (two messages 25 s apart, one `session_id`, context carried, first
  `result` at 4.79 s with stdin still open). Two places in the repo say the
  opposite, including the `PipedCliProcess` trait contract; both are stale and
  worth fixing regardless (§9).
- **Benefit (a) and a documented deadlock are the same mechanism.**
  `StderrPipeline.onFinalize` joins the stderr fork unboundedly and its own
  comment notes the tree kill that would unblock it runs downstream. Keeping
  background work alive across turns is what would make that join hang at
  session end.
- **`runFinalize` is one-shot**, so per-turn resources (the ask_user MCP Netty
  binding, the system-prompt temp file) would become session-lifetime.
- **Cost accounting would break silently**: `total_cost_usd` is cumulative on a
  held-open process (measured), and `CostTracker` sums it.
- **Backend coverage.** claude yes **[M]**; pi plausible but unconfirmed
  (credentials blocked the context-carry check) **[M]/[U]**; codex and gemini
  put the prompt on argv and cannot **[V]**; opencode already has the property
  **[V]**. So the change is work on one backend, unknown on a second, and
  inapplicable to the rest.
- **PR #47's shipped system-prompt rule would have to be retracted** in the same
  change — its text, not its tests: `SystemPromptComposerTest` pins composition
  through the rule's symbol, so rewording it breaks nothing.

## What to do next

- **Do not build this now.** If it is revisited, it is gated on one ~30-minute
  experiment: can `--json-schema` / model / permission-mode be varied per
  message over claude's control channel? If not, this is dead for claude as
  proposed — and if so, ground 1 above reopens. Full conditions and the
  ADR-worthy decisions are in §8.
- **Four corrections stand on their own**, independent of this proposal: a stale
  stdin-EOF claim in the SPI docs; a stale pi durability note in `ProgressLog`;
  a write-after-`closeStdin` on claude's control-response path; and
  `StderrPipeline`'s unbounded join.

  On the third: the defect is real, but note *why* it is unreachable rather than
  merely latent — stdin is closed before any `control_request` could arrive (no
  such frame appears in any of the baseline run's ten reviewer transcripts), and
  the `Deny` branch first named as its trigger is dead under the shipped
  `AutoApprove.All`.
