### PR TITLE
Widen the readability reviewer's comment check

### DIFF
--- a/flow/src/main/resources/orca/review/prompts/reviewers/readability.md
+++ b/flow/src/main/resources/orca/review/prompts/reviewers/readability.md
@@ -14,9 +14,11 @@ reviewers. Don't chase formatting the project's formatter handles.
 - **Names**: variables, functions, types — do they say what they are? Flag
   ambiguous, misleading, or overly abstract names. Flag boolean parameters whose
   meaning isn't obvious at the call site.
-- **Comments**: explain *why*, not *what*. Flag comments that restate the code,
-  are out of date, or could be replaced by a better name. Flag absent comments
-  where non-obvious reasoning is needed.
+- **Comments**: explain *why*, not *what*, in as few words as the fact needs.
+  Flag comments that restate the code, narrate change history ("used to be X",
+  "no longer does Y"), assert something unverified, or repeat a fact already
+  stated elsewhere in the change. Flag absent comments where non-obvious
+  reasoning is needed.
 - **Control flow**: deep nesting, long methods, dense conditionals. Suggest
   early returns, named helpers, or pattern matching when they'd clarify.
 - **Magic values**: unexplained literals/strings/numbers in the middle of logic.


### PR DESCRIPTION
The readability reviewer is the only one of the eight that mentions comments. Its bullet said:

> explain *why*, not *what*. Flag comments that restate the code, are out of date, or could be replaced by a better name.

Two gaps. "Out of date" means wrong, so a comment like "these used to be `--allowedTools` patterns" is accurate and passes. And nothing covers length, so a 31-line scaladoc that is all "why" passes too.

That showed up in PR #89: production Scala there is 3.8:1 comments to code, and six facts are stated 22 times across 7 files.

The other reviewers do not cover it either. `code-structure` scopes duplication to "same logic". `simplicity` asks exactly the right question — could this do the same job with less? — but its scope line says "flag complexity, not bugs or style", and it closes with "don't mistake terseness for simplicity".

## The change

The bullet now also flags length, change history, unverified claims, and a fact already stated elsewhere in the change.

Three choices worth noting:

- Brevity is tied to the number of facts, not a line count. A line count invites noise and is easy to game.
- Duplication is scoped to "elsewhere in the change", which stays inside this reviewer's remit — `initial-review.md` hands it the whole diff.
- The two banned phrasings are spelled out so the check is mechanical rather than a judgement call.

`code-structure` and `simplicity` are left alone. Widening `simplicity` to prose would collide with its own "clarity still wins" principle.

## Review

The bullet grows by one line. If it reads as bloat, that is the same failure it is meant to catch.