### PR TITLE
Send the fixer's declines to the re-review prompt, and the diff's base commit to the initial one

### DIFF
--- a/flow/src/main/resources/orca/review/prompts/initial-review.md
+++ b/flow/src/main/resources/orca/review/prompts/initial-review.md
@@ -8,7 +8,7 @@ Diff (everything this task has changed since its stage began, committed or
 not). Do not use `git diff HEAD` instead — it does not show work that has been
 committed:
 
-{{diffBlock}}
+{{diffBlock}}{{baseNote}}
 
 Report each finding with: severity (Critical / Warning / Info), a one-line
 title, a longer description with enough context for a fixer to act, the file and

--- a/flow/src/main/resources/orca/review/prompts/re-review.md
+++ b/flow/src/main/resources/orca/review/prompts/re-review.md
@@ -4,7 +4,7 @@ issues introduced by the fix. Stay scoped to the change set under review; do not
 expand to unrelated files. If nothing in your scope still applies, report no
 issues.
 
-{{changes}}
+{{changes}}{{declined}}
 
 The confidence contract from the initial prompt still applies: the probability
 the finding is real, on the evidence you gathered — not deference to the plan.

--- a/flow/src/main/scala/orca/review/ReviewLoop.scala
+++ b/flow/src/main/scala/orca/review/ReviewLoop.scala
@@ -202,13 +202,22 @@ private case class SessionEntry[B <: BackendTag](
   * guarantee survive both a shrinking active set (a reviewer dropped from later
   * rounds keeps its rejects) and re-reporting across rounds (a reviewer that
   * runs again overwrites rather than appends, so one finding yields one entry).
+  *
+  * `declinedByFixer` is what the last fix turn refused to fix, with the reason
+  * it gave, on its way to the next round's resumed reviewers. Replaced each
+  * round rather than accumulated: a reviewer that re-reports a declined finding
+  * gets it declined again, so the list stays current on its own, and a resumed
+  * reviewer still holds every earlier round's message in its session. Not split
+  * per reviewer either — a [[FixOutcome]] doesn't say which reviewer reported
+  * what — so every resumed reviewer is sent the whole list.
   */
 private case class ReviewLoopState(
     history: List[ReviewBatch],
     sessions: List[SessionEntry[?]],
     lintChat: Option[Lint.Summariser],
     gateRejects: List[(RosterEntry[?], List[ReviewIssue])],
-    lintGateRejects: List[ReviewIssue]
+    lintGateRejects: List[ReviewIssue],
+    declinedByFixer: List[IgnoredIssue]
 )
 private object ReviewLoopState:
   val empty: ReviewLoopState = ReviewLoopState(
@@ -216,7 +225,8 @@ private object ReviewLoopState:
     sessions = Nil,
     lintChat = None,
     gateRejects = Nil,
-    lintGateRejects = Nil
+    lintGateRejects = Nil,
+    declinedByFixer = Nil
   )
 
 /** One agent's findings split on the [[ConfidenceGate]]: `kept` goes to the
@@ -264,6 +274,12 @@ private case class RoundOutcome(
   * actually fixed under `fixed`, anything not addressed under `ignored` with a
   * reason. The loop only re-evaluates when something was fixed — an empty
   * `fixed` means nothing new for the reviewers to find, so the loop halts.
+  *
+  * The `ignored` entries go to the next round's reviewers, so a reviewer knows
+  * a finding was considered and refused rather than missed — the one thing in
+  * the loop it could not have worked out by reading the code. The `fixed`
+  * titles do not: a reviewer told its finding was fixed is handed the answer it
+  * exists to work out for itself.
   *
   * Nothing still open is lost at any exit: whatever the fixer left unaccounted
   * for, and whatever the confidence gate held back, come back in the returned
@@ -322,7 +338,9 @@ def reviewAndFixLoop[B <: BackendTag](
       * them.
       *
       * Pass `Some(...)` to pin the diff instead of sampling it — what the tests
-      * use to skip the git call.
+      * use to skip the git call. A pinned diff is also not told its base
+      * commit, since it may describe a change set the stage base doesn't
+      * bracket (see [[ReviewFixLoop.diffBase]]).
       */
     initialDiff: Option[String] = None
 )(using
@@ -433,6 +451,16 @@ private[review] class ReviewFixLoop[B <: BackendTag](
   private def sampleDiff(): String =
     initialDiff.getOrElse(ctx.git.reviewDiff(reviewBase))
 
+  /** The commit reviewers are told their diff was sampled against, sent
+    * alongside the diff so a shell-capable reviewer can read past it.
+    *
+    * `None` for a pinned `initialDiff`: that diff may describe a change set
+    * that isn't `reviewBase`-to-working-tree, so naming `reviewBase` as its
+    * base would send the reviewer to the wrong history.
+    */
+  private val diffBase: Option[String] =
+    if initialDiff.isDefined then None else reviewBase
+
   // The loop-constant context `ReviewerSelector.prepare` is handed. `prepare`
   // runs once, at loop start (see `run`), so this is the change set the
   // selection is made from — later rounds' edits don't revise it.
@@ -473,28 +501,35 @@ private[review] class ReviewFixLoop[B <: BackendTag](
       e: RosterEntry[?],
       stored: Option[SessionEntry[?]],
       currentDiff: String,
-      currentPaths: List[String]
+      currentPaths: List[String],
+      declined: List[IgnoredIssue]
   ): (ReviewResult, Option[SessionEntry[?]]) =
     stored match
-      case Some(se) => resumeReview(se, currentDiff, currentPaths)
+      case Some(se) => resumeReview(se, currentDiff, currentPaths, declined)
       case None     => firstReview(e, currentDiff)
 
-  /** Resume a reviewer's existing session, sending only what is new to it since
-    * its last round ([[ReReviewChanges]]). The run carries the `reviewer` cost
-    * role ([[ReviewerPrompts.Role]]) so the `TokensUsed` breakdown can subtotal
+  /** Resume a reviewer's existing session, sending what is new to it since its
+    * last round: the change set ([[ReReviewChanges]]) and what the fixer
+    * declined to fix. The run carries the `reviewer` cost role
+    * ([[ReviewerPrompts.Role]]) so the `TokensUsed` breakdown can subtotal
     * reviewer spend, without renaming the entry's identity.
+    *
+    * The fixer's `fixed` titles are deliberately NOT sent: a reviewer told its
+    * finding was fixed is handed the answer to the question the round exists to
+    * ask, and it still has to open the code either way.
     */
   private def resumeReview[B <: BackendTag](
       se: SessionEntry[B],
       currentDiff: String,
-      currentPaths: List[String]
+      currentPaths: List[String],
+      declined: List[IgnoredIssue]
   ): (ReviewResult, Option[SessionEntry[?]]) =
     val changes = ReReviewChanges.of(se.lastDiff, currentDiff, currentPaths)
     val result =
       se.chat
         .resultAs[ReviewResult]
         .autonomous
-        .run(ReviewLoopPrompts.reReview(changes), emitPrompt = false)
+        .run(ReviewLoopPrompts.reReview(changes, declined), emitPrompt = false)
     // Only advance `lastDiff` when something was actually sent, so a reviewer
     // that skipped a round still compares against what it has seen.
     val advanced = Option.when(changes != ReReviewChanges.AlreadySeen)(
@@ -516,7 +551,8 @@ private[review] class ReviewFixLoop[B <: BackendTag](
         .resultAs[ReviewResult]
         .autonomous
         .run(
-          ReviewLoopPrompts.initialReview(task, currentDiff, confidenceGate),
+          ReviewLoopPrompts
+            .initialReview(task, currentDiff, confidenceGate, diffBase),
           emitPrompt = false
         )
     (result, Some(SessionEntry(e, chat, currentDiff)))
@@ -573,11 +609,12 @@ private[review] class ReviewFixLoop[B <: BackendTag](
       then ctx.git.changedFiles(reviewBase)
       else Nil
 
+    val declined = currentState.declinedByFixer
     val reviewerTasks: List[() => AgentOutcome] = active.map: e =>
       val stored = storedFor(e)
       () =>
         val (result, newSession) =
-          reviewWithSession(e, stored, currentDiff, currentPaths)
+          reviewWithSession(e, stored, currentDiff, currentPaths, declined)
         AgentOutcome.Reviewer(e, applyGate(result), newSession)
 
     // Resolved outside the fork below so the next state carries the
@@ -665,7 +702,10 @@ private[review] class ReviewFixLoop[B <: BackendTag](
           else lintRound.map(_.summariser),
         gateRejects = retained ++ thisRound,
         lintGateRejects =
-          lintGated.map(_.dropped).getOrElse(currentState.lintGateRejects)
+          lintGated.map(_.dropped).getOrElse(currentState.lintGateRejects),
+        // Delivered to this round's reviewers; `run` refills it from this
+        // round's fix turn.
+        declinedByFixer = Nil
       )
       (reviewerOutcomes, lintGated.map(_.kept), nextState)
 
@@ -826,7 +866,10 @@ private[review] class ReviewFixLoop[B <: BackendTag](
             loop(
               accumulated ++ IgnoredIssues(outcome.ignored),
               iteration + 1,
-              round.state
+              // Carried into the next round's re-review prompts: without it a
+              // reviewer re-reports what the fixer deliberately declined, the
+              // fixer declines it again, and the round is spent.
+              round.state.copy(declinedByFixer = outcome.ignored)
             )
     loop(IgnoredIssues(Nil), 0, ReviewLoopState.empty)
 

--- a/flow/src/main/scala/orca/review/ReviewLoopPrompts.scala
+++ b/flow/src/main/scala/orca/review/ReviewLoopPrompts.scala
@@ -54,26 +54,78 @@ object ReviewLoopPrompts:
     * `gate` is rendered into the prompt's confidence section, so reviewers are
     * told the actual bars their findings are measured against rather than a
     * hardcoded guess at them.
+    *
+    * `base` is the commit `diff` was sampled against, when the loop knows it
+    * describes this diff (see [[ReviewFixLoop.diffBase]]). It is sent alongside
+    * the diff, never instead of it: a reviewer that can run a shell can read
+    * past the diff from there, and one that can't is unaffected.
     */
-  def initialReview(task: String, diff: String, gate: ConfidenceGate): String =
+  def initialReview(
+      task: String,
+      diff: String,
+      gate: ConfidenceGate,
+      base: Option[String]
+  ): String =
     PromptResource.render(
       InitialReviewTemplate,
       "task" -> task,
       "diffBlock" -> diffBlock(diff),
+      "baseNote" -> baseNote(base),
       "criticalBar" -> gate.critical.toString,
       "warningBar" -> gate.warning.toString,
       "infoBar" -> gate.info.toString
     )
+
+  /** The base commit as a paragraph after the diff, carrying its own leading
+    * blank line so the section disappears without a trace when there is no base
+    * — the template writes `{{diffBlock}}{{baseNote}}` with no separator of its
+    * own.
+    */
+  private def baseNote(base: Option[String]): String =
+    base.fold(""): sha =>
+      s"\n\nThe diff above is everything that changed since commit $sha. If " +
+        "you can run shell commands, use that commit to see what the diff " +
+        s"doesn't show — `git show $sha:<path>` for a file as it was before " +
+        "the change, for example. What you review is still the diff; the base " +
+        "commit is there for evidence, not for widening your scope."
 
   private val ReReviewTemplate: String =
     PromptResource.load("/orca/review/prompts/re-review.md")
 
   /** Continuation prompt for a reviewer's session on iterations after the
     * first. The session already holds the reviewer's earlier findings and every
-    * change set it has been sent, so `changes` carries only what is new to it.
+    * change set it has been sent, so `changes` carries only what is new to it —
+    * including the base commit, which the initial prompt named and this one
+    * therefore doesn't repeat.
+    *
+    * `declined` is what the fixer refused to fix last round, which is the one
+    * thing a reviewer cannot recover by reading the code.
     */
-  private[review] def reReview(changes: ReReviewChanges): String =
-    PromptResource.render(ReReviewTemplate, "changes" -> changesBlock(changes))
+  private[review] def reReview(
+      changes: ReReviewChanges,
+      declined: List[IgnoredIssue]
+  ): String =
+    PromptResource.render(
+      ReReviewTemplate,
+      "changes" -> changesBlock(changes),
+      "declined" -> declinedBlock(declined)
+    )
+
+  /** The fixer's declines as a paragraph after the change set, carrying its own
+    * leading blank line for the same reason as [[baseNote]].
+    *
+    * Worded as the fixer's position rather than a verdict on the finding. A
+    * reviewer told "this was settled" would stop checking, which is the failure
+    * this block exists to avoid — the point is to save a round on findings the
+    * fixer has already answered, not to withdraw them.
+    */
+  private def declinedBlock(declined: List[IgnoredIssue]): String =
+    if declined.isEmpty then ""
+    else
+      "\n\nThe fixer declined to fix these findings, and gave this reason " +
+        s"for each:\n\n${IgnoredIssues(declined).format}\n\nThat is the " +
+        "fixer's position, not a ruling. If you still think a finding is " +
+        "real, report it again and say why the reason is wrong."
 
   private def changesBlock(changes: ReReviewChanges): String =
     changes match

--- a/flow/src/test/scala/orca/review/ReviewAndFixTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewAndFixTest.scala
@@ -654,6 +654,89 @@ class ReviewAndFixTest extends munit.FunSuite:
     assert(sent.contains("--- a/Foo.scala"), s"diff missing from prompt: $sent")
     assert(sent.contains("do thing"), s"task missing from prompt: $sent")
 
+  test("the reviewer's first prompt names the stage's base commit"):
+    // The base is sent alongside the diff, from the same `stageBaseCommit` the
+    // diff is sampled against — not a second notion of "base".
+    val fc = ReviewLoopFixture.control(new EventDispatcher(Nil))
+    given FlowControl = fc
+    val base =
+      fc.git.headCommit().getOrElse(fail("the fixture repo has no HEAD"))
+    val _ = fc.enterStage("review", Some(base))
+    val reviewer =
+      new FakeAgent("capturing", outputs = List(ReviewResult.empty))
+    val _ = reviewAndFixLoop(
+      coderSession = ReviewLoopFixture.coderSession(new FakeAgent("coder")),
+      reviewers = List(reviewer),
+      task = "do thing",
+      reviewerSelection = ReviewerSelector.allEveryRound
+    )
+    val sent = reviewer.seenPrompts.headOption
+      .getOrElse(fail("the fresh-session run was never called"))
+    assert(sent.contains(s"since commit $base"), s"base missing: $sent")
+
+  test("a pinned initialDiff is not told the stage's base commit"):
+    // The pinned diff may describe a change set that isn't stage-base-to-tree,
+    // so naming that commit as its base would send the reviewer to the wrong
+    // history.
+    val fc = ReviewLoopFixture.control(new EventDispatcher(Nil))
+    given FlowControl = fc
+    val base =
+      fc.git.headCommit().getOrElse(fail("the fixture repo has no HEAD"))
+    val _ = fc.enterStage("review", Some(base))
+    val reviewer =
+      new FakeAgent("capturing", outputs = List(ReviewResult.empty))
+    val _ = reviewAndFixLoop(
+      coderSession = ReviewLoopFixture.coderSession(new FakeAgent("coder")),
+      reviewers = List(reviewer),
+      task = "do thing",
+      reviewerSelection = ReviewerSelector.allEveryRound,
+      initialDiff = Some("--- a/Foo.scala\n+++ b/Foo.scala\n+ added line")
+    )
+    val sent = reviewer.seenPrompts.headOption
+      .getOrElse(fail("the fresh-session run was never called"))
+    assert(!sent.contains("since commit"), s"base leaked into prompt: $sent")
+
+  test("the fixer's declines reach the next round's reviewer, its fixes don't"):
+    // A decline is the one thing a reviewer cannot recover by reading the tree:
+    // nothing in the code says a finding was considered and refused. A "fixed"
+    // title is the opposite — it answers the question the round exists to ask,
+    // so it is deliberately withheld.
+    given FlowControl = control
+    val reviewer = new FakeAgent(
+      name = "loud",
+      outputs = List(
+        ReviewResult(List(issue("real bug"), issue("nit"))),
+        ReviewResult.empty
+      )
+    )
+    val coder = new FakeAgent(
+      name = "coder",
+      outputs = List(
+        FixOutcome(
+          List(Title("real bug")),
+          List(IgnoredIssue(Title("nit"), "the shape is deliberate"))
+        )
+      )
+    )
+    val _ = reviewAndFixLoop(
+      coderSession = ReviewLoopFixture.coderSession(coder),
+      reviewers = List(reviewer),
+      task = "build the widget",
+      reviewerSelection = ReviewerSelector.allEveryRound,
+      initialDiff = Some("")
+    )
+    val resumed = reviewer.seenPrompts
+      .lift(1)
+      .getOrElse(fail("the reviewer was never resumed"))
+    assert(
+      resumed.contains("- nit: the shape is deliberate"),
+      s"decline missing from re-review prompt: $resumed"
+    )
+    assert(
+      !resumed.contains("real bug"),
+      s"fixed title leaked into re-review prompt: $resumed"
+    )
+
   test(
     "an agentDriven reviewerSelection narrows the active set via its picker LLM"
   ):

--- a/flow/src/test/scala/orca/review/ReviewLoopPromptsTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewLoopPromptsTest.scala
@@ -1,6 +1,7 @@
 package orca.review
 
 import orca.agents.given
+import orca.plan.Title
 import orca.util.{JsonSchemaGen, TextUtil}
 
 class ReviewLoopPromptsTest extends munit.FunSuite:
@@ -8,9 +9,12 @@ class ReviewLoopPromptsTest extends munit.FunSuite:
   // The template hard-wraps, so compare against whitespace-collapsed text:
   // the assertions are about the wording reaching the reviewer, not the
   // line breaks it arrives with.
-  private def rendered(gate: ConfidenceGate): String =
+  private def rendered(
+      gate: ConfidenceGate,
+      base: Option[String] = None
+  ): String =
     TextUtil.collapseWhitespace(
-      ReviewLoopPrompts.initialReview("do the thing", "", gate)
+      ReviewLoopPrompts.initialReview("do the thing", "", gate, base)
     )
 
   test("initialReview renders the caller's bars"):
@@ -41,3 +45,39 @@ class ReviewLoopPromptsTest extends munit.FunSuite:
     val schema = JsonSchemaGen[ReviewResult]
     assert(prompt.contains(clause), prompt)
     assert(schema.contains(clause), schema)
+
+  test("initialReview names the commit the diff was sampled against"):
+    // Sent alongside the diff, not instead of it: a reviewer with a shell can
+    // read past the diff from there.
+    val prompt = rendered(ConfidenceGate.default, base = Some("abc1234"))
+    assert(
+      prompt.contains("everything that changed since commit abc1234"),
+      prompt
+    )
+    assert(prompt.contains("git show abc1234:<path>"), prompt)
+
+  test("reReview carries the fixer's declines as a position, not a ruling"):
+    val prompt = TextUtil.collapseWhitespace(
+      ReviewLoopPrompts.reReview(
+        ReReviewChanges.AlreadySeen,
+        List(IgnoredIssue(Title("rename the field"), "the name is on our API"))
+      )
+    )
+    assert(
+      prompt.contains("- rename the field: the name is on our API"),
+      prompt
+    )
+    assert(
+      prompt.contains(
+        "That is the fixer's position, not a ruling. If you still think a " +
+          "finding is real, report it again and say why the reason is wrong."
+      ),
+      prompt
+    )
+
+  test("reReview says nothing about declines when the fixer declined nothing"):
+    // Same separator argument as the base-commit section above.
+    val prompt = TextUtil.collapseWhitespace(
+      ReviewLoopPrompts.reReview(ReReviewChanges.AlreadySeen, Nil)
+    )
+    assert(!prompt.contains("The fixer declined"), prompt)


### PR DESCRIPTION
Two small additions to what reviewers are told, both from merged research
(`docs/research/run-cost/08-re-review-payload.md` §(b), `09-diff-vs-coordinates.md`
"Answer").

## 1. The fixer's declines reach the next round's reviewer

`FixOutcome.ignored` — the findings the fixer refused to fix, each with its
reason — never left the loop. So a reviewer would re-report a finding the fixer
had deliberately declined, the fixer would decline it again, and the round was
spent. Because the loop keeps going while `fixed` is non-empty, that could
repeat for the life of the loop.

This is the one thing in the loop a reviewer cannot work out by reading the
code: nothing in the tree says a finding was considered and refused. The
re-review prompt now carries the titles and reasons (typically 0-3 entries),
worded as the fixer's position rather than a ruling:

> The fixer declined to fix these findings, and gave this reason for each:
>
> - &lt;title&gt;: &lt;reason&gt;
>
> That is the fixer's position, not a ruling. If you still think a finding is
> real, report it again and say why the reason is wrong.

The wording matters. Stated as a verdict this would suppress real findings.

**The `fixed` titles are deliberately not sent.** The research rejects that: a
reviewer told its finding was fixed is handed the answer to the question the
round exists to ask, and it has to open the code either way, so it saves
nothing. There is a test pinning that they stay out of the prompt.

Plumbing: one new `ReviewLoopState` field, replaced each round rather than
accumulated (a finding that is re-reported gets re-declined, so the list stays
current on its own).

## 2. The initial prompt names the diff's base commit

Reviewers get the diff inlined and nothing else. Naming the commit it was
sampled against costs a few dozen characters and lets a reviewer that can run a
shell read past the diff — `git show <base>:<path>` for a file before the
change, say.

This is strictly additive. Coordinates *instead of* the diff was measured and
rejected (+32% turns, +27% tool calls, 3x the git calls per round); the inlined
diff is untouched. The base is the `stageBaseCommit` the loop already samples
the diff against, not a second notion of "base".

One case gets no base: a caller-pinned `initialDiff`. That diff may describe a
change set the stage base does not bracket, so naming it would send the reviewer
to the wrong history.

## What a reviewer should check

- The prompt wording — both blocks are new text sent to every reviewer.
- That the declines are framed as a position and not as a verdict.
- The two prompt templates write `{{diffBlock}}{{baseNote}}` and
  `{{changes}}{{declined}}` with no separator between them; each new block
  carries its own leading blank line, so the section vanishes cleanly when
  there is nothing to send.

Six tests, each mutation-checked.
