### PR TITLE
Three prose fixes after the read-only repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,8 @@ which tools exist at all:
 val reviewer = claude.withReadOnly
 
 // NetworkOnly — reads plus read-only network (web, and on claude a host-served
-// GitHub issue/PR read), for planners that must read an issue/PR. The no-edit
-// guarantee is hard on claude and opencode, prompt-only on pi/codex/gemini
-// (ADR 0016).
+// GitHub issue/PR read), for planners that must read an issue/PR. How strongly
+// each backend blocks edits varies — see the enforcement matrix in AGENTS.md.
 val planner = claude.withNetworkOnly
 
 // Full (the default) — write-capable.

--- a/README.md
+++ b/README.md
@@ -386,8 +386,8 @@ files, single-valued (a repeated agent key is an error). Value grammar:
 unrecognised name is an error naming the valid set). The model part is passed
 **verbatim** to the harness's `withModel` — orca does not normalise or validate
 model ids, except that claude's bare `haiku` alias is sent as
-`claude-haiku-4-5`, since the CLI serves Sonnet for the alias on the read-only
-turns reviewers use. For example:
+`claude-haiku-4-5`, so a `claude:haiku` pin cannot land on a pricier tier when
+the CLI resolves the alias. For example:
 
 ```properties
 planningAgent = claude:opus

--- a/adr/0016-toolset-capability-axis-and-planner-network.md
+++ b/adr/0016-toolset-capability-axis-and-planner-network.md
@@ -33,7 +33,8 @@ the orthogonal **prompting axis** (which available tools auto-approve, only
 meaningful interactively and consulted only on `Full`). Only the two autonomous
 planner entry points (`Plan.autonomousResult` → `from`/`assessThenPlan`/`triage`)
 select `NetworkOnly`; reviewers, `reviewed`/`briefed`, selection and lint keep
-`ReadOnly`, hard everywhere.
+`ReadOnly`. How strongly each backend enforces either tier is the enforcement
+matrix in `AGENTS.md`, machine-checked by `EnforcementTableTest`.
 
 ### Per-backend `NetworkOnly` mapping
 

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -51,12 +51,9 @@ private[claude] object ClaudeArgs:
       jsonSchemaArgs(jsonSchema) ++
       mcpConfigArgs(mcpConfig)
 
-  /** `--model`, with the bare `haiku` alias replaced by its fully-qualified id.
-    *
-    * Under `--permission-mode plan` the CLI served `claude-sonnet-5` for
-    * `--model haiku` — 3x the intended rate for a `claude:haiku` role pin
-    * (measured on 2.1.220). Measured fixed on 2.1.222, but the qualified id is
-    * the cheaper failure mode. Only `haiku` is rewritten; leaving
+  /** `--model`, with the bare `haiku` alias replaced by its fully-qualified id:
+    * the CLI resolves the alias, and a `claude:haiku` role pin must not land on
+    * a pricier tier. Only `haiku` is rewritten — leaving
     * `sonnet`/`opus`/`fable` bare keeps them tracking their tier's latest.
     */
   private def modelArgs(config: AgentConfig): Seq[String] =
@@ -96,20 +93,13 @@ private[claude] object ClaudeArgs:
     CliArgs.flag("--mcp-config", file)(_.toString)
 
   /** Built-in tools a read-only turn keeps. `--tools` is an allowlist that
-    * removes every name not on it: the dropped tools are absent from the `init`
-    * frame and `ToolSearch` cannot resurrect them, so reviewers and planners
-    * have no shell and no write primitive.
+    * removes every name not on it: a dropped tool is absent from the `init`
+    * frame and `ToolSearch` cannot resurrect it, so reviewers and planners have
+    * no shell and no write primitive.
     *
-    * **It does not survive `--resume`.** Measured on 2.1.222: resuming a
-    * session created under this list, without re-passing `--tools`, brings back
-    * the full default set — `Bash`, `Edit`, `Write` and all. [[streamJson]]
-    * rebuilds the flags from each turn's own config, which is what keeps a
-    * resumed reviewer restricted; a resume path that reused stored args would
-    * not.
-    *
-    * Unknown names are dropped silently (`Read,Grep,NoSuchTool` yields
-    * `Grep,Read`, exit 0, no warning), so this list is pinned against a live
-    * CLI by `ClaudeIntegrationTest`.
+    * Nothing fails if a name here goes stale — the CLI drops a name it doesn't
+    * recognise without a warning, and the one check of this list against a live
+    * CLI (`ClaudeIntegrationTest`) runs only under `ORCA_INTEGRATION`.
     */
   private[claude] val ReadOnlyTools: Seq[String] =
     Seq("Read", "Grep", "Glob", "Skill")
@@ -117,30 +107,15 @@ private[claude] object ClaudeArgs:
   /** Maps [[AgentConfig.tools]] to claude's tool and permission flags.
     *
     * Both read-only tiers pass `--tools` (see [[ReadOnlyTools]]); `NetworkOnly`
-    * appends `networkTools` to it. Not `--permission-mode plan`: that removed
-    * no tools at all (`docs/research/run-cost/09-diff-vs-coordinates.md` §2).
-    *
-    * Both tiers also [[approve]] what they must be able to call: `mcpTools`,
-    * plus `networkTools` on `NetworkOnly`. Without that grant those names are
-    * advertised but not runnable. The two flags compose: `--allowedTools`
-    * grants, `--tools` still bounds the surface. Verified on claude 2.1.223 in
-    * the order emitted here, and pinned by `ClaudeIntegrationTest`.
-    *
-    * `--tools` is not a complete boundary: MCP tools pass through it
-    * unfiltered. Measured on claude 2.1.222 — an `init` frame under `--tools
-    * Read,Grep,Glob,Skill` still carried the `mcp__…` tools of an installed
-    * server, so an MCP server that can write is not covered by this allowlist
-    * at all. Advertised is not callable, though: the read-only tiers ignore
-    * [[AgentConfig.autoApprove]], so an MCP tool they are meant to use must be
-    * named in `mcpTools`. An un-named one comes back as a failed `tool_result`
-    * rather than prompting.
+    * appends `networkTools` to it. Both also [[approve]] what they must be able
+    * to call: `mcpTools`, plus `networkTools` on `NetworkOnly`. These tiers
+    * ignore [[AgentConfig.autoApprove]], so an MCP tool such a turn is meant to
+    * use has to arrive through `mcpTools`.
     *
     * `Full` follows [[AgentConfig.autoApprove]]: `All` → `bypassPermissions`;
-    * `Only(_)` → default permission mode plus `--allowedTools`. The allowlist
-    * adds to claude's defaults; it does not restrict the agent to the listed
-    * tools. Under `--print` nothing is prompted back to orca: a call the CLI
-    * won't run comes back as a failed `tool_result` (pinned by
-    * `ClaudeIntegrationTest`).
+    * `Only(_)` → default permission mode plus `--allowedTools`. Unlike
+    * `--tools`, that allowlist adds to claude's defaults rather than confining
+    * the agent to the names listed.
     *
     * Both flags are variadic (`--tools <tools...>`), so nothing positional may
     * follow them in the argv — [[streamJson]] emits only flag-value pairs after
@@ -189,13 +164,11 @@ private[claude] object ClaudeArgs:
     else Seq("--allowedTools", tools.mkString(","))
 
   /** How strongly claude enforces each `(tools, autoApprove)` combination — see
-    * [[permissionArgs]] for the flags this classifies. Every combination is
-    * `Hard`. The read-only tiers rest on `--tools`, which removes every
-    * unlisted built-in; the `--allowedTools`/`bypassPermissions` variants are
-    * mechanical per-tool gates.
+    * [[permissionArgs]] for the flags this classifies. Every one of them is a
+    * mechanical gate, hence `Hard` throughout.
     *
-    * Written as an exhaustive match (all arms `Hard`) rather than a bare
-    * constant so a future `ToolSet`/`AutoApprove` case fails compilation here.
+    * Written as an exhaustive match rather than a bare constant so a future
+    * `ToolSet`/`AutoApprove` case fails compilation here.
     */
   def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
     tools match

--- a/flow/src/main/scala/orca/plan/Plan.scala
+++ b/flow/src/main/scala/orca/plan/Plan.scala
@@ -160,10 +160,10 @@ object Plan:
     * operation.
     *
     * Runs `NetworkOnly`: reads plus read-only network, so the planner can fetch
-    * an issue/PR and verify external claims. Edits stay blocked (hard on
-    * claude/gemini/opencode; prompt-only on pi/codex). Reviewers and the
-    * post-planning `reviewed` turn use plain `withReadOnly` instead — no
-    * network, hard no-edit everywhere.
+    * an issue/PR and verify external claims. How strongly each backend blocks
+    * edits varies — see the enforcement matrix in `AGENTS.md`. Reviewers and
+    * the post-planning `reviewed` turn use plain `withReadOnly` instead, with
+    * no network.
     */
   private def autonomousResult[B <: BackendTag, O: JsonData: Announce, A](
       agent: Agent[B],

--- a/flow/src/main/scala/orca/review/ReviewLoopPrompts.scala
+++ b/flow/src/main/scala/orca/review/ReviewLoopPrompts.scala
@@ -57,8 +57,8 @@ object ReviewLoopPrompts:
     *
     * `base` is the commit `diff` was sampled against, when the loop knows it
     * describes this diff (see [[ReviewFixLoop.diffBase]]). It is sent alongside
-    * the diff, never instead of it: a reviewer that can run a shell can read
-    * past the diff from there, and one that can't is unaffected.
+    * the diff, never instead of it: it only lets a reviewer read the repo at
+    * that commit, and a reviewer with no way to do so is unaffected.
     */
   def initialReview(
       task: String,
@@ -83,10 +83,10 @@ object ReviewLoopPrompts:
     */
   private def baseNote(base: Option[String]): String =
     base.fold(""): sha =>
-      s"\n\nThe diff above is everything that changed since commit $sha. If " +
-        "you can run shell commands, use that commit to see what the diff " +
-        s"doesn't show — `git show $sha:<path>` for a file as it was before " +
-        "the change, for example. What you review is still the diff; the base " +
+      s"\n\nThe diff above is everything that changed since commit $sha. To " +
+        "see what the diff doesn't show, read a file as it was before the " +
+        s"change: `git_file_at` at that commit, or `git show $sha:<path>` if " +
+        "you have a shell. What you review is still the diff; the base " +
         "commit is there for evidence, not for widening your scope."
 
   private val ReReviewTemplate: String =

--- a/flow/src/test/scala/orca/review/ReviewLoopPromptsTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewLoopPromptsTest.scala
@@ -47,13 +47,14 @@ class ReviewLoopPromptsTest extends munit.FunSuite:
     assert(schema.contains(clause), schema)
 
   test("initialReview names the commit the diff was sampled against"):
-    // Sent alongside the diff, not instead of it: a reviewer with a shell can
-    // read past the diff from there.
+    // Sent alongside the diff, not instead of it: a reviewer can read the repo
+    // at that commit, via the MCP tool or a shell.
     val prompt = rendered(ConfidenceGate.default, base = Some("abc1234"))
     assert(
       prompt.contains("everything that changed since commit abc1234"),
       prompt
     )
+    assert(prompt.contains("`git_file_at` at that commit"), prompt)
     assert(prompt.contains("git show abc1234:<path>"), prompt)
 
   test("reReview carries the fixer's declines as a position, not a ruling"):

--- a/tools/src/main/scala/orca/agents/Agent.scala
+++ b/tools/src/main/scala/orca/agents/Agent.scala
@@ -120,8 +120,8 @@ trait Agent[B <: BackendTag]:
   def withReadOnly: Agent[B] = withTools(ToolSet.ReadOnly)
 
   /** Sibling tool restricted to reads plus network ([[ToolSet.NetworkOnly]]) —
-    * for planner turns that must read an issue/PR. See [[ToolSet]] for the
-    * per-backend no-edit guarantee (hard on most; prompt-only on pi / codex).
+    * for planner turns that must read an issue/PR. How strongly each backend
+    * blocks edits varies; see [[Enforcement]].
     */
   def withNetworkOnly: Agent[B] = withTools(ToolSet.NetworkOnly)
 


### PR DESCRIPTION
Three prose fixes left over from the read-only work. No behaviour change —
prompt text, comments and docs only.

## 1. The reviewer's base-commit note pointed at a shell it lost

The note sent with every reviewer's first prompt said "if you can run shell
commands, use `git show $sha:<path>`". Read-only claude reviewers have no
`Bash`, so that route does not exist for them; the `git_file_at` MCP tool does
the same job. The guard made the sentence true but it still spent tokens on
every reviewer turn.

Both routes are named now, because the sentence has to stay true for a codex
reviewer, whose sandbox does run shell commands. `ReviewLoopPromptsTest` pinned
the old wording; the assertion now pins the tool name as well as the shell one.

## 2. Three prose copies of the old enforcement matrix

#90 corrected the matrix, but the same claim was hand-copied into `Plan.scala`,
`Agent.scala` and ADR 0016, and those copies still asserted the old guarantee.
ADR 0016 disagreed with its own table nine lines below.

Each copy now points at the matrix in `AGENTS.md` instead of restating it. That
matrix is machine-checked by `EnforcementTableTest`; the copies were not, which
is how they drifted. README carried the same claim — it was still correct, but
it is a pointer now for the same reason.

## 3. Comment cleanup in `ClaudeArgs.scala`

The file was 5.1:1 comments to code. Six facts about `--tools` are stated 22
times across seven files; this cuts this file's share, 27 comment lines,
keeping one home per fact:

| fact | home kept |
| --- | --- |
| `--tools` advertises, `--allowedTools` grants | `approve` |
| `--tools` removes every unlisted built-in | `ReadOnlyTools` |
| unknown names are dropped without a warning | `ReadOnlyTools` |
| MCP tools pass `--tools` unfiltered | `ClaudeBackend` + the integration test |
| the allowlist does not survive `--resume` | the test that re-emits it |
| plan mode removed no tools | ADR 0016 |

Two fixes on top:

- The `modelArgs` haiku block was a paragraph of history about a flag this file
  no longer emits for read-only turns. The reason survives, in present tense:
  the qualified id is pinned so the alias cannot land on a pricier tier. README
  stated the same history and is fixed with it.
- The allowlist was said to be pinned against a live CLI by
  `ClaudeIntegrationTest`. That suite only runs under `ORCA_INTEGRATION`, which
  CI sets for one unrelated job, so an upstream rename fails nothing. The
  comment says that now.

`sbt scalafmtCheckAll` and `sbt clean compile test` pass, no warnings. No test
moved; the one test edit is the prompt-wording assertion above.
