### PR TITLE
Keep a path with a tab in the change set, and tighten the diff cap

### DIFF
--- a/flow/src/main/scala/orca/BoundedDiff.scala
+++ b/flow/src/main/scala/orca/BoundedDiff.scala
@@ -144,24 +144,42 @@ private[orca] object BoundedDiff:
       "does not show\n# the changes to the files below — read those files " +
       "directly.\n"
 
+  /** The note closing a cut-short diff whose file list names nothing to add.
+    * Reachable because the diff and the file list are two separate git reads
+    * (see `orca.review.ReviewFixLoop`), so an edit landing between them can
+    * leave every cut file unnamed. The cut is stated anyway: a reviewer that
+    * isn't told the diff is partial judges a fragment as if it were the whole.
+    */
+  private val UnnamedTrailer: String =
+    s"\n# The diff above was cut short at $ReviewThreshold characters. Part of " +
+      "the change\n# is not shown, and the file list needed to name it was not " +
+      "available.\n"
+
   /** The note closing a cut-short review diff: that it was cut, and every file
     * the rendered part doesn't show. Every line is a `#` comment so none of it
     * can read as part of a hunk — `- path` would look like a deleted line of
     * source — and the entries are indented under the sentence introducing them.
     */
   private def trailer(omitted: List[ChangedFile]): String =
-    TrailerHead + boundedEntries(omitted.map(entryLine), TrailerBudget)
+    if omitted.isEmpty then UnnamedTrailer
+    else TrailerHead + boundedEntries(omitted.map(entryLine), TrailerBudget)
 
   /** The longest [[trailer]] any subset of `all` can produce, which is what the
     * diff has to be sized against — the omitted set isn't known until the diff
     * has been cut. Rendering a subset is not always shorter than rendering the
     * whole list: once the entries are past [[TrailerBudget]] both fill it, and
-    * dropping short entries from the front can let longer ones in.
+    * dropping short entries from the front can let longer ones in. So the bound
+    * is the unbounded entry length, capped at the budget — not what rendering
+    * `all` happens to produce, which [[boundedEntries]] can cut short at the
+    * first entry too long to fit while a subset of it renders longer.
     */
   private def trailerMax(all: List[ChangedFile]): Int =
     // +1 per entry for the separator `boundedEntries` joins them with.
     val entries = all.map(entryLine(_).length + 1).sum
-    TrailerHead.length + math.min(entries, TrailerBudget)
+    math.max(
+      UnnamedTrailer.length,
+      TrailerHead.length + math.min(entries, TrailerBudget)
+    )
 
   private def entryLine(file: ChangedFile): String =
     val size = file.change match

--- a/flow/src/test/scala/orca/BoundedDiffTest.scala
+++ b/flow/src/test/scala/orca/BoundedDiffTest.scala
@@ -165,17 +165,44 @@ class BoundedDiffTest extends munit.FunSuite:
       "new file went unlabelled"
     )
 
+  /** A path of exactly `chars` characters, nested the way a real one is. */
+  private def deepPath(chars: Int): String =
+    val leaf = "/Deep.scala"
+    "nested/".repeat(chars / 7 + 1).take(chars - leaf.length) + leaf
+
   test("the payload stays in budget however many files the trailer names"):
     // Both halves have to be sized against each other: a long file list can
     // outweigh the diff, and neither may be allowed to spend the other's room.
-    val (diff, changed) = bigChangeSet(60)
+    //
+    // The trailer's room has to cover every subset of the file list, since
+    // which files it names isn't known until the diff has been cut. Rendering
+    // the whole list is not that bound: `boundedEntries` stops at the first
+    // entry too long to fit, so the one long path here cuts the whole list
+    // short of the budget. Showing the files ahead of it frees that room, and
+    // the shorter list then renders longer than the whole one did. The sizes
+    // are picked so the difference is a few file sections wide — reserving by
+    // the whole list overshoots the threshold by ~3 KB.
+    val inDiff = (1 to 1600).map(i => f"src/generated/G$i%05d.scala").toList
+    val notInDiff = (1 to 900).map(i => f"src/untouched/U$i%05d.scala").toList
+    val diff = inDiff.map(section(_, 2)).mkString
     assert(clue(diff.length) > BoundedDiff.ReviewThreshold, "fixture too small")
-    val extra = (1 to 4000).map(i => f"src/generated/G$i%05d.scala").toList
     val payload = BoundedDiff.reviewPayload(
       diff,
-      changed ++ extra.map(ChangedFile(_, FileChange.Lines(1, 0)))
+      (inDiff ++ (deepPath(3228) :: notInDiff))
+        .map(ChangedFile(_, FileChange.Lines(2, 0)))
     )
     assert(
       clue(payload.length) <= BoundedDiff.ReviewThreshold,
       "the payload outgrew its budget"
     )
+
+  test("a cut diff whose file list names nothing still reports the cut"):
+    // The diff and the file list are two separate git reads, so an edit landing
+    // between them can leave the list empty. The cut is real regardless — the
+    // last file's section never fits — so the note must not introduce a list of
+    // files and then show none.
+    val diff = section("src/Huge.scala", 6000)
+    assert(clue(diff.length) > BoundedDiff.ReviewThreshold, "fixture too small")
+    val payload = BoundedDiff.reviewPayload(diff, Nil)
+    assert(payload.contains("was cut short"), payload)
+    assert(!payload.contains("the files below"), payload)

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -621,12 +621,16 @@ private[orca] class OsGitTool(
   def changedFiles(since: Option[String]): List[String] =
     changedFileStats(since).map(_.path)
 
-  // `-z` NUL-terminates each record and turns off the C-quoting git otherwise
-  // applies to a tab, newline or non-ASCII byte in a name. `--no-relative` keeps
-  // the paths relative to the repository root, which `asWorkDirRelative`
-  // assumes: with `diff.relative` set in the repo git prints them relative to
-  // `workDir` instead, and the translation then adds `../` hops and names the
-  // wrong files.
+  // `-z` NUL-terminates each record, so a newline or a non-ASCII byte in a name
+  // parses unambiguously. It also turns off the C-quoting git would otherwise
+  // apply to a tab in a name — and `--numstat` separates its own fields with
+  // tabs, so a tabbed path arrives looking like extra fields and only
+  // `OsGitTool.parseNumstat` capping the split keeps it whole.
+  //
+  // `--no-relative` keeps the paths relative to the repository root, which
+  // `asWorkDirRelative` assumes: with `diff.relative` set in the repo git prints
+  // them relative to `workDir` instead, and the translation then adds `../` hops
+  // and names the wrong files.
   def changedFileStats(since: Option[String]): List[ChangedFile] =
     val args =
       "diff" +: "--numstat" +: "-z" +: "--no-relative" +:
@@ -887,6 +891,10 @@ private[orca] object OsGitTool:
     * of a count marks a binary file, which git reports as differing without
     * saying by how much.
     *
+    * The path is everything after the second tab, splitting no further: `-z`
+    * turns off the quoting git would otherwise apply to a tab in a name, so a
+    * tabbed path arrives raw and would otherwise look like extra fields.
+    *
     * Anything that doesn't parse as a record is skipped rather than failing the
     * call: a file list is worth having even if one entry of it is unreadable.
     */
@@ -897,20 +905,23 @@ private[orca] object OsGitTool:
         acc: List[ChangedFile]
     ): List[ChangedFile] =
       fields match
-        case Nil => acc.reverse
+        case Nil            => acc.reverse
         case record :: rest =>
-          record.split('\t').toList match
-            case added :: deleted :: path :: Nil =>
-              loop(rest, ChangedFile(path, change(added, deleted)) :: acc)
-            // Rename: the paths are the next two fields, old then new.
-            case added :: deleted :: Nil =>
+          // The limit stops the split at the path, and keeps the empty third
+          // field a rename's record ends with — which is what tells the two
+          // shapes apart, since git never names an empty path.
+          record.split("\t", 3).toList match
+            // Rename: the paths are the next two records, old then new.
+            case added :: deleted :: "" :: Nil =>
               rest match
                 case _ :: renamedTo :: tail =>
                   loop(
                     tail,
                     ChangedFile(renamedTo, change(added, deleted)) :: acc
                   )
-                case _ => acc.reverse
+                case _ => loop(rest, acc)
+            case added :: deleted :: path :: Nil =>
+              loop(rest, ChangedFile(path, change(added, deleted)) :: acc)
             case _ => loop(rest, acc)
     loop(raw.split(NUL).toList.filter(_.nonEmpty), Nil)
 

--- a/tools/src/test/scala/orca/tools/OsGitToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitToolTest.scala
@@ -725,6 +725,16 @@ class OsGitToolTest extends munit.FunSuite:
       os.write.over(dir / "my notes.md", "two")
       assertEquals(git.changedFiles(), List("my notes.md"))
 
+  // A tab is what separates `--numstat`'s own fields, and `-z` turns off the
+  // quoting that would otherwise hide one inside a name — so a tabbed path
+  // arrives looking like an extra field.
+  test("changedFiles names a modified path containing a tab"):
+    withRepo: (git, dir) =>
+      os.write(dir / "tab\there.md", "one")
+      git.commit("seed").orThrow
+      os.write.over(dir / "tab\there.md", "two")
+      assertEquals(git.changedFiles(), List("tab\there.md"))
+
   test("changedFileStats counts the lines a change added and removed"):
     withRepo: (git, dir) =>
       os.write(dir / "notes.md", "one\ntwo\n")


### PR DESCRIPTION
Fixes a regression from #81, plus two related holes in the review-diff cap.

## What broke

`git diff --numstat -z` separates its fields with a TAB, and `-z` turns off the quoting git would otherwise use to hide a tab inside a file name. So a path with a tab in it arrives as a fourth field:

```
git diff --numstat -z --no-relative HEAD    →  1<TAB>0<TAB>tab<TAB>here.txt<NUL>
git diff --name-only -z --no-relative HEAD  →          tab<TAB>here.txt<NUL>
```

The parser matched three fields or two, so a four-field record fell into the catch-all arm and was dropped with no trace. Master before #81 read `--name-only -z`, which has one field per record, so a tab was safe there.

Dropping the file is the bad direction. It is missing from the change set, so when the diff is over the cap its section is cut and the file appears in **neither** the diff nor the trailer — the one outcome the cap exists to prevent. It also drops the file from the list that file-gated reviewers match on.

## The fix

Split each record at most twice, so the path is everything after the second tab. This also changes how a rename is spotted: a rename record is `0<TAB>0<TAB>` followed by two more records (old path, new path). A split with a limit keeps the trailing empty field, so an empty path is now what marks a rename — git never names an empty path. The old code told a rename apart by getting two fields instead of three, which a limited split no longer produces.

## Two more fixes in the same code

**The trailer's size reservation was not an upper bound.** It was computed by rendering the whole file list. But the renderer stops at the first entry too long to fit, so one long path cuts the whole list short of the budget, while a subset starting past that path renders longer. Now the reservation is the uncapped entry length, capped at the budget.

**An empty file list produced a trailer that named nothing.** With the file list empty and the diff over the cap, the trailer said "read those files below" and listed none, while at least one file really had been cut. Reachable, because the diff and the file list are two separate git reads, so an edit landing between them is enough. It now says the list was not available.

## What a reviewer should check

- The rename arm. `"0\t0\t".split("\t", 3)` gives `["0", "0", ""]`, whereas the old unlimited split gave `["0", "0"]`. The new code matches on that empty third field. Verified against real git 2.53 for a plain rename and for a rename of a tabbed path.
- The tab test uses real git (`OsGitToolTest`), not a hand-written string, so it pins git's actual output shape.
- Each fix was mutation-checked: put the old code back, confirm exactly the intended test fails, revert. The budget test is the interesting one — the old fixture passed with the wrong reservation, the new one overshoots the threshold by 3075 characters.
- One arm was inconsistent: a rename record not followed by two more records abandoned the rest of the stream, while its sibling skipped one record and carried on. Both now skip and carry on. No test covers it — git never truncates its own output, and for any shorter input the two behave the same, which the mutation run confirmed.

## Not fixed

Two things the review raised as judgement calls, left alone:

- the trailer says "cut short at 131072 characters", which is not the size the reviewer got — up to 64 KiB is reserved for the file list. Worth fixing by reporting the actual length, but it is a wording change to a message, not a correctness bug.
- a mode-only change renders as `(+0 -0)`, since that is what `--numstat` reports for one. Telling it apart needs `--raw`, a second git call for a rare case.
