### PR TITLE
Skip untracked nested git repositories in the review diff

### DIFF
--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -249,8 +249,9 @@ trait GitTool:
     * committed; pass the commit a unit of work started from (see
     * [[headCommit]]) to see everything it produced either way.
     *
-    * An untracked symlink to a directory is one `--no-index` can't render; it
-    * appears as a line naming the path rather than being dropped silently.
+    * A path `--no-index` can't render — a symlink to a directory, or a nested
+    * git repository — appears as a line naming the path rather than being
+    * dropped silently.
     */
   def reviewDiff(since: Option[String] = None): String
 
@@ -626,25 +627,36 @@ private[orca] class OsGitTool(
     * stderr rather than the exit code tells the two apart. Reporting the second
     * as success would return an empty diff for a file that does have contents.
     *
-    * A symlink to a directory is named rather than diffed: `--no-index` walks
-    * into it and pairs `/dev/null` with a path inside (`error: Could not access
-    * 'link/null'`), which takes the failure branch above. Symlinks to a file or
-    * to nothing diff fine, as mode 120000 carrying the link target, not the
-    * target's contents.
+    * A path [[undiffableReason]] names is announced rather than diffed, so that
+    * one such path does not abort the whole review.
     */
   private def untrackedFileDiff(relPath: String): String =
-    if isSymlinkToDirectory(relPath) then
-      s"# skipped $relPath: symlink to a directory\n"
-    else
-      val result =
-        gitProc(Seq("git", "diff", "--no-index", "--", "/dev/null", relPath))
-      val differs = result.exitCode == 1 && result.err.text().isEmpty
-      if result.exitCode == 0 || differs then result.out.text()
-      else fail(s"git diff --no-index -- /dev/null $relPath", result)
+    undiffableReason(relPath) match
+      case Some(reason) => s"# skipped $relPath: $reason\n"
+      case None =>
+        val result =
+          gitProc(Seq("git", "diff", "--no-index", "--", "/dev/null", relPath))
+        val differs = result.exitCode == 1 && result.err.text().isEmpty
+        if result.exitCode == 0 || differs then result.out.text()
+        else fail(s"git diff --no-index -- /dev/null $relPath", result)
 
-  private def isSymlinkToDirectory(relPath: String): Boolean =
+  /** Why `git diff --no-index` cannot render this untracked path, or `None` if
+    * it can.
+    *
+    * `git status -uall` reports each of these as a single entry instead of
+    * recursing into it. `--no-index` then walks in and pairs `/dev/null` with a
+    * path inside (`error: Could not access 'x/null'`), which takes
+    * [[untrackedFileDiff]]'s failure branch. A nested repository is recognised
+    * by its `.git` entry — a directory in a clone, a file in a linked worktree,
+    * hence `os.exists` rather than `os.isDir`.
+    *
+    * Symlinks to a file or to nothing are diffable, as mode 120000.
+    */
+  private def undiffableReason(relPath: String): Option[String] =
     val path = workDir / os.RelPath(relPath)
-    os.isLink(path) && os.isDir(path)
+    if os.isLink(path) && os.isDir(path) then Some("symlink to a directory")
+    else if os.exists(path / ".git") then Some("nested git repository")
+    else None
 
   def diffVsBase(base: String, mode: DiffMode): String =
     val spec = mode match

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -26,9 +26,9 @@ enum DiffMode:
 case class Worktree(path: os.Path, branch: String)
 
 /** One consistent sample of what the next commit would include — see
-  * [[GitTool.pendingChanges]]. `newFiles` holds the paths of files new to the
-  * repository, which the stat cannot report and `diff` shows only as new-file
-  * hunks.
+  * [[GitTool.pendingChanges]]. `newFiles` holds the paths new to the repository
+  * — see [[GitTool.untrackedPaths]] — which the stat cannot report and `diff`
+  * shows only as new-file hunks.
   */
 case class PendingChanges(stat: String, newFiles: List[String], diff: String)
 
@@ -228,11 +228,13 @@ trait GitTool:
     */
   def diffStat(): String
 
-  /** Untracked, non-`.orca/` paths anywhere in the repository, one entry per
-    * file (untracked directories are recursed into), relative to the tool's
-    * working directory. These are the files [[diff]] can't report — they have
-    * no tracked history to diff against — but that a `git add -A` commit would
-    * include, so anything describing what is about to be committed needs them
+  /** Untracked, non-`.orca/` paths anywhere in the repository, relative to the
+    * tool's working directory. Untracked directories are recursed into, so an
+    * entry is normally one file; a directory git refuses to enter — a nested
+    * repository — stays one entry, with a trailing slash. These are the paths
+    * [[diff]] can't report — they have no tracked history to diff against — but
+    * that a `git add -A` commit would include (a nested repository as a
+    * gitlink), so anything describing what is about to be committed needs them
     * alongside the diff. [[reviewDiff]] renders their contents; this is the
     * list itself.
     */

--- a/tools/src/test/scala/orca/testkit/GitRepo.scala
+++ b/tools/src/test/scala/orca/testkit/GitRepo.scala
@@ -5,13 +5,26 @@ package orca.testkit
   * registered with [[TempDirs]] for cleanup at JVM shutdown.
   */
 object GitRepo:
-  /** Fresh temp repo: `git init -b main` + test user config. No commits. */
+  /** Fresh temp repo: `git init -b main`, test user config, and the ambient
+    * global config neutralised. No commits.
+    */
   def empty(): os.Path =
     val dir = TempDirs.dir(prefix = "orca-gitrepo-")
     val _ = os.proc("git", "init", "-b", "main").call(cwd = dir)
     val _ =
       os.proc("git", "config", "user.email", "test@example.com").call(cwd = dir)
     val _ = os.proc("git", "config", "user.name", "Test").call(cwd = dir)
+    // Neutralise the two settings a developer's global config can reach into
+    // the fixture with: git reads a missing path as empty. A global ignore rule
+    // matching a fixture name would otherwise hide it from `git status`, and
+    // the test would fail with no hint why. Under `.git/`, out of the tree.
+    val gitDir = dir / ".git"
+    val _ = os
+      .proc("git", "config", "core.excludesFile", gitDir / "no-excludes")
+      .call(cwd = dir)
+    val _ = os
+      .proc("git", "config", "core.hooksPath", gitDir / "no-hooks")
+      .call(cwd = dir)
     dir
 
   /** `empty()` plus a single `seed.txt` commit (`seed`). */

--- a/tools/src/test/scala/orca/tools/OsGitToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitToolTest.scala
@@ -656,6 +656,28 @@ class OsGitToolTest extends munit.FunSuite:
       assert(diff.contains("+++ b/linkfile"), diff)
       assert(diff.contains("new file mode 120000"), diff)
 
+  test("reviewDiff names an untracked nested git repository, and carries on"):
+    withRepo: (git, dir) =>
+      os.write(dir / "seed.txt", "seed")
+      git.commit("seed").orThrow
+      os.makeDir(dir / "nested")
+      val _ = os.proc("git", "init").call(cwd = dir / "nested")
+      os.write(dir / "new.txt", "brand new content")
+      val diff = git.reviewDiff()
+      assert(diff.contains("# skipped nested/: nested git repository"), diff)
+      assert(diff.contains("+brand new content"), diff)
+
+  // Pins the probe as `os.exists`, not `os.isDir`: a linked worktree's `.git`
+  // is a file, not a directory.
+  test("reviewDiff names an untracked linked worktree"):
+    withRepo: (git, dir) =>
+      os.write(dir / "seed.txt", "seed")
+      git.commit("seed").orThrow
+      val _ =
+        os.proc("git", "worktree", "add", "wt", "-b", "wtb").call(cwd = dir)
+      val diff = git.reviewDiff()
+      assert(diff.contains("# skipped wt/: nested git repository"), diff)
+
   test("reviewDiff includes an untracked file whose name has spaces"):
     withRepo: (git, dir) =>
       os.write(dir / "seed.txt", "seed")

--- a/tools/src/test/scala/orca/tools/OsGitToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitToolTest.scala
@@ -666,6 +666,9 @@ class OsGitToolTest extends munit.FunSuite:
       val diff = git.reviewDiff()
       assert(diff.contains("# skipped nested/: nested git repository"), diff)
       assert(diff.contains("+brand new content"), diff)
+      // Skipping the diff must not drop the path from what `add -A` will
+      // commit: git stages a nested repo as a gitlink, so `newFiles` says so.
+      assert(git.pendingChanges().newFiles.contains("nested/"))
 
   // Pins the probe as `os.exists`, not `os.isDir`: a linked worktree's `.git`
   // is a file, not a directory.
@@ -674,7 +677,8 @@ class OsGitToolTest extends munit.FunSuite:
       os.write(dir / "seed.txt", "seed")
       git.commit("seed").orThrow
       val _ =
-        os.proc("git", "worktree", "add", "wt", "-b", "wtb").call(cwd = dir)
+        os.proc("git", "worktree", "add", "-q", "wt", "-b", "wtb")
+          .call(cwd = dir)
       val diff = git.reviewDiff()
       assert(diff.contains("# skipped wt/: nested git repository"), diff)
 


### PR DESCRIPTION
An untracked nested git repository aborted the whole review loop, exactly as
an untracked symlink-to-a-directory used to before #63.

Scope: this fixes the **review** step, which is where the abort was. A nested
repository with no commits also breaks the **commit** step, in a different
method and for a different reason — see "Adjacent defect" at the end. The
shapes that occur in practice, a clone and a linked worktree, are unaffected
by that and work end to end after this change.

`git status --porcelain -uall` reports a nested repo as a single `?? nested/`
entry — git does not recurse into one. `git diff --no-index -- /dev/null
nested/` then walks in and pairs `/dev/null` with a path inside:

```
error: Could not access 'nested/null'
```

exit 1, message on stderr. `OsGitTool.untrackedFileDiff` classifies that
correctly — its `exit 1 && empty stderr` predicate means "the sides differ",
and this is exit 1 *with* stderr — so it calls `fail`, which throws
`OrcaFlowException`, taking down `reviewDiff()` and the review loop.

## The fix

Same shape as #63, extended rather than duplicated. The predicate is
untouched: it was tightened deliberately in #46, and loosening it would
restore the bug where a real access failure was read as "no difference" and
every new file's contents silently vanished from the review.

#63's single `isSymlinkToDirectory` guard becomes `undiffableReason`, which
returns the reason a path cannot be rendered, or `None`. `untrackedFileDiff`
either announces the reason or diffs. One classifier, one skip-line format,
one place to look — not a second mechanism beside the first.

`untrackedPaths()` is deliberately left alone, so `pendingChanges().newFiles`
still lists the nested repo. Verified that `git add -A` really does stage it,
as a gitlink:

```
160000 6c55db07e7c55c14841619cbd283c26fd41b5cd2 0	nested
100644 e31de1f3a235fd5e8f97207b8e43cd2aa06a6417 0	seed.txt
160000 f7cd797a6bbc2d9570027ccfbb00d17b3aadedf8 0	wt
```

which is exactly what that list promises. Filtering earlier would make it lie.

**The skip is announced**, as `# skipped nested/: nested git repository` —
a different message from #63's, because it is a different cause, and a
reviewer told nothing was omitted is worse than one told what was.

## What was measured, not assumed

Against git 2.53.0:

| untracked entry | `status -uall` | `--no-index` |
|---|---|---|
| nested clone (`.git` dir) | `?? nested/` | exit 1, `error: Could not access 'nested/null'` |
| linked worktree (`.git` file) | `?? wt/` | exit 1, `error: Could not access 'wt/null'` |
| ordinary new directory | `?? dir/file.txt` (recursed) | renders fine |

**Both shapes of nested repo are covered.** A clone carries a `.git`
directory, a linked worktree a `.git` file — so the probe is
`os.exists(path / ".git")`, not `os.isDir`.

**The trailing slash is real.** Unlike #63's symlink (`?? linkdir`, no
slash), a nested repo is reported as `nested/`. `os.RelPath("nested/")`
resolves it fine, so the guard sees the path git actually emits.

**No false positive is reachable.** `-uall` recurses into every ordinary
untracked directory and lists its files individually, so the only
directory-shaped entries it can emit are ones git refused to enter. Empty
directories and fully-ignored directories are not reported at all.

## Tests

Two, each mutation-checked to fail alone.

**The abort** — a nested clone alongside an ordinary new file. Disabling the
guard fails it with the reported error verbatim: `orca.OrcaFlowException: git
diff --no-index -- /dev/null nested/ failed (exit 1): error: Could not access
'nested/null'`.

**The linked worktree** — guards the decision, not the bug, as #63's
symlink-to-a-file test does. Narrowing the probe to `os.isDir(path / ".git")`
fails this test and *only* this test; disabling the guard fails both. That
asymmetry is why it is not a duplicate of the clone case.

Both assert the reason text, not just the path: swapping the two branches'
reasons fails both tests.

## Adjacent defect, not fixed here

A nested repo with **no commits yet** breaks `git add -A` outright — `error:
'nested/' does not have a commit checked out` … `fatal: adding files failed`,
exit 128, nothing staged at all. `reviewDiff()` and `pendingChanges()` now
survive that shape, but `OsGitTool.commit` still throws on it, so the flow
dies one step later and the agent's real work goes uncommitted with it. It is
a pre-existing hole in a different method with a different fix, so it is left
for its own change rather than widened into this one. A cloned nested repo
and a linked worktree — the shapes that occur in practice — both carry
commits and are unaffected.

One correction to the note left in #63: orca's own `.claude/worktrees/` is
gitignored (`.gitignore:49`), so `status -uall` never reports it and it never
reaches this code path. The linked-worktree case is live in repositories that
do not ignore theirs, not in this one.


## Review follow-ups (second commit)

Docs and test hygiene, no behaviour change to the fix.

- `untrackedPaths()` said "one entry per file (untracked directories are
  recursed into)" and `PendingChanges` said `newFiles` holds "the paths of
  FILES new to the repository". A nested repo is neither — it is a directory,
  with a trailing slash, that git refused to enter. Both corrected.
- `GitRepo.empty()` did not isolate `core.excludesFile` or `core.hooksPath`,
  so a developer's global config could reach into every fixture in the suite.
  Measured: a global ignore rule matching `wt/` makes the worktree invisible
  to `git status`, `untrackedPaths()` returns `Nil`, and the assertion fails
  with no hint why. Both now point at nonexistent paths under `.git/`, which
  git reads as empty.
- The nested-repo test now also pins `pendingChanges().newFiles.contains
  ("nested/")` — the decision this PR argues for but had not checked.
  Filtering undiffable paths out of `newFiles` alone fails only that
  assertion.
- `git worktree add -q`; os-lib inherits stderr, so it was leaking `Preparing
  worktree (new branch 'wtb')` into the test log.
