### PR TITLE
Stop stripMargin eating a `|` line in the reviewer-picker prompt

### DIFF
--- a/flow/src/main/scala/orca/review/ReviewerSelectionRequest.scala
+++ b/flow/src/main/scala/orca/review/ReviewerSelectionRequest.scala
@@ -31,12 +31,7 @@ private[review] object ReviewerSelectionRequest:
       val reviewers = r.availableReviewers
         .map(ri => s"  - ${ri.name}: ${ri.description}")
         .mkString("\n")
-      s"""Task: ${r.taskTitle}
-         |
-         |Changed files:
-         |$files
-         |
-         |Available reviewers:
-         |$reviewers
-         |
-         |${r.instructions}""".stripMargin
+      // No `stripMargin`: `instructions` is flow-author text handed in whole,
+      // so a `|`-leading line in it would arrive with the `|` eaten.
+      s"Task: ${r.taskTitle}\n\nChanged files:\n$files\n\n" +
+        s"Available reviewers:\n$reviewers\n\n${r.instructions}"

--- a/flow/src/test/scala/orca/review/ReviewTypesTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewTypesTest.scala
@@ -53,6 +53,19 @@ class ReviewTypesTest extends munit.FunSuite:
       summon[AgentInput[FixRequest]].serialize(request).contains("\n  |a| b|")
     )
 
+  test("the picker prompt keeps an instruction line that starts with `|`"):
+    val request = ReviewerSelectionRequest(
+      taskTitle = Title("Add a check"),
+      changedFiles = List("Foo.scala"),
+      availableReviewers = List(ReviewerInfo("security", "security review")),
+      instructions = "pick one:\n  |a| b|"
+    )
+    assert(
+      summon[AgentInput[ReviewerSelectionRequest]]
+        .serialize(request)
+        .contains("\n  |a| b|")
+    )
+
   test("IgnoredIssues ++ concatenates entries"):
     val a = IgnoredIssues(List(IgnoredIssue(Title("Style nit"), "accepted")))
     val b = IgnoredIssues(List(IgnoredIssue(Title("Style nit"), "deferred")))


### PR DESCRIPTION
`ReviewerSelectionRequest`'s picker prompt interpolated `instructions` into a `stripMargin` block. `stripMargin` runs over the *interpolated* result, not the literal, so every line of the injected text after the first that starts with optional whitespace followed by `|` loses that `|`.

`instructions` is a public overridable parameter of `ReviewerSelector.agentDriven`; it defaults to a loaded markdown resource, so it is arbitrary flow-author text. The shipped default has no `|`-leading line, so today this only bites on an override — same latency as the sites fixed in #54 and #66, and the same argument.

This is the eighth site, fixed the same way as the other seven: plain concatenation, plus a short comment saying why there is no margin. The output text is unchanged byte-for-byte.

## Test

One test in `ReviewTypesTest`, next to the analogous `FixRequest` one: an `instructions` value with a `|`-leading second line must survive into the prompt. Run against the pre-fix source it fails, and only it fails.

`sbt scalafmtCheckAll` clean, `sbt clean compile test` green, zero warnings.
