### PR TITLE
Drop the run manifest's version gate

### DIFF
--- a/runner/src/main/scala/orca/runner/manifest/RunManifest.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifest.scala
@@ -136,23 +136,26 @@ private[orca] case class ManifestTurn(
     apiCalls: Option[Long]
 )
 
-/** Schema v5 (ADR 0021 §8) of a per-run manifest written to
+/** A per-run manifest written to
   * `.orca/cache/runs/<startedAt-epoch-ms>-<pid>.json`, read by the shell to
-  * offer "continue a session". `manifestVersion` is a hard gate: a reader
-  * checks it before decoding and skips anything it doesn't write itself, rather
-  * than guessing at an unfamiliar schema — that gate is the one place
-  * cross-version tolerance lives, so the codec below doesn't need to be
-  * tolerant too. `outcome` is `"running"` until [[RunManifestWriter.finish]]
-  * finalizes it to `"succeeded"` or `"failed"` — a stale `"running"` with a
-  * dead `pid` means the run crashed, and the shell still offers its recorded
-  * sessions.
+  * offer "continue a session". `outcome` is `"running"` until
+  * [[RunManifestWriter.finish]] finalizes it to `"succeeded"` or `"failed"` — a
+  * stale `"running"` with a dead `pid` means the run crashed, and the shell
+  * still offers its recorded sessions.
+  *
+  * Carries no schema version (ADR 0021 §8 amendment, 2026-08-05). The
+  * compatibility rule is about writing instead: additions are `Option` or carry
+  * a default, and nothing is renamed, retyped, or has its wire strings
+  * respelled. A field this build doesn't declare is skipped, which is what lets
+  * a manifest written by an earlier build still list its sessions. The rule is
+  * only as good as `RunManifestGoldenTest`, which decodes a frozen file no
+  * schema change may edit.
   *
   * `cost` and `turns` make a run's spend answerable from this file alone, with
   * no agent transcript involved — subject to the reporting gaps noted on
   * [[ManifestCostSummary]] and [[ManifestTurn]].
   */
 private[orca] case class RunManifest(
-    manifestVersion: Int,
     orcaVersion: String,
     flow: Option[String],
     workDir: String,
@@ -166,14 +169,6 @@ private[orca] case class RunManifest(
 )
 
 private[orca] object RunManifest:
-  /** The manifest schema version this build reads and writes — bumped whenever
-    * the wire shape changes. Readers skip any file whose version differs, in
-    * either direction: orca owes no compatibility across 0.x shapes, and
-    * `.orca/cache/runs/` is pruned cache data, so an unreadable run costs a
-    * "continue" offer for that run and nothing else.
-    */
-  val SupportedVersion = 5
-
   // The `outcome` and `ManifestSession.kind` wire strings, named once here so
   // the writer that produces them (RunManifestWriter's Outcome/SessionKind
   // enums) and every reader that matches on them share one spelling.
@@ -187,11 +182,19 @@ private[orca] object RunManifest:
   // Only a jsoniter codec — no `JsonData`/`Schema` half, deliberately: the
   // manifest crosses the process/disk boundary to the shell, never an HTTP or
   // LLM boundary, so it needs on-disk (de)serialisation but no tool schema.
-  // Strict, like every other in-process codec (`JsonData.strictCodecConfig`):
-  // a missing collection field fails to parse rather than silently defaulting
-  // to empty. The `manifestVersion` gate above is the only cross-version
-  // tolerance this format needs — a writer bug producing a malformed manifest
-  // should fail loudly, not decode as a plausible-looking empty one.
+  //
+  // Strict (`JsonData.strictCodecConfig`) even with the version gate gone:
+  // strictness only forces COLLECTION fields to be present, and `sessions` is
+  // the one whose absence must not read as empty — the menu renders the count
+  // verbatim, so a silently empty list becomes a "(0 session(s))" row leading
+  // nowhere. Cross-version tolerance is unaffected: jsoniter skips unknown
+  // fields under any config, and an added `Option`/defaulted field is optional
+  // under a strict one. A collection added later must be wrapped in `Option`,
+  // or it lands on every reader as newly required.
+  //
+  // Deliberately NOT the progress log's `withRequireCollectionFields(false)`:
+  // that would make `sessions` optional, which is the one thing this format
+  // cannot afford.
   given codec: ConfiguredJsonValueCodec[RunManifest] =
     ConfiguredJsonValueCodec.derived[RunManifest](using
       JsonData.strictCodecConfig

--- a/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
@@ -283,7 +283,6 @@ private[runner] class RunManifestWriterState(
     */
   private def write(): Unit =
     val manifest = RunManifest(
-      manifestVersion = RunManifest.SupportedVersion,
       orcaVersion = orcaVersion,
       flow = flowName,
       workDir = workDir.toString,

--- a/runner/src/test/resources/orca/manifest/golden-run-manifest.json
+++ b/runner/src/test/resources/orca/manifest/golden-run-manifest.json
@@ -1,0 +1,56 @@
+{
+  "manifestVersion": 5,
+  "orcaVersion": "0.1.0",
+  "flow": "implement.sc",
+  "workDir": "/home/user/project",
+  "pid": 4242,
+  "startedAt": "2026-08-04T09:15:00Z",
+  "finishedAt": "2026-08-04T09:48:12Z",
+  "outcome": "succeeded",
+  "sessions": [
+    {
+      "harness": "claude-code",
+      "wireId": "0f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0",
+      "agent": "implementer",
+      "role": "coding",
+      "stage": "implement",
+      "sessionName": "coder",
+      "kind": "durable",
+      "firstSeenAt": "2026-08-04T09:16:03Z",
+      "lastActiveAt": "2026-08-04T09:47:55Z"
+    },
+    {
+      "harness": "codex",
+      "reason": "codex sessions do not survive the run",
+      "agent": "reviewer-scala-fp",
+      "kind": "oneShot",
+      "firstSeenAt": "2026-08-04T09:30:11Z",
+      "lastActiveAt": "2026-08-04T09:30:44Z"
+    }
+  ],
+  "cost": {
+    "total": {
+      "inputTokens": 812340,
+      "outputTokens": 19022,
+      "cacheReadInputTokens": 640112,
+      "cacheWriteInputTokens": 88010,
+      "reasoningOutputTokens": 0
+    },
+    "cost": { "amount": 4.1875, "estimated": false },
+    "byRole": [],
+    "byAgent": [],
+    "byStage": []
+  },
+  "turns": [
+    {
+      "at": "2026-08-04T09:16:03Z",
+      "agent": "implementer",
+      "role": "coding",
+      "stage": "implement",
+      "promptTokens": 107422,
+      "attempt": 1,
+      "session": "0f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0",
+      "apiCalls": 3
+    }
+  ]
+}

--- a/runner/src/test/resources/orca/manifest/golden-running-manifest.json
+++ b/runner/src/test/resources/orca/manifest/golden-running-manifest.json
@@ -1,0 +1,30 @@
+{
+  "manifestVersion": 5,
+  "orcaVersion": "0.1.0",
+  "workDir": "/home/user/project",
+  "pid": 5150,
+  "startedAt": "2026-08-04T11:02:00Z",
+  "outcome": "running",
+  "sessions": [
+    {
+      "harness": "gemini",
+      "agent": "planner",
+      "kind": "oneShot",
+      "firstSeenAt": "2026-08-04T11:02:30Z",
+      "lastActiveAt": "2026-08-04T11:02:41Z"
+    }
+  ],
+  "cost": {
+    "total": {
+      "inputTokens": 4100,
+      "outputTokens": 320,
+      "cacheReadInputTokens": 0,
+      "cacheWriteInputTokens": 0,
+      "reasoningOutputTokens": 0
+    },
+    "byRole": [],
+    "byAgent": [],
+    "byStage": []
+  },
+  "turns": []
+}

--- a/runner/src/test/scala/orca/runner/manifest/RunManifestGoldenTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/RunManifestGoldenTest.scala
@@ -1,58 +1,129 @@
 package orca.runner.manifest
 
 import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
+import orca.events.Cost
 
-/** Decodes a frozen manifest written by an older build, byte for byte as that
-  * build produced it (ADR 0021 §8 amendment, 2026-08-05).
+/** Decodes manifests as older builds left them on disk (ADR 0021 §8 amendment,
+  * 2026-08-05).
   *
-  * FROZEN: `golden-run-manifest.json` must never be edited to accommodate a
-  * schema change. It is the only thing standing behind the additive-only rule
-  * that replaced `manifestVersion` — every other fixture in the repo is
-  * hand-built inside its test and gets updated in the same commit as the
-  * schema, so none of them can catch a field becoming required. If this test
-  * fails, the schema change is the bug.
+  * FROZEN: neither fixture may be edited to accommodate a schema change. They
+  * are the only thing standing behind the additive-only rule that replaced
+  * `manifestVersion` — every other manifest fixture in the repo is hand-built
+  * inside its test and gets updated in the same commit as the schema, so none
+  * of them can catch a field becoming required, renamed, or retyped. If one of
+  * these fails, the schema change is the bug.
   *
-  * The file still carries `manifestVersion`, `cost.cost` and per-turn
-  * `promptTokens`: fields this build no longer declares, kept precisely because
-  * skipping them is the behaviour under test.
+  * Hand-authored to match what an older build emitted, then pretty-printed for
+  * readability — the writer itself emits compact JSON. Both carry
+  * `manifestVersion`, which this build no longer declares, because skipping it
+  * is part of what is under test.
+  *
+  * Compared by whole-value equality rather than field by field: a structural
+  * comparison cannot forget a field, so renaming an `Option` — which would
+  * otherwise decode as a silent `None` and pass — fails here.
   */
 class RunManifestGoldenTest extends munit.FunSuite:
 
-  private def golden: RunManifest =
-    val text = scala.io.Source
-      .fromResource("orca/manifest/golden-run-manifest.json")
-      .mkString
+  private def decode(resource: String): RunManifest =
+    val text = scala.io.Source.fromResource(s"orca/manifest/$resource").mkString
     readFromString[RunManifest](text)(using RunManifest.codec)
 
-  test("a manifest from an older build still decodes, unknown fields skipped"):
-    assertEquals(golden.orcaVersion, "0.1.0")
-    assertEquals(golden.workDir, "/home/user/project")
-    assertEquals(golden.pid, 4242L)
-    assertEquals(golden.startedAt, "2026-08-04T09:15:00Z")
-    assertEquals(golden.outcome, RunManifest.OutcomeSucceeded)
+  test("a finished run's manifest from an older build decodes unchanged"):
+    assertEquals(
+      decode("golden-run-manifest.json"),
+      RunManifest(
+        orcaVersion = "0.1.0",
+        flow = Some("implement.sc"),
+        workDir = "/home/user/project",
+        pid = 4242,
+        startedAt = "2026-08-04T09:15:00Z",
+        finishedAt = Some("2026-08-04T09:48:12Z"),
+        outcome = RunManifest.OutcomeSucceeded,
+        sessions = List(
+          ManifestSession(
+            harness = "claude-code",
+            wireId = Some("0f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0"),
+            reason = None,
+            agent = "implementer",
+            role = Some("coding"),
+            stage = Some("implement"),
+            sessionName = Some("coder"),
+            kind = RunManifest.KindDurable,
+            firstSeenAt = "2026-08-04T09:16:03Z",
+            lastActiveAt = "2026-08-04T09:47:55Z"
+          ),
+          ManifestSession(
+            harness = "codex",
+            wireId = None,
+            reason = Some("codex sessions do not survive the run"),
+            agent = "reviewer-scala-fp",
+            role = None,
+            stage = None,
+            sessionName = None,
+            kind = RunManifest.KindOneShot,
+            firstSeenAt = "2026-08-04T09:30:11Z",
+            lastActiveAt = "2026-08-04T09:30:44Z"
+          )
+        ),
+        cost = ManifestCostSummary(
+          total = ManifestUsage(812340, 19022, 640112, 88010, 0),
+          cost = Some(Cost(BigDecimal("4.1875"), estimated = false)),
+          byRole = Nil,
+          byAgent = Nil,
+          byStage = Nil
+        ),
+        turns = List(
+          ManifestTurn(
+            at = "2026-08-04T09:16:03Z",
+            agent = "implementer",
+            role = Some("coding"),
+            stage = Some("implement"),
+            promptTokens = 107422,
+            attempt = 1,
+            session = Some("0f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0"),
+            apiCalls = Some(3L)
+          )
+        )
+      )
+    )
 
-  test("every session field of an older build's manifest survives the decode"):
-    val durable = golden.sessions.head
-    assertEquals(durable.harness, "claude-code")
-    assertEquals(durable.wireId, Some("0f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0"))
-    assertEquals(durable.agent, "implementer")
-    assertEquals(durable.role, Some("coding"))
-    assertEquals(durable.stage, Some("implement"))
-    assertEquals(durable.sessionName, Some("coder"))
-    assertEquals(durable.kind, RunManifest.KindDurable)
-    assertEquals(durable.firstSeenAt, "2026-08-04T09:16:03Z")
-    assertEquals(durable.lastActiveAt, "2026-08-04T09:47:55Z")
-    assertEquals(durable.resumable, true)
-
-  /** The wireId-less arm: `reason` present, `role`/`stage`/`sessionName`
-    * absent. Absent optionals are how the writer omits `None`, so this pins
-    * that an old file's omissions still read as `None` rather than failing.
+  /** The in-flight shape, which the finished fixture cannot cover: `outcome`
+    * still `"running"` and `finishedAt` absent. That is what a crashed run
+    * leaves behind, and continuing its sessions is the feature this format
+    * exists for — so retyping `finishedAt` out of `Option` has to fail here.
     */
-  test("an older manifest's one-shot session decodes with its fields absent"):
-    val oneShot = golden.sessions(1)
-    assertEquals(oneShot.wireId, None)
-    assertEquals(oneShot.reason, Some("codex sessions do not survive the run"))
-    assertEquals(oneShot.role, None)
-    assertEquals(oneShot.stage, None)
-    assertEquals(oneShot.sessionName, None)
-    assertEquals(oneShot.resumable, false)
+  test("a crashed run's manifest from an older build decodes unchanged"):
+    assertEquals(
+      decode("golden-running-manifest.json"),
+      RunManifest(
+        orcaVersion = "0.1.0",
+        flow = None,
+        workDir = "/home/user/project",
+        pid = 5150,
+        startedAt = "2026-08-04T11:02:00Z",
+        finishedAt = None,
+        outcome = RunManifest.OutcomeRunning,
+        sessions = List(
+          ManifestSession(
+            harness = "gemini",
+            wireId = None,
+            reason = None,
+            agent = "planner",
+            role = None,
+            stage = None,
+            sessionName = None,
+            kind = RunManifest.KindOneShot,
+            firstSeenAt = "2026-08-04T11:02:30Z",
+            lastActiveAt = "2026-08-04T11:02:41Z"
+          )
+        ),
+        cost = ManifestCostSummary(
+          total = ManifestUsage(4100, 320, 0, 0, 0),
+          cost = None,
+          byRole = Nil,
+          byAgent = Nil,
+          byStage = Nil
+        ),
+        turns = Nil
+      )
+    )

--- a/runner/src/test/scala/orca/runner/manifest/RunManifestGoldenTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/RunManifestGoldenTest.scala
@@ -1,0 +1,58 @@
+package orca.runner.manifest
+
+import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
+
+/** Decodes a frozen manifest written by an older build, byte for byte as that
+  * build produced it (ADR 0021 §8 amendment, 2026-08-05).
+  *
+  * FROZEN: `golden-run-manifest.json` must never be edited to accommodate a
+  * schema change. It is the only thing standing behind the additive-only rule
+  * that replaced `manifestVersion` — every other fixture in the repo is
+  * hand-built inside its test and gets updated in the same commit as the
+  * schema, so none of them can catch a field becoming required. If this test
+  * fails, the schema change is the bug.
+  *
+  * The file still carries `manifestVersion`, `cost.cost` and per-turn
+  * `promptTokens`: fields this build no longer declares, kept precisely because
+  * skipping them is the behaviour under test.
+  */
+class RunManifestGoldenTest extends munit.FunSuite:
+
+  private def golden: RunManifest =
+    val text = scala.io.Source
+      .fromResource("orca/manifest/golden-run-manifest.json")
+      .mkString
+    readFromString[RunManifest](text)(using RunManifest.codec)
+
+  test("a manifest from an older build still decodes, unknown fields skipped"):
+    assertEquals(golden.orcaVersion, "0.1.0")
+    assertEquals(golden.workDir, "/home/user/project")
+    assertEquals(golden.pid, 4242L)
+    assertEquals(golden.startedAt, "2026-08-04T09:15:00Z")
+    assertEquals(golden.outcome, RunManifest.OutcomeSucceeded)
+
+  test("every session field of an older build's manifest survives the decode"):
+    val durable = golden.sessions.head
+    assertEquals(durable.harness, "claude-code")
+    assertEquals(durable.wireId, Some("0f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0"))
+    assertEquals(durable.agent, "implementer")
+    assertEquals(durable.role, Some("coding"))
+    assertEquals(durable.stage, Some("implement"))
+    assertEquals(durable.sessionName, Some("coder"))
+    assertEquals(durable.kind, RunManifest.KindDurable)
+    assertEquals(durable.firstSeenAt, "2026-08-04T09:16:03Z")
+    assertEquals(durable.lastActiveAt, "2026-08-04T09:47:55Z")
+    assertEquals(durable.resumable, true)
+
+  /** The wireId-less arm: `reason` present, `role`/`stage`/`sessionName`
+    * absent. Absent optionals are how the writer omits `None`, so this pins
+    * that an old file's omissions still read as `None` rather than failing.
+    */
+  test("an older manifest's one-shot session decodes with its fields absent"):
+    val oneShot = golden.sessions(1)
+    assertEquals(oneShot.wireId, None)
+    assertEquals(oneShot.reason, Some("codex sessions do not survive the run"))
+    assertEquals(oneShot.role, None)
+    assertEquals(oneShot.stage, None)
+    assertEquals(oneShot.sessionName, None)
+    assertEquals(oneShot.resumable, false)

--- a/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
@@ -69,7 +69,6 @@ class RunManifestWriterTest extends munit.FunSuite:
     )
     val manifest = soleManifest(workDir)
     assertEquals(manifest.outcome, "running")
-    assertEquals(manifest.manifestVersion, RunManifest.SupportedVersion)
     assertEquals(manifest.sessions.map(_.harness), List("claude"))
 
   test(

--- a/shell/src/main/scala/orca/shell/sessions/ManifestReader.scala
+++ b/shell/src/main/scala/orca/shell/sessions/ManifestReader.scala
@@ -69,11 +69,22 @@ private[shell] object ManifestReader:
   /** A manifest from any build decodes here: unknown fields are skipped, so
     * only a file missing something this build requires — or unreadable — is
     * refused (ADR 0021 §8 amendment, 2026-08-05).
+    *
+    * Only the first line of a decode failure is reported. jsoniter appends a
+    * multi-line hex dump of the buffer to its message, and `Main`'s loop
+    * reprints every warning on each menu redraw, for up to 20 kept manifests —
+    * so the untrimmed message paints the menu over. Same trimming, and same
+    * reason, as `ProgressStore.parseLog`.
     */
   private def readManifest(file: os.Path): Either[String, RunManifest] =
     try
       Right(readFromString[RunManifest](os.read(file))(using RunManifest.codec))
-    catch case NonFatal(e) => Left(s"skipping $file: ${e.getMessage}")
+    catch case NonFatal(e) => Left(s"skipping $file: ${firstLine(e)}")
+
+  private def firstLine(e: Throwable): String =
+    Option(e.getMessage)
+      .flatMap(_.linesIterator.nextOption())
+      .getOrElse(e.getClass.getSimpleName)
 
   /** The production value of [[list]]'s `pidAlive` parameter (ADR 0021 §8):
     * `ProcessHandle.of` finds nothing for a pid that's been reaped — treated as

--- a/shell/src/main/scala/orca/shell/sessions/ManifestReader.scala
+++ b/shell/src/main/scala/orca/shell/sessions/ManifestReader.scala
@@ -1,10 +1,6 @@
 package orca.shell.sessions
 
-import com.github.plokhotnyuk.jsoniter_scala.core.{
-  JsonValueCodec,
-  readFromString
-}
-import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
 import orca.OrcaDir
 import orca.runner.manifest.RunManifest
 
@@ -23,19 +19,17 @@ private[shell] case class RecordedRun(manifest: RunManifest, crashed: Boolean)
   */
 private[shell] object ManifestReader:
 
-  /** Newest-first by `startedAt`. Skips a file whose `manifestVersion` isn't
-    * the one this build writes, or whose `startedAt` doesn't parse as an
-    * `Instant` (a hand-edited or corrupt file — the writer always produces a
-    * well-formed one), collecting a notice naming the file into the returned
-    * warnings rather than guessing at an unknown schema or ordering it by a
-    * silent fallback timestamp. A manifest with `outcome: "running"` whose
-    * `pid` is no longer alive is a crashed run — its sessions are still
-    * offered, per ADR 0021 §8. Reads `.orca/cache/runs/` passively
-    * ([[OrcaDir.runsPath]], not [[OrcaDir.cacheRunsPath]]) — an absent or empty
-    * directory yields `(Nil, Nil)` without creating anything on disk. A file
-    * that fails to parse as JSON, or doesn't match the `RunManifest` schema, is
-    * skipped with a warning naming the file rather than aborting the whole
-    * listing.
+  /** Newest-first by `startedAt`. Skips a file that doesn't decode, or whose
+    * `startedAt` doesn't parse as an `Instant` (a hand-edited or corrupt file —
+    * the writer always produces a well-formed one), collecting a notice naming
+    * the file into the returned warnings rather than ordering it by a silent
+    * fallback timestamp. A manifest with `outcome: "running"` whose `pid` is no
+    * longer alive is a crashed run — its sessions are still offered, per ADR
+    * 0021 §8. Reads `.orca/cache/runs/` passively ([[OrcaDir.runsPath]], not
+    * [[OrcaDir.cacheRunsPath]]) — an absent or empty directory yields `(Nil,
+    * Nil)` without creating anything on disk. A file that fails to parse as
+    * JSON, or doesn't match the `RunManifest` schema, is skipped with a warning
+    * naming the file rather than aborting the whole listing.
     */
   def list(
       workDir: os.Path,
@@ -72,29 +66,14 @@ private[shell] object ManifestReader:
         warnings.reverse
       )
 
-  /** The version is read on its own, before the full decode, so a manifest
-    * written by another build is skipped by version rather than surfacing
-    * whichever field its schema happens to disagree about first.
+  /** A manifest from any build decodes here: unknown fields are skipped, so
+    * only a file missing something this build requires — or unreadable — is
+    * refused (ADR 0021 §8 amendment, 2026-08-05).
     */
   private def readManifest(file: os.Path): Either[String, RunManifest] =
     try
-      val text = os.read(file)
-      val version = readFromString[SchemaVersion](text).manifestVersion
-      if version != RunManifest.SupportedVersion then
-        Left(
-          s"skipping $file: manifestVersion $version, this build reads ${RunManifest.SupportedVersion}"
-        )
-      else Right(readFromString[RunManifest](text)(using RunManifest.codec))
+      Right(readFromString[RunManifest](os.read(file))(using RunManifest.codec))
     catch case NonFatal(e) => Left(s"skipping $file: ${e.getMessage}")
-
-  /** Just enough of a manifest to gate on: declaring one field is what lets
-    * this decode a manifest of any schema version, since everything else is
-    * then an unknown field, which jsoniter skips.
-    */
-  private case class SchemaVersion(manifestVersion: Int)
-
-  private given schemaVersionCodec: JsonValueCodec[SchemaVersion] =
-    JsonCodecMaker.make
 
   /** The production value of [[list]]'s `pidAlive` parameter (ADR 0021 §8):
     * `ProcessHandle.of` finds nothing for a pid that's been reaped — treated as

--- a/shell/src/test/scala/orca/shell/MainTest.scala
+++ b/shell/src/test/scala/orca/shell/MainTest.scala
@@ -110,7 +110,6 @@ class MainTest extends munit.FunSuite:
       sessions: List[ManifestSession]
   ): RunManifest =
     RunManifest(
-      manifestVersion = RunManifest.SupportedVersion,
       orcaVersion = "0.0.test",
       flow = Some("a-flow.sc"),
       workDir = workDir,

--- a/shell/src/test/scala/orca/shell/actions/SessionActionTest.scala
+++ b/shell/src/test/scala/orca/shell/actions/SessionActionTest.scala
@@ -23,7 +23,6 @@ class SessionActionTest extends munit.FunSuite:
 
   private def manifest(s: ManifestSession): RunManifest =
     RunManifest(
-      manifestVersion = RunManifest.SupportedVersion,
       orcaVersion = "0.0.test",
       flow = Some("a-flow.sc"),
       workDir = "/work",

--- a/shell/src/test/scala/orca/shell/cli/CliTest.scala
+++ b/shell/src/test/scala/orca/shell/cli/CliTest.scala
@@ -736,7 +736,6 @@ class CliTest extends munit.FunSuite:
       sessions: List[ManifestSession]
   ): RunManifest =
     RunManifest(
-      manifestVersion = RunManifest.SupportedVersion,
       orcaVersion = "0.0.test",
       flow = Some("a-flow.sc"),
       workDir = workDir,
@@ -939,28 +938,29 @@ class CliTest extends munit.FunSuite:
 
   // --- stdout/stderr separation (CLI review finding 1) ---
 
-  private def writeFutureManifest(dir: os.Path): Unit =
+  /** A manifest missing the required `workDir` — the reader refuses it and
+    * warns, which is what this test needs a warning for.
+    */
+  private def writeUnreadableManifest(dir: os.Path): Unit =
     val json =
-      s"""{
-        |  "manifestVersion": ${RunManifest.SupportedVersion + 1},
+      """{
         |  "orcaVersion": "0.0.test",
-        |  "workDir": "/work",
         |  "pid": 1,
         |  "startedAt": "2026-07-18T09:00:00Z",
         |  "outcome": "succeeded",
         |  "sessions": []
         |}""".stripMargin
     os.write(
-      dir / ".orca" / "cache" / "runs" / "future.json",
+      dir / ".orca" / "cache" / "runs" / "unreadable.json",
       json,
       createFolders = true
     )
 
   test(
-    "runContinue --list --json: a manifestVersion warning lands on stderr, only JSON on stdout"
+    "runContinue --list --json: a skipped-manifest warning lands on stderr, only JSON on stdout"
   ):
     val dir = TempDirs.dir()
-    writeFutureManifest(dir)
+    writeUnreadableManifest(dir)
     val (out, err) = capturedBoth(
       assertEquals(
         ContinueCli
@@ -969,17 +969,11 @@ class CliTest extends munit.FunSuite:
       )
     )
     assertEquals(out.trim, "[]")
-    assert(
-      err.contains(
-        s"manifestVersion ${RunManifest.SupportedVersion + 1}, this build reads"
-      ),
-      err
-    )
+    assert(err.contains("unreadable.json"), err)
 
   private def writeCrashedManifest(dir: os.Path): Unit =
     val json =
       s"""{
-        |  "manifestVersion": ${RunManifest.SupportedVersion},
         |  "orcaVersion": "0.0.test",
         |  "workDir": "/work",
         |  "pid": 999999,
@@ -1045,7 +1039,6 @@ class CliTest extends munit.FunSuite:
     val goneWorkDir = (dir / "gone").toString
     val json =
       s"""{
-        |  "manifestVersion": ${RunManifest.SupportedVersion},
         |  "orcaVersion": "0.0.test",
         |  "workDir": "$goneWorkDir",
         |  "pid": 1,

--- a/shell/src/test/scala/orca/shell/sessions/ManifestReaderTest.scala
+++ b/shell/src/test/scala/orca/shell/sessions/ManifestReaderTest.scala
@@ -91,8 +91,9 @@ class ManifestReaderTest extends munit.FunSuite:
     )
     assertEquals(warnings, Nil)
 
-  test("list skips a manifest missing a required field, warning by filename"):
+  test("a skipped manifest is warned about without sinking the listing"):
     val workDir = TempDirs.dir()
+    writeManifest(workDir, "good.json", startedAt = "2026-07-18T11:00:00Z")
     os.write(
       runsDir(workDir) / "no-workdir.json",
       """{
@@ -105,7 +106,7 @@ class ManifestReaderTest extends munit.FunSuite:
       createFolders = true
     )
     val (runs, warnings) = ManifestReader.list(workDir, alwaysDead)
-    assertEquals(runs, Nil)
+    assertEquals(runs.map(_.manifest.startedAt), List("2026-07-18T11:00:00Z"))
     assertEquals(warnings.size, 1)
     assert(
       warnings.head.contains("no-workdir.json"),
@@ -117,6 +118,8 @@ class ManifestReaderTest extends munit.FunSuite:
     */
   test("list skips a manifest with no sessions array, warning by filename"):
     val workDir = TempDirs.dir()
+    // `sessions` is the ONLY field omitted, so this fails for that reason and
+    // no other — the point being that it must not read as an empty list.
     os.write(
       runsDir(workDir) / "no-sessions.json",
       """{
@@ -124,7 +127,20 @@ class ManifestReaderTest extends munit.FunSuite:
         |  "workDir": "/work",
         |  "pid": 111,
         |  "startedAt": "2026-07-18T10:00:00Z",
-        |  "outcome": "succeeded"
+        |  "outcome": "succeeded",
+        |  "cost": {
+        |    "total": {
+        |      "inputTokens": 0,
+        |      "outputTokens": 0,
+        |      "cacheReadInputTokens": 0,
+        |      "cacheWriteInputTokens": 0,
+        |      "reasoningOutputTokens": 0
+        |    },
+        |    "byRole": [],
+        |    "byAgent": [],
+        |    "byStage": []
+        |  },
+        |  "turns": []
         |}""".stripMargin,
       createFolders = true
     )
@@ -132,8 +148,9 @@ class ManifestReaderTest extends munit.FunSuite:
     assertEquals(runs, Nil)
     assertEquals(warnings.size, 1)
     assert(
-      warnings.head.contains("no-sessions.json"),
-      s"expected the filename in the warning, got: ${warnings.head}"
+      warnings.head.contains("no-sessions.json") &&
+        warnings.head.contains("sessions"),
+      s"expected the filename and field in the warning, got: ${warnings.head}"
     )
 
   test("a running manifest with a dead pid is included and marked crashed"):

--- a/shell/src/test/scala/orca/shell/sessions/ManifestReaderTest.scala
+++ b/shell/src/test/scala/orca/shell/sessions/ManifestReaderTest.scala
@@ -1,7 +1,6 @@
 package orca.shell.sessions
 
 import orca.OrcaFlowException
-import orca.runner.manifest.RunManifest
 import orca.testkit.TempDirs
 
 class ManifestReaderTest extends munit.FunSuite:
@@ -16,13 +15,14 @@ class ManifestReaderTest extends munit.FunSuite:
       workDir: os.Path,
       name: String,
       startedAt: String,
-      manifestVersion: Int = RunManifest.SupportedVersion,
       pid: Long = 111,
-      outcome: String = "succeeded"
+      outcome: String = "succeeded",
+      // Spliced in verbatim, to plant a field this build does not declare.
+      extraField: String = ""
   ): Unit =
     val json =
       s"""{
-         |  "manifestVersion": $manifestVersion,
+         |  $extraField
          |  "orcaVersion": "0.0.test",
          |  "workDir": "${workDir.toString}",
          |  "pid": $pid,
@@ -71,18 +71,32 @@ class ManifestReaderTest extends munit.FunSuite:
       )
     )
 
-  test(
-    "an older manifest is skipped by version, leaving the current one listed"
-  ):
+  /** The version gate is gone (ADR 0021 §8 amendment, 2026-08-05), so a
+    * `manifestVersion` on disk is just an unknown field. Manifests predating
+    * `cost`/`turns` list too once those fields leave this schema.
+    */
+  test("a manifest carrying an older manifestVersion is listed, not skipped"):
     val workDir = TempDirs.dir()
-    // A verbatim v2 manifest: it also lacks v3's `cost`/`turns`, so this only
-    // passes if the version is checked before the body is decoded.
+    writeManifest(
+      workDir,
+      "v2.json",
+      startedAt = "2026-07-18T10:00:00Z",
+      extraField = """"manifestVersion": 2,"""
+    )
+    writeManifest(workDir, "current.json", startedAt = "2026-07-18T11:00:00Z")
+    val (runs, warnings) = ManifestReader.list(workDir, alwaysDead)
+    assertEquals(
+      runs.map(_.manifest.startedAt),
+      List("2026-07-18T11:00:00Z", "2026-07-18T10:00:00Z")
+    )
+    assertEquals(warnings, Nil)
+
+  test("list skips a manifest missing a required field, warning by filename"):
+    val workDir = TempDirs.dir()
     os.write(
-      runsDir(workDir) / "v2.json",
+      runsDir(workDir) / "no-workdir.json",
       """{
-        |  "manifestVersion": 2,
         |  "orcaVersion": "0.0.test",
-        |  "workDir": "/work",
         |  "pid": 111,
         |  "startedAt": "2026-07-18T10:00:00Z",
         |  "outcome": "succeeded",
@@ -90,32 +104,35 @@ class ManifestReaderTest extends munit.FunSuite:
         |}""".stripMargin,
       createFolders = true
     )
-    writeManifest(workDir, "current.json", startedAt = "2026-07-18T11:00:00Z")
     val (runs, warnings) = ManifestReader.list(workDir, alwaysDead)
-    assertEquals(runs.map(_.manifest.startedAt), List("2026-07-18T11:00:00Z"))
+    assertEquals(runs, Nil)
     assertEquals(warnings.size, 1)
     assert(
-      warnings.head.contains("v2.json") && warnings.head.contains(
-        "manifestVersion 2"
-      ),
-      s"expected the filename and version in the warning, got: ${warnings.head}"
+      warnings.head.contains("no-workdir.json"),
+      s"expected the filename in the warning, got: ${warnings.head}"
     )
 
-  test(
-    "list skips a manifestVersion newer than this build writes, warning by filename"
-  ):
+  /** `sessions` is the one collection the codec keeps strict: absent must not
+    * read as empty, or the menu offers a "(0 session(s))" row leading nowhere.
+    */
+  test("list skips a manifest with no sessions array, warning by filename"):
     val workDir = TempDirs.dir()
-    writeManifest(
-      workDir,
-      "future.json",
-      startedAt = "2026-07-18T10:00:00Z",
-      manifestVersion = RunManifest.SupportedVersion + 1
+    os.write(
+      runsDir(workDir) / "no-sessions.json",
+      """{
+        |  "orcaVersion": "0.0.test",
+        |  "workDir": "/work",
+        |  "pid": 111,
+        |  "startedAt": "2026-07-18T10:00:00Z",
+        |  "outcome": "succeeded"
+        |}""".stripMargin,
+      createFolders = true
     )
     val (runs, warnings) = ManifestReader.list(workDir, alwaysDead)
     assertEquals(runs, Nil)
     assertEquals(warnings.size, 1)
     assert(
-      warnings.head.contains("future.json"),
+      warnings.head.contains("no-sessions.json"),
       s"expected the filename in the warning, got: ${warnings.head}"
     )
 


### PR DESCRIPTION
First of four PRs implementing the ADR 0021 §8 amendment (#92). Tasks T1 and T2 of the plan.

## What was wrong

The manifest at `.orca/cache/runs/<id>.json` carried a `manifestVersion`, and the shell matched it exactly in both directions — any other value and the file was skipped.

The manifest holds two unrelated things: the sessions the shell offers under "continue a session", and cost and turn data written for debugging. The session half has not changed since the manifest shipped in #27. Every version bump since — #61, #64, #71, #77 — was cost or turn work. So adding a cost field made the shell skip every manifest the previous build wrote, and the user lost "continue a session" for those runs, for a change that had nothing to do with sessions.

## What this does

Removes `manifestVersion`, `RunManifest.SupportedVersion`, and the reader's pre-decode version check. jsoniter already skipped unknown fields, so a manifest written by an older build now lists instead of being refused.

The codec stays strict, which is deliberate and worth spelling out: strictness only forces *collection* fields to be present, and `sessions` is one field whose absence must not read as empty. The menu renders the count verbatim, so a silently empty list becomes a "Continue a session from the last flow run (0 session(s))" row leading to an empty picker. Switching to the progress log's tolerant config would have introduced exactly that.

What replaces the gate is a rule about writing rather than reading: fields added from here on are optional, and nothing is renamed, retyped, or has its wire strings respelled.

## The frozen fixture

The rule needs something holding it. Nothing in the repo did: every manifest fixture is hand-built inside its own test and gets updated in the same commit as the schema, so none of them can catch a field becoming required.

So this adds `runner/src/test/resources/orca/manifest/golden-run-manifest.json` — a literal manifest as an older build wrote it, which no schema change may edit — and a test that decodes it. It still carries `manifestVersion`, `cost.cost` and per-turn `promptTokens`, fields this build no longer declares, because skipping them is the behaviour under test.

Mutation-checked: adding a required field to `RunManifest` makes exactly the three golden tests fail.

## Tests

The two version-gate cases in `ManifestReaderTest` are replaced by three that pin what the reader does now — an old `manifestVersion` is listed rather than skipped, a manifest missing a required field is skipped with a warning, and a manifest with no `sessions` array is skipped rather than read as empty.

`CliTest`'s stdout/stderr separation test provoked its warning with a future version number, which no longer produces one. It now uses a manifest missing `workDir`, which also covers the required-field check.

## Note

`cost` and `turns` are still on `RunManifest` here. They move to a separate append-only file in the next PR, which is when manifests predating those fields start decoding too.
