### PR TITLE
Stop the trailer rendering a change as "+0 -0"

### DIFF
--- a/flow/src/main/scala/orca/BoundedDiff.scala
+++ b/flow/src/main/scala/orca/BoundedDiff.scala
@@ -184,9 +184,8 @@ private[orca] object BoundedDiff:
   private def entryLine(file: ChangedFile): String =
     val size = file.change match
       // `+0 -0` reads as "nothing changed", which is never why a file is in a
-      // change set. Not narrowed further: git reports no counts for a mode
-      // change, a pure rename and an empty file alike, and telling them apart
-      // needs a second read (`git diff --raw`) of a tree that has moved on.
+      // change set. Left this vague because the counts are all this side has:
+      // see `FileChange.Lines` for the causes they cannot tell apart.
       case FileChange.Lines(0, 0)           => "no lines changed"
       case FileChange.Lines(added, deleted) => s"+$added -$deleted"
       case FileChange.Binary                => "binary"

--- a/flow/src/main/scala/orca/BoundedDiff.scala
+++ b/flow/src/main/scala/orca/BoundedDiff.scala
@@ -183,6 +183,11 @@ private[orca] object BoundedDiff:
 
   private def entryLine(file: ChangedFile): String =
     val size = file.change match
+      // `+0 -0` reads as "nothing changed", which is never why a file is in a
+      // change set. Not narrowed further: git reports no counts for a mode
+      // change, a pure rename and an empty file alike, and telling them apart
+      // needs a second read (`git diff --raw`) of a tree that has moved on.
+      case FileChange.Lines(0, 0)           => "no lines changed"
       case FileChange.Lines(added, deleted) => s"+$added -$deleted"
       case FileChange.Binary                => "binary"
       case FileChange.New                   => "new file"

--- a/flow/src/test/scala/orca/BoundedDiffTest.scala
+++ b/flow/src/test/scala/orca/BoundedDiffTest.scala
@@ -165,6 +165,16 @@ class BoundedDiffTest extends munit.FunSuite:
       "new file went unlabelled"
     )
 
+  test("the trailer never renders a change as `+0 -0`"):
+    // git counts no lines for a mode change, a pure rename or an empty file,
+    // and "+0 -0" reads as nothing having changed.
+    val (diff, changed) = bigChangeSet(60)
+    val payload = BoundedDiff.reviewPayload(
+      diff,
+      changed :+ ChangedFile("script.sh", FileChange.Lines(0, 0))
+    )
+    assert(payload.contains("#   script.sh (no lines changed)"), payload)
+
   /** A path of exactly `chars` characters, nested the way a real one is. */
   private def deepPath(chars: Int): String =
     val leaf = "/Deep.scala"

--- a/flow/src/test/scala/orca/BoundedDiffTest.scala
+++ b/flow/src/test/scala/orca/BoundedDiffTest.scala
@@ -166,8 +166,8 @@ class BoundedDiffTest extends munit.FunSuite:
     )
 
   test("the trailer never renders a change as `+0 -0`"):
-    // git counts no lines for a mode change, a pure rename or an empty file,
-    // and "+0 -0" reads as nothing having changed.
+    // "+0 -0" reads as nothing having changed, which is never why a file is in
+    // a change set.
     val (diff, changed) = bigChangeSet(60)
     val payload = BoundedDiff.reviewPayload(
       diff,

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -37,8 +37,8 @@ case class PendingChanges(stat: String, newFiles: List[String], diff: String)
   */
 enum FileChange:
   /** Lines added and removed, as `git diff --numstat` counts them. Both are
-    * zero when nothing in the content changed — a mode change, a pure rename,
-    * or an empty file.
+    * zero when the content itself did not change — a mode change, a pure
+    * rename, or a file that became tracked while empty.
     */
   case Lines(added: Int, deleted: Int)
 

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -36,7 +36,10 @@ case class PendingChanges(stat: String, newFiles: List[String], diff: String)
   * [[GitTool.changedFileStats]].
   */
 enum FileChange:
-  /** Lines added and removed, as `git diff --numstat` counts them. */
+  /** Lines added and removed, as `git diff --numstat` counts them. Both are
+    * zero when nothing in the content changed — a mode change, a pure rename,
+    * or an empty file.
+    */
   case Lines(added: Int, deleted: Int)
 
   /** A binary file: git reports that it differs, never by how many lines. */


### PR DESCRIPTION
`git diff --numstat` reports `0	0	<path>` for a change that touches no content, so `FileChange.Lines(0, 0)` rendered in the review trailer as `+0 -0`. The file is named, so nothing is hidden — but "+0 -0" reads as "nothing changed", which is never why a file is in a change set. It now reads `no lines changed`.

## Why no new `FileChange` case

A `ModeOnly` case would need a second git read to detect. Checked against git 2.53 in a scratch repo: `--numstat` gives `0 0` for all three of a `chmod +x`, a pure rename, and a new empty file — only `git diff --raw` separates them (`M` with two modes, `R100`, `A`). That is a second command over a working tree that has moved on since the first, which is the exact resampling `pendingChanges` exists to avoid, for a label on a rare file.

So one honest label covers all three causes instead. `FileChange.Lines`' scaladoc now says what `0, 0` means, since that is a fact about the data every consumer needs.

## Test

`BoundedDiffTest`: a `Lines(0, 0)` entry in the trailer must not render `+0 -0`. Remove the new case and it is the only test that fails.

`sbt scalafmtCheckAll` clean, `sbt clean compile test` green, zero warnings.
