### PR TITLE
Fix the manifest write gate, and stop manifest-less runs evicting continuable ones

### DIFF
--- a/adr/0021-orca-shell.md
+++ b/adr/0021-orca-shell.md
@@ -656,10 +656,17 @@ resume is global, but the resumed context still references that directory):
 > session commit grows without bound, which is the very case this change starts
 > recording.
 >
-> One stated trade-off: a run that spends tokens without committing a session now
-> occupies a retention slot where it previously wrote nothing, so the shell's
-> listing can hold fewer than 20 *continuable* runs. Rare, and preferable to
-> unbounded growth.
+> A run that spends tokens without committing a session is the common case, not
+> a rare one: every fresh run names its branch through a cheap agent call
+> (`BranchNamingStrategy.shortenPrompt`) before its first stage, so one cancelled
+> at the plan prompt leaves a cost log and no manifest. Ranked by run id alone,
+> twenty such runs would empty the shell's listing. Retention therefore keeps two
+> sets of 20: the newest runs that own a manifest, and the newest runs of any
+> kind. The first holds the listing at 20 continuable runs however many
+> manifest-less runs pile up; the second bounds a workdir that stops producing
+> manifests altogether, where the first has nothing to rank against. A run's
+> files are still kept or deleted together, so a cost log never outlives its
+> manifest. The directory holds between 20 and 40 runs.
 >
 > **This needs a carve-out in the 0.x versioning rule.** AGENTS.md forbids
 > default values on persisted fields and forbids back-compat machinery outright,

--- a/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
@@ -104,8 +104,9 @@ private[runner] class RunManifestWriterState(
 
   private val log = LoggerFactory.getLogger("orca.flow")
 
-  /** How many of the newest RUNS `pruneOldManifests` keeps — a run owns up to
-    * two files.
+  /** The size of each of `pruneOldRuns`' two kept sets ([[keptRunIds]]) — a run
+    * owns up to two files, and the sets overlap, so the runs directory holds
+    * between this many and twice this many runs.
     */
   private val MaxKeptRuns = 20
 
@@ -354,32 +355,66 @@ private[runner] class RunManifestWriterState(
   private def pruneOnce(): Unit =
     if !state.prunedOnce then
       state = state.copy(prunedOnce = true)
-      pruneOldManifests(OrcaDir.cacheRunsPath(workDir))
+      pruneOldRuns(OrcaDir.cacheRunsPath(workDir))
 
-  /** Keeps the newest [[MaxKeptRuns]] runs, deleting both files of each older
-    * one. Grouping by run id rather than counting files is what keeps the
-    * budget in runs, and what stops a cost log outliving the manifest it
-    * belongs to. Run ids sort chronologically as strings (fixed-width epoch
-    * prefix); a run with only one of its two files is still one run.
+  /** Deletes every file of every run outside [[keptRunIds]]. Grouping by run id
+    * rather than counting files is what keeps the budget in runs, and what
+    * stops a cost log outliving the manifest it belongs to.
     *
     * Fully best-effort — the listing itself and each delete are both guarded —
     * since a failure here (a vanished dir, a concurrent cleanup) must not turn
     * into a quarantined listener or an aborted write.
     */
-  private def pruneOldManifests(dir: os.Path): Unit =
+  private def pruneOldRuns(dir: os.Path): Unit =
     try
-      os.list(dir)
-        .groupBy(runIdOf)
-        .toList
-        .collect { case (Some(id), files) => (id, files) }
-        .sortBy((id, _) => id)
-        .reverse
-        .drop(MaxKeptRuns)
-        .flatMap((_, files) => files)
-        .foreach: p =>
-          try os.remove(p)
-          catch case NonFatal(_) => ()
+      val runs = runsNewestFirst(dir)
+      val kept = keptRunIds(runs)
+      for
+        (id, files) <- runs if !kept.contains(id)
+        file <- files
+      do
+        try os.remove(file)
+        catch case NonFatal(_) => ()
     catch case NonFatal(_) => ()
+
+  /** A run's id and the files it left in `.orca/cache/runs/`. */
+  private type Run = (String, Seq[os.Path])
+
+  /** Runs newest first. Run ids sort chronologically as strings (fixed-width
+    * epoch prefix); a run with only one of its two files is still one run.
+    */
+  private def runsNewestFirst(dir: os.Path): List[Run] =
+    os.list(dir)
+      .groupBy(runIdOf)
+      .toList
+      .collect { case (Some(id), files) => (id, files.toSeq) }
+      .sortBy((id, _) => id)
+      .reverse
+
+  /** Two kept sets: the newest [[MaxKeptRuns]] runs that own a manifest, and
+    * the newest [[MaxKeptRuns]] runs of any kind.
+    *
+    * The first is what keeps the shell's "continue a session" list full.
+    * Manifest-less runs are common — every fresh run spends tokens naming its
+    * branch (`BranchNamingStrategy.shortenPrompt`) before its first stage, so
+    * one cancelled at the plan prompt leaves a cost log and nothing else — and
+    * on the newest-first ranking alone [[MaxKeptRuns]] of them would evict
+    * every continuable run.
+    *
+    * The second bounds a workdir that stops producing manifests altogether,
+    * where the first set alone has nothing to rank against.
+    */
+  private def keptRunIds(newestFirst: List[Run]): Set[String] =
+    def newest(runs: List[Run]): Set[String] =
+      runs.take(MaxKeptRuns).map((id, _) => id).toSet
+    newest(newestFirst.filter((_, files) => files.exists(isManifest))) ++
+      newest(newestFirst)
+
+  /** `ext == "json"` is also the shell's listing filter
+    * (`ManifestReader.list`), so "owns a manifest" means "the shell can offer
+    * this run's sessions".
+    */
+  private def isManifest(file: os.Path): Boolean = file.ext == "json"
 
   /** The run a file in `.orca/cache/runs/` belongs to, or `None` for anything
     * this writer didn't produce (a leftover temp file, a stray edit).

--- a/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
@@ -178,11 +178,13 @@ private[runner] class RunManifestWriterState(
       // Guarded because `upsertSession` reads `.orca/` to name the session: an
       // unreadable or vanished directory would otherwise throw straight out of
       // the `tell` handler and quarantine the writer for the rest of the run.
+      // Swallowing that leaves no entry, so the write stays gated — a manifest
+      // listing no sessions is a dead row in the shell's menu.
       guarded("session upsert"):
         state = state.copy(entries =
           upsertSession(harness, clientId, wireId, agent, role)
         )
-      safeWrite()
+      if hasCommittedSession then safeWrite()
     case OrcaEvent.TokensUsed(agent, model, usage, role, attempt, session) =>
       if !state.anyTurnRecorded then
         guarded("cost log header"):

--- a/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
@@ -38,6 +38,11 @@ class RunManifestWriterTest extends munit.FunSuite:
   private def manifestFiles(workDir: os.Path): List[os.Path] =
     os.list(OrcaDir.cacheRunsPath(workDir)).filter(_.ext == "json").toList
 
+  private def costLogFiles(workDir: os.Path): List[os.Path] =
+    os.list(OrcaDir.cacheRunsPath(workDir))
+      .filter(_.last.endsWith("-cost.jsonl"))
+      .toList
+
   private def readManifest(path: os.Path): RunManifest =
     readFromString[RunManifest](os.read(path))(using RunManifest.codec)
 
@@ -335,7 +340,41 @@ class RunManifestWriterTest extends munit.FunSuite:
     val writer =
       newWriter(workDir, fixedClock(Instant.parse("2026-07-18T10:00:00Z")))
     writer.onEvent(OrcaEvent.TokensUsed("claude", None, Usage(10, 1, None)))
-    assertEquals(manifestFiles(workDir).size, 19)
+    assert(
+      !os.exists(runsDir / "1000000000001-1.json"),
+      "the oldest of 25 seeded runs must be gone"
+    )
+
+  /** A run that spends tokens without committing a session is the norm, not the
+    * exception: every fresh run names its branch with a cheap agent call before
+    * its first stage. Ranked by run id alone, twenty of them would empty the
+    * shell's "continue a session" list.
+    */
+  test("manifest-less runs never evict a run that owns a manifest"):
+    val workDir = TempDirs.dir()
+    val runsDir = OrcaDir.cacheRunsPath(workDir)
+    for i <- 1 to 20 do os.write(runsDir / f"1000000000$i%03d-1.json", "{}")
+    for i <- 21 to 40 do
+      os.write(runsDir / f"1000000000$i%03d-1-cost.jsonl", "")
+    val writer =
+      newWriter(workDir, fixedClock(Instant.parse("2026-07-18T10:00:00Z")))
+    writer.onEvent(OrcaEvent.TokensUsed("claude", None, Usage(10, 1, None)))
+    assertEquals(manifestFiles(workDir).size, 20)
+
+  /** Keeping every manifest-less run newer than the oldest kept manifest would
+    * grow without bound in a workdir that stops committing sessions, so they
+    * are ranked among themselves too.
+    */
+  test("manifest-less runs are bounded even where no manifest is evicted"):
+    val workDir = TempDirs.dir()
+    val runsDir = OrcaDir.cacheRunsPath(workDir)
+    for i <- 1 to 20 do os.write(runsDir / f"1000000000$i%03d-1.json", "{}")
+    for i <- 21 to 60 do
+      os.write(runsDir / f"1000000000$i%03d-1-cost.jsonl", "")
+    val writer =
+      newWriter(workDir, fixedClock(Instant.parse("2026-07-18T10:00:00Z")))
+    writer.onEvent(OrcaEvent.TokensUsed("claude", None, Usage(10, 1, None)))
+    assertEquals(costLogFiles(workDir).size, 20)
 
   /** The upsert reads `.orca/` to name the session, and its failure is
     * swallowed. An execute-only `.orca/` makes that `os.list` fail while writes

--- a/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
@@ -337,6 +337,39 @@ class RunManifestWriterTest extends munit.FunSuite:
     writer.onEvent(OrcaEvent.TokensUsed("claude", None, Usage(10, 1, None)))
     assertEquals(manifestFiles(workDir).size, 19)
 
+  /** The upsert reads `.orca/` to name the session, and its failure is
+    * swallowed. An execute-only `.orca/` makes that `os.list` fail while writes
+    * into `.orca/cache/runs/` still succeed — the mode is ignored for root, so
+    * the test checks the setup took before relying on it.
+    */
+  test("a failed session upsert leaves no manifest behind"):
+    val workDir = TempDirs.dir()
+    val writer =
+      newWriter(workDir, fixedClock(Instant.parse("2026-07-18T10:00:00Z")))
+    val orcaDir = OrcaDir.rootPath(workDir)
+    os.perms.set(orcaDir, "--x--x--x")
+    try
+      assume(
+        scala.util.Try(os.list(orcaDir)).isFailure,
+        "needs a user that file permissions apply to"
+      )
+      writer.onEvent(
+        OrcaEvent
+          .SessionCommitted(
+            "claude",
+            "client-1",
+            Some("wire-1"),
+            "claude",
+            None
+          )
+      )
+      assertEquals(
+        manifestFiles(workDir),
+        Nil,
+        "a manifest with no sessions must not be created"
+      )
+    finally os.perms.set(orcaDir, "rwx------")
+
   test("atomic write leaves no temp files behind"):
     val workDir = TempDirs.dir()
     val writer =


### PR DESCRIPTION
Two defects in `RunManifestWriter` that #97 left on master. Both touch the same
file, so they ship as one PR with a commit each.

## 1. The `SessionCommitted` branch wrote unconditionally

The guard covered only the state update:

```scala
guarded("session upsert"):
  state = state.copy(entries = upsertSession(...))
safeWrite()          // ran even when the upsert threw
```

`upsertSession` reads `.orca/` to name the session, so an unreadable or vanished
directory left `entries` empty — and the writer still created `<id>.json` with
`"sessions":[]`. The shell then renders "Continue a session from the last flow
run (0 session(s))", the dead menu row the creation gate and the strict
`sessions` codec both exist to prevent.

The write is now gated on `hasCommittedSession`, matching the stage branches a
few lines above. That predicate is `state.entries.nonEmpty`, which is exactly
"we have at least one session to write": a failed upsert leaves `entries`
untouched, and a run that committed a session earlier still writes.

Before #97 the same failure threw out of the `tell` handler — that quarantined
the writer, which was also wrong, but it left no file.

**Test.** `.orca/` is made execute-only, so `os.list` inside the upsert fails
while writes into `.orca/cache/runs/` still succeed. File modes are ignored for
root, so the test checks the setup actually took before relying on it.

## 2. Retention counted manifest-less runs against continuable ones

`MaxKeptRuns = 20` counted runs, and a run that writes only a cost log took a
slot. The ADR called that "rare, and preferable to unbounded growth". It is not
rare.

`BaseAgent.quietTextTurn` emits `TokensUsed` and never `SessionCommitted` —
deliberate, and pinned by `BaseAgentTest`. Every fresh run reaches it during
setup, before any stage: `FlowLifecycle` picks
`BranchNamingStrategy.shortenPrompt` as the default naming strategy, which calls
`Agent.cheapOneShot`, which calls `quietTextTurn`. So a cost log exists and
`pruneOnce()` has already fired before the flow's first stage. Any run that dies
between branch creation and the first `SessionCommitted` — Ctrl-C at the plan
prompt, a setup failure — leaves a cost-log-only run holding a slot. Twenty of
those and the shell's list is empty. Only `--skip-branch` avoids the call.

### The rule

Retention keeps two sets of `MaxKeptRuns` runs, ranked by run id:

- the newest that own a manifest — this restores 20 continuable runs;
- the newest of any kind — this bounds the directory.

A run outside both loses all its files, so a run's two files are still kept or
deleted together and a cost log never outlives its manifest. The directory now
holds between 20 and 40 runs.

**Deviation from the review's shape.** The review proposed keeping the newest 20
manifest-owning runs and deleting manifest-less runs below the oldest kept
manifest. That has no bound above the floor: manifest-less runs newer than the
oldest kept manifest are all kept, so a workdir that stops committing sessions
grows forever — and with fewer than 20 manifests there is no floor at all, so
nothing is ever deleted. That is the exact failure #98 moved the prune trigger
to close. Ranking manifest-less runs among themselves as well costs one extra
selection and keeps the bound.

`adr/0021-orca-shell.md` is corrected to state what the fix guarantees instead
of calling the old behaviour rare.

## Mutation checks

Each mutation was applied, the suite run, and the mutation reverted.

| Mutation | Failing test |
| --- | --- |
| `safeWrite()` unconditional in the `SessionCommitted` branch | `a failed session upsert leaves no manifest behind` — only |
| drop the manifest-owning kept set (rank by run id alone) | `manifest-less runs never evict a run that owns a manifest` — only |
| replace the any-kind kept set with the review's floor rule | `manifest-less runs are bounded even where no manifest is evicted` — only |

One pre-existing test changed shape. `a run that only ever appends cost lines
still prunes` asserted a manifest count, which under the new rule also encodes
the ranking the two new tests own. It now asserts the oldest seeded run is gone,
which is what it was actually about — the trigger sitting on the first write of
either file. Re-checked against #98's own mutation (moving `pruneOnce()` back
onto the manifest write path): it still fails.

`sbt scalafmtCheckAll` clean, `sbt clean compile test` green with zero warnings.
