### PR TITLE
Plan mode is not a capability gate: correct the scaladocs that say it is

### DIFF
--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -100,13 +100,18 @@ private[claude] object ClaudeArgs:
     CliArgs.flag("--mcp-config", file)(_.toString)
 
   /** Maps [[AgentConfig.tools]] to claude's permission flags. Both read-only
-    * tiers use `--permission-mode plan`, which makes Edit/Write/Bash
-    * unavailable (not just non-auto-approved) — a hard no-edit guarantee.
+    * tiers use `--permission-mode plan`, which is not a no-edit guarantee: plan
+    * mode removes no tools. The `init` message's tool list under
+    * `--permission-mode plan` is byte-identical to the default mode's, `Bash`,
+    * `Write`, `Edit` and `NotebookEdit` included. What blocking happens comes
+    * from the approval layer, which the default mode applies too, and above
+    * that it is model judgement — opus reviewers ran 199 `Bash` calls under
+    * plan mode with zero denials
+    * (`docs/research/run-cost/09-diff-vs-coordinates.md` §2).
     *
     * `NetworkOnly` additionally pre-approves `networkTools` via
-    * `--allowedTools`, layering read-only network access onto plan mode. The
-    * list is command-scoped, so plan mode still blocks general bash and every
-    * edit; an empty list leaves plain plan mode.
+    * `--allowedTools`, layering network access onto plan mode. The list is
+    * command-scoped (`Bash(gh api:*)`); an empty list leaves plain plan mode.
     *
     * `Full` follows [[AgentConfig.autoApprove]]: `All` → `bypassPermissions`;
     * `Only(_)` → default permission mode plus `--allowedTools`. The allowlist
@@ -141,9 +146,9 @@ private[claude] object ClaudeArgs:
 
   /** How strongly claude enforces each `(tools, autoApprove)` combination — see
     * [[autoApproveArgs]] for the flags this classifies. Every combination is
-    * `Hard`: plan mode makes edits/shell mechanically unavailable, and every
-    * `--allowedTools`/`bypassPermissions` variant is a mechanical per-tool
-    * gate.
+    * `Hard`. The read-only tiers rest on plan mode, which [[autoApproveArgs]]
+    * records as removing no tools; the `--allowedTools`/`bypassPermissions`
+    * variants are mechanical per-tool gates.
     *
     * Written as an exhaustive match (all arms `Hard`) rather than a bare
     * constant so a future `ToolSet`/`AutoApprove` case fails compilation here.

--- a/docs/research/run-cost/09-diff-vs-coordinates.md
+++ b/docs/research/run-cost/09-diff-vs-coordinates.md
@@ -128,6 +128,22 @@ git version 2.53.0
 Same flag, same CLI build, same absent approver; the gate holds on haiku and does
 not on opus. Whatever decides that lives inside the CLI.
 
+**Plan mode removes nothing.** Measured since, on 2.1.222: the `init` message's
+tool list under `--permission-mode plan` is byte-identical to the same command's
+in the default mode — `Bash`, `Write`, `Edit` and `NotebookEdit` all still
+advertised. So plan mode is not capability removal, and the model can still ask
+for any of them.
+
+What blocking does happen is the approval layer, which the default mode has too:
+under `--print` there is no approver, so anything not auto-approved is denied.
+`echo HELLO > CTRL.txt` was denied identically in both modes. Above that layer it
+is model judgement — in one turn opus ran `ls`, `git log`, `wc`, `findmnt`,
+`stat` and `uname` with zero denials, and `git status` writes `.git/index`. Plan
+mode also writes `~/.claude/plans/<slug>.md` itself.
+
+This changes nothing above; it names the mechanism. Plan mode is the wrong
+instrument for a no-edit guarantee, not a broken instance of the right one.
+
 **This makes the finding more serious, not less.** An `autoApprove` explanation
 would have located the defect in orca, where a one-line change fixes it. The
 measured explanation locates it in the backend, behind a flag orca passes and a
@@ -147,8 +163,9 @@ Two consequences:
    ran 199 `Bash` calls under `permissionMode: plan`, so the documented
    guarantee is false. `ClaudeArgs.scala:102-104` ("makes Edit/Write/Bash
    unavailable") and `ReviewerSelector.scala:84-85` ("claude's plan mode
-   doesn't [run commands]") are wrong for the same reason. The tests pin only
-   the flag string (`ClaudeArgsTest.scala:97-133`), never the behaviour.
+   doesn't [run commands]") were wrong for the same reason; both scaladocs have
+   since been corrected. The tests pin only the flag string
+   (`ClaudeArgsTest.scala:97-133`), never the behaviour.
    *`AgentConfig.autoApprove`'s scaladoc is not falsified by this*, and an
    earlier draft that said so had elided the clauses that matter: in full it
    reads "Only meaningful for **interactive** sessions consulted only when

--- a/flow/src/main/scala/orca/review/ReviewerSelector.scala
+++ b/flow/src/main/scala/orca/review/ReviewerSelector.scala
@@ -81,11 +81,13 @@ object ReviewerSelector:
     *
     * The picker is handed the task title, the changed file names and those
     * descriptions, and runs under [[orca.agents.ToolSet.ReadOnly]] in the
-    * flow's work dir. That gates edits everywhere but not the shell — codex's
-    * read-only sandbox still runs commands, claude's plan mode doesn't — so the
-    * default brief tells it to open the changed files rather than judge by
-    * their paths, to use `git diff HEAD` only if the shell happens to be there,
-    * and to include a reviewer whenever it is unsure.
+    * flow's work dir. Whether a shell is there varies by backend — codex's
+    * read-only sandbox runs commands, opencode and pi have no shell tool at
+    * all, and claude's plan mode leaves `Bash` advertised (measured: see
+    * `docs/research/run-cost/09-diff-vs-coordinates.md` §2) — so the default
+    * brief tells it to open the changed files rather than judge by their paths,
+    * to use `git diff HEAD` only if the shell happens to be there, and to
+    * include a reviewer whenever it is unsure.
     *
     * `filePatterns` is a code-side pre-filter applied before the LLM call:
     * reviewers whose pattern doesn't match any of `changedFiles` are dropped,

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
@@ -58,9 +58,9 @@ private[gemini] object GeminiArgs:
 
   /** Web tools pre-approved on [[ToolSet.NetworkOnly]] turns. Plan mode gates
     * `web_fetch` behind an approval no autonomous turn can answer; listing it
-    * in `--allowed-tools` pre-approves it, so the planner gets web reads while
-    * plan mode still blocks edits and shell. (`--allowed-tools` is deprecated
-    * for a `settings.json` Policy Engine in gemini 1.0.)
+    * in `--allowed-tools` pre-approves it, so the planner gets web reads.
+    * (`--allowed-tools` is deprecated for a `settings.json` Policy Engine in
+    * gemini 1.0.)
     */
   private val NetworkTools: Seq[String] = Seq("web_fetch")
 
@@ -91,8 +91,12 @@ private[gemini] object GeminiArgs:
   /** How strongly gemini enforces each `(tools, autoApprove)` combination — see
     * [[approvalArgs]] for the flags this classifies.
     *
-    *   - `ReadOnly` / `NetworkOnly` → `Hard`: `plan` makes writes and shell
-    *     mechanically unavailable.
+    *   - `ReadOnly` / `NetworkOnly` → `Hard`, on the assumption that `plan`
+    *     makes writes and shell mechanically unavailable. Unverified: no
+    *     headless `plan` turn has been run against a write attempt. claude's
+    *     `--permission-mode plan`, the same class of mechanism, was measured
+    *     and removes no tools
+    *     (`docs/research/run-cost/09-diff-vs-coordinates.md` §2).
     *   - `Full` + `AutoApprove.All` → `Hard`: `yolo` honours "approve
     *     everything" verbatim.
     *   - `Full` + `AutoApprove.Only(_)` → `Ignored`: no per-tool allowlist, so


### PR DESCRIPTION
Comments and one research doc. No behaviour change, no `Enforcement` value
changed, no test touched.

## What was measured

`--permission-mode plan` removes no tools. On claude 2.1.222 the `init`
message's tool list under plan mode is byte-identical to the default mode's —
`Bash`, `Write`, `Edit` and `NotebookEdit` are all still advertised.

The blocking that does happen is the approval layer, which the default mode has
too: under `--print` there is no approver, so anything not auto-approved is
denied. `echo HELLO > CTRL.txt` was denied the same way in both modes. Above
that layer it is up to the model — in one turn opus ran `ls`, `git log`, `wc`,
`findmnt`, `stat` and `uname` with no denials.

This lines up with what #73 already measured: ten reviewer sessions under
`permissionMode: plan` made 199 `Bash` calls with zero denials, and one wrote a
file and ran `scala-cli`.

## What changed

- `docs/research/run-cost/09-diff-vs-coordinates.md` §2 — adds the tool-list
  evidence. Its conclusion does not change; the new part is that plan mode is
  the wrong instrument for a no-edit guarantee, not a broken instance of the
  right one.
- `ClaudeArgs.scala` — the scaladoc said plan mode "makes Edit/Write/Bash
  unavailable (not just non-auto-approved) — a hard no-edit guarantee". Now it
  says what plan mode does. Two follow-on sentences in the same file repeated
  the claim and are corrected with it.
- `GeminiArgs.scala` — the same claim for `--approval-mode plan`, which has
  never been measured (no credentials on the test host, so no turn reached the
  model). Now marked unverified.
- `ReviewerSelector.scala` — said "claude's plan mode doesn't [run commands]".

The `Enforcement` values and `EnforcementTableTest` are untouched: what to do
about the `Hard` cells is a separate decision.

## Checks

`sbt scalafmtCheckAll` clean. `sbt clean compile test` green with no warnings,
486 + 229 tests, none moved.
