### PR TITLE
ADR 0021 §8: split the run manifest from the cost record

### DIFF
--- a/adr/0021-orca-shell.md
+++ b/adr/0021-orca-shell.md
@@ -481,8 +481,11 @@ resume is global, but the resumed context still references that directory):
 > shell decodes the whole file strictly behind an exact-version gate, so a purely
 > additive cost field invalidates the session data it happens to share a file
 > with, and the user loses "continue a session" for every run recorded by the
-> previous build. The two halves have different rates of change and different
-> readers, so they get different files.
+> previous build. Second, because every write rewrites the whole file,
+> `write()` re-serialises the entire turn log and recomputes all four aggregates
+> on each of ~40 stage/session writes — O(turns × writes) for data nothing reads
+> back. The two halves have different readers, different rates of change, and
+> different write shapes, so they get different files.
 >
 > **Layout.** `.orca/cache/runs/` holds two files per run, sharing the
 > `<startedAt-epoch-ms>-<pid>` run id:
@@ -490,93 +493,168 @@ resume is global, but the resumed context still references that directory):
 > - `<id>.json` — run fields plus sessions, rewritten whole as today. The
 >   shell's file, and the only one it reads.
 > - `<id>-cost.jsonl` — one JSON object per line, appended as the run goes. The
->   debug/measurement record. The shell must not read it; after this change the
->   `shell` module names no cost type at all, in production **or** test code
->   (three shell tests currently pass `ManifestCostSummary.empty` to a
->   `RunManifest` constructor — that coupling disappearing is the acceptance
->   signal that the split is complete).
+>   debug/measurement record.
 >
-> The `.jsonl` extension is load-bearing, not cosmetic. Both the shell's reader
-> and the writer's pruner select files with `_.ext == "json"`
+> The `.jsonl` extension is load-bearing, not cosmetic. The shell's reader and
+> the writer's pruner both select files with `_.ext == "json"`
 > (`ManifestReader.scala:50`, `RunManifestWriter.scala:329`), so a `-cost.json`
 > sibling would land in the shell's listing as a manifest that fails to decode —
-> one spurious warning per run, every redraw. `.jsonl` keeps that filter correct
-> without a name-pattern special case, and matches how pi's transcripts are
-> already named. The pruner, which must now see both files, selects by run id
-> instead.
+> one spurious warning per run, on every menu redraw and every `orca continue`.
+> `.jsonl` keeps both filters correct with no suffix special-case, is honest
+> about a file that is not a single JSON value, and matches how pi's transcripts
+> are already named.
 >
-> Neither file requires the other. A session manifest with no cost file is a run
-> whose turns weren't recorded; a cost file with no session manifest is a run
-> that spent tokens without committing a session — which today writes nothing at
-> all, so this is new coverage, not a gap. Each reader treats the other's absence
-> as ordinary.
+> **What replaces the version gate.** `manifestVersion`,
+> `RunManifest.SupportedVersion` and the reader's pre-decode version check are
+> removed. Both files decode with `withRequireCollectionFields(false)`, and every
+> field added from here on is declared `Option` or given a Scala default —
+> jsoniter defaults an absent scalar only when the case class declares one, so
+> the config alone buys nothing for scalars and the declaration is what does the
+> work.
 >
-> **No version gate.** `manifestVersion`, `RunManifest.SupportedVersion` and the
-> reader's pre-decode version check are removed outright. Both files decode with
-> the tolerant config the progress log already uses
-> (`withRequireCollectionFields(false)`): unknown fields are skipped, absent
-> collections read as empty, and absent scalars take their declared default. The
-> rule that replaces the gate is a rule about writing, not reading: **every field
-> added from here on is optional with a default.** That is what makes an additive
-> change unable to invalidate anything, and the codec enforces it — a new
-> required field without a default fails to decode the previous build's files, in
-> the writer's own tests, before it ships.
+> That covers additions. It does not cover renames, retypes, or respelled wire
+> vocabulary, and one of those gets *worse*: today `ManifestSession` has no
+> defaults at all, so renaming a field is a loud decode error. Once fields carry
+> defaults, a rename reads as an unknown key skipped plus a defaulted absent key
+> — silent, and wrong in a way the user sees. Rename `sessionName` and every
+> durable lineage collapses onto the agent name in the picker, with no warning
+> anywhere. So the rule is **additive only**: no field is renamed, retyped, or
+> has its wire strings respelled; a changed meaning gets a new field beside the
+> old one. The same applies to the `outcome` and `kind` vocabularies, and to
+> `wireId`'s format — that last one is the only case where losing the gate turns
+> a missing offer into a broken action, since the shell execs `claude --resume
+> <id>` straight from it.
 >
-> A small set of fields stays required, because a file missing them cannot be
-> displayed at all: `workDir`, `pid`, `startedAt`, `outcome`. A file missing one,
-> or whose `startedAt` doesn't parse, is skipped with a warning naming it —
-> the existing behaviour for a corrupt file, now the only reason to skip one.
+> **The rule needs a mechanism, and it does not have one yet.** No test in the
+> repo decodes a previous build's bytes: every fixture is either hand-built in
+> the test and edited in lockstep with the schema, or round-tripped through the
+> current case class. An implementer adding a required field would update the
+> fixtures in the same commit and see green. So this change checks in **frozen
+> golden fixtures** — a literal manifest and a literal cost log, committed as
+> test resources, never edited — that must keep decoding. Without them the
+> additive-only rule is a comment. `ManifestReaderTest`'s verbatim v2 JSON is
+> the seed for the first one; it currently exists to prove the gate skips it, and
+> inverts into proving tolerance reads it.
+>
+> **Required fields.** `workDir`, `pid`, `startedAt`, `outcome` and `sessions`
+> stay required with no default. The first four are what the shell dereferences
+> unconditionally. `sessions` is on the list for a different reason: dropping
+> `withRequireCollectionFields(true)` would let an absent array read as empty,
+> and the menu renders the count verbatim — "Continue a session from the last
+> flow run (0 session(s))", leading to an empty picker, with no warning. A file
+> missing any of the five is skipped with a warning naming it. That is not the
+> only way a listing ends early: a symlinked `.orca/cache/runs` still aborts the
+> whole listing rather than skipping a file.
+>
+> **Existing files.** Nothing is migrated and nothing is discarded. Every session
+> field has sat at the same path since #27, so v1–v5 manifests all decode under
+> the tolerant session-only schema, skipping `manifestVersion`, `cost` and
+> `turns` as unknown keys. Their cost data is lost, which is acceptable —
+> `.orca/cache/` is gitignored local cache. Note the behaviour change this
+> implies: manifests the gate currently hides become visible.
+>
+> **The cost file.** JSONL, appended a line at a time with no read-modify-write.
+> A JSON array cannot be appended to — its closing bracket makes every append a
+> rewrite, and an unterminated one is unreadable in full.
+>
+> Each line carries a `type` discriminator, so an unknown record kind is skipped
+> rather than breaking the reader — the additive rule applied to the line
+> vocabulary. Three kinds: a `"run"` header (orca version, flow, work dir),
+> `"turn"` lines, and a `"finish"` trailer carrying the outcome. The trailer is
+> what lets a cost file answer "did this run finish?" on its own; its absence is
+> the crash signal. The header duplicates three fields that also live in
+> `<id>.json` and the two could in principle disagree — accepted, because the
+> alternative is a cost file that cannot be read without its sibling, and the
+> sibling is exactly what a session-less run does not have.
+>
+> **No persisted summary.** `ManifestCostSummary` and its subtotals are dropped
+> from disk; `CostAccumulator` and `Tally` go with them. Each turn line instead
+> carries its own `ManifestUsage` (all five axes), `apiCalls`, and resolved
+> `Option[Cost]`, so total, by-role, by-agent and by-stage all become read-time
+> folds — the algebra survives, since `Usage.+` is componentwise and `Cost.+`
+> ORs `estimated`. `promptTokens` is dropped: it is `usage.inputTokens` verbatim,
+> and keeping both on one line is the same self-disagreeing duplicate this
+> paragraph exists to remove.
+>
+> A turn also carries enough session identity to stand alone. `ManifestTurn.session`
+> is today a foreign key into `RunManifest.sessions`, and it dangles exactly when
+> the sibling was never written or was pruned — so the harness, agent and session
+> name are denormalised onto the line. One more optional field each, which is
+> precisely what the additive rule makes cheap, and it is what the next question
+> below needs.
+>
+> The fold needs somewhere to live: a small `CostLog.read` ships in `runner` as
+> production code. Without it "aggregates become read-time folds" describes code
+> in nobody's repo, and two claims here — that a reader drops a bad line and
+> keeps the rest, and that the golden fixture is decoded by a test — have nothing
+> to call.
+>
+> **Creation gates.** The session manifest keeps its existing gate: it comes into
+> existence on the first `SessionCommitted`, because that gate is the only thing
+> preventing the "(0 session(s))" menu item above. The cost file gets its own,
+> on the first `TokensUsed`. They cannot share one: on the autonomous text path
+> `emitTokens` fires *before* `emitSessionCommitted`, so gating cost on the
+> session event would mean buffering turns until it opens — reintroducing the
+> in-memory turn log this change exists to remove, and discarding it entirely for
+> a `quietTextTurn`-only run.
+>
+> **Writing.** The append opens the file per line rather than holding a handle
+> for the run: a held handle survives neither the directory being replaced
+> underneath it nor `finish`, and would need a close hook on the actor. The
+> append must go through the same `safeWrite` guard as the session write —
+> `TokensUsed` handling is pure in-memory accumulation today and cannot throw,
+> and after this change it does IO on every turn; a throw out of a `tell`
+> handler closes the actor's channel and quarantines the writer for the rest of
+> the run, session writes included.
+>
+> One property is genuinely lost and is not recoverable. Because every session
+> write rewrites the whole file, a swallowed failure today is self-healing — the
+> next successful write restores complete content, which is what
+> `RunManifestWriterTest`'s rug-pull case pins. An append has no such property: a
+> swallowed append is that turn, gone. Accepted; this file is measurement, and
+> the session half keeps its atomic rewrite. The realistic torn-line source is
+> also not a kill (the kernel already has those bytes) but a short write that
+> throws mid-line, after which the next append concatenates onto an unterminated
+> line and costs two records rather than one. The writer terminates the file with
+> a newline before appending again.
+>
+> **Retention.** The keep-20 prune counts run ids, not files, and deletes a run's
+> two files together — 20 runs, as before, not 10. Grouping by run id is what the
+> existing filename sort cannot do once a second file per run exists: `<id>.json`
+> and `<id>-cost.jsonl` sort adjacently but as two entries, and since `.jsonl`
+> fails the `ext == "json"` filter a file-counting prune would delete session
+> manifests while leaving their cost files behind forever. The prune trigger also
+> moves: it fires once, on the first write of *either* file, not from inside the
+> session write — otherwise a workdir where flows keep failing before their first
+> session commit grows without bound, which is the very case this change starts
+> recording.
+>
+> One stated trade-off: a run that spends tokens without committing a session now
+> occupies a retention slot where it previously wrote nothing, so the shell's
+> listing can hold fewer than 20 *continuable* runs. Rare, and preferable to
+> unbounded growth.
 >
 > **This needs a carve-out in the 0.x versioning rule.** AGENTS.md forbids
 > default values on persisted fields and forbids back-compat machinery outright,
 > with one documented exception for `ProgressLog`/`SessionRecord`. The manifest
 > becomes the second, for the same reason the first exists: this is live local
 > data that has to survive an orca upgrade, and invalidating it costs a
-> user-visible feature rather than a re-run. The carve-out is narrow —
-> defaults are permitted on the two `.orca/cache/runs/` shapes and nowhere else,
-> and only on fields added after this change; the required set above keeps its
+> user-visible feature rather than a re-run. The carve-out is narrow — defaults
+> are permitted on the two `.orca/cache/runs/` shapes and nowhere else, and only
+> on fields added after this change; the five required fields above keep the
 > no-default rule, so a call site that forgets `pid` still fails to compile.
 > AGENTS.md is edited to say so in the same change, or the next reviewer
 > correctly flags every optional field added here.
 >
-> **Existing v5 files.** Nothing is migrated and nothing is discarded: a v5
-> manifest already carries every session field at the same path, so the tolerant
-> session-only schema reads it as-is, skipping `manifestVersion`, `cost` and
-> `turns` as unknown fields. Its cost data is not carried into a `-cost.json` and
-> is simply lost — acceptable, since `.orca/cache/` is gitignored local cache
-> that already prunes to 20 runs, and no code reads the old `cost`/`turns` fields
-> anyway. This is the last schema change that gets to be careless about them.
->
-> **JSONL, not a JSON array.** The cost file is appended a line at a time with no
-> read-modify-write, so a run's turns cost one small write each instead of a
-> whole-file rewrite, and the writer holds no growing in-memory turn buffer. A
-> crash mid-write loses at most the final partial line; a reader drops an
-> unparseable line and keeps the rest. A JSON array cannot do either — its
-> closing bracket makes every append a rewrite, and an unterminated one is
-> unreadable in full.
->
-> Each line carries a `type` discriminator: `"run"` for the single header record
-> (orca version, flow, work dir — the run-level context the session manifest
-> would otherwise be the only home for), `"turn"` for a turn. A reader skips a
-> `type` it does not know, so a later record kind is a non-event for existing
-> readers — the same additive rule as above, applied to the line vocabulary.
->
-> **No persisted summary.** `ManifestCostSummary` and its subtotals are dropped
-> from disk. Each turn line instead carries its own full `usage` and resolved
-> `cost`, making every aggregate — total, by role, by agent, by stage — a
-> read-time fold over the lines. Persisting a fold alongside the values it folds
-> is what forced the whole-file rewrite, and it is the one thing in this file
-> that could disagree with itself.
->
-> **Retention.** The keep-20 prune counts run ids, not files, and deletes a run's
-> two files together — so the budget is 20 runs, as before, not 10. A run id with
-> only one of its two files present still counts as one run and is pruned the
-> same way; the missing half is not an error at any point. Grouping by run id is
-> what the existing filename sort cannot do once a second file per run exists:
-> `<id>.json` and `<id>-cost.jsonl` sort adjacently but as two entries, so a
-> file-counting prune would keep ten runs and, because `.jsonl` fails the `ext ==
-> "json"` filter, would delete session manifests while leaving their cost files
-> behind forever.
+> **Done when.** The `shell` module names no `orca.runner.manifest` cost type —
+> `ManifestCostSummary`, `ManifestSubtotal`, `ManifestUsage`, `ManifestTurn` — in
+> production or test code. Four shell test files reference them today; three pass
+> `ManifestCostSummary.empty` to a constructor, and `ManifestRoundTripTest`
+> asserts on `cost.total`, `cost.byRole` and `turns`, so its cost half moves to a
+> `runner` round trip against the cost file rather than being deleted. The
+> criterion is deliberately about `orca.runner.manifest` types and not "cost" in
+> general: `PriceList` stays in `RunManifestWriter.start`'s signature, since the
+> writer resolves each turn's cost.
 >
 > **Enabled, not scheduled.** Recording each turn's `model` becomes cheap once
 > the cost file is additive, and there is a concrete question waiting for it: a

--- a/adr/0021-orca-shell.md
+++ b/adr/0021-orca-shell.md
@@ -470,6 +470,97 @@ resume is global, but the resumed context still references that directory):
 > checkout, within the 30-day retention) and reports "no resumable pi transcript at
 > \<dir\>" when it fails.
 
+> **Amendment (2026-08-05).** The manifest splits in two and loses its version
+> gate. The shell's menu behaviour, the session shape, and the resume table are
+> unchanged; only the file layout and the compatibility rule move. This
+> supersedes the 2026-08-03 amendment's "readers gate on an exact version match"
+> sentence.
+>
+> **Why.** Every schema bump since §8 shipped — #61, #64, #71 (v4), #77 (v5) —
+> was cost or turn work; the session half has not changed since #27. Yet the
+> shell decodes the whole file strictly behind an exact-version gate, so a purely
+> additive cost field invalidates the session data it happens to share a file
+> with, and the user loses "continue a session" for every run recorded by the
+> previous build. The two halves have different rates of change and different
+> readers, so they get different files.
+>
+> **Layout.** `.orca/cache/runs/` holds two files per run, sharing the
+> `<startedAt-epoch-ms>-<pid>` run id:
+>
+> - `<id>.json` — run fields plus sessions, rewritten whole as today. The
+>   shell's file, and the only one it reads.
+> - `<id>-cost.json` — one JSON object per line, appended as the run goes. The
+>   debug/measurement record. The shell must not read it; after this change the
+>   `shell` module names no cost type at all, in production **or** test code
+>   (three shell tests currently pass `ManifestCostSummary.empty` to a
+>   `RunManifest` constructor — that coupling disappearing is the acceptance
+>   signal that the split is complete).
+>
+> Neither file requires the other. A session manifest with no cost file is a run
+> whose turns weren't recorded; a cost file with no session manifest is a run
+> that spent tokens without committing a session — which today writes nothing at
+> all, so this is new coverage, not a gap. Each reader treats the other's absence
+> as ordinary.
+>
+> **No version gate.** `manifestVersion`, `RunManifest.SupportedVersion` and the
+> reader's pre-decode version check are removed outright. Both files decode with
+> the tolerant config the progress log already uses
+> (`withRequireCollectionFields(false)`): unknown fields are skipped, absent
+> collections read as empty, and absent scalars take their declared default. The
+> rule that replaces the gate is a rule about writing, not reading: **every field
+> added from here on is optional with a default.** That is what makes an additive
+> change unable to invalidate anything, and the codec enforces it — a new
+> required field without a default fails to decode the previous build's files, in
+> the writer's own tests, before it ships.
+>
+> A small set of fields stays required, because a file missing them cannot be
+> displayed at all: `workDir`, `pid`, `startedAt`, `outcome`. A file missing one,
+> or whose `startedAt` doesn't parse, is skipped with a warning naming it —
+> the existing behaviour for a corrupt file, now the only reason to skip one.
+>
+> **Existing v5 files.** Nothing is migrated and nothing is discarded: a v5
+> manifest already carries every session field at the same path, so the tolerant
+> session-only schema reads it as-is, skipping `manifestVersion`, `cost` and
+> `turns` as unknown fields. Its cost data is not carried into a `-cost.json` and
+> is simply lost — acceptable, since `.orca/cache/` is gitignored local cache
+> that already prunes to 20 runs, and no code reads the old `cost`/`turns` fields
+> anyway. This is the last schema change that gets to be careless about them.
+>
+> **JSONL, not a JSON array.** The cost file is appended a line at a time with no
+> read-modify-write, so a run's turns cost one small write each instead of a
+> whole-file rewrite, and the writer holds no growing in-memory turn buffer. A
+> crash mid-write loses at most the final partial line; a reader drops an
+> unparseable line and keeps the rest. A JSON array cannot do either — its
+> closing bracket makes every append a rewrite, and an unterminated one is
+> unreadable in full.
+>
+> Each line carries a `type` discriminator: `"run"` for the single header record
+> (orca version, flow, work dir — the run-level context the session manifest
+> would otherwise be the only home for), `"turn"` for a turn. A reader skips a
+> `type` it does not know, so a later record kind is a non-event for existing
+> readers — the same additive rule as above, applied to the line vocabulary.
+>
+> **No persisted summary.** `ManifestCostSummary` and its subtotals are dropped
+> from disk. Each turn line instead carries its own full `usage` and resolved
+> `cost`, making every aggregate — total, by role, by agent, by stage — a
+> read-time fold over the lines. Persisting a fold alongside the values it folds
+> is what forced the whole-file rewrite, and it is the one thing in this file
+> that could disagree with itself.
+>
+> **Retention.** The keep-20 prune counts run ids, not files, and deletes a run's
+> two files together — so the budget is 20 runs, as before, not 10. A run id with
+> only one of its two files present still counts as one run and is pruned the
+> same way; the missing half is not an error at any point.
+>
+> **Enabled, not scheduled.** Recording each turn's `model` becomes cheap once
+> the cost file is additive, and there is a concrete question waiting for it: a
+> dated haiku model id appears on turns billing at Sonnet rates, while a
+> session-id join places that same id in fully-qualified-haiku sessions. Both
+> observations can only hold together if a turn's model id and its tokens come
+> from different sessions — a check that needs `model` on the turn *and* on the
+> session. Not a task here: the parallel claude plan-mode removal may remove the
+> cause.
+
 ### 9. Creating a new flow with a harness
 
 Menu flow (feedback item 9, goal-first): pick global vs project target upfront

--- a/adr/0021-orca-shell.md
+++ b/adr/0021-orca-shell.md
@@ -489,12 +489,21 @@ resume is global, but the resumed context still references that directory):
 >
 > - `<id>.json` — run fields plus sessions, rewritten whole as today. The
 >   shell's file, and the only one it reads.
-> - `<id>-cost.json` — one JSON object per line, appended as the run goes. The
+> - `<id>-cost.jsonl` — one JSON object per line, appended as the run goes. The
 >   debug/measurement record. The shell must not read it; after this change the
 >   `shell` module names no cost type at all, in production **or** test code
 >   (three shell tests currently pass `ManifestCostSummary.empty` to a
 >   `RunManifest` constructor — that coupling disappearing is the acceptance
 >   signal that the split is complete).
+>
+> The `.jsonl` extension is load-bearing, not cosmetic. Both the shell's reader
+> and the writer's pruner select files with `_.ext == "json"`
+> (`ManifestReader.scala:50`, `RunManifestWriter.scala:329`), so a `-cost.json`
+> sibling would land in the shell's listing as a manifest that fails to decode —
+> one spurious warning per run, every redraw. `.jsonl` keeps that filter correct
+> without a name-pattern special case, and matches how pi's transcripts are
+> already named. The pruner, which must now see both files, selects by run id
+> instead.
 >
 > Neither file requires the other. A session manifest with no cost file is a run
 > whose turns weren't recorded; a cost file with no session manifest is a run
@@ -517,6 +526,18 @@ resume is global, but the resumed context still references that directory):
 > displayed at all: `workDir`, `pid`, `startedAt`, `outcome`. A file missing one,
 > or whose `startedAt` doesn't parse, is skipped with a warning naming it —
 > the existing behaviour for a corrupt file, now the only reason to skip one.
+>
+> **This needs a carve-out in the 0.x versioning rule.** AGENTS.md forbids
+> default values on persisted fields and forbids back-compat machinery outright,
+> with one documented exception for `ProgressLog`/`SessionRecord`. The manifest
+> becomes the second, for the same reason the first exists: this is live local
+> data that has to survive an orca upgrade, and invalidating it costs a
+> user-visible feature rather than a re-run. The carve-out is narrow —
+> defaults are permitted on the two `.orca/cache/runs/` shapes and nowhere else,
+> and only on fields added after this change; the required set above keeps its
+> no-default rule, so a call site that forgets `pid` still fails to compile.
+> AGENTS.md is edited to say so in the same change, or the next reviewer
+> correctly flags every optional field added here.
 >
 > **Existing v5 files.** Nothing is migrated and nothing is discarded: a v5
 > manifest already carries every session field at the same path, so the tolerant
@@ -550,7 +571,12 @@ resume is global, but the resumed context still references that directory):
 > **Retention.** The keep-20 prune counts run ids, not files, and deletes a run's
 > two files together — so the budget is 20 runs, as before, not 10. A run id with
 > only one of its two files present still counts as one run and is pruned the
-> same way; the missing half is not an error at any point.
+> same way; the missing half is not an error at any point. Grouping by run id is
+> what the existing filename sort cannot do once a second file per run exists:
+> `<id>.json` and `<id>-cost.jsonl` sort adjacently but as two entries, so a
+> file-counting prune would keep ten runs and, because `.jsonl` fails the `ext ==
+> "json"` filter, would delete session manifests while leaving their cost files
+> behind forever.
 >
 > **Enabled, not scheduled.** Recording each turn's `model` becomes cheap once
 > the cost file is additive, and there is a concrete question waiting for it: a

--- a/docs/superpowers/plans/2026-08-05-manifest-cost-split.md
+++ b/docs/superpowers/plans/2026-08-05-manifest-cost-split.md
@@ -1,0 +1,180 @@
+# Split the run manifest from the cost record — development plan
+
+Implements the ADR 0021 §8 amendment of 2026-08-05 (PR #92). Written from the
+reviewed ADR; the two design reviews' findings are already folded into the ADR,
+so this plan takes them as given.
+
+**Shape.** `.orca/cache/runs/` gains a second file per run. `<id>.json` keeps
+run fields and sessions and loses `manifestVersion`, `cost` and `turns`.
+`<id>-cost.jsonl` is new: append-only, one JSON object per line, never read by
+the shell.
+
+**Grouping into PRs.** Four PRs, in order. Each is independently reviewable and
+leaves the tree green.
+
+| PR | Tasks | Theme |
+|---|---|---|
+| A | T1, T2 | Drop the version gate; tolerant session manifest |
+| B | T3, T4 | The cost log: writer, reader, wiring |
+| C | T5 | Retention across the pair |
+| D | T6 | AGENTS.md carve-out and doc sweep |
+
+PR B depends on A (the manifest shape changes under it). C depends on B (there
+is no second file to prune until B lands). D is independent but goes last so it
+documents what actually shipped.
+
+---
+
+## PR A — drop the version gate
+
+### T1 — Tolerant, version-free session manifest
+Remove `manifestVersion` from `RunManifest` and `RunManifest.SupportedVersion`;
+swap the codec from `JsonData.strictCodecConfig` to
+`withRequireCollectionFields(false).withTransientEmpty(false)`. Remove
+`ManifestReader.readManifest`'s version branch and its `SchemaVersion` /
+`schemaVersionCodec` helpers, leaving one decode with a warning on failure.
+
+`workDir`, `pid`, `startedAt`, `outcome` and `sessions` keep no default —
+`sessions` specifically so an absent array cannot render the menu's
+"(0 session(s))" row. `cost` and `turns` come off `RunManifest` in T3; until
+then they stay, so this task compiles on its own.
+
+Rewrite the scaladoc at `RunManifest.scala:139-153` and `:187-194` — both argue
+for the gate — and `ManifestReader.scala:26-39`.
+
+*Done when:* a manifest carrying `manifestVersion`, `cost` and `turns` decodes
+as session-only with no warning, and one carrying none of them decodes
+identically. `ManifestReaderTest`'s two version-gate cases (`:74-102`,
+`:104-120`) are gone; the first one's verbatim v2 JSON survives as the
+assertion that an old file now reads. `CliTest`'s stderr-separation test
+(`:940-980`) needs a new way to provoke a warning — a manifest missing
+`workDir` is the natural one, and it doubles as the required-field check.
+
+### T2 — Frozen golden fixtures
+Check in a literal manifest as a test resource, never edited afterwards: the
+v5 shape, with a populated `sessions` array (the existing v2 fixture has an
+empty one, which would not catch a session-field regression). A test decodes it
+and asserts every session field. This is the mechanism behind the ADR's
+additive-only rule; without it the rule is a comment, since every other fixture
+in the repo is edited in lockstep with the schema.
+
+*Done when:* the fixture file is committed under `src/test/resources`, a test
+decodes it, and adding a required field to `RunManifest` or `ManifestSession`
+makes exactly that test fail. Mutation-check that: add `foo: String`, confirm
+the fixture test is the failure, revert.
+
+---
+
+## PR B — the cost log
+
+### T3 — `CostLog` writer and record shape
+New file in `orca.runner.manifest`. Three record types behind a `type`
+discriminator: `run` (orca version, flow, work dir), `turn`, `finish`
+(outcome). One codec, tolerant, unknown `type` skipped on read.
+
+The turn record carries `at`, `agent`, `role`, `stage`, `attempt`, `apiCalls`,
+a full `ManifestUsage` (all five axes — this is what keeps `RunManifestTest`'s
+"mirrors every `Usage` axis" guard meaningful) and `Option[Cost]`. It also
+carries the denormalised session identity — harness, agent, session name — so a
+line stands alone when its sibling manifest was never written or was pruned.
+`promptTokens` does not survive: it is `usage.inputTokens` verbatim.
+
+Appends open the file per line — no held handle, which would need a close hook
+on the actor and would not survive the directory being replaced underneath it.
+After a failed append the writer terminates the file with a newline before
+appending again, so a short write costs one record rather than running the next
+one onto the same line.
+
+Delete `CostAccumulator.scala` in full, `Tally` included, and
+`ManifestCostSummary` / `ManifestSubtotal`.
+
+*Done when:* a writer driven with two `TokensUsed` events produces a file whose
+lines are, in order, one `run`, two `turn`, and — after `finish` — one
+`finish`. A turn's usage axes and resolved cost round-trip. No
+`ManifestCostSummary` type remains in the tree.
+
+### T4 — Wire it into `RunManifestWriterState`, with its own gate
+`TokensUsed` stops accumulating and appends. The append goes through
+`safeWrite`'s guard: that handler is pure in-memory today and cannot throw,
+and after this it does IO on every turn — an escape from a `tell` handler
+closes the actor's channel and quarantines the writer for the rest of the run,
+session writes included.
+
+The cost file gets its own creation gate on the first `TokensUsed`. It cannot
+share the session manifest's gate: on the autonomous text path `emitTokens`
+fires before `emitSessionCommitted` (`BaseAgent.scala:115-116`), so gating cost
+on the session event means buffering turns until it opens — the in-memory turn
+log this change exists to remove, discarded entirely for a `quietTextTurn`-only
+run. `finish` writes the trailer and must land before the caller proceeds, so
+it stays an `ask`.
+
+`RunManifestWriterTest`'s cost cases (`:423-490`, `:492-557`) move to the cost
+file. `ManifestRoundTripTest`'s cost assertions (`:79-82`) move to a `runner`
+round trip; the shell keeps only its session half. Its `manifestFiles` helper
+(`:39-40`) filters `ext == "json"`, which `.jsonl` already excludes — confirm
+rather than assume.
+
+*Done when:* a run that emits `TokensUsed` but never `SessionCommitted` writes a
+cost file and no session manifest; a run that emits neither writes neither.
+`RunManifestWriterTest:366-382` (session-less run writes nothing) still passes,
+narrowed to the session half, with a sibling covering the cost half. The
+`shell` module names no `orca.runner.manifest` cost type in production or test
+code — `PriceList` stays in `RunManifestWriter.start`'s signature and is not in
+scope.
+
+---
+
+## PR C — retention across the pair
+
+### T5 — Prune by run id
+`pruneOldManifests` groups by run id — strip `.json` or `-cost.jsonl` — keeps
+the newest 20 ids, and deletes both files of each older id. A run id with only
+one of its two files is one run and prunes the same way; a missing half is
+never an error.
+
+The trigger moves out of `write()`: it fires once, on the first write of either
+file, sharing one `prunedOnce`. Left where it is, a run that never commits a
+session never prunes, which is exactly the run T4 starts recording.
+
+Watch the ordering: prune currently runs after this run's own file exists,
+which is what makes `RunManifestWriterTest:282-287` ("the current run's own
+manifest must survive pruning") hold at 19 old + 1 current. Firing on a first
+cost append instead means this run's session manifest does not exist yet, so 20
+old survive and the current one makes 21. Pick one and pin it in the test —
+either is defensible, but the test's invariant must match.
+
+*Done when:* 25 pre-seeded runs, some as pairs and some as orphaned halves,
+prune to the newest 20 run ids with both files of each deleted run gone and no
+orphan left behind. A run that only ever appends cost lines prunes.
+
+---
+
+## PR D — the convention and the docs
+
+### T6 — AGENTS.md carve-out
+AGENTS.md's "Versioning (0.x)" section forbids defaults on persisted fields and
+back-compat machinery, with one documented exception for
+`ProgressLog`/`SessionRecord`. Add the second, worded as narrowly as the ADR:
+defaults are permitted on the two `.orca/cache/runs/` shapes and nowhere else,
+only on fields added after this change, and the five required manifest fields
+keep the no-default rule.
+
+Without this the next reviewer correctly flags every optional field the split
+introduces.
+
+*Done when:* AGENTS.md names both exceptions and says what the manifest one does
+not cover (renames, retypes, respelled wire vocabulary).
+
+---
+
+## Verification, every task
+
+`sbt scalafmtCheckAll`, then `sbt clean compile test` in the foreground. Zero
+warnings. Tests mutation-checked: apply the mutation, confirm exactly the
+intended test fails, revert.
+
+## Out of scope, recorded
+
+Per-turn `model`. The ADR records it as enabled by the additive cost file, not
+as work: the parallel claude plan-mode removal may remove the question that
+wants it. Answering it needs `model` on the turn *and* on the session.


### PR DESCRIPTION
Amends ADR 0021 §8. No code changes.

## The problem

The run manifest at `.orca/cache/runs/<id>.json` holds two things with nothing in common: the sessions the shell offers under "continue a session", and the cost and turn data written for debugging.

They change at completely different rates. The session half has not changed since the manifest shipped in #27. Every schema bump since — #61, #64, #71, #77 — was cost or turn work. But both halves sit behind one `manifestVersion` gate, and the shell decodes the whole file strictly, including the cost fields it never reads. So adding a cost field bumps the version, and every manifest the previous build wrote is skipped. The user loses "continue a session" for those runs, for a change that had nothing to do with sessions.

There is a second cost. Because the file is rewritten whole, each of the ~40 stage and session writes re-serialises the entire turn log and recomputes all four cost aggregates — for data nothing ever reads back.

## The change

Two files per run, sharing the same run id:

- `<id>.json` — run fields and sessions, rewritten whole as today. The shell reads this and nothing else.
- `<id>-cost.jsonl` — one JSON object per line, appended as the run goes. The debug record.

The `.jsonl` extension is doing real work: the shell's reader and the writer's pruner both pick files by `ext == "json"`, so a `-cost.json` sibling would show up in the shell's listing as a manifest that fails to decode, once per run, on every menu redraw.

`manifestVersion` and the version gate are deleted. Both files decode tolerantly, and every field added from here on is optional with a default.

## What the review changed

Two sub-agent design reviews ran over the first draft. Four things came back that the amendment had wrong, and they are folded in.

- **The enforcement claim was false.** The draft said the codec would catch a new required field "in the writer's own tests". It would not — no test in the repo decodes a previous build's bytes; every fixture is hand-built and edited in lockstep with the schema. The change now checks in frozen golden fixtures that must keep decoding, which is the only thing that makes the rule real.
- **Dropping the gate makes renames silent.** Today `ManifestSession` has no defaults, so renaming a field is a loud decode error. Once fields carry defaults, a rename reads as an unknown key skipped plus a defaulted absent key. Rename `sessionName` and every durable lineage silently collapses onto the agent name in the picker. So the rule is additive-only — no renames, no retypes, no respelled wire strings — and the ADR now says which cases it does not cover.
- **The prune trigger is in the wrong place.** It fires from inside the session write, so a run that never commits a session never prunes. That is exactly the run this change starts recording, so the cache would grow without bound. It moves to the first write of either file.
- **`sessions` has to stay required.** Losing strict collection fields would let an absent array read as empty, and the menu renders the count verbatim — a "Continue a session from the last flow run (0 session(s))" item leading to an empty picker, with no warning.

Also settled rather than left to an implementer: the two creation gates and why they can't be shared (on the autonomous path the token event fires before the session event, so one gate would mean buffering turns — the thing this change removes); the `safeWrite` guard on the append path, since `TokensUsed` handling currently cannot throw and after this it does IO; open-per-append; a `finish` trailer so a cost file can say whether its run ended; denormalised session identity on the turn line, since the existing `session` field is a foreign key that dangles; dropping `promptTokens` as a duplicate of `usage.inputTokens`; and a small `CostLog.read` so "read-time fold" describes code that exists.

## Other decisions

- **Old files** are neither migrated nor discarded. Every session field has sat at the same path since #27, so v1–v5 all decode under the tolerant schema. Their cost data is lost, which is fine — `.orca/cache/` is gitignored. Manifests the gate currently hides become visible.
- **No persisted summary.** Each turn line carries its own usage and cost, so every total and breakdown is a fold over the lines. The algebra survives: `Usage.+` is componentwise and `Cost.+` ORs `estimated`.
- **Retention** counts runs, not files, and deletes both files of a run together. One stated trade-off: a run that spends tokens without committing a session now takes a slot where it previously wrote nothing.
- **A carve-out in the 0.x versioning rule.** AGENTS.md forbids defaults on persisted fields, with one exception for the progress log. The manifest becomes the second, for the same reason — live local data that has to survive an upgrade. AGENTS.md is edited in the same change, or the next reviewer correctly flags every optional field.

## Not in scope

Recording each turn's `model` gets cheap once the file is additive, and there is a question waiting for it — a dated haiku model id appears on turns billing at Sonnet rates. Recorded as enabled by this change, not as work to do, since the parallel plan-mode removal may remove the cause.

An earlier version of this brief had the progress log take over "continue a session" as well. That does not work: successful teardown deletes the progress log (ADR 0018 R5), so continuing a chat after a green run — the main use case — would stop working. The progress log keeps driving "resume interrupted run" only.
