### PR TITLE
Give claude read-only turns a --tools allowlist, not plan mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ which tools exist at all:
 // ReadOnly — reads only, no shell, no edits (reviewers, plan review, brief).
 val reviewer = claude.withReadOnly
 
-// NetworkOnly — reads plus read-only network (web + GitHub), for planners that
-// must read an issue/PR. The no-edit guarantee is hard on claude, gemini and
+// NetworkOnly — reads plus read-only network (web), for planners that must
+// read an issue/PR. The no-edit guarantee is hard on claude, gemini and
 // opencode, prompt-only on pi/codex (ADR 0016).
 val planner = claude.withNetworkOnly
 

--- a/adr/0016-toolset-capability-axis-and-planner-network.md
+++ b/adr/0016-toolset-capability-axis-and-planner-network.md
@@ -9,8 +9,8 @@ Planning turns run autonomously (stdin closed, no `ask_user` MCP) and
 read-only. On every backend the read-only mode also blocks the network the
 planner needs to read an issue/PR it was pointed at: claude's read-only tier
 withholds `WebFetch`/`WebSearch`, codex's `--sandbox read-only` blocks all
-network, pi's read-only
-`--tools` has no web tool, gemini's `--approval-mode plan` gates web/shell.
+network, pi's read-only `--tools` has no web tool, gemini's `--approval-mode
+plan` gates web/shell.
 
 Capability was previously encoded as a boolean `AgentConfig.readOnly` layered over
 the `AutoApprove` enum, munged together in each backend's args mapping. Two
@@ -70,7 +70,7 @@ measured planner use of `gh` was zero, and orca reads issues host-side via
 
 ## Consequences
 
-- Claude planners get scoped read-only network with the hard no-edit guarantee
+- Claude planners get read-only network with the hard no-edit guarantee
   intact; pi/codex planners get network with a prompt-only guarantee;
   gemini/opencode planners stay network-free and rely on pre-fetching.
 - `withReadOnly` semantics are unchanged for the six non-planner turn kinds.

--- a/adr/0016-toolset-capability-axis-and-planner-network.md
+++ b/adr/0016-toolset-capability-axis-and-planner-network.md
@@ -7,9 +7,9 @@ Related: [ADR 0003](0003-pluggable-llm-backends.md) (backend surface), [ADR 0011
 
 Planning turns run autonomously (stdin closed, no `ask_user` MCP) and
 read-only. On every backend the read-only mode also blocks the network the
-planner needs to read an issue/PR it was pointed at: claude's
-`--permission-mode plan` prompts for `WebFetch`/`gh` (and an autonomous turn
-can't answer), codex's `--sandbox read-only` blocks all network, pi's read-only
+planner needs to read an issue/PR it was pointed at: claude's read-only tier
+withholds `WebFetch`/`WebSearch`, codex's `--sandbox read-only` blocks all
+network, pi's read-only
 `--tools` has no web tool, gemini's `--approval-mode plan` gates web/shell.
 
 Capability was previously encoded as a boolean `AgentConfig.readOnly` layered over
@@ -39,7 +39,7 @@ select `NetworkOnly`; reviewers, `reviewed`/`briefed`, selection and lint keep
 
 | Backend | `NetworkOnly` | No-edit guarantee | Network |
 | --- | --- | --- | --- |
-| claude | `plan` + `--allowedTools <networkTools>` | **hard** (command-scoped allowlist; plan mode blocks general bash + edits) | web + scoped `gh` |
+| claude | `--tools <read-only tools + networkTools>` | **hard** (`--tools` removes every unlisted built-in, shell and edits included) | web |
 | pi | `--tools …,bash` | **prompt-only** (bash permits writes) | shell (`gh`/`curl`) |
 | codex | `--full-auto` + `-c sandbox_workspace_write.network_access=true` | **prompt-only** (workspace-write permits writes) | shell + web |
 | gemini | `--approval-mode plan --allowed-tools web_fetch` | hard | web |
@@ -57,12 +57,16 @@ disabled set, so web may work (server-dependent, unverified).
 
 ### Claude allowlist placement
 
-The claude network allowlist (`--allowedTools` strings like `Bash(gh api:*)`) is
-claude-specific, so it lives on `ClaudeBackend` (default
-`DefaultNetworkTools`), not the shared `AgentConfig`. It is configurable per flow
-via `claude.withNetworkTools(...)`. The default includes `Bash(gh api:*)` for
-broad GitHub reads — note `gh api -X POST` can mutate GitHub (not local files);
-flows wanting a tighter set override it.
+The claude network tool names are claude-specific, so they live on
+`ClaudeBackend` (default `DefaultNetworkTools`), not the shared `AgentConfig`.
+Configurable per flow via `claude.withNetworkTools(...)`.
+
+Amended 2026-08-05 (#78, #84): claude's read-only tiers moved from
+`--permission-mode plan` to a `--tools` allowlist, which is the capability
+removal plan mode was assumed to be and was not. `--tools` takes bare tool
+names, so the default's five command-scoped `Bash(gh …)` entries are gone;
+measured planner use of `gh` was zero, and orca reads issues host-side via
+`GitHubTool.readIssue`. The default is now `WebFetch`, `WebSearch`.
 
 ## Consequences
 

--- a/adr/0016-toolset-capability-axis-and-planner-network.md
+++ b/adr/0016-toolset-capability-axis-and-planner-network.md
@@ -39,7 +39,7 @@ select `NetworkOnly`; reviewers, `reviewed`/`briefed`, selection and lint keep
 
 | Backend | `NetworkOnly` | No-edit guarantee | Network |
 | --- | --- | --- | --- |
-| claude | `--tools <read-only tools + networkTools>` | **hard** (`--tools` removes every unlisted built-in, shell and edits included) | web |
+| claude | `--allowedTools <networkTools>` + `--tools <read-only tools + networkTools>` | **hard** (`--tools` removes every unlisted built-in, shell and edits included) | web |
 | pi | `--tools …,bash` | **prompt-only** (bash permits writes) | shell (`gh`/`curl`) |
 | codex | `--full-auto` + `-c sandbox_workspace_write.network_access=true` | **prompt-only** (workspace-write permits writes) | shell + web |
 | gemini | `--approval-mode plan --allowed-tools web_fetch` | hard | web |
@@ -67,6 +67,11 @@ removal plan mode was assumed to be and was not. `--tools` takes bare tool
 names, so the default's five command-scoped `Bash(gh …)` entries are gone;
 measured planner use of `gh` was zero, and orca reads issues host-side via
 `GitHubTool.readIssue`. The default is now `WebFetch`, `WebSearch`.
+
+`--tools` advertises a tool without granting it: the default permission mode
+still gates `WebFetch`, and stdin is closed, so the call fails. `NetworkOnly`
+therefore also passes `--allowedTools <networkTools>`; the two flags compose,
+with `--tools` still bounding the surface.
 
 ## Consequences
 

--- a/adr/0016-toolset-capability-axis-and-planner-network.md
+++ b/adr/0016-toolset-capability-axis-and-planner-network.md
@@ -39,7 +39,7 @@ select `NetworkOnly`; reviewers, `reviewed`/`briefed`, selection and lint keep
 
 | Backend | `NetworkOnly` | No-edit guarantee | Network |
 | --- | --- | --- | --- |
-| claude | `--allowedTools <networkTools>` + `--tools <read-only tools + networkTools>` | **hard** (`--tools` removes every unlisted built-in, shell and edits included) | web |
+| claude | `--tools <read-only tools + networkTools>` + `--allowedTools <networkTools>` | **hard** (`--tools` removes every unlisted built-in, shell and edits included) | web |
 | pi | `--tools …,bash` | **prompt-only** (bash permits writes) | shell (`gh`/`curl`) |
 | codex | `--full-auto` + `-c sandbox_workspace_write.network_access=true` | **prompt-only** (workspace-write permits writes) | shell + web |
 | gemini | `--approval-mode plan --allowed-tools web_fetch` | hard | web |
@@ -71,7 +71,9 @@ measured planner use of `gh` was zero, and orca reads issues host-side via
 `--tools` advertises a tool without granting it: the default permission mode
 still gates `WebFetch`, and stdin is closed, so the call fails. `NetworkOnly`
 therefore also passes `--allowedTools <networkTools>`; the two flags compose,
-with `--tools` still bounding the surface.
+with `--tools` still bounding the surface. MCP tools need the same grant —
+one `--allowedTools` carrying every name to approve, since a repeated flag is
+unverified.
 
 ## Consequences
 

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -96,9 +96,15 @@ private[claude] object ClaudeArgs:
 
   /** Built-in tools a read-only turn keeps. `--tools` is an allowlist that
     * removes every name not on it: the dropped tools are absent from the `init`
-    * frame, `ToolSearch` cannot resurrect them, subagents inherit the list, and
-    * it survives `--resume`. Reviewers and planners therefore have no shell and
-    * no write primitive.
+    * frame and `ToolSearch` cannot resurrect them, so reviewers and planners
+    * have no shell and no write primitive.
+    *
+    * **It does not survive `--resume`.** Measured on 2.1.222: resuming a
+    * session created under this list, without re-passing `--tools`, brings back
+    * the full default set — `Bash`, `Edit`, `Write` and all. [[streamJson]]
+    * rebuilds the flags from each turn's own config, which is what keeps a
+    * resumed reviewer restricted; a resume path that reused stored args would
+    * not.
     *
     * Unknown names are dropped silently (`Read,Grep,NoSuchTool` yields
     * `Grep,Read`, exit 0, no warning), so this list is pinned against a live
@@ -117,7 +123,10 @@ private[claude] object ClaudeArgs:
     * unfiltered. Measured on claude 2.1.222 — an `init` frame under `--tools
     * Read,Grep,Glob,Skill` still carried the `mcp__…` tools of an installed
     * server, so an MCP server that can write is not covered by this allowlist
-    * at all.
+    * at all. The read-only tiers also ignore [[AgentConfig.autoApprove]], so an
+    * MCP tool reaching a read-only turn is advertised but not pre-approved: it
+    * comes back as a failed `tool_result` rather than prompting. No in-repo
+    * flow hits that — every interactive turn is `Full`.
     *
     * `Full` follows [[AgentConfig.autoApprove]]: `All` → `bypassPermissions`;
     * `Only(_)` → default permission mode plus `--allowedTools`. The allowlist
@@ -125,6 +134,10 @@ private[claude] object ClaudeArgs:
     * tools. Under `--print` nothing is prompted back to orca: a call the CLI
     * won't run comes back as a failed `tool_result` (pinned by
     * `ClaudeIntegrationTest`).
+    *
+    * Both flags are variadic (`--tools <tools...>`), so nothing positional may
+    * follow them in the argv — [[streamJson]] emits only flag-value pairs after
+    * this, and the prompt goes over stdin.
     */
   private def permissionArgs(
       config: AgentConfig,

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -119,6 +119,13 @@ private[claude] object ClaudeArgs:
     * appends `networkTools` to it. Not `--permission-mode plan`: that removed
     * no tools at all (`docs/research/run-cost/09-diff-vs-coordinates.md` §2).
     *
+    * `NetworkOnly` also pre-approves `networkTools` via `--allowedTools`.
+    * `--tools` only advertises: under the default permission mode `WebFetch` is
+    * still gated, and with stdin closed nobody can approve it, so the call
+    * comes back as a failed `tool_result`. The two flags compose —
+    * `--allowedTools` grants, `--tools` still bounds the surface (pinned by
+    * `ClaudeIntegrationTest`).
+    *
     * `--tools` is not a complete boundary: MCP tools pass through it
     * unfiltered. Measured on claude 2.1.222 — an `init` frame under `--tools
     * Read,Grep,Glob,Skill` still carried the `mcp__…` tools of an installed
@@ -147,7 +154,11 @@ private[claude] object ClaudeArgs:
       case ToolSet.ReadOnly =>
         Seq("--tools", ReadOnlyTools.mkString(","))
       case ToolSet.NetworkOnly =>
-        Seq("--tools", (ReadOnlyTools ++ networkTools).mkString(","))
+        val preApproved =
+          if networkTools.isEmpty then Seq.empty
+          else Seq("--allowedTools", networkTools.mkString(","))
+        preApproved ++
+          Seq("--tools", (ReadOnlyTools ++ networkTools).mkString(","))
       case ToolSet.Full =>
         config.autoApprove match
           case AutoApprove.All =>

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -119,12 +119,10 @@ private[claude] object ClaudeArgs:
     * appends `networkTools` to it. Not `--permission-mode plan`: that removed
     * no tools at all (`docs/research/run-cost/09-diff-vs-coordinates.md` §2).
     *
-    * `NetworkOnly` also pre-approves `networkTools` via `--allowedTools`.
-    * `--tools` only advertises: under the default permission mode `WebFetch` is
-    * still gated, and with stdin closed nobody can approve it, so the call
-    * comes back as a failed `tool_result`. The two flags compose —
-    * `--allowedTools` grants, `--tools` still bounds the surface (pinned by
-    * `ClaudeIntegrationTest`).
+    * `NetworkOnly` also [[approve]]s `networkTools`, without which they are
+    * advertised but not runnable. The two flags compose: `--allowedTools`
+    * grants, `--tools` still bounds the surface. Verified on claude 2.1.223 in
+    * the order emitted here, and pinned by `ClaudeIntegrationTest`.
     *
     * `--tools` is not a complete boundary: MCP tools pass through it
     * unfiltered. Measured on claude 2.1.222 — an `init` frame under `--tools
@@ -154,11 +152,8 @@ private[claude] object ClaudeArgs:
       case ToolSet.ReadOnly =>
         Seq("--tools", ReadOnlyTools.mkString(","))
       case ToolSet.NetworkOnly =>
-        val preApproved =
-          if networkTools.isEmpty then Seq.empty
-          else Seq("--allowedTools", networkTools.mkString(","))
-        preApproved ++
-          Seq("--tools", (ReadOnlyTools ++ networkTools).mkString(","))
+        Seq("--tools", (ReadOnlyTools ++ networkTools).mkString(",")) ++
+          approve(networkTools)
       case ToolSet.Full =>
         config.autoApprove match
           case AutoApprove.All =>
@@ -167,6 +162,19 @@ private[claude] object ClaudeArgs:
           case AutoApprove.Only(tools) if tools.isEmpty => Seq.empty
           case AutoApprove.Only(tools) =>
             Seq("--allowedTools", tools.toSeq.sorted.mkString(","))
+
+  /** Grants `tools` on a read-only turn. `--tools` only advertises: the turn
+    * stays in the default permission mode, where `WebFetch` and MCP tools are
+    * gated, and stdin is closed under `--print`, so an ungranted call comes
+    * back as a failed `tool_result`.
+    *
+    * One flag carrying one list. Whether claude honours a repeated
+    * `--allowedTools` is unverified, so a caller with more to grant widens this
+    * argument rather than calling twice.
+    */
+  private def approve(tools: Seq[String]): Seq[String] =
+    if tools.isEmpty then Seq.empty
+    else Seq("--allowedTools", tools.mkString(","))
 
   /** How strongly claude enforces each `(tools, autoApprove)` combination — see
     * [[permissionArgs]] for the flags this classifies. Every combination is

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -52,16 +52,16 @@ private[claude] object ClaudeArgs:
 
   /** `--model`, with the bare `haiku` alias replaced by its fully-qualified id.
     *
-    * Under `--permission-mode plan` (every read-only turn — see
-    * `autoApproveArgs`) the CLI serves `claude-sonnet-5` for `--model haiku`,
-    * 3x the intended rate for a `claude:haiku` role pin. Its init line still
-    * names haiku, so re-checking this means reading the model off the assistant
-    * messages or the result's `modelUsage`, not off the init line. It honours
-    * `claude-haiku-4-5` in the same mode; verified against claude 2.1.220.
+    * Under `--permission-mode plan` the CLI served `claude-sonnet-5` for
+    * `--model haiku`, 3x the intended rate for a `claude:haiku` role pin
+    * (claude 2.1.220). Orca no longer passes plan mode, and 2.1.222 resolves
+    * the bare alias correctly under `--tools`, but the qualified id is kept as
+    * the cheaper failure mode. Re-checking it means reading the model off the
+    * assistant messages or the result's `modelUsage` — the init line names
+    * haiku either way.
     *
-    * Only `haiku` is rewritten — the CLI resolves `sonnet`/`opus`/`fable`
-    * correctly in plan mode, and leaving those bare keeps them tracking the
-    * latest model in their tier.
+    * Only `haiku` is rewritten; leaving `sonnet`/`opus`/`fable` bare keeps them
+    * tracking the latest model in their tier.
     */
   private def modelArgs(config: AgentConfig): Seq[String] =
     CliArgs.flag("--model", config.model): model =>
@@ -99,19 +99,34 @@ private[claude] object ClaudeArgs:
   private def mcpConfigArgs(file: Option[os.Path]): Seq[String] =
     CliArgs.flag("--mcp-config", file)(_.toString)
 
-  /** Maps [[AgentConfig.tools]] to claude's permission flags. Both read-only
-    * tiers use `--permission-mode plan`, which is not a no-edit guarantee: plan
-    * mode removes no tools. The `init` message's tool list under
-    * `--permission-mode plan` is byte-identical to the default mode's, `Bash`,
-    * `Write`, `Edit` and `NotebookEdit` included. What blocking happens comes
-    * from the approval layer, which the default mode applies too, and above
-    * that it is model judgement — opus reviewers ran 199 `Bash` calls under
-    * plan mode with zero denials
-    * (`docs/research/run-cost/09-diff-vs-coordinates.md` §2).
+  /** Built-in tools a read-only turn keeps. `--tools` is an allowlist that
+    * removes every name not on it: the dropped tools are absent from the `init`
+    * frame, `ToolSearch` cannot resurrect them, subagents inherit the list, and
+    * it survives `--resume`. Reviewers and planners therefore have no shell and
+    * no write primitive.
     *
-    * `NetworkOnly` additionally pre-approves `networkTools` via
-    * `--allowedTools`, layering network access onto plan mode. The list is
-    * command-scoped (`Bash(gh api:*)`); an empty list leaves plain plan mode.
+    * Unknown names are dropped silently (`Read,Grep,NoSuchTool` yields
+    * `Grep,Read`, exit 0, no warning), so this list is pinned against a live
+    * CLI by `ClaudeIntegrationTest`.
+    */
+  private[claude] val ReadOnlyTools: Seq[String] =
+    Seq("Read", "Grep", "Glob", "Skill")
+
+  /** Maps [[AgentConfig.tools]] to claude's permission flags.
+    *
+    * Both read-only tiers pass `--tools` (see [[ReadOnlyTools]]); `NetworkOnly`
+    * appends `networkTools` to it. This is capability removal, not approval
+    * policy — the predecessor, `--permission-mode plan`, removed no tools at
+    * all: its `init` list was byte-identical to the default mode's, `Bash`,
+    * `Write` and `Edit` included, and opus reviewers ran 199 `Bash` calls under
+    * it with zero denials (`docs/research/run-cost/09-diff-vs-coordinates.md`
+    * §2).
+    *
+    * **`--tools` is not a complete boundary: MCP tools pass through it
+    * unfiltered.** Measured on claude 2.1.222 — an `init` frame under `--tools
+    * Read,Grep,Glob,Skill` still carried the `mcp__…` tools of an installed
+    * server. Orca's own `ask_user` surviving is wanted; an MCP server that can
+    * write is not covered by this allowlist at all.
     *
     * `Full` follows [[AgentConfig.autoApprove]]: `All` → `bypassPermissions`;
     * `Only(_)` → default permission mode plus `--allowedTools`. The allowlist
@@ -125,16 +140,10 @@ private[claude] object ClaudeArgs:
       networkTools: Seq[String]
   ): Seq[String] =
     config.tools match
-      case ToolSet.ReadOnly => Seq("--permission-mode", "plan")
-      case ToolSet.NetworkOnly if networkTools.isEmpty =>
-        Seq("--permission-mode", "plan")
+      case ToolSet.ReadOnly =>
+        Seq("--tools", ReadOnlyTools.mkString(","))
       case ToolSet.NetworkOnly =>
-        Seq(
-          "--permission-mode",
-          "plan",
-          "--allowedTools",
-          networkTools.mkString(",")
-        )
+        Seq("--tools", (ReadOnlyTools ++ networkTools).mkString(","))
       case ToolSet.Full =>
         config.autoApprove match
           case AutoApprove.All =>
@@ -146,9 +155,9 @@ private[claude] object ClaudeArgs:
 
   /** How strongly claude enforces each `(tools, autoApprove)` combination — see
     * [[autoApproveArgs]] for the flags this classifies. Every combination is
-    * `Hard`. The read-only tiers rest on plan mode, which [[autoApproveArgs]]
-    * records as removing no tools; the `--allowedTools`/`bypassPermissions`
-    * variants are mechanical per-tool gates.
+    * `Hard`. The read-only tiers rest on `--tools`, which removes every
+    * unlisted built-in; the `--allowedTools`/`bypassPermissions` variants are
+    * mechanical per-tool gates.
     *
     * Written as an exhaustive match (all arms `Hard`) rather than a bare
     * constant so a future `ToolSet`/`AutoApprove` case fails compilation here.

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -46,22 +46,17 @@ private[claude] object ClaudeArgs:
       modelArgs(config) ++
       systemPromptFileArgs(systemPromptFile) ++
       sessionArgs(dispatch) ++
-      autoApproveArgs(config, networkTools) ++
+      permissionArgs(config, networkTools) ++
       jsonSchemaArgs(jsonSchema) ++
       mcpConfigArgs(mcpConfig)
 
   /** `--model`, with the bare `haiku` alias replaced by its fully-qualified id.
     *
     * Under `--permission-mode plan` the CLI served `claude-sonnet-5` for
-    * `--model haiku`, 3x the intended rate for a `claude:haiku` role pin
-    * (claude 2.1.220). Orca no longer passes plan mode, and 2.1.222 resolves
-    * the bare alias correctly under `--tools`, but the qualified id is kept as
-    * the cheaper failure mode. Re-checking it means reading the model off the
-    * assistant messages or the result's `modelUsage` — the init line names
-    * haiku either way.
-    *
-    * Only `haiku` is rewritten; leaving `sonnet`/`opus`/`fable` bare keeps them
-    * tracking the latest model in their tier.
+    * `--model haiku` — 3x the intended rate for a `claude:haiku` role pin
+    * (measured on 2.1.220). Measured fixed on 2.1.222, but the qualified id is
+    * the cheaper failure mode. Only `haiku` is rewritten; leaving
+    * `sonnet`/`opus`/`fable` bare keeps them tracking their tier's latest.
     */
   private def modelArgs(config: AgentConfig): Seq[String] =
     CliArgs.flag("--model", config.model): model =>
@@ -112,21 +107,17 @@ private[claude] object ClaudeArgs:
   private[claude] val ReadOnlyTools: Seq[String] =
     Seq("Read", "Grep", "Glob", "Skill")
 
-  /** Maps [[AgentConfig.tools]] to claude's permission flags.
+  /** Maps [[AgentConfig.tools]] to claude's tool and permission flags.
     *
     * Both read-only tiers pass `--tools` (see [[ReadOnlyTools]]); `NetworkOnly`
-    * appends `networkTools` to it. This is capability removal, not approval
-    * policy — the predecessor, `--permission-mode plan`, removed no tools at
-    * all: its `init` list was byte-identical to the default mode's, `Bash`,
-    * `Write` and `Edit` included, and opus reviewers ran 199 `Bash` calls under
-    * it with zero denials (`docs/research/run-cost/09-diff-vs-coordinates.md`
-    * §2).
+    * appends `networkTools` to it. Not `--permission-mode plan`: that removed
+    * no tools at all (`docs/research/run-cost/09-diff-vs-coordinates.md` §2).
     *
-    * **`--tools` is not a complete boundary: MCP tools pass through it
-    * unfiltered.** Measured on claude 2.1.222 — an `init` frame under `--tools
+    * `--tools` is not a complete boundary: MCP tools pass through it
+    * unfiltered. Measured on claude 2.1.222 — an `init` frame under `--tools
     * Read,Grep,Glob,Skill` still carried the `mcp__…` tools of an installed
-    * server. Orca's own `ask_user` surviving is wanted; an MCP server that can
-    * write is not covered by this allowlist at all.
+    * server, so an MCP server that can write is not covered by this allowlist
+    * at all.
     *
     * `Full` follows [[AgentConfig.autoApprove]]: `All` → `bypassPermissions`;
     * `Only(_)` → default permission mode plus `--allowedTools`. The allowlist
@@ -135,7 +126,7 @@ private[claude] object ClaudeArgs:
     * won't run comes back as a failed `tool_result` (pinned by
     * `ClaudeIntegrationTest`).
     */
-  private def autoApproveArgs(
+  private def permissionArgs(
       config: AgentConfig,
       networkTools: Seq[String]
   ): Seq[String] =
@@ -154,7 +145,7 @@ private[claude] object ClaudeArgs:
             Seq("--allowedTools", tools.toSeq.sorted.mkString(","))
 
   /** How strongly claude enforces each `(tools, autoApprove)` combination — see
-    * [[autoApproveArgs]] for the flags this classifies. Every combination is
+    * [[permissionArgs]] for the flags this classifies. Every combination is
     * `Hard`. The read-only tiers rest on `--tools`, which removes every
     * unlisted built-in; the `--allowedTools`/`bypassPermissions` variants are
     * mechanical per-tool gates.

--- a/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
@@ -295,11 +295,11 @@ object ClaudeBackend:
 
   /** Built-in tools added to `ClaudeArgs.ReadOnlyTools` on
     * [[ToolSet.NetworkOnly]] turns. Bare tool names only — `--tools` takes no
-    * command scoping, so the `Bash(gh …)` entries this list used to carry
-    * cannot appear in it. They are not replaced: measured planner use of `gh`
-    * was zero (`docs/research/run-cost/12-reviewer-tool-surface.md` §5), and
-    * orca reads issues host-side via `GitHubTool.readIssue`. Flows wanting a
-    * different set pass their own via `claude.withNetworkTools(...)`.
+    * command scoping, so there is no `gh` entry. Nothing replaces it: measured
+    * planner use of `gh` was zero
+    * (`docs/research/run-cost/12-reviewer-tool-surface.md` §5) and orca reads
+    * issues host-side via `GitHubTool.readIssue`. Flows wanting a different set
+    * pass their own via `claude.withNetworkTools(...)`.
     */
   private[claude] val DefaultNetworkTools: Seq[String] =
     Seq("WebFetch", "WebSearch")

--- a/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
@@ -60,9 +60,9 @@ private[orca] class ClaudeBackend(
     sharedClosedFlag: AtomicBoolean = new AtomicBoolean(false)
 ) extends AgentBackend[BackendTag.ClaudeCode.type](sharedClosedFlag):
 
-  /** Return a sibling backend that, on [[ToolSet.NetworkOnly]] turns,
-    * pre-approves `tools` (claude `--allowedTools` syntax). Lives on the
-    * backend, not `AgentConfig`, since the strings are claude-specific.
+  /** Return a sibling backend that, on [[ToolSet.NetworkOnly]] turns, adds
+    * `tools` to the read-only `--tools` allowlist. Lives on the backend, not
+    * `AgentConfig`, since the names are claude-specific.
     *
     * Shares `closedFlag` with `this`: the sibling is a genuinely different
     * `AgentBackend` instance, so without threading the SAME flag through, a
@@ -293,21 +293,16 @@ object ClaudeBackend:
   private[claude] def cwdSlug(cwd: os.Path): String =
     cwd.toString.replace('/', '-')
 
-  /** Read-only network tools pre-approved on [[ToolSet.NetworkOnly]] turns.
-    * Command-scoped, so plan mode still blocks general bash and all edits.
-    * `Bash(gh api:*)` is broad GitHub reads — note `gh api -X POST` can mutate
-    * GitHub (not local files); flows wanting a tighter set pass their own via
-    * `claude.withNetworkTools(...)`.
+  /** Built-in tools added to `ClaudeArgs.ReadOnlyTools` on
+    * [[ToolSet.NetworkOnly]] turns. Bare tool names only — `--tools` takes no
+    * command scoping, so the `Bash(gh …)` entries this list used to carry
+    * cannot appear in it. They are not replaced: measured planner use of `gh`
+    * was zero (`docs/research/run-cost/12-reviewer-tool-surface.md` §5), and
+    * orca reads issues host-side via `GitHubTool.readIssue`. Flows wanting a
+    * different set pass their own via `claude.withNetworkTools(...)`.
     */
-  private[claude] val DefaultNetworkTools: Seq[String] = Seq(
-    "WebFetch",
-    "WebSearch",
-    "Bash(gh issue view:*)",
-    "Bash(gh pr view:*)",
-    "Bash(gh search:*)",
-    "Bash(gh repo view:*)",
-    "Bash(gh api:*)"
-  )
+  private[claude] val DefaultNetworkTools: Seq[String] =
+    Seq("WebFetch", "WebSearch")
 
   /** Fully-qualified tool name (MCP server name + tool slug). Always
     * auto-approved on the interactive path — the user is already typing an

--- a/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
@@ -64,13 +64,28 @@ private[orca] class ClaudeBackend(
     * `tools` to the read-only `--tools` allowlist. Lives on the backend, not
     * `AgentConfig`, since the names are claude-specific.
     *
+    * Rejects anything that is not a bare tool name. These used to be
+    * `--allowedTools` patterns and could be command-scoped (`Bash(gh api:*)`);
+    * `--tools` takes bare names and drops what it does not recognise silently,
+    * exit 0, no warning. Without this check a flow script carrying the old
+    * syntax would keep compiling, keep running, and grant nothing.
+    *
     * Shares `closedFlag` with `this`: the sibling is a genuinely different
     * `AgentBackend` instance, so without threading the SAME flag through, a
     * handle derived here and leaked past flow-end would bypass the
     * use-after-close guard.
     */
   def withNetworkTools(tools: Seq[String]): ClaudeBackend =
-    new ClaudeBackend(cli, tools, projectsDir, workDir, closedFlag)
+    tools.filterNot(ClaudeBackend.BareToolName.matches) match
+      case Nil =>
+        new ClaudeBackend(cli, tools, projectsDir, workDir, closedFlag)
+      case bad =>
+        throw new IllegalArgumentException(
+          s"withNetworkTools takes bare claude tool names; these are not: " +
+            s"${bad.mkString(", ")}. Command-scoped entries like " +
+            "\"Bash(gh api:*)\" belonged to the old --allowedTools mapping and " +
+            "are silently ignored by --tools."
+        )
 
   /** Claude's sessions live on disk (`~/.claude/projects/.../<id>.jsonl`) and
     * outlive the process, so it is durable: the claim survives a restart
@@ -303,6 +318,11 @@ object ClaudeBackend:
     */
   private[claude] val DefaultNetworkTools: Seq[String] =
     Seq("WebFetch", "WebSearch")
+
+  /** What `--tools` accepts: a bare built-in name. Not MCP names — those pass
+    * `--tools` unfiltered, so listing one there does nothing.
+    */
+  private val BareToolName = "[A-Za-z][A-Za-z0-9]*".r
 
   /** Fully-qualified tool name (MCP server name + tool slug). Always
     * auto-approved on the interactive path — the user is already typing an

--- a/claude/src/main/scala/orca/tools/claude/DefaultClaudeAgent.scala
+++ b/claude/src/main/scala/orca/tools/claude/DefaultClaudeAgent.scala
@@ -64,10 +64,10 @@ private[orca] class DefaultClaudeAgent(
     )
 
 private[orca] object DefaultClaudeAgent:
-  /** The cheap tier. Spelled out rather than the `haiku` alias, which plan mode
-    * mis-resolves — see `ClaudeArgs.modelArgs`. That rewrite covers a
-    * `claude:haiku` pin too, so neither spelling tracks a new haiku generation:
-    * this constant is the one place to bump when one ships.
+  /** The cheap tier. Spelled out rather than the `haiku` alias, which the CLI
+    * mis-resolved under plan mode — see `ClaudeArgs.modelArgs`. That rewrite
+    * covers a `claude:haiku` pin too, so neither spelling tracks a new haiku
+    * generation: this constant is the one place to bump when one ships.
     */
   val Haiku: Model = Model("claude-haiku-4-5")
 

--- a/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
@@ -119,6 +119,16 @@ class ClaudeArgsTest extends munit.FunSuite:
     val args = streamJson(AgentConfig(tools = ToolSet.NetworkOnly))
     assert(args.containsSlice(Seq("--tools", "Read,Grep,Glob,Skill")), args)
 
+  test("a resumed ReadOnly turn re-emits --tools"):
+    // The CLI does not carry --tools across --resume: resuming without it
+    // restores the full default set, Bash/Edit/Write included. Every turn
+    // rebuilding its own flags is what keeps a resumed reviewer restricted.
+    val args = streamJson(
+      AgentConfig(tools = ToolSet.ReadOnly),
+      dispatch = Dispatch.Resume(testSid)
+    )
+    assert(args.containsSlice(Seq("--tools", "Read,Grep,Glob,Skill")), args)
+
   test("ToolSet.ReadOnly never emits networkTools even when supplied"):
     // Reviewers/triage use ReadOnly and must stay network-free.
     val args = streamJson(

--- a/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
@@ -45,7 +45,7 @@ class ClaudeArgsTest extends munit.FunSuite:
     assert(!streamJson(AgentConfig()).contains("--model"))
 
   test("the `haiku` alias — what `claude:haiku` pins — is sent qualified"):
-    // Plan mode serves claude-sonnet-5 for the bare alias — see
+    // Plan mode served claude-sonnet-5 for the bare alias (2.1.220) — see
     // ClaudeArgs.modelArgs.
     val args = streamJson(AgentConfig(model = Some(Model("haiku"))))
     assert(args.containsSlice(Seq("--model", "claude-haiku-4-5")), args)
@@ -115,7 +115,7 @@ class ClaudeArgsTest extends munit.FunSuite:
       args
     )
 
-  test("ToolSet.NetworkOnly with no networkTools is the read-only allowlist"):
+  test("ToolSet.NetworkOnly with no networkTools maps to the read-only list"):
     val args = streamJson(AgentConfig(tools = ToolSet.NetworkOnly))
     assert(args.containsSlice(Seq("--tools", "Read,Grep,Glob,Skill")), args)
 

--- a/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
@@ -93,36 +93,31 @@ class ClaudeArgsTest extends munit.FunSuite:
     assert(!args.contains("--permission-mode"), args)
     assert(!args.contains("--allowedTools"), args)
 
-  test(
-    "ToolSet.ReadOnly maps to --permission-mode plan, overriding autoApprove"
-  ):
-    // The read-only tier is the planner/reviewer hard restriction —
-    // Edit/Write/Bash unavailable, not just non-auto-approved. It wins over
-    // `autoApprove` (the agent is verifying claims, not editing).
+  test("ToolSet.ReadOnly maps to --tools, overriding autoApprove"):
+    // The read-only tier is the planner/reviewer hard restriction, and it wins
+    // over `autoApprove` (the agent is verifying claims, not editing).
     val args = streamJson(
       AgentConfig(autoApprove = AutoApprove.All, tools = ToolSet.ReadOnly)
     )
-    assert(args.containsSlice(Seq("--permission-mode", "plan")), args)
+    assert(args.containsSlice(Seq("--tools", "Read,Grep,Glob,Skill")), args)
     assert(!args.contains("bypassPermissions"), args)
-    assert(!args.contains("--allowedTools"), args)
+    assert(!args.contains("--permission-mode"), args)
 
-  test(
-    "ToolSet.NetworkOnly layers networkTools onto plan mode via --allowedTools"
-  ):
+  test("ToolSet.NetworkOnly appends networkTools to the read-only allowlist"):
     val args = streamJson(
       AgentConfig(tools = ToolSet.NetworkOnly),
-      networkTools = Seq("WebFetch", "Bash(gh api:*)")
+      networkTools = Seq("WebFetch", "WebSearch")
     )
-    assert(args.containsSlice(Seq("--permission-mode", "plan")), args)
     assert(
-      args.containsSlice(Seq("--allowedTools", "WebFetch,Bash(gh api:*)")),
+      args.containsSlice(
+        Seq("--tools", "Read,Grep,Glob,Skill,WebFetch,WebSearch")
+      ),
       args
     )
 
-  test("ToolSet.NetworkOnly with no networkTools stays plain plan mode"):
+  test("ToolSet.NetworkOnly with no networkTools is the read-only allowlist"):
     val args = streamJson(AgentConfig(tools = ToolSet.NetworkOnly))
-    assert(args.containsSlice(Seq("--permission-mode", "plan")), args)
-    assert(!args.contains("--allowedTools"), args)
+    assert(args.containsSlice(Seq("--tools", "Read,Grep,Glob,Skill")), args)
 
   test("ToolSet.ReadOnly never emits networkTools even when supplied"):
     // Reviewers/triage use ReadOnly and must stay network-free.
@@ -130,8 +125,8 @@ class ClaudeArgsTest extends munit.FunSuite:
       AgentConfig(tools = ToolSet.ReadOnly),
       networkTools = Seq("WebFetch")
     )
-    assert(args.containsSlice(Seq("--permission-mode", "plan")), args)
-    assert(!args.contains("--allowedTools"), args)
+    assert(args.containsSlice(Seq("--tools", "Read,Grep,Glob,Skill")), args)
+    assert(!args.contains("WebFetch"), args)
 
   test("Dispatch.Fresh emits --session-id <uuid>"):
     val args =

--- a/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeArgsTest.scala
@@ -115,9 +115,22 @@ class ClaudeArgsTest extends munit.FunSuite:
       args
     )
 
+  test("ToolSet.NetworkOnly pre-approves the network tools"):
+    // --tools only advertises; without --allowedTools the fetch is gated and,
+    // with stdin closed, comes back as a failed tool_result.
+    val args = streamJson(
+      AgentConfig(tools = ToolSet.NetworkOnly),
+      networkTools = Seq("WebFetch", "WebSearch")
+    )
+    assert(
+      args.containsSlice(Seq("--allowedTools", "WebFetch,WebSearch")),
+      args
+    )
+
   test("ToolSet.NetworkOnly with no networkTools maps to the read-only list"):
     val args = streamJson(AgentConfig(tools = ToolSet.NetworkOnly))
     assert(args.containsSlice(Seq("--tools", "Read,Grep,Glob,Skill")), args)
+    assert(!args.contains("--allowedTools"), args)
 
   test("a resumed ReadOnly turn re-emits --tools"):
     // The CLI does not carry --tools across --resume: resuming without it

--- a/claude/src/test/scala/orca/tools/claude/ClaudeBackendTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeBackendTest.scala
@@ -104,6 +104,14 @@ class ClaudeBackendTest extends munit.FunSuite:
         "Read,Grep,Glob,Skill,WebFetch,WebSearch"
       )
 
+  test("withNetworkTools rejects the old command-scoped syntax"):
+    // --tools drops a name it doesn't recognise silently, so a flow script
+    // still passing `Bash(gh api:*)` would grant nothing and say nothing.
+    val thrown = intercept[IllegalArgumentException]:
+      new ClaudeBackend(new SpawnStubCliRunner(Nil))
+        .withNetworkTools(Seq("WebFetch", "Bash(gh api:*)"))
+    assert(thrown.getMessage.contains("Bash(gh api:*)"), thrown.getMessage)
+
   test("withNetworkTools overrides the default network tools"):
     val runner = new SpawnStubCliRunner(List(successfulProcess()))
     SupervisedBackend.using(

--- a/claude/src/test/scala/orca/tools/claude/ClaudeBackendTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeBackendTest.scala
@@ -90,7 +90,7 @@ class ClaudeBackendTest extends munit.FunSuite:
         .text()
     assertEquals(staged, "", "the MCP config must be unstageable")
 
-  test("NetworkOnly autonomous call pre-approves the default network tools"):
+  test("NetworkOnly autonomous call allows the default network tools"):
     val runner = new SpawnStubCliRunner(List(successfulProcess()))
     withBackend(runner): backend =>
       val _ = backend.runAutonomous(
@@ -99,12 +99,12 @@ class ClaudeBackendTest extends munit.FunSuite:
         AgentConfig().copy(tools = ToolSet.NetworkOnly)
       )
       val args = runner.calls.head
-      assert(args.containsSlice(Seq("--permission-mode", "plan")), args)
-      val allowed = args(args.indexOf("--allowedTools") + 1)
-      assert(allowed.contains("WebFetch"), allowed)
-      assert(allowed.contains("Bash(gh api:*)"), allowed)
+      assertEquals(
+        args(args.indexOf("--tools") + 1),
+        "Read,Grep,Glob,Skill,WebFetch,WebSearch"
+      )
 
-  test("withNetworkTools overrides the default allowlist"):
+  test("withNetworkTools overrides the default network tools"):
     val runner = new SpawnStubCliRunner(List(successfulProcess()))
     SupervisedBackend.using(
       new ClaudeBackend(runner).withNetworkTools(Seq("WebFetch"))
@@ -115,7 +115,10 @@ class ClaudeBackendTest extends munit.FunSuite:
         AgentConfig().copy(tools = ToolSet.NetworkOnly)
       )
       val args = runner.calls.head
-      assert(args.containsSlice(Seq("--allowedTools", "WebFetch")), args)
+      assertEquals(
+        args(args.indexOf("--tools") + 1),
+        "Read,Grep,Glob,Skill,WebFetch"
+      )
 
   test(
     "a withNetworkTools sibling shares the parent's closed latch"

--- a/claude/src/test/scala/orca/tools/claude/ClaudeIntegrationTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeIntegrationTest.scala
@@ -160,6 +160,8 @@ class ClaudeIntegrationTest extends munit.FunSuite:
     )
 
   test("the NetworkOnly allowlist reaches claude with every name intact"):
+    // Pins the names only. The init frame lists what is advertised, which says
+    // nothing about whether the tool may run — the next test covers that.
     assertEquals(
       grantedTools(
         AgentConfig(tools = ToolSet.NetworkOnly),
@@ -167,6 +169,41 @@ class ClaudeIntegrationTest extends munit.FunSuite:
       ),
       (ClaudeArgs.ReadOnlyTools ++ ClaudeBackend.DefaultNetworkTools).toSet
     )
+
+  test("a NetworkOnly turn can run a fetch, not merely advertise one"):
+    // Advertisement is not approval: `--tools` alone leaves WebFetch gated, and
+    // with stdin closed nobody can approve, so the planner gets a failed
+    // tool_result and plans from the prompt alone. Needs live network.
+    withBackend: backend =>
+      val conversation = backend.runInteractive(
+        prompt =
+          "Use the WebFetch tool on https://example.com and reply with " +
+            "the page title. Use no other tool.",
+        session = fresh,
+        displayPrompt = "fetch example.com",
+        config = AgentConfig(tools = ToolSet.NetworkOnly),
+        outputSchema = None
+      )
+      try
+        val events = conversation.events.toList
+        val _ = conversation.awaitResult()
+        assert(
+          events.exists:
+            case ConversationEvent.AssistantToolCall("WebFetch", _) => true
+            case _                                                  => false
+          ,
+          s"claude never called WebFetch: $events"
+        )
+        // claude's tool_result blocks carry no tool name, so this covers every
+        // result; the prompt asks for WebFetch and nothing else.
+        assert(
+          !events.exists:
+            case ConversationEvent.ToolResult(_, ok, _) => !ok
+            case _                                      => false
+          ,
+          s"a tool call was denied on a NetworkOnly turn: $events"
+        )
+      finally conversation.cancel()
 
   /** Run the shipped args for `config` and return the built-in tools claude
     * announces in its `system.init` frame. `mcp__*` names are excluded: they

--- a/claude/src/test/scala/orca/tools/claude/ClaudeIntegrationTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeIntegrationTest.scala
@@ -117,9 +117,9 @@ class ClaudeIntegrationTest extends munit.FunSuite:
   ):
     withBackend: backend =>
       // The CLI refuses `/etc/hostname` because it is outside the backend's
-      // workDir. A read inside the workspace runs fine under this config, since
-      // `--allowedTools` adds to claude's defaults rather than restricting to
-      // them. What is pinned is not the refusal but its shape: it arrives as a
+      // workDir; a read inside the workspace runs fine, since `Only(empty)`
+      // emits no flags at all and default permission mode allows workspace
+      // reads. What is pinned is not the refusal but its shape: it arrives as a
       // failed tool_result, not as a `can_use_tool` control request. Stdin is
       // closed at spawn, so orca could not answer such a request — a future CLI
       // reviving that subchannel fails here first (see

--- a/claude/src/test/scala/orca/tools/claude/ClaudeIntegrationTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeIntegrationTest.scala
@@ -1,15 +1,19 @@
 package orca.tools.claude
 
+import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
+import com.github.plokhotnyuk.jsoniter_scala.macros.ConfiguredJsonValueCodec
 import orca.agents.{
   AutoApprove,
   BackendTag,
   AgentConfig,
   SessionId,
+  ToolSet,
   WireSessionId
 }
-import orca.backend.{ConversationEvent, SupervisedBackend}
+import orca.backend.{ConversationEvent, Dispatch, SupervisedBackend}
 import orca.subprocess.OsProcCliRunner
 import orca.testkit.TempDirs
+import orca.tools.claude.streamjson.OutboundMessage
 
 /** End-to-end tests against the real `claude` CLI. Gated on the
   * `ORCA_INTEGRATION` environment variable so `sbt test` without the flag
@@ -141,3 +145,64 @@ class ClaudeIntegrationTest extends munit.FunSuite:
           s"expected the refused Read to surface as a failed tool_result: $events"
         )
       finally conversation.cancel()
+
+  // --- `--tools` allowlist ---
+  //
+  // The CLI drops an unknown tool name silently: `--tools Read,Grep,NoSuchTool`
+  // yields an init list of `Grep,Read`, exit 0, no warning. A rename upstream
+  // would strip a tool from every read-only turn with no signal, so the two
+  // shipped allowlists are pinned against the live CLI here.
+
+  test("the ReadOnly allowlist reaches claude with every name intact"):
+    assertEquals(
+      grantedTools(AgentConfig(tools = ToolSet.ReadOnly), Seq.empty),
+      ClaudeArgs.ReadOnlyTools.toSet
+    )
+
+  test("the NetworkOnly allowlist reaches claude with every name intact"):
+    assertEquals(
+      grantedTools(
+        AgentConfig(tools = ToolSet.NetworkOnly),
+        ClaudeBackend.DefaultNetworkTools
+      ),
+      (ClaudeArgs.ReadOnlyTools ++ ClaudeBackend.DefaultNetworkTools).toSet
+    )
+
+  /** Run the shipped args for `config` and return the built-in tools claude
+    * announces in its `system.init` frame. `mcp__*` names are excluded: they
+    * pass through `--tools` unfiltered and depend on the host's MCP config.
+    */
+  private def grantedTools(
+      config: AgentConfig,
+      networkTools: Seq[String]
+  ): Set[String] =
+    val args = ClaudeArgs.streamJson(
+      config = config,
+      systemPromptFile = None,
+      dispatch = Dispatch.Fresh(
+        Some(
+          WireSessionId[BackendTag.ClaudeCode.type](
+            java.util.UUID.randomUUID().toString
+          )
+        )
+      ),
+      networkTools = networkTools
+    )
+    val stdout = os
+      .proc(args)
+      .call(
+        cwd = TempDirs.dir(),
+        stdin = OutboundMessage.toJson(OutboundMessage.UserText("Reply: ok")) +
+          "\n"
+      )
+      .out
+      .lines()
+    val init = stdout
+      .find(_.contains("\"subtype\":\"init\""))
+      .getOrElse(fail(s"no init frame in claude's output: $stdout"))
+    readFromString[InitTools](init).tools
+      .filterNot(_.startsWith("mcp__"))
+      .toSet
+
+private case class InitTools(tools: List[String])
+    derives ConfiguredJsonValueCodec

--- a/docs/research/run-cost/11-repair-read-only.md
+++ b/docs/research/run-cost/11-repair-read-only.md
@@ -55,6 +55,19 @@ primitives. A denylist only removes the names you thought of.
 Reproduced here on 2.1.222: `--tools Read,Grep,Glob,Skill,WebFetch,WebSearch`
 gives an `init` list of exactly those six, plus two `mcp__…` tools (task R5).
 
+**Corrected during R1 (PR #89): the last two bullets are wrong.**
+
+`--tools` does **not** survive `--resume`. Measured on 2.1.222: a session
+created under `--tools Read,Grep,Glob,Skill`, resumed without re-passing the
+flag, comes back with the full default set of 28 tools — `Bash`, `Edit` and
+`Write` included. The flag is per-invocation, not session state. Orca is safe
+because `ClaudeArgs.streamJson` rebuilds every turn's flags from that turn's own
+config, which `ClaudeArgsTest` now pins; a resume path that reused stored args
+would silently unlock every reviewer.
+
+"Subagents inherit it" describes a path that cannot be taken: `Task` is not in
+the allowlist, so a read-only turn cannot spawn a subagent at all.
+
 ## 3. Development plan
 
 ### **[TODO]** R1 — Replace the mechanism

--- a/flow/src/main/scala/orca/plan/Plan.scala
+++ b/flow/src/main/scala/orca/plan/Plan.scala
@@ -98,9 +98,10 @@ object Plan:
 
   /** Interactive planning — opens a conversation the user can drive (clarifying
     * questions, refinements) before the agent produces the result. Not
-    * read-only — the agent runs with normal permissions; the prompt asks it not
-    * to edit, and the user sees any violation. Use [[autonomous]] when no
-    * mid-session questions are needed.
+    * read-only: the prompt is what forbids edits here, and the user sees any
+    * violation. The tier was picked when read-only was believed to cost the
+    * `ask_user` MCP tool; claude's `--tools` allowlist does not, so this is
+    * revisitable. Use [[autonomous]] when no mid-session questions are needed.
     *
     * Each operation returns a [[Sessioned]] so the conversation can carry into
     * implementation.

--- a/flow/src/main/scala/orca/plan/Plan.scala
+++ b/flow/src/main/scala/orca/plan/Plan.scala
@@ -98,10 +98,9 @@ object Plan:
 
   /** Interactive planning — opens a conversation the user can drive (clarifying
     * questions, refinements) before the agent produces the result. Not
-    * read-only: plan mode would disable the `ask_user` MCP tool, so the agent
-    * runs with normal permissions; the prompt asks it not to edit, and the user
-    * sees any violation. Use [[autonomous]] when no mid-session questions are
-    * needed.
+    * read-only — the agent runs with normal permissions; the prompt asks it not
+    * to edit, and the user sees any violation. Use [[autonomous]] when no
+    * mid-session questions are needed.
     *
     * Each operation returns a [[Sessioned]] so the conversation can carry into
     * implementation.

--- a/flow/src/main/scala/orca/review/ReviewerSelector.scala
+++ b/flow/src/main/scala/orca/review/ReviewerSelector.scala
@@ -82,12 +82,11 @@ object ReviewerSelector:
     * The picker is handed the task title, the changed file names and those
     * descriptions, and runs under [[orca.agents.ToolSet.ReadOnly]] in the
     * flow's work dir. Whether a shell is there varies by backend — codex's
-    * read-only sandbox runs commands, opencode and pi have no shell tool at
-    * all, and claude's plan mode leaves `Bash` advertised (measured: see
-    * `docs/research/run-cost/09-diff-vs-coordinates.md` §2) — so the default
-    * brief tells it to open the changed files rather than judge by their paths,
-    * to use `git diff HEAD` only if the shell happens to be there, and to
-    * include a reviewer whenever it is unsure.
+    * read-only sandbox runs commands, while claude, opencode and pi have no
+    * shell tool at all — so the default brief tells it to open the changed
+    * files rather than judge by their paths, to use `git diff HEAD` only if the
+    * shell happens to be there, and to include a reviewer whenever it is
+    * unsure.
     *
     * `filePatterns` is a code-side pre-filter applied before the LLM call:
     * reviewers whose pattern doesn't match any of `changedFiles` are dropped,

--- a/tools/src/main/scala/orca/agents/Agent.scala
+++ b/tools/src/main/scala/orca/agents/Agent.scala
@@ -334,8 +334,8 @@ trait ClaudeAgent extends Agent[BackendTag.ClaudeCode.type]:
 
   override protected def defaultCheap: ClaudeAgent = haiku
 
-  /** Set the read-only network allowlist used on [[ToolSet.NetworkOnly]] turns
-    * (claude `--allowedTools` syntax, e.g. `Bash(gh api:*)`, `WebFetch`).
+  /** Set the network tools added to the read-only `--tools` allowlist on
+    * [[ToolSet.NetworkOnly]] turns. Bare claude tool names, e.g. `WebFetch`.
     * Claude-specific, so it's here rather than on `AgentConfig`; defaults to
     * `ClaudeBackend.DefaultNetworkTools`. Pass it before handing the tool to a
     * planning helper: `claude.opus.withNetworkTools(Seq("WebFetch"))`.

--- a/tools/src/main/scala/orca/agents/AgentConfig.scala
+++ b/tools/src/main/scala/orca/agents/AgentConfig.scala
@@ -76,8 +76,8 @@ enum Enforcement:
   *
   *   - **ReadOnly** — reads only; no shell, no edits. The no-edit gate planners
   *     and reviewers rely on.
-  *   - **NetworkOnly** — reads plus read-only network (web + GitHub), for
-  *     planners that must read an issue/PR they were pointed at.
+  *   - **NetworkOnly** — reads plus read-only network (web), for planners that
+  *     must read an issue/PR they were pointed at.
   *   - **Full** — every tool, write-capable; prompting then follows
   *     [[AgentConfig.autoApprove]].
   *


### PR DESCRIPTION
Claude's read-only tiers used `--permission-mode plan`. Plan mode removes no
tools: the `init` tool list under it is byte-identical to the default mode's,
`Bash`, `Write` and `Edit` included, and opus reviewers ran 199 `Bash` calls
under it with zero denials (#73). So `withReadOnly` on claude was a request, not
a restriction.

This replaces it with `--tools`, which is a real capability removal — the
dropped tools are absent from `init` and `ToolSearch` cannot resurrect them.

- `ReadOnly` → `--tools Read,Grep,Glob,Skill`
- `NetworkOnly` → the same plus `ClaudeBackend.DefaultNetworkTools`, and
  `--allowedTools <network tools>` on top

Verified against claude 2.1.222: those flags yield an `init` list of exactly
`Glob, Grep, Read, Skill`, and the network set adds exactly `WebFetch,
WebSearch`.

`NetworkOnly` needs `--allowedTools` as well because `--tools` only advertises.
The turn still runs in the default permission mode, where `WebFetch` is gated,
and stdin is closed under `--print`, so nobody can approve it and the call comes
back as a failed `tool_result` — the planner then plans from the prompt alone,
without saying so. Verified on 2.1.223 that the two flags compose:
`--allowedTools` grants, and `--tools` still bounds the surface (the `init`
frame lists only the six allowlisted tools, no `Bash`/`Edit`/`Write`).

MCP tools fail the same way, which is what #94's own `--allowedTools` fixes. So
the grant lives in one `approve(tools)` helper that emits a single flag with a
single list — whether claude honours a repeated `--allowedTools` is unverified,
and #94 should widen the argument rather than add a second call. Verified on
2.1.223 that one list carrying an `mcp__…` name plus `WebFetch`/`WebSearch`
grants all three.

`DefaultNetworkTools` loses its five `Bash(gh …)` entries. `--tools` takes bare
tool names, so command-scoped entries cannot go in it. They are not replaced:
measured planner use of `gh` across six sessions was zero, and orca already
fetches issues host-side via `GitHubTool.readIssue`. The default is now
`WebFetch`, `WebSearch`, and the tier stays a real no-edit tier.

## What read-only agents lose

`Bash`. This is a real cost, not a clean win.

Measured over 87 reviewer sessions (#84), 64% of the 1016 `Bash` calls are
search, file reads and directory listings — fully covered by `Grep`, `Read` and
`Glob`. 3% write files or run builds and should stop. But **75% of calls batch
more than one operation** (a search, a line-range read and an `echo` separator
in one call), and `Read`/`Grep`/`Glob` are one operation per call. Expect more
turns even where the capability is covered.

34% of calls touch git, and nothing here replaces that. 82% of the git use
re-derives the change set the prompt already carries, which reviewers should
stop doing anyway; the 12% that reaches outside the diff is a real loss, and it
takes `git show <base>:<path>` — the affordance #79 added to the review prompt —
with it. A follow-up PR gives that back over MCP.

Per production call site, without a shell:

| site | without `Bash` |
|---|---|
| `Reviewers.scala` reviewers | the bet: the diff has been inlined into the prompt since #73 |
| `ReviewerSelector.scala` picker | fine — handed the title, changed files and descriptions |
| `Lint.scala` summariser | fine — reads captured lint output, already via `Read` |
| `Plan.scala` self-review | loses `gh`, which it never used |
| `StackDiscovery.scala` | unaffected — ADR 0019 already assumes no shell |
| `Agent.scala` `cheapOneShot` | fine — one line of text |

## Two things the research got wrong

**`--tools` does not survive `--resume`.** #78 said it did. Measured on 2.1.222:
resuming a session created under `--tools`, without re-passing the flag,
restores the full default set — `Bash`, `Edit`, `Write` and all 28 tools. Orca
is safe because `ClaudeArgs.streamJson` rebuilds every turn's flags from that
turn's own config, and a test now pins that a resumed `ReadOnly` turn re-emits
`--tools`. A future resume path that reused stored args would silently unlock
every reviewer.

**"Subagents inherit the list" describes a path that cannot be taken.** `Task`
is not in the allowlist, so a read-only turn cannot spawn a subagent at all.

## Pinning the list

Unknown tool names are dropped **silently**: `--tools Read,Grep,NoSuchTool`
gives an `init` list of `Grep,Read`, exit 0, no warning. A rename upstream would
strip a tool from every read-only turn with no signal. Two integration tests
(gated on `ORCA_INTEGRATION`) run the shipped args against the real CLI and
assert the `init` frame lists every name orca sent, so both an upstream rename
and a bogus name orca ships fail the build.

The `init` frame only tells you what was advertised. A third integration test
runs a `NetworkOnly` turn that actually fetches a page and asserts no
`tool_result` comes back an error — that is the one that catches a missing
grant, and it is what the `--allowedTools` fix above was found by.

## `--tools` is not a complete boundary

MCP tools pass through it unfiltered — verified live in #84 and again here. An
MCP server that can write would not be covered by the allowlist at all. That
caveat is recorded on `ClaudeArgs.permissionArgs`, next to the allowlist itself.

Enforcement cells are unchanged — claude's `ReadOnly`/`NetworkOnly` were already
claimed `Hard`; that claim is now true.


## Live A/B: the same reviewer, the same change set, both builds

Ran one real reviewer (`code-functionality`, the shipped prompt) over this
branch's own diff, in an isolated clone, once per build. The only difference
between the arms is the read-only tier's flags.

| | BEFORE (`plan`) | AFTER (`--tools`) |
|---|---|---|
| model responses | **49** | **15** |
| tool calls | 63 | 23 |
| tools used | `Bash` × 63 | `Grep` 13, `Read` 5, `git_show` 3, `git_file_at` 1, `Glob` 1 |
| calls batching >1 op | 55 / 63 | n/a |
| findings | 1 critical, 3 warnings | 1 critical, 4 warnings |

The AFTER run took **fewer** turns, not more. One run per arm and model
variance is large, so treat the direction as the result and not the ratio — but
it is the opposite of the cost this PR expected. The BEFORE run spent much of
its budget re-deriving the change set (`git status`, `git diff --stat`,
`git log`) that the prompt already carried, which is the 82% pattern #84
measured.

Neither run's findings were shallower. The AFTER reviewer never said it could
not check something; it found a real bug in the follow-up PR's MCP code that the
BEFORE reviewer missed.

## The BEFORE run is why this PR exists

`plan` mode's reviewer, nominally `Enforcement.Hard` no-edit, in one session:

- `rm -rf /tmp/circesrc && mkdir circesrc && unzip …` — wrote files
- `sbt -batch "tools/Test/compile; claude/Test/compile"` — **ran the build**,
  creating 1241 files under five `target/` directories inside the reviewed
  checkout
- `sbt tools/Test/console` — opened a REPL
- `scala-cli run …` several times — executed code it had written
- spawned another `claude` process

The AFTER run's filesystem delta over the same checkout was orca's own
`.orca/cache/` markers, which orca writes host-side. Nothing from the agent.
Neither run modified a tracked file.

