### PR TITLE
Record why the per-round snapshot sketch does not work

### DIFF
--- a/docs/research/run-cost/08-re-review-payload.md
+++ b/docs/research/run-cost/08-re-review-payload.md
@@ -314,14 +314,38 @@ committed anyway. A reviewer whose `git diff HEAD` comes back empty concludes
 nothing changed and reports clean; nothing downstream can tell that apart from a
 real all-clear.
 
-Mechanism note, unverified: `reviewDiff(since)` already accepts any commit-ish
-and already splices untracked file contents (`GitTool.scala:573-574`), so the
-missing piece is a per-round snapshot to diff against. A tree object written
-through a throwaway index (`GIT_INDEX_FILE=<tmp> git add -A && git write-tree`)
-gives one without touching HEAD, the real index, or the working tree, and
-`reviewDiff(Some(previousTree))` then reads as "everything that changed since
-your last round". Whether ignore rules make that snapshot agree with
-`untrackedPaths()` was not checked.
+**Mechanism note — checked, and the sketch does not work.** (git 2.53, scratch
+repo, 2026-08-05.)
+
+The sketch was: a tree written through a throwaway index (`GIT_INDEX_FILE=<tmp>
+git add -A && git write-tree`) gives a per-round snapshot without touching HEAD,
+the real index or the working tree, and `reviewDiff(Some(previousTree))` then
+reads as "everything that changed since your last round". The snapshot half is
+fine. The `reviewDiff` half is not:
+
+- `git diff <tree>` walks the **real index** to decide what is tracked, so a
+  file that is untracked there but present in the snapshot comes out as a
+  **deletion**. Measured: snapshot taken with an untracked `untracked.txt` in
+  it, working tree then untouched, `git diff <tree>` reports `D untracked.txt`.
+- `reviewDiff` also splices every current untracked file in as a new-file diff
+  (`GitTool.scala:573-574`), so the same file arrives a second time, in full.
+
+A resumed reviewer would therefore be told, every round, that each new file was
+deleted and re-added. Ignore rules — the thing this note flagged as unchecked —
+are not the problem: `git add -A` and `untrackedPaths()` (`git status -uall`,
+no `--ignored`) both skip ignored files, so those two do agree.
+
+What does produce the increment is a **tree-to-tree** diff between two
+snapshots. Measured: `git diff <prevTree> <nowTree>` reports exactly the
+modified tracked file and the added untracked one, no phantom deletion, and it
+renders an added file in full, so no splice is needed at all. That is a
+different mechanism from the one above, and a bigger change than "a `GitTool`
+addition": the snapshot has to carry orca's `.orca/` exclusion pathspec, `git
+add -A` into an empty index re-hashes the whole working tree every round
+(seeding the temp index from the real one avoids that), it writes blobs into the
+object store from a path that is otherwise read-only, and `SessionEntry` has to
+carry a tree per reviewer instead of the diff text it compares today. Not
+attempted.
 
 **Ordering.** (b) is a prompt-and-plumbing change of a few lines and can ship on
 its own. (c) needs a `GitTool` addition and touches `ReviewLoopState`, so it

--- a/docs/research/run-cost/08-re-review-payload.md
+++ b/docs/research/run-cost/08-re-review-payload.md
@@ -323,17 +323,22 @@ the real index or the working tree, and `reviewDiff(Some(previousTree))` then
 reads as "everything that changed since your last round". The snapshot half is
 fine. The `reviewDiff` half is not:
 
-- `git diff <tree>` walks the **real index** to decide what is tracked, so a
-  file that is untracked there but present in the snapshot comes out as a
-  **deletion**. Measured: snapshot taken with an untracked `untracked.txt` in
-  it, working tree then untouched, `git diff <tree>` reports `D untracked.txt`.
-- `reviewDiff` also splices every current untracked file in as a new-file diff
-  (`GitTool.scala:573-574`), so the same file arrives a second time, in full.
+- `git diff <tree>` decides what is tracked from the **real index**, so an
+  untracked file is invisible to it both ways: one that is in the snapshot
+  comes out as a **deletion**, and one created since the snapshot is not
+  reported at all. Measured: snapshot taken with an untracked `untracked.txt`
+  in it, working tree then untouched, `git diff <tree>` reports `D
+  untracked.txt`; `git add -N` on that path, with no content change, makes the
+  deletion go away.
+- `reviewDiff` also splices the current untracked files in as new-file diffs
+  (`GitTool.scala:618-619,652-656`), so a file already in the snapshot arrives
+  a second time, in full.
 
-A resumed reviewer would therefore be told, every round, that each new file was
-deleted and re-added. Ignore rules — the thing this note flagged as unchecked —
-are not the problem: `git add -A` and `untrackedPaths()` (`git status -uall`,
-no `--ignored`) both skip ignored files, so those two do agree.
+A resumed reviewer would therefore be told, every round, that each file still
+untracked from an earlier round was deleted and re-added. Ignore rules — the
+thing this note flagged as unchecked — are not the problem: `git add -A` and
+`untrackedPaths()` (`git status -uall`, no `--ignored`) both skip ignored
+files, so those two do agree.
 
 What does produce the increment is a **tree-to-tree** diff between two
 snapshots. Measured: `git diff <prevTree> <nowTree>` reports exactly the


### PR DESCRIPTION
The per-reviewer diff increment (T2.5 §6(c)) was unblocked by #81, so I went to build it. The first step was checking the mechanism the document sketches — a per-round tree written through a throwaway index, then `reviewDiff(Some(previousTree))`. It does not work, so this PR records the check instead of the feature.

## What was checked

git 2.53, scratch repo.

- The snapshot half is fine: `GIT_INDEX_FILE=<tmp> git add -A && git write-tree` writes a tree without touching HEAD, the real index or the working tree.
- The `reviewDiff` half is not. `git diff <tree>` decides what is tracked from the **real index**, so a file that is untracked there but present in the snapshot comes out as a deletion. Measured: snapshot taken with an untracked file in it, working tree then untouched, `git diff <tree>` reports `D untracked.txt`. On top of that, `reviewDiff` splices every current untracked file in as a new-file diff, so the same file arrives again in full.

A resumed reviewer would be told every round that each file still untracked from an earlier round was deleted and re-added. (`git diff <tree>` is blind to untracked files both ways: one created since the snapshot is not reported at all.)

The unknown the document flagged — whether ignore rules make the snapshot agree with `untrackedPaths()` — is not the problem. `git add -A` and `git status -uall` both skip ignored files, so those two agree.

## What would work

A tree-to-tree diff between two snapshots. Measured: `git diff <prevTree> <nowTree>` reports exactly the modified tracked file and the added untracked one, no phantom deletion, and it renders an added file in full so no splice is needed.

That is a different mechanism, and a bigger change than the "GitTool addition" §(c) assumes: the snapshot needs orca's `.orca/` exclusion pathspec, `git add -A` into an empty index re-hashes the whole working tree each round, it writes blobs into the object store from an otherwise read-only path, and `SessionEntry` has to carry a tree per reviewer rather than the diff text it compares today. Left for a decision rather than forced into this change.

Documentation only — one file, no code.
