### PR TITLE
Record a turn's session and API-call count in the manifest

### DIFF
--- a/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
@@ -66,6 +66,17 @@ private[claude] class ClaudeConversation(
     */
   private var deltasSinceLastFullTurn: Boolean = false
 
+  /** Ids of the model responses seen since the last result message — the turn's
+    * API-call count ([[orca.events.Usage.apiCalls]]), which nothing on the wire
+    * reports directly. A set, not a counter: the CLI emits one `assistant`
+    * message per content group, several sharing one response id.
+    *
+    * Counts main-loop responses only. A `Task` subagent's requests are folded
+    * into the result's token totals but emit no top-level `assistant` message,
+    * so a turn that dispatches one under-counts.
+    */
+  private var responseIdsThisTurn: Set[String] = Set.empty
+
   /** Tool-use ids suppressed in `handleAssistantTurn` — `ask_user` invocations
     * and (in structured mode) the CLI-injected `StructuredOutput` exit call.
     * `handleUserTurn` drops the matching `tool_result` so the suppressed
@@ -102,8 +113,10 @@ private[claude] class ClaudeConversation(
   private def handle(msg: InboundMessage): Unit = msg match
     case InboundMessage.SystemInit(_, model) =>
       initModel = model
-    case InboundMessage.AssistantTurn(content) => handleAssistantTurn(content)
-    case InboundMessage.UserTurn(content)      => handleUserTurn(content)
+    case InboundMessage.AssistantTurn(content, messageId) =>
+      responseIdsThisTurn ++= messageId
+      handleAssistantTurn(content)
+    case InboundMessage.UserTurn(content) => handleUserTurn(content)
     case result: InboundMessage.Result =>
       if result.isError then handleResultError(result)
       else handleResult(result)
@@ -190,11 +203,25 @@ private[claude] class ClaudeConversation(
     settleSuccess(
       wireId = result.sessionId,
       output = resultBody(result).getOrElse(""),
-      usage = result.usage,
+      usage = withApiCalls(result.usage),
       // Fall back to the model claude announced in system.init when the
       // result message omits it.
       modelId = result.model.orElse(initModel)
     )
+
+  /** Attaches the turn's API-call count to its usage and clears the tally, so
+    * the next turn of a multi-turn conversation counts its own responses.
+    *
+    * Having seen no response id leaves the count absent rather than zero: a
+    * turn that reports tokens made requests, so zero would mean "none happened"
+    * where the truth is "none were observed".
+    */
+  private def withApiCalls(usage: orca.events.Usage): orca.events.Usage =
+    val counted =
+      if responseIdsThisTurn.isEmpty then usage
+      else usage.copy(apiCalls = Some(responseIdsThisTurn.size.toLong))
+    responseIdsThisTurn = Set.empty
+    counted
 
   /** The result message's payload: the `--json-schema` validated value when the
     * session ran structured, else the free-form reply; `None` when the message
@@ -232,7 +259,7 @@ private[claude] class ClaudeConversation(
       new AgentTurnFailed(
         s"claude session failed (subtype ${result.subtype}, " +
           s"session ${result.sessionId}): $message",
-        usage = Some(result.usage)
+        usage = Some(withApiCalls(result.usage))
       )
     )
 

--- a/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
@@ -71,9 +71,13 @@ private[claude] class ClaudeConversation(
     * reports directly. A set, not a counter: the CLI emits one `assistant`
     * message per content group, several sharing one response id.
     *
-    * Counts main-loop responses only. A `Task` subagent's requests are folded
-    * into the result's token totals but emit no top-level `assistant` message,
-    * so a turn that dispatches one under-counts.
+    * A turn that dispatches a subagent counts the subagent's responses too —
+    * the CLI forwards them on this stream, even though it files them under a
+    * separate session transcript. Measured on one such turn: 53 responses
+    * counted here against 18 in the dispatching session's own transcript. Its
+    * token total is the CLI's aggregate for the whole turn and did not equal
+    * the sum of either set, so `promptTokens / apiCalls` means little on a turn
+    * like that.
     */
   private var responseIdsThisTurn: Set[String] = Set.empty
 

--- a/claude/src/main/scala/orca/tools/claude/streamjson/InboundMessage.scala
+++ b/claude/src/main/scala/orca/tools/claude/streamjson/InboundMessage.scala
@@ -79,6 +79,13 @@ private[claude] object InboundMessage:
     // wire's "cache creation" is orca's cache write.
     val cacheWrite = u.cache_creation_input_tokens.getOrElse(0L)
     val cacheRead = u.cache_read_input_tokens.getOrElse(0L)
+    // `num_turns` counts this turn's agentic iterations — one model request
+    // each, and it resets per turn rather than accumulating over a resumed
+    // session. Verified against claude 2.1.220 by counting the `message_start`
+    // stream events on the same runs (1/2/4 calls, and 2 on a `--resume`):
+    // `num_turns` matched every time. The `assistant` messages did NOT — the
+    // CLI emits several per model response — so counting those would
+    // over-report.
     Result(
       subtype = wire.subtype,
       sessionId = wire.session_id,
@@ -89,7 +96,8 @@ private[claude] object InboundMessage:
         outputTokens = u.output_tokens.getOrElse(0L),
         cost = wire.total_cost_usd,
         cacheReadInputTokens = cacheRead,
-        cacheWriteInputTokens = cacheWrite
+        cacheWriteInputTokens = cacheWrite,
+        apiCalls = wire.num_turns
       ),
       isError = wire.is_error.getOrElse(false),
       model = wire.model
@@ -140,7 +148,8 @@ private[claude] object InboundMessage:
       usage: Option[UsageWire] = None,
       total_cost_usd: Option[BigDecimal] = None,
       is_error: Option[Boolean] = None,
-      model: Option[String] = None
+      model: Option[String] = None,
+      num_turns: Option[Long] = None
   ) derives ConfiguredJsonValueCodec
 
   private case class ControlRequestWire(request_id: String, request: RawJson)

--- a/claude/src/main/scala/orca/tools/claude/streamjson/InboundMessage.scala
+++ b/claude/src/main/scala/orca/tools/claude/streamjson/InboundMessage.scala
@@ -18,7 +18,15 @@ private[claude] enum InboundMessage:
     * [[Result]] message's own `model` field; when both are present they agree.
     */
   case SystemInit(sessionId: String, model: Option[String])
-  case AssistantTurn(content: List[ContentBlock])
+
+  /** `messageId` is the model response this content came from. The CLI splits
+    * one response across several `assistant` messages (prose, then each tool
+    * call), all repeating the same id — so counting DISTINCT ids counts model
+    * responses, which is what [[orca.events.Usage.apiCalls]] wants. `None` if
+    * the CLI ever omits it, which would make the count an undercount, so the
+    * driver keeps it optional rather than substituting a placeholder.
+    */
+  case AssistantTurn(content: List[ContentBlock], messageId: Option[String])
   case UserTurn(content: List[ContentBlock])
 
   /** Final turn result. When the session ran with `--json-schema`, the
@@ -63,7 +71,7 @@ private[claude] object InboundMessage:
 
   private def parseAssistant(line: String): InboundMessage =
     val wire = readFromString[MessageWire](line)
-    AssistantTurn(wire.message.toBlocks)
+    AssistantTurn(wire.message.toBlocks, wire.message.id)
 
   private def parseUser(line: String): InboundMessage =
     val wire = readFromString[MessageWire](line)
@@ -79,13 +87,11 @@ private[claude] object InboundMessage:
     // wire's "cache creation" is orca's cache write.
     val cacheWrite = u.cache_creation_input_tokens.getOrElse(0L)
     val cacheRead = u.cache_read_input_tokens.getOrElse(0L)
-    // `num_turns` counts this turn's agentic iterations — one model request
-    // each, and it resets per turn rather than accumulating over a resumed
-    // session. Verified against claude 2.1.220 by counting the `message_start`
-    // stream events on the same runs (1/2/4 calls, and 2 on a `--resume`):
-    // `num_turns` matched every time. The `assistant` messages did NOT — the
-    // CLI emits several per model response — so counting those would
-    // over-report.
+    // The result message's own `num_turns` looks like a call count and is not
+    // one: measured against claude 2.1.220 it is (tool calls + 1), so a
+    // response issuing three tool calls at once reports three turns where one
+    // request was made. The count comes from the distinct `assistant` message
+    // ids instead — see [[ClaudeConversation]].
     Result(
       subtype = wire.subtype,
       sessionId = wire.session_id,
@@ -96,8 +102,7 @@ private[claude] object InboundMessage:
         outputTokens = u.output_tokens.getOrElse(0L),
         cost = wire.total_cost_usd,
         cacheReadInputTokens = cacheRead,
-        cacheWriteInputTokens = cacheWrite,
-        apiCalls = wire.num_turns
+        cacheWriteInputTokens = cacheWrite
       ),
       isError = wire.is_error.getOrElse(false),
       model = wire.model
@@ -125,8 +130,10 @@ private[claude] object InboundMessage:
       model: Option[String] = None
   ) derives ConfiguredJsonValueCodec
 
-  private case class InnerMessage(content: List[RawJson] = Nil)
-      derives ConfiguredJsonValueCodec:
+  private case class InnerMessage(
+      content: List[RawJson] = Nil,
+      id: Option[String] = None
+  ) derives ConfiguredJsonValueCodec:
     def toBlocks: List[ContentBlock] =
       content.map(b => ContentBlock.parse(b.value))
 
@@ -148,8 +155,7 @@ private[claude] object InboundMessage:
       usage: Option[UsageWire] = None,
       total_cost_usd: Option[BigDecimal] = None,
       is_error: Option[Boolean] = None,
-      model: Option[String] = None,
-      num_turns: Option[Long] = None
+      model: Option[String] = None
   ) derives ConfiguredJsonValueCodec
 
   private case class ControlRequestWire(request_id: String, request: RawJson)

--- a/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
@@ -60,6 +60,34 @@ class ClaudeConversationTest extends munit.FunSuite:
     assertEquals(result.output, "done")
     assertEquals(result.usage, Usage(5L, 7L, None))
 
+  // Nothing on the wire reports how many requests a turn made. The CLI splits
+  // one model response into several `assistant` messages sharing one id, and a
+  // response can carry several tool calls, so neither message count nor tool
+  // count is the answer — only the distinct ids are.
+  convTest("a turn's API-call count is its distinct response ids"):
+    val process = new FakePipedCliProcess()
+    val conv = new ClaudeConversation(process, AgentConfig())
+
+    // One response, split into prose and two parallel tool calls...
+    process.enqueueStdout(
+      """{"type":"assistant","message":{"id":"msg_a","role":"assistant","content":[{"type":"text","text":"checking"}]}}"""
+    )
+    process.enqueueStdout(
+      """{"type":"assistant","message":{"id":"msg_a","role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read","input":{}},{"type":"tool_use","id":"t2","name":"Read","input":{}}]}}"""
+    )
+    // ...then a second response.
+    process.enqueueStdout(
+      """{"type":"assistant","message":{"id":"msg_b","role":"assistant","content":[{"type":"text","text":"done"}]}}"""
+    )
+    process.enqueueStdout(
+      """{"type":"result","subtype":"success","session_id":"sid-calls","result":"done","usage":{"input_tokens":9,"output_tokens":4}}"""
+    )
+    process.closeStdout()
+
+    val _ = conv.events.toList
+    val Right(result) = conv.awaitResult(): @unchecked
+    assertEquals(result.usage.apiCalls, Some(2L))
+
   convTest(
     "is_error after streaming deltas emits a short marker, not a duplicate"
   ):

--- a/claude/src/test/scala/orca/tools/claude/streamjson/InboundMessageTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/streamjson/InboundMessageTest.scala
@@ -55,6 +55,25 @@ class InboundMessageTest extends munit.FunSuite:
       )
     )
 
+  // Every one of a turn's iterations re-sends the whole prompt, so the count is
+  // what turns the recorded prompt size into a bill.
+  test("result carries num_turns as the turn's API-call count"):
+    val msg = InboundMessage.parse(
+      """{"type":"result","subtype":"success","session_id":"sid-1","num_turns":4,"usage":{"input_tokens":10,"output_tokens":20}}"""
+    )
+    assertEquals(
+      msg.asInstanceOf[InboundMessage.Result].usage.apiCalls,
+      Some(4L)
+    )
+
+  // A CLI build that stops reporting the count must leave it absent: a silent
+  // fallback to one would read downstream exactly like a measured single call.
+  test("result without num_turns reports no API-call count"):
+    val msg = InboundMessage.parse(
+      """{"type":"result","subtype":"success","session_id":"sid-1","usage":{"input_tokens":10,"output_tokens":20}}"""
+    )
+    assertEquals(msg.asInstanceOf[InboundMessage.Result].usage.apiCalls, None)
+
   test("result surfaces the resolved model id when present"):
     val msg = InboundMessage.parse(
       """{"type":"result","subtype":"success","session_id":"sid-1","model":"claude-opus-4-7"}"""

--- a/claude/src/test/scala/orca/tools/claude/streamjson/InboundMessageTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/streamjson/InboundMessageTest.scala
@@ -25,8 +25,20 @@ class InboundMessageTest extends munit.FunSuite:
     assertEquals(
       msg,
       InboundMessage.AssistantTurn(
-        List(ContentBlock.Text("hi"), ContentBlock.Thinking("ponder"))
+        List(ContentBlock.Text("hi"), ContentBlock.Thinking("ponder")),
+        None
       )
+    )
+
+  // The driver counts a turn's model responses by their distinct ids, so the id
+  // has to survive parsing.
+  test("assistant turn carries the id of the response it came from"):
+    val msg = InboundMessage.parse(
+      """{"type":"assistant","message":{"id":"msg_01ab","role":"assistant","content":[{"type":"text","text":"hi"}]}}"""
+    )
+    assertEquals(
+      msg.asInstanceOf[InboundMessage.AssistantTurn].messageId,
+      Some("msg_01ab")
     )
 
   test("result picks up structured_output as raw JSON + tallies usage"):
@@ -55,22 +67,11 @@ class InboundMessageTest extends munit.FunSuite:
       )
     )
 
-  // Every one of a turn's iterations re-sends the whole prompt, so the count is
-  // what turns the recorded prompt size into a bill.
-  test("result carries num_turns as the turn's API-call count"):
+  // `num_turns` is the obvious-looking call count and is the wrong one — it
+  // counts tool calls, not requests. The driver must not pick it up here.
+  test("result ignores num_turns: the call count is not the parser's to set"):
     val msg = InboundMessage.parse(
       """{"type":"result","subtype":"success","session_id":"sid-1","num_turns":4,"usage":{"input_tokens":10,"output_tokens":20}}"""
-    )
-    assertEquals(
-      msg.asInstanceOf[InboundMessage.Result].usage.apiCalls,
-      Some(4L)
-    )
-
-  // A CLI build that stops reporting the count must leave it absent: a silent
-  // fallback to one would read downstream exactly like a measured single call.
-  test("result without num_turns reports no API-call count"):
-    val msg = InboundMessage.parse(
-      """{"type":"result","subtype":"success","session_id":"sid-1","usage":{"input_tokens":10,"output_tokens":20}}"""
     )
     assertEquals(msg.asInstanceOf[InboundMessage.Result].usage.apiCalls, None)
 
@@ -112,7 +113,7 @@ class InboundMessageTest extends munit.FunSuite:
     val msg = InboundMessage.parse(
       """{"type":"assistant","message":{"role":"assistant","content":[]}}"""
     )
-    assertEquals(msg, InboundMessage.AssistantTurn(Nil))
+    assertEquals(msg, InboundMessage.AssistantTurn(Nil, None))
 
   test(
     "result with all optional fields absent defaults usage to zero and isError to false"

--- a/flow/src/main/scala/orca/events/CostTracker.scala
+++ b/flow/src/main/scala/orca/events/CostTracker.scala
@@ -67,7 +67,7 @@ class CostTracker(pricing: PriceList = Pricing.default) extends OrcaListener:
   def onEvent(event: OrcaEvent): Unit = event match
     // `attempt` is ignored: a retry's tokens count toward the run's spend like
     // any other turn's.
-    case OrcaEvent.TokensUsed(agent, model, usage, role, _) =>
+    case OrcaEvent.TokensUsed(agent, model, usage, role, _, _) =>
       val cost = Pricing.resolve(pricing.table, model, usage)
       val _ = state.updateAndGet(_.record(agent, model, usage, cost, role))
     case _ => ()

--- a/runner/src/main/scala/orca/runner/LoggingListener.scala
+++ b/runner/src/main/scala/orca/runner/LoggingListener.scala
@@ -33,13 +33,14 @@ private[orca] class LoggingListener extends OrcaListener:
         "structured result: {}",
         summary.filter(_.nonEmpty).getOrElse(raw)
       )
-    case OrcaEvent.TokensUsed(agent, model, usage, role, attempt) =>
+    case OrcaEvent.TokensUsed(agent, model, usage, role, attempt, session) =>
       log.debug(
-        "tokens: agent={} role={} model={} attempt={} usage={}",
+        "tokens: agent={} role={} model={} attempt={} session={} usage={}",
         agent,
         role.getOrElse("(none)"),
         model.map(_.name).getOrElse("(unknown)"),
         attempt,
+        session.getOrElse("(none)"),
         usage
       )
     case OrcaEvent.Error(message) => log.error("error: {}", message)

--- a/runner/src/main/scala/orca/runner/manifest/RunManifest.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifest.scala
@@ -115,9 +115,11 @@ private[orca] object ManifestCostSummary:
   * session, which holds for reviewers and fails for the implementer.
   *
   * `apiCalls` is how many model requests the turn made — see
-  * [[orca.events.Usage.apiCalls]], including why `None` is not one. Each of
-  * them re-sends the whole prompt, so `promptTokens / apiCalls` is the per-call
-  * prompt and the rest is what the turn's own work added.
+  * [[orca.events.Usage.apiCalls]], including why `None` is not one. Every call
+  * re-sends the conversation so far, so `promptTokens / apiCalls` is the MEAN
+  * prompt per call and no single call matches it: the first is the smallest and
+  * the last the largest. A turn's fixed floor is the first call's prompt, which
+  * this file does not record — only the mean is derivable here.
   *
   * `at` is stamped when the writer records the turn, not when the tokens were
   * spent: the event crosses an actor mailbox first.

--- a/runner/src/main/scala/orca/runner/manifest/RunManifest.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifest.scala
@@ -108,6 +108,17 @@ private[orca] object ManifestCostSummary:
   * [[orca.events.OrcaEvent.TokensUsed]]); turns with `attempt > 1` are what
   * retries added to the run's spend.
   *
+  * `session` is the key the turn's conversation is recorded under in
+  * [[RunManifest.sessions]] — `ManifestSession.wireId` when there is one, else
+  * the client id. It makes "the first turn of a session" exact; without it the
+  * only way to spot one is a `agent` name that happens to be unique to a single
+  * session, which holds for reviewers and fails for the implementer.
+  *
+  * `apiCalls` is how many model requests the turn made — see
+  * [[orca.events.Usage.apiCalls]], including why `None` is not one. Each of
+  * them re-sends the whole prompt, so `promptTokens / apiCalls` is the per-call
+  * prompt and the rest is what the turn's own work added.
+  *
   * `at` is stamped when the writer records the turn, not when the tokens were
   * spent: the event crosses an actor mailbox first.
   */
@@ -117,10 +128,12 @@ private[orca] case class ManifestTurn(
     role: Option[String],
     stage: Option[String],
     promptTokens: Long,
-    attempt: Int
+    attempt: Int,
+    session: Option[String],
+    apiCalls: Option[Long]
 )
 
-/** Schema v4 (ADR 0021 §8) of a per-run manifest written to
+/** Schema v5 (ADR 0021 §8) of a per-run manifest written to
   * `.orca/cache/runs/<startedAt-epoch-ms>-<pid>.json`, read by the shell to
   * offer "continue a session". `manifestVersion` is a hard gate: a reader
   * checks it before decoding and skips anything it doesn't write itself, rather
@@ -156,7 +169,7 @@ private[orca] object RunManifest:
     * `.orca/cache/runs/` is pruned cache data, so an unreadable run costs a
     * "continue" offer for that run and nothing else.
     */
-  val SupportedVersion = 4
+  val SupportedVersion = 5
 
   // The `outcome` and `ManifestSession.kind` wire strings, named once here so
   // the writer that produces them (RunManifestWriter's Outcome/SessionKind

--- a/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
@@ -164,14 +164,16 @@ private[runner] class RunManifestWriterState(
       safeWrite()
     // Accumulate only: a turn fires far more often than a stage or session
     // event, and every write rewrites the whole file.
-    case OrcaEvent.TokensUsed(agent, model, usage, role, attempt) =>
+    case OrcaEvent.TokensUsed(agent, model, usage, role, attempt, session) =>
       val turn = ManifestTurn(
         at = clock().toString,
         agent = agent,
         role = role,
         stage = state.stageStack.headOption,
         promptTokens = usage.inputTokens,
-        attempt = attempt
+        attempt = attempt,
+        session = session,
+        apiCalls = usage.apiCalls
       )
       state = state.copy(cost =
         state.cost
@@ -216,7 +218,7 @@ private[runner] class RunManifestWriterState(
       agent: String,
       role: Option[String]
   ): List[Entry] =
-    val key = wireId.getOrElse(clientId)
+    val key = OrcaEvent.sessionKey(clientId, wireId)
     val now = clock().toString
     val stage = state.stageStack.headOption
     val sessionName = durableSessionName(clientId)

--- a/runner/src/test/scala/flowtests/FlowCompilesTest.scala
+++ b/runner/src/test/scala/flowtests/FlowCompilesTest.scala
@@ -225,7 +225,7 @@ object FlowCanary:
         val tracker = new CostTracker()
         val _: Option[Cost] = tracker.totalCost
         val listener: OrcaListener =
-          case OrcaEvent.TokensUsed(_, _, usage, _, _) =>
+          case OrcaEvent.TokensUsed(_, _, usage, _, _, _) =>
             val _: Usage = usage
           case _ => ()
         val _ = listener

--- a/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
+++ b/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
@@ -250,8 +250,8 @@ class OrcaOverridesTest extends munit.FunSuite:
     // agent's "wired" event must be among them.
     var seen: List[String] = Nil
     val recorder: OrcaListener =
-      case OrcaEvent.TokensUsed(agent, _, _, _, _) => seen = agent :: seen
-      case _                                       => ()
+      case OrcaEvent.TokensUsed(agent, _, _, _, _, _) => seen = agent :: seen
+      case _                                          => ()
     supervised:
       val interaction = TerminalInteraction.start(
         out = new PrintStream(new ByteArrayOutputStream()),

--- a/runner/src/test/scala/orca/runner/manifest/RunManifestTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/RunManifestTest.scala
@@ -13,6 +13,9 @@ class RunManifestTest extends munit.FunSuite:
   test("ManifestUsage mirrors every token axis of Usage"):
     assertEquals(
       ManifestUsage.empty.productElementNames.toSet,
-      // `cost` is Usage's one non-token field, deliberately not persisted.
-      Usage.empty.productElementNames.toSet - "cost"
+      // Usage's two non-token fields, deliberately not persisted here: `cost`
+      // at all (see ManifestUsage's scaladoc), and `apiCalls` per turn instead
+      // (ManifestTurn) — a subtotal's summed count would silently under-report
+      // whenever a backend that can't count contributed to it.
+      Usage.empty.productElementNames.toSet - "cost" - "apiCalls"
     )

--- a/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
@@ -490,7 +490,7 @@ class RunManifestWriterTest extends munit.FunSuite:
     )
 
   test(
-    "per-turn log records each turn's identity, stage, prompt size, attempt"
+    "per-turn log records identity, stage, prompt size, attempt, session, API calls"
   ):
     val workDir = TempDirs.dir()
     val writer =
@@ -500,15 +500,24 @@ class RunManifestWriterTest extends munit.FunSuite:
       OrcaEvent
         .SessionCommitted("claude", "client-1", Some("wire-1"), "claude", None)
     )
+    // The session key matches the one `SessionCommitted` above dedups under, so
+    // this turn joins to the session recorded in the manifest.
     writer.onEvent(
-      OrcaEvent.TokensUsed("claude", None, Usage(107_000, 500, None), None)
+      OrcaEvent.TokensUsed(
+        "claude",
+        None,
+        Usage(107_000, 500, None, apiCalls = Some(3L)),
+        None,
+        session = Some("wire-1")
+      )
     )
     // Closing the stage between the two turns pins that the stage is stamped
     // when a turn is recorded, not when the manifest is later written.
     writer.onEvent(OrcaEvent.StageCompleted("code"))
     // The CLI answering from leftover session state: no request went out, so
-    // every counter is zero. Recorded as a retry so the assertion below shows
-    // the attempt index reaching the manifest, rather than a constant 1.
+    // every counter is zero and the backend reported no call count. Recorded as
+    // a retry so the assertion below shows the attempt index reaching the
+    // manifest, rather than a constant 1.
     writer.onEvent(
       OrcaEvent.TokensUsed(
         "reviewer",
@@ -530,7 +539,9 @@ class RunManifestWriterTest extends munit.FunSuite:
           role = None,
           stage = Some("code"),
           promptTokens = 107_000,
-          attempt = 1
+          attempt = 1,
+          session = Some("wire-1"),
+          apiCalls = Some(3L)
         ),
         ManifestTurn(
           at = "2026-07-18T10:00:00Z",
@@ -538,7 +549,9 @@ class RunManifestWriterTest extends munit.FunSuite:
           role = Some("reviewer"),
           stage = None,
           promptTokens = 0,
-          attempt = 2
+          attempt = 2,
+          session = None,
+          apiCalls = None
         )
       )
     )

--- a/tools/src/main/scala/orca/agents/AgentCall.scala
+++ b/tools/src/main/scala/orca/agents/AgentCall.scala
@@ -178,17 +178,6 @@ class DefaultAgentCall[B <: BackendTag, O](
       )
     )
 
-  /** The key [[emitSessionCommitted]]'s event will be deduplicated under, so a
-    * turn names the same session the manifest records. Resolved per turn rather
-    * than once per call: the wire id is minted during the first turn, so a
-    * value cached before it would name the session by its client id only.
-    */
-  private def sessionKeyOf(session: SessionId[B]): String =
-    OrcaEvent.sessionKey(
-      session.value,
-      backend.sessions.persistableWireId(session).map(_.value)
-    )
-
   /** THE retry policy — the only place that decides whether an autonomous-turn
     * failure gets retried: parse failures (corrective re-prompt, same session
     * resumed) and pre-spawn open failures (a fresh spawn) are retried;
@@ -236,7 +225,7 @@ class DefaultAgentCall[B <: BackendTag, O](
           usage,
           agentRole,
           turnsRecorded,
-          Some(sessionKeyOf(session))
+          Some(backend.sessions.sessionKey(session))
         )
       )
 
@@ -363,7 +352,7 @@ class DefaultAgentCall[B <: BackendTag, O](
         result.model.orElse(effective.model),
         result.usage,
         agentRole,
-        session = Some(sessionKeyOf(session))
+        session = Some(backend.sessions.sessionKey(session))
       )
     )
     val parsed = ResponseParser.parse[O](result.output)

--- a/tools/src/main/scala/orca/agents/AgentCall.scala
+++ b/tools/src/main/scala/orca/agents/AgentCall.scala
@@ -178,6 +178,17 @@ class DefaultAgentCall[B <: BackendTag, O](
       )
     )
 
+  /** The key [[emitSessionCommitted]]'s event will be deduplicated under, so a
+    * turn names the same session the manifest records. Resolved per turn rather
+    * than once per call: the wire id is minted during the first turn, so a
+    * value cached before it would name the session by its client id only.
+    */
+  private def sessionKeyOf(session: SessionId[B]): String =
+    OrcaEvent.sessionKey(
+      session.value,
+      backend.sessions.persistableWireId(session).map(_.value)
+    )
+
   /** THE retry policy — the only place that decides whether an autonomous-turn
     * failure gets retried: parse failures (corrective re-prompt, same session
     * resumed) and pre-spawn open failures (a fresh spawn) are retried;
@@ -219,7 +230,14 @@ class DefaultAgentCall[B <: BackendTag, O](
     def recordTurn(model: Option[Model], usage: Usage): Unit =
       turnsRecorded += 1
       events.onEvent(
-        OrcaEvent.TokensUsed(agentName, model, usage, agentRole, turnsRecorded)
+        OrcaEvent.TokensUsed(
+          agentName,
+          model,
+          usage,
+          agentRole,
+          turnsRecorded,
+          Some(sessionKeyOf(session))
+        )
       )
 
     /** One attempt: build this iteration's prompt (the initial one, or a
@@ -344,7 +362,8 @@ class DefaultAgentCall[B <: BackendTag, O](
         agentName,
         result.model.orElse(effective.model),
         result.usage,
-        agentRole
+        agentRole,
+        session = Some(sessionKeyOf(session))
       )
     )
     val parsed = ResponseParser.parse[O](result.output)

--- a/tools/src/main/scala/orca/agents/BaseAgent.scala
+++ b/tools/src/main/scala/orca/agents/BaseAgent.scala
@@ -110,9 +110,9 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
         val effective = effectiveConfig(callConfig)
         if emitPrompt then events.onEvent(OrcaEvent.UserPrompt(prompt))
         val result =
-          runAccountingForFailure(effective):
+          runAccountingForFailure(effective, session):
             backend.runAutonomous(prompt, session, effective, events)
-        emitTokens(effective, result)
+        emitTokens(effective, session, result)
         emitSessionCommitted(session)
         result.output
 
@@ -130,15 +130,16 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
       e match
         case _: OrcaEvent.AssistantMessage | _: OrcaEvent.ToolUse => ()
         case other => events.onEvent(other)
+    val session = SessionId.fresh[B]
     val result =
-      runAccountingForFailure(effective):
+      runAccountingForFailure(effective, session):
         backend.runAutonomous(
           prompt,
-          SessionId.fresh[B],
+          session,
           effective,
           quietEvents
         )
-    emitTokens(effective, result)
+    emitTokens(effective, session, result)
     result.output
 
   def resultAs[O: JsonData: Announce]: AgentCall[B, O] =
@@ -160,23 +161,50 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
     * the bucket key is whatever the caller pinned.
     */
   private def runAccountingForFailure(
-      effective: AgentConfig
+      effective: AgentConfig,
+      session: SessionId[B]
   )(turn: => AgentResult[B]): AgentResult[B] =
     try turn
     catch
       case e: AgentTurnFailed =>
         e.usage.foreach: usage =>
           events.onEvent(
-            OrcaEvent.TokensUsed(name, effective.model, usage, role)
+            OrcaEvent.TokensUsed(
+              name,
+              effective.model,
+              usage,
+              role,
+              session = Some(sessionKeyOf(session))
+            )
           )
         throw e
 
   /** `model` prefers the response-reported model (most precise), falling back
     * to whatever the caller pinned in config, `None` when neither is known.
     */
-  private def emitTokens(effective: AgentConfig, result: AgentResult[B]): Unit =
+  private def emitTokens(
+      effective: AgentConfig,
+      session: SessionId[B],
+      result: AgentResult[B]
+  ): Unit =
     val model = result.model.orElse(effective.model)
-    events.onEvent(OrcaEvent.TokensUsed(name, model, result.usage, role))
+    events.onEvent(
+      OrcaEvent.TokensUsed(
+        name,
+        model,
+        result.usage,
+        role,
+        session = Some(sessionKeyOf(session))
+      )
+    )
+
+  /** The key [[emitSessionCommitted]]'s event will be deduplicated under, so a
+    * turn names the same session the manifest records. Resolved per turn rather
+    * than once per call: the wire id is minted during the first turn, so a
+    * value cached before it would name the session by its client id only.
+    */
+  private def sessionKeyOf(session: SessionId[B]): String =
+    OrcaEvent.sessionKey(session.value, resumeWireId(session).map(_.value))
 
   /** Fires once a session's first turn commits (ADR 0021 §8): reads
     * `resumeWireId` after `backend.runAutonomous` returns, so `wireId` reflects

--- a/tools/src/main/scala/orca/agents/BaseAgent.scala
+++ b/tools/src/main/scala/orca/agents/BaseAgent.scala
@@ -174,7 +174,7 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
               effective.model,
               usage,
               role,
-              session = Some(sessionKeyOf(session))
+              session = Some(backend.sessions.sessionKey(session))
             )
           )
         throw e
@@ -194,17 +194,9 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
         model,
         result.usage,
         role,
-        session = Some(sessionKeyOf(session))
+        session = Some(backend.sessions.sessionKey(session))
       )
     )
-
-  /** The key [[emitSessionCommitted]]'s event will be deduplicated under, so a
-    * turn names the same session the manifest records. Resolved per turn rather
-    * than once per call: the wire id is minted during the first turn, so a
-    * value cached before it would name the session by its client id only.
-    */
-  private def sessionKeyOf(session: SessionId[B]): String =
-    OrcaEvent.sessionKey(session.value, resumeWireId(session).map(_.value))
 
   /** Fires once a session's first turn commits (ADR 0021 §8): reads
     * `resumeWireId` after `backend.runAutonomous` returns, so `wireId` reflects

--- a/tools/src/main/scala/orca/backend/SessionSupport.scala
+++ b/tools/src/main/scala/orca/backend/SessionSupport.scala
@@ -137,6 +137,21 @@ final class SessionSupport[B <: BackendTag] private (
   def persistableWireId(client: SessionId[B]): Option[WireSessionId[B]] =
     if probe.isDefined then resumeWire(client) else None
 
+  /** The one identity this session is known by across events — see
+    * [[orca.events.OrcaEvent.sessionKey]]. Lives next to the client→wire map so
+    * every emitter derives it the same way; a second derivation elsewhere is
+    * how a turn stops joining to the session that produced it.
+    *
+    * Resolve it per turn, not once per call: the wire id is minted during the
+    * first turn, so a value taken before that names the session by its client
+    * id only.
+    */
+  def sessionKey(client: SessionId[B]): String =
+    orca.events.OrcaEvent.sessionKey(
+      SessionId.value(client),
+      persistableWireId(client).map(WireSessionId.value)
+    )
+
   /** Will the next call on `client` continue an already-live conversation
     * (rather than start a fresh one that must be re-seeded)? The
     * durable-session runtime asks this before deciding whether to re-inject the

--- a/tools/src/main/scala/orca/events/OrcaEvent.scala
+++ b/tools/src/main/scala/orca/events/OrcaEvent.scala
@@ -48,13 +48,20 @@ enum OrcaEvent:
     * counts turns, not tries — an attempt that fails before the model runs
     * emits no event, so it doesn't shift the index of the turn that follows.
     * Emission sites that never retry leave the default.
+    *
+    * `session` is [[OrcaEvent.sessionKey]] for the conversation this turn ran
+    * in — the same key [[SessionCommitted]] is deduplicated under, so turns and
+    * sessions join on it. Two turns of one session carry the same value; the
+    * first turn of a session is the earliest turn carrying it. `None` only
+    * where the emitter has no conversation to name (test stubs).
     */
   case TokensUsed(
       agent: String,
       model: Option[Model],
       usage: Usage,
       role: Option[String] = None,
-      attempt: Int = 1
+      attempt: Int = 1,
+      session: Option[String] = None
   )
 
   /** The agent's final structured payload, after parsing succeeded. `raw` is
@@ -106,6 +113,16 @@ enum OrcaEvent:
       agent: String,
       role: Option[String]
   )
+
+object OrcaEvent:
+  /** The one identity a session is known by across events: its wire id once the
+    * backend has minted one, else the client id orca allocated. Named here so
+    * [[OrcaEvent.TokensUsed.session]] and the manifest writer's session dedup
+    * key cannot drift apart — if they did, turns would stop joining to the
+    * sessions that produced them.
+    */
+  def sessionKey(clientId: String, wireId: Option[String]): String =
+    wireId.getOrElse(clientId)
 
 /** Sink for [[OrcaEvent]]s.
   *

--- a/tools/src/main/scala/orca/events/Usage.scala
+++ b/tools/src/main/scala/orca/events/Usage.scala
@@ -17,9 +17,15 @@ package orca.events
   *     cache-heavy run badly.
   *   - `reasoningOutputTokens` is the internal-reasoning sub-portion of
   *     `outputTokens` (codex / o-series).
+  *   - `apiCalls` is how many model requests the token counts above cover. A
+  *     turn that runs a tool makes at least two, and every one of them re-sends
+  *     the whole prompt — so it is what turns a prompt size into a bill. `None`
+  *     means the backend does not report it, which is not the same as one: an
+  *     inferred count would be indistinguishable from a measured one
+  *     downstream, so backends that cannot count leave it unset.
   *
-  * All three breakdowns are non-cumulative, so callers can report cache-hit,
-  * cache-write and reasoning ratios directly.
+  * All three token breakdowns are non-cumulative, so callers can report
+  * cache-hit, cache-write and reasoning ratios directly.
   *
   * A new backend must fold cache-read and cache-written tokens INTO
   * `inputTokens` rather than report them alongside it, and leave
@@ -37,9 +43,13 @@ case class Usage(
     cost: Option[BigDecimal],
     cacheReadInputTokens: Long = 0L,
     reasoningOutputTokens: Long = 0L,
-    cacheWriteInputTokens: Long = 0L
+    cacheWriteInputTokens: Long = 0L,
+    apiCalls: Option[Long] = None
 ):
-  /** Combine two usages; cost is `Some` iff at least one side reports it. */
+  /** Combine two usages; `cost` and `apiCalls` are `Some` iff at least one side
+    * reports them, so a sum that mixes a reporting backend with a silent one
+    * under-counts rather than dropping the half that was measured.
+    */
   def +(that: Usage): Usage =
     Usage(
       inputTokens = inputTokens + that.inputTokens,
@@ -48,8 +58,10 @@ case class Usage(
       cacheReadInputTokens = cacheReadInputTokens + that.cacheReadInputTokens,
       reasoningOutputTokens =
         reasoningOutputTokens + that.reasoningOutputTokens,
-      cacheWriteInputTokens = cacheWriteInputTokens + that.cacheWriteInputTokens
+      cacheWriteInputTokens =
+        cacheWriteInputTokens + that.cacheWriteInputTokens,
+      apiCalls = (apiCalls ++ that.apiCalls).reduceOption(_ + _)
     )
 
 object Usage:
-  val empty: Usage = Usage(0L, 0L, None, 0L, 0L, 0L)
+  val empty: Usage = Usage(0L, 0L, None, 0L, 0L, 0L, None)

--- a/tools/src/test/scala/orca/agents/BaseAgentTest.scala
+++ b/tools/src/test/scala/orca/agents/BaseAgentTest.scala
@@ -263,6 +263,21 @@ class BaseAgentTest extends munit.FunSuite:
     assertEquals(committed.head.agent, "stub")
     assertEquals(committed.head.role, None)
 
+  // A turn joins to the session that produced it only if it names that session
+  // by the same key `SessionCommitted` is deduplicated under — here the wire id
+  // the backend minted during the call, not the client id orca started with.
+  test("a turn names its session by the wire id the backend committed"):
+    val seen =
+      new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
+    val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
+    val tool =
+      new StubTool(new CommittingBackend("wire-joined"), listener = listener)
+    val _ = tool.run("prompt")
+    assertEquals(
+      seen.get().collect { case t: OrcaEvent.TokensUsed => t.session },
+      List(Some("wire-joined"))
+    )
+
   // `quietTextTurn` runs `backend.runAutonomous` directly on a fresh session,
   // bypassing `runWithSession` entirely — it must never surface a session to
   // the manifest writer.

--- a/tools/src/test/scala/orca/events/UsageTest.scala
+++ b/tools/src/test/scala/orca/events/UsageTest.scala
@@ -10,7 +10,8 @@ class UsageTest extends munit.FunSuite:
       outputTokens = 100L,
       cost = Some(BigDecimal("0.10")),
       cacheReadInputTokens = 600L,
-      cacheWriteInputTokens = 300L
+      cacheWriteInputTokens = 300L,
+      apiCalls = Some(2L)
     )
     val fewerWrites = Usage(
       inputTokens = 500L,
@@ -20,9 +21,13 @@ class UsageTest extends munit.FunSuite:
       reasoningOutputTokens = 20L,
       // non-zero, and different from `withWrites`, so a keep-one-side `+`
       // can't produce the expected total on this axis either
-      cacheWriteInputTokens = 90L
+      cacheWriteInputTokens = 90L,
+      // Unset, as a backend that cannot count its API calls leaves it — the
+      // total below must still keep the two counts that were measured.
+      apiCalls = None
     )
-    val plain = Usage(7L, 3L, Some(BigDecimal("0.01")))
+    val plain =
+      Usage(7L, 3L, Some(BigDecimal("0.01")), apiCalls = Some(5L))
     assertEquals(
       (withWrites + fewerWrites) + plain,
       Usage(
@@ -31,12 +36,13 @@ class UsageTest extends munit.FunSuite:
         cost = Some(BigDecimal("0.11")),
         cacheReadInputTokens = 800L,
         reasoningOutputTokens = 20L,
-        cacheWriteInputTokens = 390L
+        cacheWriteInputTokens = 390L,
+        apiCalls = Some(7L)
       )
     )
     assertEquals(fewerWrites + withWrites, withWrites + fewerWrites)
 
   test("empty is the identity of +"):
-    val u = Usage(10L, 5L, Some(BigDecimal("0.02")), 4L, 1L, 3L)
+    val u = Usage(10L, 5L, Some(BigDecimal("0.02")), 4L, 1L, 3L, Some(2L))
     assertEquals(Usage.empty + u, u)
     assertEquals(u + Usage.empty, u)


### PR DESCRIPTION
Adds the two fields specced in `docs/research/run-cost/06-preamble-measurement.md` §7 (branch `research/preamble-measurement`, PR #68), so the per-turn log answers two questions it currently cannot.

## The gaps

**Which session a turn belongs to.** Today the only way to spot a session's first turn is an agent name that happens to be unique to one session. That holds for reviewers and fails for the implementer: several sessions all report `main`, and nothing separates them.

**How many API calls a turn made.** Every call re-sends the whole prompt, so the call count is what turns a recorded prompt size into a bill. Without it the count has to be inferred by dividing a turn's tokens by a separately measured preamble — and the cost of one extra reviewer tool call cannot be measured at all.

## The change

`ManifestTurn` gains `session` and `apiCalls`. `session` is the same key `SessionCommitted` is deduplicated under (wire id when there is one, else the client id), now named once in `OrcaEvent.sessionKey` so the emitters and the manifest writer cannot drift apart. Schema version goes 4 → 5; readers already skip any version they don't write themselves.

`apiCalls` travels on `Usage`, next to `cost` — same "only some backends report it" shape, same combine rule. It is not persisted in `ManifestUsage`: a summed subtotal would quietly under-report whenever a backend that can't count contributed to it.

## Where the count comes from, and the wrong answer that looked right

Only claude reports a real count, and nothing on its wire states it directly.

The obvious candidate is `num_turns` on the result message. **It is not the API-call count — it is (tool calls + 1).** The first version of this PR used it, because four probes agreed with the `message_start` stream events exactly:

| probe run | `message_start` | `num_turns` |
|---|---:|---:|
| no tool call | 1 | 1 |
| one tool call | 2 | 2 |
| three sequential tool calls | 4 | 4 |
| one tool call, on `--resume` | 2 | 2 |

They agreed because in every one of those runs the model made exactly one tool call per response. A real orca run in this repository broke the tie: across eight turns, `num_turns` exceeded the number of distinct model responses in six of them. A follow-up probe pinned it down — one response issuing three tool calls at once produces 2 `message_start` events and reports `num_turns: 4`.

So the count comes from the **distinct `id` on the turn's `assistant` messages**. That matches `message_start` on every run checked, including the parallel-tool one, and matches what the CLI transcripts record as separate requests. The ids have to be deduplicated: the CLI splits one response into several `assistant` messages (prose, then each tool call) that all repeat the same id, so counting messages over-reports just as badly as `num_turns` does.

Seeing no response id at all leaves the count absent rather than zero — a turn that reports tokens made requests, so zero would claim none happened.

Known gap, written on the field: a `Task` subagent's requests are folded into the turn's token totals but emit no top-level `assistant` message, so a turn that dispatches one under-counts.

codex, gemini, opencode and pi leave `apiCalls` unset. `None` is deliberately not one: a guessed count would be indistinguishable from a measured one to whoever reads the manifest later, which is the exact mistake this field exists to stop — and the `num_turns` detour above is what that mistake looks like in practice.

## Compatibility

The version bump invalidates v4 manifests in `.orca/cache/runs/`. That is cache data — an unreadable run costs a "continue" offer for that run and nothing else. No migration shims: a reader meeting an older version still skips it cleanly, as before.

## Tests

- claude parser: an `assistant` message carries the id of the response it came from; a result message does **not** pick up `num_turns`.
- claude driver: a turn's call count is its distinct response ids — the test feeds one response split across two `assistant` messages (one of them with two parallel tool calls) plus a second response, and expects 2.
- `Usage`: `+` sums the count, and keeps the measured side when mixing with a backend that doesn't report.
- `BaseAgent`: a turn names its session by the wire id the backend committed, not the client id it started with.
- writer: both fields reach the per-turn log; a turn with neither records both as absent.
- the existing "ManifestUsage mirrors every token axis" guard now states why `apiCalls` is excluded.

Each was mutation-checked: the mutation was applied, exactly the intended test failed, and the change was reverted. The distinctness mutation (make every response id unique) is the one that catches a message-counting regression.

`sbt scalafmtCheckAll` and `sbt clean compile test` both pass, zero warnings.

## Two follow-ups from reviewing this branch

- The wire-id lookup behind the session key was written twice, in `BaseAgent` and `DefaultAgentCall`, which is the one layer where the drift `OrcaEvent.sessionKey` exists to prevent could still happen. It now lives on `SessionSupport`, next to the client→wire map it reads.
- `ManifestTurn` claimed `promptTokens / apiCalls` is the per-call prompt. It is the mean: every call re-sends the conversation so far, so the first is the smallest and the last the largest. One measured reviewer turn ran 32,109 → 105,702 across 19 calls against a mean of 77,069.
