### PR TITLE
Keep the developer's git config out of test fixtures

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,13 +40,11 @@ lazy val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
   libraryDependencies ++= Seq(munit),
   testFrameworks += new TestFramework("munit.Framework"),
   // Tests shell out to `git`, which reads the developer's global and system
-  // config unless told otherwise: a global ignore rule, hooks path,
-  // gitattributes filter, `commit.gpgsign`, `status.showUntrackedFiles` or
-  // `core.autocrlf` all change what a fixture repo does, usually with no hint
-  // why. Pointing both config files at an empty one neutralises the whole
-  // class at once (git 2.32+). Fixtures set `user.name`/`user.email` in the
-  // repo, so commits still work. Env vars can only be set on a new process,
-  // hence the fork.
+  // config unless told otherwise: a global ignore rule or `commit.gpgsign`
+  // changes what a fixture repo does, usually with no hint why. Pointing both
+  // config files at an empty one neutralises the whole class at once (git
+  // 2.32+). Fixtures set `user.name`/`user.email` in the repo, so commits
+  // still work. Env vars can only be set on a new process, hence the fork.
   Test / fork := true,
   Test / envVars ++= Map(
     "GIT_CONFIG_GLOBAL" -> "/dev/null",
@@ -153,26 +151,7 @@ lazy val flow = (project in file("flow"))
       jsonSchemaValidator,
       scala3Compiler,
       munitScalacheck
-    ),
-    // The CC negative-compile suite invokes the Scala 3 compiler
-    // (`dotty.tools.dotc.Main`) in-process against this
-    // module's own test classpath (it needs orca.CheckedPar, orca.FlowControl,
-    // the capability tokens, ox and the Scala library). Materialise the
-    // classpath into a resource the suite reads, rather than depending on the
-    // forked JVM's `java.class.path`. It must be
-    // `dependencyClasspath`, NOT `fullClasspath`: the latter includes this
-    // module's own Test products, whose task graph depends back on Test
-    // resources — a cycle that deadlocks sbt's task engine (observed, not
-    // hypothetical). dependencyClasspath still carries everything the fixtures
-    // reference (tools/flow Compile classes plus external deps).
-    Test / resourceGenerators += Def.task {
-      val cp = (Test / dependencyClasspath).value
-        .map(_.data.getAbsolutePath)
-        .mkString(java.io.File.pathSeparator)
-      val f = (Test / resourceManaged).value / "cc-test-classpath.txt"
-      IO.write(f, cp)
-      Seq(f)
-    }.taskValue
+    )
   )
 
 lazy val runner = (project in file("runner"))
@@ -190,10 +169,11 @@ lazy val runner = (project in file("runner"))
   .settings(
     // Published as just "orca" so flow-script coordinates stay short.
     name := "orca",
-    // Fork tests: `flow(...)` mutates the global logback root logger (OrcaLog's
-    // per-run appender) and can `System.exit` on a NonFatal failure — a forked
-    // JVM keeps that out of the shared test runner.
-    Test / fork := true,
+    // This module leans on the fork in `commonSettings` for a second reason:
+    // `flow(...)` mutates the global logback root logger (OrcaLog's per-run
+    // appender) and can `System.exit` on a NonFatal failure, neither of which
+    // may reach the shared test runner.
+    //
     // `runFlow`'s reentrancy guard (`FlowLock.acquireProcess`) is a
     // process-wide `AtomicBoolean` — correct for real usage (one `flow(...)`
     // per process), but sbt's default `Test / parallelExecution` would let two
@@ -222,11 +202,10 @@ lazy val shell = (project in file("shell"))
     // declared explicitly since shell uses it directly.
     libraryDependencies ++= Seq(osLib, jsoniter, jsoniterMacros, ox, jline, jlineConsoleUi, fansi, mainargs),
     // ChildTerminal's SIGINT test mutates process-global JVM signal state
-    // (`sun.misc.Signal.handle` on INT). Fork so that state never lives in
-    // the sbt/Bloop daemon's own JVM, and serialize so no concurrently
-    // running suite observes the temporarily-ignored handler — the same
-    // isolation runner uses for its process-global lock and logger state.
-    Test / fork := true,
+    // (`sun.misc.Signal.handle` on INT). The fork in `commonSettings` keeps
+    // that state out of the sbt/Bloop daemon's own JVM; serialize so no
+    // concurrently running suite observes the temporarily-ignored handler —
+    // the same isolation runner uses for its lock and logger state.
     Test / parallelExecution := false,
     Test / javaOptions += buildVersionProperty.value,
     // Bundles the top-level flows/*.sc scripts as jar resources under

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,19 @@ lazy val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
   versionScheme := Some("semver-spec"),
   libraryDependencies ++= Seq(munit),
   testFrameworks += new TestFramework("munit.Framework"),
+  // Tests shell out to `git`, which reads the developer's global and system
+  // config unless told otherwise: a global ignore rule, hooks path,
+  // gitattributes filter, `commit.gpgsign`, `status.showUntrackedFiles` or
+  // `core.autocrlf` all change what a fixture repo does, usually with no hint
+  // why. Pointing both config files at an empty one neutralises the whole
+  // class at once (git 2.32+). Fixtures set `user.name`/`user.email` in the
+  // repo, so commits still work. Env vars can only be set on a new process,
+  // hence the fork.
+  Test / fork := true,
+  Test / envVars ++= Map(
+    "GIT_CONFIG_GLOBAL" -> "/dev/null",
+    "GIT_CONFIG_SYSTEM" -> "/dev/null"
+  ),
   homepage := Some(url("https://github.com/VirtusLab/orca")),
   organizationHomepage := Some(url("https://virtuslab.com")),
   licenses := Seq(
@@ -144,9 +157,9 @@ lazy val flow = (project in file("flow"))
     // The CC negative-compile suite invokes the Scala 3 compiler
     // (`dotty.tools.dotc.Main`) in-process against this
     // module's own test classpath (it needs orca.CheckedPar, orca.FlowControl,
-    // the capability tokens, ox and the Scala library). flow's tests are not
-    // forked, so `java.class.path` is only sbt's launcher classpath — unusable.
-    // Materialise the classpath into a resource the suite reads. It must be
+    // the capability tokens, ox and the Scala library). Materialise the
+    // classpath into a resource the suite reads, rather than depending on the
+    // forked JVM's `java.class.path`. It must be
     // `dependencyClasspath`, NOT `fullClasspath`: the latter includes this
     // module's own Test products, whose task graph depends back on Test
     // resources — a cycle that deadlocks sbt's task engine (observed, not

--- a/flow/src/test/scala/orca/CcNegativeCompileTest.scala
+++ b/flow/src/test/scala/orca/CcNegativeCompileTest.scala
@@ -41,15 +41,10 @@ class CcNegativeCompileTest extends munit.FunSuite:
     def doReport(dia: Diagnostic)(using Context): Unit =
       val _ = diagnostics += dia
 
-  /** The Test classpath, materialised by the build's `resourceGenerators` (flow
-    * tests aren't forked, so `java.class.path` would only be sbt's launcher
-    * classpath). Loaded once and reused across every fixture compile.
+  /** The Test classpath. Tests are forked, so it is what the JVM was started
+    * with, plus the two sbt jars that run the fork — inert to `dotc`.
     */
-  private lazy val classpath: String =
-    val is = getClass.getResourceAsStream("/cc-test-classpath.txt")
-    assert(is != null, "cc-test-classpath.txt resource missing — check build")
-    try new String(is.readAllBytes(), "UTF-8").trim
-    finally is.close()
+  private def classpath: String = System.getProperty("java.class.path")
 
   /** Compile one fixture source with `dotc` and return its error messages. Each
     * call spins a fresh reporter and output dir; the classpath (the expensive

--- a/tools/src/test/scala/orca/testkit/GitRepo.scala
+++ b/tools/src/test/scala/orca/testkit/GitRepo.scala
@@ -5,8 +5,11 @@ package orca.testkit
   * registered with [[TempDirs]] for cleanup at JVM shutdown.
   */
 object GitRepo:
-  /** Fresh temp repo: `git init -b main`, test user config, and the ambient
-    * global config neutralised. No commits.
+  /** Fresh temp repo: `git init -b main` plus test user config. No commits.
+    *
+    * The developer's global and system git config is out of the picture for the
+    * whole test JVM (`GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` in `build.sbt`),
+    * which is why the user config below has to be set here.
     */
   def empty(): os.Path =
     val dir = TempDirs.dir(prefix = "orca-gitrepo-")
@@ -14,17 +17,6 @@ object GitRepo:
     val _ =
       os.proc("git", "config", "user.email", "test@example.com").call(cwd = dir)
     val _ = os.proc("git", "config", "user.name", "Test").call(cwd = dir)
-    // Neutralise the two settings a developer's global config can reach into
-    // the fixture with: git reads a missing path as empty. A global ignore rule
-    // matching a fixture name would otherwise hide it from `git status`, and
-    // the test would fail with no hint why. Under `.git/`, out of the tree.
-    val gitDir = dir / ".git"
-    val _ = os
-      .proc("git", "config", "core.excludesFile", gitDir / "no-excludes")
-      .call(cwd = dir)
-    val _ = os
-      .proc("git", "config", "core.hooksPath", gitDir / "no-hooks")
-      .call(cwd = dir)
     dir
 
   /** `empty()` plus a single `seed.txt` commit (`seed`). */

--- a/tools/src/test/scala/orca/testkit/GitRepoTest.scala
+++ b/tools/src/test/scala/orca/testkit/GitRepoTest.scala
@@ -1,0 +1,15 @@
+package orca.testkit
+
+class GitRepoTest extends munit.FunSuite:
+  // The isolation itself is a build setting, not fixture code (build.sbt,
+  // `Test / envVars`), so pin here that the test JVM really has it: without it
+  // a developer's global config silently changes what fixtures do.
+  test("a fixture repo sees no global or system git config"):
+    val dir = GitRepo.empty()
+    val nonLocal = os
+      .proc("git", "config", "--list", "--show-scope")
+      .call(cwd = dir)
+      .out
+      .lines()
+      .filterNot(_.startsWith("local"))
+    assertEquals(nonLocal.toList, Nil)


### PR DESCRIPTION
#70 stopped two global git config keys from reaching test fixtures — `core.excludesFile` and `core.hooksPath` — by overriding them inside the fixture repo. That fixes the two keys we happened to trip over. The class is much wider: a global gitattributes filter, `commit.gpgsign`, `status.showUntrackedFiles`, `core.autocrlf`, `diff.noprefix` and more all change what a fixture repo does, usually with no hint why. Git has no per-repo "ignore the global config" switch, so overriding key by key is the only thing that can be done from inside the repo — and it can never be complete.

The complete switch is the environment. This points `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` at `/dev/null` for the test JVM (git 2.32+), which means the tests have to fork. Both settings go in `commonSettings`, so every module gets them, and `runner`/`shell` keep their own `Test / fork` lines since they need forking for their own reasons.

With the global config gone, the fixture's local `user.name` / `user.email` become load-bearing rather than a belt-and-braces override — noted in the scaladoc. The two per-key overrides are deleted.

## Test

`GitRepoTest` states the invariant directly: in a fixture repo, `git config --list --show-scope` shows nothing outside `local`. Drop the `envVars` block and it is the only test that fails (checked against the full suite).

`sbt scalafmtCheckAll` clean, `sbt clean compile test` green across all modules with forking on, zero warnings.

## Follow-up in the second commit

Forking has a side effect worth taking: a forked test JVM is started with the test classpath on `java.class.path`, which is the thing the `flow` build was materialising into a `cc-test-classpath.txt` resource for the CC negative-compile suite to read. The generator and the resource loading are gone; the suite reads the system property. Its positive-compile fixtures pin that the classpath is really the right one.

`runner` and `shell` no longer set `Test / fork` themselves. Why each of them needs a forked JVM is still recorded where it was.
