### PR TITLE
Simplify the comments added by the loop-cost-ceiling change

### DIFF
--- a/flow/src/main/scala/orca/events/CostTracker.scala
+++ b/flow/src/main/scala/orca/events/CostTracker.scala
@@ -65,7 +65,8 @@ class CostTracker(pricing: PriceList = Pricing.default) extends OrcaListener:
   private val state: AtomicReference[State] = AtomicReference(State())
 
   def onEvent(event: OrcaEvent): Unit = event match
-    // Not an axis: a retry's tokens count toward the run's spend like any other.
+    // `attempt` is ignored: a retry's tokens count toward the run's spend like
+    // any other turn's.
     case OrcaEvent.TokensUsed(agent, model, usage, role, _) =>
       val cost = Pricing.resolve(pricing.table, model, usage)
       val _ = state.updateAndGet(_.record(agent, model, usage, cost, role))

--- a/flow/src/main/scala/orca/review/ReviewLoop.scala
+++ b/flow/src/main/scala/orca/review/ReviewLoop.scala
@@ -39,9 +39,9 @@ private[review] enum LoopStep:
   case NeedsFix
 
 /** How many fix attempts [[fixLoop]] and [[reviewAndFixLoop]] allow before
-  * bailing out. Named once so the two cannot drift apart, and public because
-  * the shipped flows state the number at their call sites rather than
-  * inheriting it — their agreement with this value is asserted, not assumed.
+  * giving up. Named once so the two can't drift apart. Public because the
+  * shipped flows pass the number at their call sites instead of inheriting it,
+  * and a test checks those numbers against this one.
   */
 val DefaultMaxIterations: Int = 3
 
@@ -69,10 +69,9 @@ private[review] def stopPolicy(
     )
   else LoopStep.NeedsFix
 
-/** The cap exit's message, naming what it leaves open. Callers routinely
-  * discard the returned [[IgnoredIssues]] — every shipped flow does — so
-  * without the titles here a cap that bound too early leaves no trace a reader
-  * of the run can act on.
+/** The message shown when the loop gives up at the cap, listing the issues left
+  * open. Every shipped flow discards the returned [[IgnoredIssues]], so this
+  * message is the only place a too-low cap shows up in a run.
   */
 private[review] def capExitMessage(
     maxIterations: Int,
@@ -301,9 +300,9 @@ def reviewAndFixLoop[B <: BackendTag](
       * [[ConfidenceGate]] for why the bar varies by severity.
       */
     confidenceGate: ConfidenceGate = ConfidenceGate.default,
-    /** Fix attempts before the loop bails out, folding whatever is still open
-      * into the returned [[IgnoredIssues]]. Counts fixes, not evaluations: the
-      * default of 3 runs up to four review rounds.
+    /** How many fix attempts before the loop gives up, folding whatever is
+      * still open into the returned [[IgnoredIssues]]. Counts fixes, not
+      * evaluations: the default of 3 allows up to four review rounds.
       */
     maxIterations: Int = DefaultMaxIterations,
     fixInstructions: String = ReviewLoopPrompts.Fix,

--- a/flow/src/test/scala/orca/review/FixLoopTest.scala
+++ b/flow/src/test/scala/orca/review/FixLoopTest.scala
@@ -119,8 +119,8 @@ class FixLoopTest extends munit.FunSuite:
 
   test("the library default cap is 3 fix attempts, so 4 evaluations"):
     given FlowContext = ctx
-    // Never-converging shape with `maxIterations` omitted, so the evaluation
-    // count reads the shared default back.
+    // The loop never converges and `maxIterations` is omitted, so the
+    // evaluation count reads the shared default back.
     var evaluates = 0
     val _ = fixLoop(
       evaluate = () =>
@@ -132,8 +132,8 @@ class FixLoopTest extends munit.FunSuite:
     assertEquals(evaluates, 4)
 
   test("the cap exit names the issues it leaves open"):
-    // Callers routinely discard the returned IgnoredIssues, so this message is
-    // the only place a too-low cap becomes visible in a run.
+    // Callers discard the returned IgnoredIssues, so this message is the only
+    // place a too-low cap becomes visible in a run.
     val rec = new Recorder
     given FlowContext = new TestFlowContext(new EventDispatcher(List(rec)))
     val _ = fixLoop(

--- a/runner/src/main/scala/orca/runner/manifest/RunManifest.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifest.scala
@@ -104,9 +104,9 @@ private[orca] object ManifestCostSummary:
   * to zero when a terminal frame omits them, and claude takes its cost from a
   * separate field — so a zero-token turn can still carry a reported cost.
   *
-  * `attempt` is the turn's 1-based position among the turns its call produced
-  * (see [[orca.events.OrcaEvent.TokensUsed]]), so the spend of turns with
-  * `attempt > 1` is what retries added to the run.
+  * `attempt` is the turn's 1-based position among the turns of its call (see
+  * [[orca.events.OrcaEvent.TokensUsed]]); turns with `attempt > 1` are what
+  * retries added to the run's spend.
   *
   * `at` is stamped when the writer records the turn, not when the tokens were
   * spent: the event crosses an actor mailbox first.

--- a/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
@@ -507,8 +507,8 @@ class RunManifestWriterTest extends munit.FunSuite:
     // when a turn is recorded, not when the manifest is later written.
     writer.onEvent(OrcaEvent.StageCompleted("code"))
     // The CLI answering from leftover session state: no request went out, so
-    // every counter is zero. Recorded as a retry, so the assertion below shows
-    // the attempt index reaching the manifest rather than being a constant.
+    // every counter is zero. Recorded as a retry so the assertion below shows
+    // the attempt index reaching the manifest, rather than a constant 1.
     writer.onEvent(
       OrcaEvent.TokensUsed(
         "reviewer",

--- a/shell/src/test/scala/orca/shell/flows/BuiltInFlowsTest.scala
+++ b/shell/src/test/scala/orca/shell/flows/BuiltInFlowsTest.scala
@@ -34,12 +34,12 @@ class BuiltInFlowsTest extends munit.FunSuite:
     indexNames.foreach(name => assert(resourceText(name).trim.nonEmpty, name))
 
   test("every fix-loop call in a flow states the library's default cap"):
-    // A reader of a flow shouldn't have to guess which cap the run used, so
-    // each call states the number rather than inheriting it — and states THE
-    // default, so raising `DefaultMaxIterations` fails here until the flows
-    // follow. `flows/` is outside scalafmt's scope, so the spacing is loose.
-    // Comparing counts is a heuristic, not a per-call proof: it catches a call
-    // added without a cap, but not two caps stated on one of two calls.
+    // Each call states the cap instead of inheriting it, so a reader of the
+    // flow knows which cap the run used. The stated number must be the default,
+    // so raising `DefaultMaxIterations` fails here until the flows follow.
+    // `flows/` is outside scalafmt's scope, hence the loose spacing allowed in
+    // the regex. Counting per file is a heuristic, not a per-call proof: it
+    // catches a call added without a cap, but not two caps on one of two calls.
     val calls = "\\b(?:reviewAndFixLoop|fixLoop)\\(".r
     val caps = s"maxIterations\\s*=\\s*$DefaultMaxIterations\\b".r
     val counted = indexNames.map: name =>

--- a/tools/src/main/scala/orca/agents/AgentCall.scala
+++ b/tools/src/main/scala/orca/agents/AgentCall.scala
@@ -209,11 +209,11 @@ class DefaultAgentCall[B <: BackendTag, O](
     // re-executes sequentially — never concurrently.
     var lastFailure: Option[FailedAttempt] = None
 
-    // Counts turns EMITTED by this call, not attempts entered: an attempt that
-    // dies before the model runs (a pre-spawn open failure, retried below)
-    // reports no turn, so counting on entry would tag the eventual turn as a
-    // retry of spend that never happened. Same sequential-write contract as
-    // `lastFailure` above.
+    // Counts the turns this call reported, not the attempts it started: an
+    // attempt that dies before the model runs (a pre-spawn open failure,
+    // retried below) reports no turn. Counting on entry would label the first
+    // turn that is actually paid for as a retry. Same sequential-write contract
+    // as `lastFailure` above.
     var turnsRecorded = 0
 
     def recordTurn(model: Option[Model], usage: Usage): Unit =

--- a/tools/src/main/scala/orca/events/OrcaEvent.scala
+++ b/tools/src/main/scala/orca/events/OrcaEvent.scala
@@ -43,11 +43,11 @@ enum OrcaEvent:
     *     review loop's `Some("reviewer")`, via `withRole`). `None` for an
     *     ordinary call. Purely a grouping/display hint.
     *
-    * `attempt` is this turn's 1-based position among the turns ONE call
-    * produced: `2`+ means a retry re-sent the prompt and billed again. It
-    * counts turns, not tries — an attempt that failed before the model ran
-    * emits nothing, so it never inflates the next one's index. Emission sites
-    * that don't retry leave it at the default.
+    * `attempt` is this turn's 1-based position among the turns of a single
+    * call: 2 or more means a retry re-sent the prompt and paid for it again. It
+    * counts turns, not tries — an attempt that fails before the model runs
+    * emits no event, so it doesn't shift the index of the turn that follows.
+    * Emission sites that never retry leave the default.
     */
   case TokensUsed(
       agent: String,

--- a/tools/src/test/scala/orca/agents/BaseAgentTest.scala
+++ b/tools/src/test/scala/orca/agents/BaseAgentTest.scala
@@ -216,9 +216,9 @@ class BaseAgentTest extends munit.FunSuite:
       List(1, 2)
     )
 
-  // The counter's whole invariant: an attempt that dies before the model runs
-  // is retried but records no turn, so it must not push the turn that follows
-  // to `2` and bill a first try as retry overhead.
+  // An attempt that dies before the model runs is retried but records no turn,
+  // so it must not push the turn that follows to `2` and make a first try look
+  // like retry overhead.
   test("an attempt that failed before the model ran doesn't advance the index"):
     val seen =
       new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
@@ -616,10 +616,10 @@ class BaseAgentTest extends munit.FunSuite:
         outputSchema: Option[String]
     ): AgentResult[BackendTag.Pi.type] =
       val schema = outputSchema
-      // Named, so a test scripted with too few replies says so instead of
-      // surfacing the iterator's bare NoSuchElementException — which it does
-      // only after the retry schedule runs out, since the policy retries
-      // anything but `AgentTurnFailed`.
+      // A test scripted with too few replies should say so, rather than
+      // surface the iterator's NoSuchElementException — and only once the
+      // retry schedule runs out, since the policy retries anything but
+      // `AgentTurnFailed`.
       if !remaining.hasNext then
         throw new IllegalStateException("scripted replies exhausted")
       val reply = remaining.next()


### PR DESCRIPTION
A language pass over the comments and scaladoc #71 added. #71 merged before
the pass ran and its branch is gone, so the same change comes as a follow-up.

Comments only — no behaviour change, and the test suite is untouched.

What changed:

- `DefaultMaxIterations`, `capExitMessage` and the `maxIterations` parameter
  doc: plainer wording, same reasons kept.
- `AgentCall`'s attempt counter: still says why the counter counts turns
  reported rather than attempts started, without the shouting.
- `OrcaEvent.TokensUsed` and `ManifestTurn`: same rule, fewer words.
- The `BuiltInFlowsTest` comment about the regex heuristic's limit, and the
  test comments in `FixLoopTest`, `BaseAgentTest` and `RunManifestWriterTest`.

`sbt scalafmtCheckAll` clean; `sbt clean compile test` green with zero
warnings, same test count as master.
