### PR TITLE
Fix the MCP output cap, the unbounded git_show read, rev validation, and two stripMargin sites

### DIFF
--- a/tools/src/main/scala/orca/backend/mcp/GitHubMcpServer.scala
+++ b/tools/src/main/scala/orca/backend/mcp/GitHubMcpServer.scala
@@ -7,7 +7,6 @@ import ox.Ox
 import sttp.tapir.Schema
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
-import scala.util.control.NonFatal
 
 private[mcp] case class GitHubIssueInput(
     owner: String,
@@ -58,20 +57,13 @@ private[orca] object GitHubMcpServer:
   ): Either[String, String] =
     IssueHandle
       .parse(s"${in.owner}/${in.repo}#${in.number}")
-      .flatMap: handle =>
+      .map: handle =>
         // `GitHubTool` aborts a failed `gh` call by throwing — right for a flow
         // stage, wrong here, where an agent naming an issue that does not exist
-        // should get an answer rather than end the turn.
-        //
-        // Bounded because `readIssueComments` pages the whole thread: its size
-        // is set by whoever commented, not by this repository.
-        try
-          Right(
-            McpHost.bounded(
-              render(github.readIssue(handle), github.readIssueComments(handle))
-            )
-          )
-        catch case NonFatal(e) => Left(e.getMessage)
+        // should get an answer rather than end the turn. `McpHost` catches it
+        // into the error channel, and bounds this result: `readIssueComments`
+        // pages the whole thread, whose size is set by whoever commented.
+        render(github.readIssue(handle), github.readIssueComments(handle))
 
   private def render(issue: Issue, comments: List[Comment]): String =
     val header =

--- a/tools/src/main/scala/orca/backend/mcp/GitHubMcpServer.scala
+++ b/tools/src/main/scala/orca/backend/mcp/GitHubMcpServer.scala
@@ -65,13 +65,13 @@ private[orca] object GitHubMcpServer:
         // pages the whole thread, whose size is set by whoever commented.
         render(github.readIssue(handle), github.readIssueComments(handle))
 
-  private def render(issue: Issue, comments: List[Comment]): String =
+  /** No `stripMargin`: an issue body is arbitrary GitHub markdown, and a table
+    * row starts its line with `|`, which it would eat.
+    */
+  private[mcp] def render(issue: Issue, comments: List[Comment]): String =
     val header =
-      s"""# ${issue.title}
-         |
-         |state: ${issue.state} · author: ${issue.author}
-         |
-         |${issue.body}""".stripMargin
+      s"# ${issue.title}\n\nstate: ${issue.state} · " +
+        s"author: ${issue.author}\n\n${issue.body}"
     val conversation = comments.map: c =>
       s"\n\n---\n\n**${c.author}**\n\n${c.body}"
     (header +: conversation).mkString

--- a/tools/src/main/scala/orca/backend/mcp/McpHost.scala
+++ b/tools/src/main/scala/orca/backend/mcp/McpHost.scala
@@ -6,6 +6,7 @@ import sttp.shared.Identity
 import sttp.tapir.server.netty.sync.NettySyncServer
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.util.control.NonFatal
 
 /** One MCP server orca stands up for a single agent turn: a Netty binding on
   * `127.0.0.1` at an ephemeral port, serving whatever tools it was started
@@ -27,22 +28,43 @@ private[orca] class McpHost private[mcp] (val port: Int, stopFn: () => Unit)
 
 private[orca] object McpHost:
 
-  /** Chars any one tool result returns. Past this the tail is dropped and the
-    * result says so, so a single call costs a bounded number of tokens rather
-    * than the turn's whole context.
+  /** Chars any one tool result returns, on either channel. Past this the tail
+    * is dropped and the result says so, so a single call costs a bounded number
+    * of tokens rather than the turn's whole context.
     */
   private[mcp] val MaxOutputChars: Int = 60000
 
   /** Apply [[MaxOutputChars]], naming the cut so the agent can narrow its
     * request instead of assuming it saw everything.
     */
-  private[mcp] def bounded(output: String): String =
+  private def bounded(output: String): String =
     if output.length <= MaxOutputChars then output
     else
       output.take(MaxOutputChars) +
         s"\n\n[cut after $MaxOutputChars characters — narrow the request]"
 
-  /** Bind `tools` on a fresh port in the enclosing scope.
+  /** The two guarantees every result served here carries: neither channel
+    * exceeds [[MaxOutputChars]], and a handler that throws yields a tool error
+    * rather than a transport failure the agent cannot read.
+    */
+  private def guardedResult(
+      result: => Either[String, String]
+  ): Either[String, String] =
+    try result.map(bounded).left.map(bounded)
+    catch
+      case NonFatal(e) =>
+        Left(bounded(Option(e.getMessage).getOrElse(e.toString)))
+
+  /** Put a tool's logic behind [[guardedResult]]. [[start]] applies this to
+    * every tool it binds, which is what makes the guarantees structural: a tool
+    * cannot opt out of them by forgetting.
+    */
+  private[mcp] def guarded[I](
+      t: ServerTool[I, Identity]
+  ): ServerTool[I, Identity] =
+    t.copy(logic = (in, headers) => guardedResult(t.logic(in, headers)))
+
+  /** Bind `tools` on a fresh port in the enclosing scope, each [[guarded]].
     *
     * `toolTimeout` becomes Netty's request timeout, raising it from the
     * framework default so a slow tool doesn't have its connection closed
@@ -62,7 +84,7 @@ private[orca] object McpHost:
       .modifyConfig(
         _.requestTimeout(toolTimeout).idleTimeout(toolTimeout + 1.minute)
       )
-      .addEndpoint(mcpEndpoint(tools, List("mcp")))
+      .addEndpoint(mcpEndpoint(tools.map(t => guarded(t)), List("mcp")))
       .start()
     val stopped = new java.util.concurrent.atomic.AtomicBoolean(false)
     useCloseableInScope(

--- a/tools/src/main/scala/orca/backend/mcp/RepoMcpServer.scala
+++ b/tools/src/main/scala/orca/backend/mcp/RepoMcpServer.scala
@@ -78,13 +78,11 @@ private[orca] object RepoMcpServer:
       .handle(in => render(git.fileAt(in.rev, in.path)))
     McpHost.start(List(showTool, fileAtTool), ToolTimeout)
 
-  /** Map a read outcome onto MCP's success/error channels, bounding the success
-    * payload.
-    */
+  /** Map a read outcome onto MCP's success/error channels. */
   private type ToolResult = Either[String, String]
 
   private def render(result: Either[GitReadFailed, String]): ToolResult =
-    result.left.map(_.getMessage).map(McpHost.bounded)
+    result.left.map(_.getMessage)
 
   /** System-prompt hint naming the tools. Read-only turns have no shell, so
     * without this the agent has no reason to look for them.

--- a/tools/src/main/scala/orca/subprocess/QuietProc.scala
+++ b/tools/src/main/scala/orca/subprocess/QuietProc.scala
@@ -42,3 +42,54 @@ private[orca] object QuietProc:
         stderr = os.Pipe,
         check = false
       )
+
+  /** Run `args` to completion, keeping at most `maxOutBytes` of stdout: the
+    * rest is drained and dropped, so the exit code and stderr are still the
+    * ones [[call]] would report and the child never blocks on a full pipe.
+    *
+    * For commands whose output size is set by what they are reading rather than
+    * by their arguments — [[call]] would put all of it on the heap as a
+    * `String` before the caller could react.
+    */
+  def callCapped(
+      args: Seq[String],
+      maxOutBytes: Int,
+      cwd: os.Path = os.pwd,
+      env: Map[String, String] = Map.empty
+  ): CappedResult =
+    log.debug("exec: {}", args.mkString(" "))
+    val kept = new java.io.ByteArrayOutputStream()
+    var produced = 0L
+    // os-lib runs this on a pump thread of its own and joins it before `call`
+    // returns; that join is what publishes `kept` and `produced` here.
+    val capture = os.ProcessOutput: (buf, n) =>
+      produced += n
+      val room = maxOutBytes - kept.size()
+      if room > 0 then kept.write(buf, 0, math.min(n, room))
+    val result = os
+      .proc(args)
+      .call(
+        cwd = cwd,
+        env = env,
+        stdin = os.Pipe,
+        stdout = capture,
+        stderr = os.Pipe,
+        check = false
+      )
+    CappedResult(
+      exitCode = result.exitCode,
+      out = String(kept.toByteArray, java.nio.charset.StandardCharsets.UTF_8),
+      truncated = produced > maxOutBytes,
+      err = result.err.text()
+    )
+
+/** Outcome of [[QuietProc.callCapped]]. `out` is a prefix of what the child
+  * wrote whenever `truncated` — and, being a prefix of bytes rather than of
+  * characters, can end in a replacement character where the cut split one.
+  */
+private[orca] case class CappedResult(
+    exitCode: Int,
+    out: String,
+    truncated: Boolean,
+    err: String
+)

--- a/tools/src/main/scala/orca/subprocess/QuietProc.scala
+++ b/tools/src/main/scala/orca/subprocess/QuietProc.scala
@@ -43,45 +43,61 @@ private[orca] object QuietProc:
         check = false
       )
 
-  /** Run `args` to completion, keeping at most `maxOutBytes` of stdout: the
-    * rest is drained and dropped, so the exit code and stderr are still the
-    * ones [[call]] would report and the child never blocks on a full pipe.
+  /** Run `args` to completion, keeping at most `maxBytes` of each of stdout and
+    * stderr: the rest is drained and dropped, so the exit code is the one
+    * [[call]] would report and the child never blocks on a full pipe.
     *
     * For commands whose output size is set by what they are reading rather than
     * by their arguments — [[call]] would put all of it on the heap as a
-    * `String` before the caller could react.
+    * `String` before the caller could react. stderr is capped as well because
+    * it is no more bounded than stdout: one `git show` through a chatty
+    * `textconv` filter was measured retaining ~400 KB of it.
     */
   def callCapped(
       args: Seq[String],
-      maxOutBytes: Int,
+      maxBytes: Int,
       cwd: os.Path = os.pwd,
       env: Map[String, String] = Map.empty
   ): CappedResult =
     log.debug("exec: {}", args.mkString(" "))
-    val kept = new java.io.ByteArrayOutputStream()
-    var produced = 0L
-    // os-lib runs this on a pump thread of its own and joins it before `call`
-    // returns; that join is what publishes `kept` and `produced` here.
-    val capture = os.ProcessOutput: (buf, n) =>
-      produced += n
-      val room = maxOutBytes - kept.size()
-      if room > 0 then kept.write(buf, 0, math.min(n, room))
+    val outKept = new java.io.ByteArrayOutputStream()
+    val errKept = new java.io.ByteArrayOutputStream()
     val result = os
       .proc(args)
       .call(
         cwd = cwd,
         env = env,
         stdin = os.Pipe,
-        stdout = capture,
-        stderr = os.Pipe,
+        stdout = keepFirst(maxBytes, outKept),
+        stderr = keepFirst(maxBytes, errKept),
         check = false
       )
+    val outBytes = outKept.toByteArray
     CappedResult(
       exitCode = result.exitCode,
-      out = String(kept.toByteArray, java.nio.charset.StandardCharsets.UTF_8),
-      truncated = produced > maxOutBytes,
-      err = result.err.text()
+      out = utf8(outBytes.take(maxBytes)),
+      truncated = outBytes.length > maxBytes,
+      err = utf8(errKept.toByteArray.take(maxBytes))
     )
+
+  /** A stream sink retaining the first `maxBytes` written to it, plus one byte
+    * — that extra byte is how "the child wrote more than the cap" is told from
+    * "it wrote exactly the cap", and it never reaches the result.
+    *
+    * os-lib writes this from a pump thread of its own and joins that thread
+    * before `call` returns; the join is what publishes `into`'s contents to the
+    * caller.
+    */
+  private def keepFirst(
+      maxBytes: Int,
+      into: java.io.ByteArrayOutputStream
+  ): os.ProcessOutput =
+    os.ProcessOutput: (buf, n) =>
+      val room = maxBytes + 1 - into.size()
+      if room > 0 then into.write(buf, 0, math.min(n, room))
+
+  private def utf8(bytes: Array[Byte]): String =
+    String(bytes, java.nio.charset.StandardCharsets.UTF_8)
 
 /** Outcome of [[QuietProc.callCapped]]. `out` is a prefix of what the child
   * wrote whenever `truncated` — and, being a prefix of bytes rather than of

--- a/tools/src/main/scala/orca/subprocess/QuietProc.scala
+++ b/tools/src/main/scala/orca/subprocess/QuietProc.scala
@@ -68,31 +68,38 @@ private[orca] object QuietProc:
         cwd = cwd,
         env = env,
         stdin = os.Pipe,
-        stdout = keepFirst(maxBytes, outKept),
-        stderr = keepFirst(maxBytes, errKept),
+        stdout = os.ProcessOutput(keepFirst(maxBytes, outKept)),
+        stderr = os.ProcessOutput(keepFirst(maxBytes, errKept)),
         check = false
       )
-    val outBytes = outKept.toByteArray
     CappedResult(
       exitCode = result.exitCode,
-      out = utf8(outBytes.take(maxBytes)),
-      truncated = outBytes.length > maxBytes,
-      err = utf8(errKept.toByteArray.take(maxBytes))
+      out = utf8(withoutSentinel(outKept.toByteArray, maxBytes)),
+      truncated = outKept.size() > maxBytes,
+      err = utf8(withoutSentinel(errKept.toByteArray, maxBytes))
     )
 
-  /** A stream sink retaining the first `maxBytes` written to it, plus one byte
-    * — that extra byte is how "the child wrote more than the cap" is told from
-    * "it wrote exactly the cap", and it never reaches the result.
+  /** What a sink retained, less the sentinel byte. Reads the answer off the
+    * sink rather than re-cutting at `maxBytes`, so a sink that stopped bounding
+    * anything returns too much rather than the right prefix by luck — which is
+    * what makes the bound itself observable to a caller.
+    */
+  private def withoutSentinel(kept: Array[Byte], maxBytes: Int): Array[Byte] =
+    if kept.length > maxBytes then kept.dropRight(1) else kept
+
+  /** A stream sink retaining the first `maxBytes` written to it, plus one
+    * sentinel byte — that extra byte is how "the child wrote more than the cap"
+    * is told from "it wrote exactly the cap", and it never reaches the result.
     *
     * os-lib writes this from a pump thread of its own and joins that thread
     * before `call` returns; the join is what publishes `into`'s contents to the
     * caller.
     */
-  private def keepFirst(
+  private[subprocess] def keepFirst(
       maxBytes: Int,
       into: java.io.ByteArrayOutputStream
-  ): os.ProcessOutput =
-    os.ProcessOutput: (buf, n) =>
+  ): (Array[Byte], Int) => Unit =
+    (buf, n) =>
       val room = maxBytes + 1 - into.size()
       if room > 0 then into.write(buf, 0, math.min(n, room))
 

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -424,7 +424,7 @@ trait GitTool:
   ): Either[GitReadFailed, String]
 
   /** `git show <rev>:<path>` — one file's full contents as of `rev`. Same
-    * argument validation as [[show]]. A file over `OsGitTool.MaxReadBytes` is
+    * argument validation as [[show]]. A file over `OsGitTool.MaxFileAtBytes` is
     * refused rather than cut: the size is known before the read, so naming the
     * limit beats a truncated file.
     */
@@ -899,11 +899,11 @@ private[orca] class OsGitTool(
     // binary, a checked-in dataset) would otherwise be an OOM rather than an
     // answer.
     val size = gitRead(Seq("cat-file", "-s", "--end-of-options", blob)).ok()
-    if size.trim.toLongOption.exists(_ > OsGitTool.MaxReadBytes) then
+    if size.trim.toLongOption.exists(_ > OsGitTool.MaxFileAtBytes) then
       Left(
         new GitReadFailed.Refused(
           s"'$path' is ${size.trim} bytes at $rev, over the " +
-            s"${OsGitTool.MaxReadBytes}-byte limit for a whole-file read"
+            s"${OsGitTool.MaxFileAtBytes}-byte limit for a whole-file read"
         )
       ).ok()
     else gitRead(Seq("show", "--end-of-options", blob)).ok()
@@ -1027,15 +1027,20 @@ private[orca] class OsGitTool(
 
 private[orca] object OsGitTool:
 
-  /** Most stdout an agent-facing read yields. Comfortably above any source
-    * file; past it the request is a wrong one, not a big one.
-    *
-    * Held to in whichever of two ways the command allows: [[OsGitTool.fileAt]]
-    * knows the size before reading (`cat-file -s`) so it refuses and says why,
-    * while a commit's diff has no such query, leaving `gitRead` to drop the
-    * tail of whatever a command produces past it.
+  /** Most stdout `gitRead` keeps from one read. A heap bound, and only that:
+    * `McpHost` cuts an agent's copy of the same answer to a small fraction of
+    * this, so the marker `gitRead` appends reaches only a direct [[GitTool]]
+    * caller. Applied as the output arrives, since a commit's diff has no size
+    * to ask for beforehand.
     */
   private[tools] val MaxReadBytes: Int = 2 * 1024 * 1024
+
+  /** Largest blob [[GitTool.fileAt]] reads whole. `cat-file -s` answers the
+    * size up front, which buys a refusal naming the file where [[MaxReadBytes]]
+    * could only cut it. Comfortably above any source file; a request over it is
+    * a wrong path, not a big one.
+    */
+  private[tools] val MaxFileAtBytes: Int = 2 * 1024 * 1024
 
   /** Pathspec arguments scoping a diff to "the whole repository, minus orca's
     * bookkeeping". `:(top)` is what makes it repo-wide: a magic pathspec is

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -404,7 +404,8 @@ trait GitTool:
     *
     * Built for agent-supplied arguments, so `rev` and `paths` are validated
     * before they reach git ([[GitRead.rev]], [[GitRead.path]]) and cannot be
-    * read as flags or escape the repository.
+    * read as flags or escape the repository. The result is capped at
+    * `OsGitTool.MaxReadBytes` and says so where it was cut.
     */
   def show(
       rev: String,
@@ -413,7 +414,9 @@ trait GitTool:
   ): Either[GitReadFailed, String]
 
   /** `git show <rev>:<path>` — one file's full contents as of `rev`. Same
-    * argument validation as [[show]].
+    * argument validation as [[show]]. A file over `OsGitTool.MaxReadBytes` is
+    * refused rather than cut: the size is known before the read, so naming the
+    * limit beats a truncated file.
     */
   def fileAt(rev: String, path: String): Either[GitReadFailed, String]
 
@@ -886,11 +889,11 @@ private[orca] class OsGitTool(
     // binary, a checked-in dataset) would otherwise be an OOM rather than an
     // answer.
     val size = gitRead(Seq("cat-file", "-s", "--end-of-options", blob)).ok()
-    if size.trim.toLongOption.exists(_ > OsGitTool.MaxFileAtBytes) then
+    if size.trim.toLongOption.exists(_ > OsGitTool.MaxReadBytes) then
       Left(
         new GitReadFailed.Refused(
           s"'$path' is ${size.trim} bytes at $rev, over the " +
-            s"${OsGitTool.MaxFileAtBytes}-byte limit for a whole-file read"
+            s"${OsGitTool.MaxReadBytes}-byte limit for a whole-file read"
         )
       ).ok()
     else gitRead(Seq("show", "--end-of-options", blob)).ok()
@@ -898,11 +901,25 @@ private[orca] class OsGitTool(
   /** Run a read-only git command, mapping a non-zero exit to
     * [[GitReadFailed.Refused]] instead of aborting the flow — an agent asking
     * for a revision that does not exist gets an answer, not a crash.
+    *
+    * Capped at [[OsGitTool.MaxReadBytes]] and marked when cut: `rev` names a
+    * commit, so the output is as large as whatever was committed there.
     */
   private def gitRead(args: Seq[String]): Either[GitReadFailed, String] =
-    val result = gitProc("git" +: args)
-    if result.exitCode == 0 then Right(result.out.text())
-    else Left(new GitReadFailed.Refused(result.err.text().trim))
+    val result = QuietProc.callCapped(
+      "git" +: args,
+      OsGitTool.MaxReadBytes,
+      cwd = workDir,
+      env = OsGitTool.nonInteractiveEnv
+    )
+    if result.exitCode != 0 then
+      Left(new GitReadFailed.Refused(result.err.trim))
+    else if result.truncated then
+      Right(
+        result.out +
+          s"\n\n[cut after ${OsGitTool.MaxReadBytes} bytes — narrow the request]"
+      )
+    else Right(result.out)
 
   def addWorktree(
       path: os.Path,
@@ -966,9 +983,10 @@ private[orca] class OsGitTool(
       catch case NonFatal(_) => path.toNIO.toAbsolutePath.normalize()
     normalised(left) == normalised(right)
 
-  /** Run a git subprocess. Every git invocation routes through here so they all
-    * carry [[OsGitTool.nonInteractiveEnv]] — no git (or ssh it spawns) can
-    * block the flow on an interactive credential or passphrase prompt.
+  /** Run a git subprocess. Every git invocation routes through here or
+    * [[gitRead]], so they all carry [[OsGitTool.nonInteractiveEnv]] — no git
+    * (or ssh it spawns) can block the flow on an interactive credential or
+    * passphrase prompt.
     */
   private def gitProc(args: Seq[String]): os.CommandResult =
     QuietProc.call(args, cwd = workDir, env = OsGitTool.nonInteractiveEnv)
@@ -999,10 +1017,15 @@ private[orca] class OsGitTool(
 
 private[orca] object OsGitTool:
 
-  /** Largest blob [[OsGitTool.fileAt]] will read whole. Comfortably above any
-    * source file; a request over it is a wrong path, not a big one.
+  /** Most stdout an agent-facing read yields. Comfortably above any source
+    * file; past it the request is a wrong one, not a big one.
+    *
+    * Held to in whichever of two ways the command allows: [[OsGitTool.fileAt]]
+    * knows the size before reading (`cat-file -s`) so it refuses and says why,
+    * while a commit's diff has no such query, leaving `gitRead` to drop the
+    * tail of whatever a command produces past it.
     */
-  private[tools] val MaxFileAtBytes: Long = 2 * 1024 * 1024
+  private[tools] val MaxReadBytes: Int = 2 * 1024 * 1024
 
   /** Pathspec arguments scoping a diff to "the whole repository, minus orca's
     * bookkeeping". `:(top)` is what makes it repo-wide: a magic pathspec is

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -1198,6 +1198,11 @@ private[orca] object OsGitTool:
     * exception. `cmd` is the argv after `git ` (e.g. `commit -m seed` or `add
     * -A`). Sectioned so the original stderr stays at the top and the
     * diagnostics follow on their own lines.
+    *
+    * No `stripMargin`: `stderr` carries whatever git and any hook it ran wrote,
+    * so a line of it can start with `|`, which a margin block would eat. The
+    * two diagnostic blocks only escape that because each of their lines is
+    * indented first.
     */
   private[tools] def gitFailureMessage(
       cmd: String,
@@ -1210,13 +1215,9 @@ private[orca] object OsGitTool:
     val fsckBlock =
       if diag.fsck.trim.isEmpty then "  (no issues reported)"
       else diag.fsck.linesIterator.map("  " + _).mkString("\n")
-    s"""git $cmd failed: ${stderr.trim}
-       |
-       |git status --porcelain:
-       |$statusBlock
-       |
-       |git fsck --no-progress:
-       |$fsckBlock""".stripMargin
+    s"git $cmd failed: ${stderr.trim}\n\n" +
+      s"git status --porcelain:\n$statusBlock\n\n" +
+      s"git fsck --no-progress:\n$fsckBlock"
 
   /** Parse the output of `git worktree list --porcelain`. Entries are separated
     * by blank lines; each entry has `worktree <path>` followed by `HEAD <sha>`

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -886,9 +886,14 @@ private[orca] class OsGitTool(
       if checkedPaths.isEmpty then Nil else "--" +: checkedPaths
     // `--end-of-options` after the flags, so git cannot read `checkedRev` as
     // one however it is spelled.
-    gitRead(
+    val output = gitRead(
       Seq("show") ++ statFlag ++ Seq("--end-of-options", checkedRev) ++ pathspec
     ).ok()
+    // A cut diff is still an answer, as long as it says where it stops.
+    if output.truncated then
+      output.text +
+        s"\n\n[cut after ${OsGitTool.MaxReadBytes} bytes — narrow the request]"
+    else output.text
 
   def fileAt(rev: String, path: String): Either[GitReadFailed, String] = either:
     val checkedRev = GitRead.rev(rev).ok()
@@ -898,7 +903,8 @@ private[orca] class OsGitTool(
     // a String, and the path is caller-chosen, so one wrong file (a vendored
     // binary, a checked-in dataset) would otherwise be an OOM rather than an
     // answer.
-    val size = gitRead(Seq("cat-file", "-s", "--end-of-options", blob)).ok()
+    val size =
+      gitRead(Seq("cat-file", "-s", "--end-of-options", blob)).ok().text
     if size.trim.toLongOption.exists(_ > OsGitTool.MaxFileAtBytes) then
       Left(
         new GitReadFailed.Refused(
@@ -906,16 +912,31 @@ private[orca] class OsGitTool(
             s"${OsGitTool.MaxFileAtBytes}-byte limit for a whole-file read"
         )
       ).ok()
-    else gitRead(Seq("show", "--end-of-options", blob)).ok()
+    else
+      val output = gitRead(Seq("show", "--end-of-options", blob)).ok()
+      // The read's own cap is the last word, whatever the size check let
+      // through: a prefix returned as a file's contents is corruption the
+      // caller cannot see, where a refusal is merely an answer it dislikes.
+      if output.truncated then
+        Left(
+          new GitReadFailed.Refused(
+            s"'$path' at $rev is longer than the " +
+              s"${OsGitTool.MaxReadBytes}-byte read limit"
+          )
+        ).ok()
+      else output.text
 
   /** Run a read-only git command, mapping a non-zero exit to
     * [[GitReadFailed.Refused]] instead of aborting the flow — an agent asking
     * for a revision that does not exist gets an answer, not a crash.
     *
-    * Capped at [[OsGitTool.MaxReadBytes]] and marked when cut: `rev` names a
-    * commit, so the output is as large as whatever was committed there.
+    * Reports truncation rather than folding it into the text: `show` marks a
+    * cut diff and carries on, while `fileAt` refuses, and only the caller knows
+    * which its answer can survive.
     */
-  private def gitRead(args: Seq[String]): Either[GitReadFailed, String] =
+  private def gitRead(
+      args: Seq[String]
+  ): Either[GitReadFailed, OsGitTool.ReadOutput] =
     val result = QuietProc.callCapped(
       "git" +: args,
       maxBytes = OsGitTool.MaxReadBytes,
@@ -924,12 +945,7 @@ private[orca] class OsGitTool(
     )
     if result.exitCode != 0 then
       Left(new GitReadFailed.Refused(result.err.trim))
-    else if result.truncated then
-      Right(
-        result.out +
-          s"\n\n[cut after ${OsGitTool.MaxReadBytes} bytes — narrow the request]"
-      )
-    else Right(result.out)
+    else Right(OsGitTool.ReadOutput(result.out, result.truncated))
 
   def addWorktree(
       path: os.Path,
@@ -1039,8 +1055,17 @@ private[orca] object OsGitTool:
     * size up front, which buys a refusal naming the file where [[MaxReadBytes]]
     * could only cut it. Comfortably above any source file; a request over it is
     * a wrong path, not a big one.
+    *
+    * Must not exceed [[MaxReadBytes]] — past that the read cuts what the size
+    * check admitted. `fileAt` refuses a cut read rather than trusting this, so
+    * the cost of breaking it is a refusal, not a silently truncated file.
     */
   private[tools] val MaxFileAtBytes: Int = 2 * 1024 * 1024
+
+  /** One capped read's output, and whether git wrote past [[MaxReadBytes]] so
+    * `text` holds only the start of the answer.
+    */
+  private case class ReadOutput(text: String, truncated: Boolean)
 
   /** Pathspec arguments scoping a diff to "the whole repository, minus orca's
     * bookkeeping". `:(top)` is what makes it repo-wide: a magic pathspec is

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -47,8 +47,9 @@ sealed abstract class GitReadFailed(message: String)
 object GitReadFailed:
   final class InvalidRev(rev: String)
       extends GitReadFailed(
-        s"'$rev' is not a revision name (letters, digits, '.', '_', '/', '-', " +
-          "'@', '^', '~', '{', '}', no '..', not starting with a dash)"
+        s"'$rev' is not a single revision (letters, digits, '.', '_', '/', " +
+          "'-', '@', '^', '~', '{', '}', no range '..' / '^-' / '^@', not " +
+          "starting with a dash)"
       )
 
   final class InvalidPath(path: String)
@@ -67,6 +68,14 @@ object GitReadFailed:
 private[tools] object GitRead:
   private val RevPattern = """[A-Za-z0-9._/@^~{}-]+""".r
 
+  /** Every way of spelling a range that [[RevPattern]] admits. `git show` on
+    * one prints a commit per member, where a single revision prints what
+    * somebody committed: `x^-` is `x^..x` — on a merge, the whole merged branch
+    * — and `x^@` is every parent. `git` forbids all three in a refname, so
+    * rejecting them costs nothing.
+    */
+  private val RangeOperators = List("..", "^-", "^@")
+
   /** A single ref or sha, in any of the spellings the tools advertise:
     * `HEAD~1`, `HEAD^`, `@` and `HEAD@{1}` all name one commit, and
     * `git_file_at`'s description asks for a file "before the change under
@@ -74,14 +83,10 @@ private[tools] object GitRead:
     *
     * The leading-dash rejection stops a revision position being read as a flag;
     * callers additionally pass `--end-of-options`.
-    *
-    * `..` is rejected, which costs nothing — git forbids it in a refname — and
-    * rules out handing `git show` a range, whose output is unbounded where a
-    * single commit's is what somebody committed.
     */
   def rev(value: String): Either[GitReadFailed, String] =
     if RevPattern.matches(value) && !value.startsWith("-") &&
-      !value.contains("..")
+      !RangeOperators.exists(value.contains)
     then Right(value)
     else Left(new GitReadFailed.InvalidRev(value))
 

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -918,7 +918,7 @@ private[orca] class OsGitTool(
   private def gitRead(args: Seq[String]): Either[GitReadFailed, String] =
     val result = QuietProc.callCapped(
       "git" +: args,
-      OsGitTool.MaxReadBytes,
+      maxBytes = OsGitTool.MaxReadBytes,
       cwd = workDir,
       env = OsGitTool.nonInteractiveEnv
     )

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -49,7 +49,7 @@ object GitReadFailed:
       extends GitReadFailed(
         s"'$rev' is not a single revision (letters, digits, '.', '_', '/', " +
           "'-', '@', '^', '~', '{', '}', no range '..' / '^-' / '^@', not " +
-          "starting with a dash)"
+          "starting with a dash or a '^')"
       )
 
   final class InvalidPath(path: String)
@@ -68,25 +68,32 @@ object GitReadFailed:
 private[tools] object GitRead:
   private val RevPattern = """[A-Za-z0-9._/@^~{}-]+""".r
 
-  /** Every way of spelling a range that [[RevPattern]] admits. `git show` on
-    * one prints a commit per member, where a single revision prints what
-    * somebody committed: `x^-` is `x^..x` — on a merge, the whole merged branch
-    * — and `x^@` is every parent. `git` forbids all three in a refname, so
-    * rejecting them costs nothing.
+  /** Range operators [[RevPattern]] admits, in the middle of a revision: `x^-`
+    * is `x^..x` — on a merge, the whole merged branch — and `x^@` is every
+    * parent. `git` forbids all three in a refname, so rejecting them costs
+    * nothing.
     */
   private val RangeOperators = List("..", "^-", "^@")
+
+  /** True when `value` names anything other than one commit. A leading `^`
+    * excludes rather than names: `git show ^HEAD` exits 0 having printed
+    * nothing, so without this an agent gets a blank answer it cannot tell from
+    * an empty commit.
+    */
+  private def isRange(value: String): Boolean =
+    value.startsWith("^") || RangeOperators.exists(value.contains)
 
   /** A single ref or sha, in any of the spellings the tools advertise:
     * `HEAD~1`, `HEAD^`, `@` and `HEAD@{1}` all name one commit, and
     * `git_file_at`'s description asks for a file "before the change under
-    * review", which is what `HEAD~1` is for.
+    * review", which is what `HEAD~1` is for. `x^{/text}` searches history but
+    * still resolves to one commit, so it is allowed.
     *
     * The leading-dash rejection stops a revision position being read as a flag;
     * callers additionally pass `--end-of-options`.
     */
   def rev(value: String): Either[GitReadFailed, String] =
-    if RevPattern.matches(value) && !value.startsWith("-") &&
-      !RangeOperators.exists(value.contains)
+    if RevPattern.matches(value) && !value.startsWith("-") && !isRange(value)
     then Right(value)
     else Left(new GitReadFailed.InvalidRev(value))
 

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -48,7 +48,7 @@ object GitReadFailed:
   final class InvalidRev(rev: String)
       extends GitReadFailed(
         s"'$rev' is not a revision name (letters, digits, '.', '_', '/', '-', " +
-          "not starting with a dash)"
+          "'@', '^', '~', '{', '}', no '..', not starting with a dash)"
       )
 
   final class InvalidPath(path: String)
@@ -65,10 +65,15 @@ object GitReadFailed:
   * other than a value.
   */
 private[tools] object GitRead:
-  private val RevPattern = """[A-Za-z0-9._/-]+""".r
+  private val RevPattern = """[A-Za-z0-9._/@^~{}-]+""".r
 
-  /** A single ref or sha. The leading-dash rejection stops a revision position
-    * being read as a flag; callers additionally pass `--end-of-options`.
+  /** A single ref or sha, in any of the spellings the tools advertise:
+    * `HEAD~1`, `HEAD^`, `@` and `HEAD@{1}` all name one commit, and
+    * `git_file_at`'s description asks for a file "before the change under
+    * review", which is what `HEAD~1` is for.
+    *
+    * The leading-dash rejection stops a revision position being read as a flag;
+    * callers additionally pass `--end-of-options`.
     *
     * `..` is rejected, which costs nothing — git forbids it in a refname — and
     * rules out handing `git show` a range, whose output is unbounded where a

--- a/tools/src/test/scala/orca/backend/mcp/GitHubMcpServerTest.scala
+++ b/tools/src/test/scala/orca/backend/mcp/GitHubMcpServerTest.scala
@@ -1,0 +1,13 @@
+package orca.backend.mcp
+
+import orca.tools.{Comment, Issue}
+
+class GitHubMcpServerTest extends munit.FunSuite:
+
+  test("an issue body's markdown table reaches the agent with its rows intact"):
+    val table = "| col |\n| --- |\n| cell |"
+    val rendered = GitHubMcpServer.render(
+      Issue(title = "t", body = table, author = "a", state = "open"),
+      Nil
+    )
+    assert(rendered.contains(table), rendered)

--- a/tools/src/test/scala/orca/backend/mcp/GitHubMcpServerTest.scala
+++ b/tools/src/test/scala/orca/backend/mcp/GitHubMcpServerTest.scala
@@ -1,6 +1,6 @@
 package orca.backend.mcp
 
-import orca.tools.{Comment, Issue}
+import orca.tools.Issue
 
 class GitHubMcpServerTest extends munit.FunSuite:
 

--- a/tools/src/test/scala/orca/backend/mcp/McpHostTest.scala
+++ b/tools/src/test/scala/orca/backend/mcp/McpHostTest.scala
@@ -44,23 +44,32 @@ class McpHostTest extends munit.FunSuite:
       Left("gh exploded")
     )
 
-  test("a bound tool answers a throwing call over the wire, not with a 500"):
-    // The one thing the tests above cannot see: that `start` actually puts the
-    // guard in front of what it binds. Without it a throwing handler reaches
-    // Netty, and the agent gets a transport failure it cannot read.
+  test("a bound tool answers a throwing call over the wire, cut to the cap"):
+    // The one thing the tests above cannot see: that `start` puts this guard in
+    // front of what it binds. Without the catch a throwing handler reaches
+    // Netty and the agent gets a transport failure it cannot read; an
+    // oversized message asserts the same call carries the cap, so wiring some
+    // other guard in would not satisfy this.
     supervised:
+      val message = "gh exploded " + "x" * McpHost.MaxOutputChars
       val throwing =
         tool("probe")
           .input[Probe]
-          .handle(_ => throw new RuntimeException("gh exploded"))
+          .handle(_ => throw new RuntimeException(message))
       val host = McpHost.start(List(throwing), 10.seconds)
       val response = call(
         host.url,
         """{"jsonrpc":"2.0","id":1,"method":"tools/call",""" +
           """"params":{"name":"probe","arguments":{"text":""}}}"""
       )
-      assertEquals(response.statusCode(), 200, response.body())
-      assert(response.body().contains("gh exploded"), response.body())
+      assertEquals(response.statusCode(), 200, response.body().take(200))
+      assert(response.body().contains("gh exploded"), response.body().take(200))
+      // The marker's own dash is non-ASCII, so match the part that survives
+      // whatever charset the response is decoded with.
+      assert(
+        response.body().contains(s"cut after ${McpHost.MaxOutputChars} char"),
+        response.body().takeRight(200)
+      )
 
   /** POST one JSON-RPC message to a running host. The client is closed rather
     * than left to a finalizer: its idle keep-alive connection otherwise holds

--- a/tools/src/test/scala/orca/backend/mcp/McpHostTest.scala
+++ b/tools/src/test/scala/orca/backend/mcp/McpHostTest.scala
@@ -2,7 +2,12 @@ package orca.backend.mcp
 
 import chimp.tool
 import io.circe.Codec
+import ox.supervised
 import sttp.tapir.Schema
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import scala.concurrent.duration.DurationInt
 
 private case class Probe(text: String) derives Codec, Schema
 
@@ -38,3 +43,36 @@ class McpHostTest extends munit.FunSuite:
       resultOf(_ => throw new RuntimeException("gh exploded")),
       Left("gh exploded")
     )
+
+  test("a bound tool answers a throwing call over the wire, not with a 500"):
+    // The one thing the tests above cannot see: that `start` actually puts the
+    // guard in front of what it binds. Without it a throwing handler reaches
+    // Netty, and the agent gets a transport failure it cannot read.
+    supervised:
+      val throwing =
+        tool("probe")
+          .input[Probe]
+          .handle(_ => throw new RuntimeException("gh exploded"))
+      val host = McpHost.start(List(throwing), 10.seconds)
+      val response = call(
+        host.url,
+        """{"jsonrpc":"2.0","id":1,"method":"tools/call",""" +
+          """"params":{"name":"probe","arguments":{"text":""}}}"""
+      )
+      assertEquals(response.statusCode(), 200, response.body())
+      assert(response.body().contains("gh exploded"), response.body())
+
+  /** POST one JSON-RPC message to a running host. The client is closed rather
+    * than left to a finalizer: its idle keep-alive connection otherwise holds
+    * the binding open, and `stop()` waits ten seconds for it.
+    */
+  private def call(url: String, rpc: String): HttpResponse[String] =
+    val request = HttpRequest
+      .newBuilder()
+      .uri(URI.create(url))
+      .header("Content-Type", "application/json")
+      .POST(HttpRequest.BodyPublishers.ofString(rpc))
+      .build()
+    val client = HttpClient.newHttpClient()
+    try client.send(request, HttpResponse.BodyHandlers.ofString())
+    finally client.close()

--- a/tools/src/test/scala/orca/backend/mcp/McpHostTest.scala
+++ b/tools/src/test/scala/orca/backend/mcp/McpHostTest.scala
@@ -1,0 +1,40 @@
+package orca.backend.mcp
+
+import chimp.tool
+import io.circe.Codec
+import sttp.tapir.Schema
+
+private case class Probe(text: String) derives Codec, Schema
+
+class McpHostTest extends munit.FunSuite:
+
+  /** What a tool with this logic returns once bound through [[McpHost]] — the
+    * guard, not the handler, is what these tests are about.
+    */
+  private def resultOf(
+      logic: Probe => Either[String, String]
+  ): Either[String, String] =
+    McpHost
+      .guarded(tool("probe").input[Probe].handle(logic))
+      .logic(Probe(""), Nil)
+
+  test("a result of exactly the cap passes through whole"):
+    val text = "x" * McpHost.MaxOutputChars
+    assertEquals(resultOf(_ => Right(text)), Right(text))
+
+  test("a result one char over the cap is cut, and names the cut"):
+    val out =
+      resultOf(_ => Right("x" * (McpHost.MaxOutputChars + 1))).toOption.get
+    assert(out.startsWith("x" * McpHost.MaxOutputChars), out.take(80))
+    assert(out.endsWith("characters — narrow the request]"), out.takeRight(80))
+
+  test("an error over the cap is cut too: it costs the same tokens"):
+    val out =
+      resultOf(_ => Left("x" * (McpHost.MaxOutputChars + 1))).left.toOption.get
+    assert(out.endsWith("characters — narrow the request]"), out.takeRight(80))
+
+  test("a handler that throws returns a tool error rather than escaping"):
+    assertEquals(
+      resultOf(_ => throw new RuntimeException("gh exploded")),
+      Left("gh exploded")
+    )

--- a/tools/src/test/scala/orca/subprocess/QuietProcTest.scala
+++ b/tools/src/test/scala/orca/subprocess/QuietProcTest.scala
@@ -23,3 +23,31 @@ class QuietProcTest extends munit.FunSuite:
   test("call doesn't throw on non-zero exit"):
     val result = QuietProc.call(Seq("bash", "-c", "exit 7"), cwd = os.pwd)
     assertEquals(result.exitCode, 7)
+
+  test("callCapped keeps output of exactly the cap whole"):
+    val result = QuietProc.callCapped(Seq("printf", "12345678"), maxBytes = 8)
+    assertEquals(result.out, "12345678")
+    assertEquals(result.truncated, false)
+
+  test("callCapped cuts output one byte past the cap, and reports the cut"):
+    val result = QuietProc.callCapped(Seq("printf", "123456789"), maxBytes = 8)
+    assertEquals(result.out, "12345678")
+    assertEquals(result.truncated, true)
+
+  /** The capped path still owes its caller the failure text: `OsGitTool`'s read
+    * turns stderr into the message an agent gets back.
+    */
+  test("callCapped captures stderr"):
+    val result = QuietProc.callCapped(
+      Seq("bash", "-c", "printf OUT; printf ERR 1>&2"),
+      maxBytes = 64
+    )
+    assertEquals(result.out, "OUT")
+    assertEquals(result.err, "ERR")
+
+  test("callCapped caps stderr as well: it is no more bounded than stdout"):
+    val result = QuietProc.callCapped(
+      Seq("bash", "-c", "printf 123456789 1>&2"),
+      maxBytes = 8
+    )
+    assertEquals(result.err, "12345678")

--- a/tools/src/test/scala/orca/subprocess/QuietProcTest.scala
+++ b/tools/src/test/scala/orca/subprocess/QuietProcTest.scala
@@ -24,13 +24,27 @@ class QuietProcTest extends munit.FunSuite:
     val result = QuietProc.call(Seq("bash", "-c", "exit 7"), cwd = os.pwd)
     assertEquals(result.exitCode, 7)
 
+  /** The heap bound itself, which no result can show: every field of
+    * `CappedResult` reads the same whether the sink stopped at the cap or
+    * retained the lot.
+    */
+  test("the sink stops retaining at the cap, however much arrives"):
+    val into = new java.io.ByteArrayOutputStream()
+    val write = QuietProc.keepFirst(8, into)
+    write(Array.fill[Byte](4)('x'.toByte), 4)
+    write(Array.fill[Byte](1000)('x'.toByte), 1000)
+    // Eight, plus the sentinel byte that marks the cap as exceeded.
+    assertEquals(into.size(), 9)
+
   test("callCapped keeps output of exactly the cap whole"):
     val result = QuietProc.callCapped(Seq("printf", "12345678"), maxBytes = 8)
     assertEquals(result.out, "12345678")
     assertEquals(result.truncated, false)
 
-  test("callCapped cuts output one byte past the cap, and reports the cut"):
-    val result = QuietProc.callCapped(Seq("printf", "123456789"), maxBytes = 8)
+  test("callCapped cuts output past the cap, and reports the cut"):
+    // Two bytes over, not one: at one byte over a sink that never bounded
+    // anything would still leave exactly the right prefix behind.
+    val result = QuietProc.callCapped(Seq("printf", "1234567890"), maxBytes = 8)
     assertEquals(result.out, "12345678")
     assertEquals(result.truncated, true)
 
@@ -47,7 +61,7 @@ class QuietProcTest extends munit.FunSuite:
 
   test("callCapped caps stderr as well: it is no more bounded than stdout"):
     val result = QuietProc.callCapped(
-      Seq("bash", "-c", "printf 123456789 1>&2"),
+      Seq("bash", "-c", "printf 1234567890 1>&2"),
       maxBytes = 8
     )
     assertEquals(result.err, "12345678")

--- a/tools/src/test/scala/orca/tools/OsGitToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitToolTest.scala
@@ -841,11 +841,27 @@ class OsGitToolTest extends munit.FunSuite:
         git.show("nosuchref")
       )
 
+  test("the revision spellings that name a commit's predecessor are accepted"):
+    // `git_file_at`'s description asks the agent for a file as it was before
+    // the change under review, and `git show`'s default format prints no parent
+    // sha — so refusing these leaves no way to name the parent at all.
+    withRepo: (git, dir) =>
+      os.write(dir / "a.txt", "before")
+      git.commit("first").orThrow
+      os.write.over(dir / "a.txt", "after")
+      git.commit("second").orThrow
+      assertEquals(git.fileAt("HEAD~1", "a.txt"), Right("before"))
+      assertEquals(git.fileAt("HEAD^", "a.txt"), Right("before"))
+      assertEquals(git.fileAt("HEAD@{1}", "a.txt"), Right("before"))
+      assertEquals(git.fileAt("@", "a.txt"), Right("after"))
+
   test("a revision that could be read as a flag is rejected before git runs"):
     // The rev reaches git in a revision position, so a leading dash must not
     // survive validation — `--end-of-options` is the second line of defence.
+    // Spelled with characters a revision may contain, so it is the dash guard
+    // being tested rather than the character class.
     withRepo: (git, _) =>
-      val failure = git.show("--upload-pack=touch pwned").left.toOption.get
+      val failure = git.show("--all").left.toOption.get
       assert(failure.isInstanceOf[GitReadFailed.InvalidRev], failure)
 
   test("a path climbing out of the repository is rejected"):

--- a/tools/src/test/scala/orca/tools/OsGitToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitToolTest.scala
@@ -895,6 +895,10 @@ class OsGitToolTest extends munit.FunSuite:
       assert(rejected(git.show("main..HEAD")))
       assert(rejected(git.show("HEAD^-")))
       assert(rejected(git.show("HEAD^@")))
+      // A leading `^` excludes instead of naming, and git exits 0 having
+      // printed nothing — an empty answer the agent cannot tell from a commit
+      // that changed nothing.
+      assert(rejected(git.show("^HEAD")))
 
   test("a whole-file read can never outgrow what one read holds"):
     // Above this, `fileAt`'s size check admits a file the read then cuts. The

--- a/tools/src/test/scala/orca/tools/OsGitToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitToolTest.scala
@@ -896,6 +896,21 @@ class OsGitToolTest extends munit.FunSuite:
       assert(rejected(git.show("HEAD^-")))
       assert(rejected(git.show("HEAD^@")))
 
+  test("a whole-file read can never outgrow what one read holds"):
+    // Above this, `fileAt`'s size check admits a file the read then cuts. The
+    // cut is caught and refused, but the two limits are set independently, so
+    // nothing else says they are related at all.
+    assert(OsGitTool.MaxFileAtBytes <= OsGitTool.MaxReadBytes)
+
+  test("fileAt returns a blob of exactly the limit whole"):
+    withRepo: (git, dir) =>
+      os.write(dir / "big.bin", "x" * OsGitTool.MaxFileAtBytes)
+      git.commit("add big").orThrow
+      assertEquals(
+        git.fileAt("HEAD", "big.bin").map(_.length),
+        Right(OsGitTool.MaxFileAtBytes)
+      )
+
   test("fileAt refuses a blob past the whole-file limit"):
     withRepo: (git, dir) =>
       os.write(dir / "big.bin", "x" * (OsGitTool.MaxFileAtBytes + 1))

--- a/tools/src/test/scala/orca/tools/OsGitToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitToolTest.scala
@@ -18,6 +18,10 @@ class OsGitToolTest extends munit.FunSuite:
     val dir = GitRepo.empty()
     body(new OsGitTool(dir), dir)
 
+  /** True when a read never reached git: the revision failed validation. */
+  private def rejected(result: Either[GitReadFailed, String]): Boolean =
+    result.left.exists(_.isInstanceOf[GitReadFailed.InvalidRev])
+
   /** Variant that captures the events the tool emits. */
   private def withRepoCapturingEvents(
       body: (OsGitTool, os.Path, AtomicReference[List[OrcaEvent]]) => Unit
@@ -859,8 +863,10 @@ class OsGitToolTest extends munit.FunSuite:
       git.commit("second").orThrow
       assertEquals(git.fileAt("HEAD~1", "a.txt"), Right("before"))
       assertEquals(git.fileAt("HEAD^", "a.txt"), Right("before"))
-      assertEquals(git.fileAt("HEAD@{1}", "a.txt"), Right("before"))
       assertEquals(git.fileAt("@", "a.txt"), Right("after"))
+      // Which commit `HEAD@{1}` names is up to how the fixture moved HEAD, so
+      // this asserts only that the spelling survives validation.
+      assert(!rejected(git.fileAt("HEAD@{1}", "a.txt")))
 
   test("a revision that could be read as a flag is rejected before git runs"):
     // The rev reaches git in a revision position, so a leading dash must not
@@ -868,18 +874,27 @@ class OsGitToolTest extends munit.FunSuite:
     // Spelled with characters a revision may contain, so it is the dash guard
     // being tested rather than the character class.
     withRepo: (git, _) =>
-      val failure = git.show("--all").left.toOption.get
-      assert(failure.isInstanceOf[GitReadFailed.InvalidRev], failure)
+      assert(rejected(git.show("--all")))
+
+  test("a revision carrying a character no revision may contain is rejected"):
+    // The character class is the guard here: nothing about this is a range, and
+    // it does not start with a dash — but a space would smuggle in a flag.
+    withRepo: (git, _) =>
+      assert(rejected(git.show("HEAD --output=x")))
 
   test("a path climbing out of the repository is rejected"):
     withRepo: (git, _) =>
       val failure = git.fileAt("HEAD", "../outside.txt").left.toOption.get
       assert(failure.isInstanceOf[GitReadFailed.InvalidPath], failure)
 
-  test("a range is rejected: git show on one would be unbounded"):
+  test("every range spelling is rejected: git show on one is unbounded"):
+    // `^-` and `^@` are ranges spelled entirely with characters a revision may
+    // contain: `HEAD^-` is `HEAD^..HEAD`, which on a merge is the whole merged
+    // branch, and `HEAD^@` is every parent.
     withRepo: (git, _) =>
-      val failure = git.show("main..HEAD").left.toOption.get
-      assert(failure.isInstanceOf[GitReadFailed.InvalidRev], failure)
+      assert(rejected(git.show("main..HEAD")))
+      assert(rejected(git.show("HEAD^-")))
+      assert(rejected(git.show("HEAD^@")))
 
   test("fileAt refuses a blob past the whole-file limit"):
     withRepo: (git, dir) =>

--- a/tools/src/test/scala/orca/tools/OsGitToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitToolTest.scala
@@ -860,7 +860,21 @@ class OsGitToolTest extends munit.FunSuite:
 
   test("fileAt refuses a blob past the whole-file limit"):
     withRepo: (git, dir) =>
-      os.write(dir / "big.bin", "x" * (OsGitTool.MaxFileAtBytes.toInt + 1))
+      os.write(dir / "big.bin", "x" * (OsGitTool.MaxReadBytes + 1))
       git.commit("add big").orThrow
       val failure = git.fileAt("HEAD", "big.bin").left.toOption.get
       assert(failure.getMessage.contains("whole-file read"), failure.getMessage)
+
+  test("show cuts a commit whose diff is past the read limit, and says so"):
+    // No size query answers "how big is this commit's diff?", so the cut
+    // happens as the output is read rather than before it: what git wrote past
+    // the limit never reaches the heap.
+    withRepo: (git, dir) =>
+      os.write(
+        dir / "big.txt",
+        ("x" * 99 + "\n") * (OsGitTool.MaxReadBytes / 50)
+      )
+      git.commit("add big").orThrow
+      val out = git.show("HEAD").orThrow
+      assert(clue(out.length) < OsGitTool.MaxReadBytes + 100)
+      assert(out.endsWith("bytes — narrow the request]"), out.takeRight(80))

--- a/tools/src/test/scala/orca/tools/OsGitToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitToolTest.scala
@@ -444,6 +444,13 @@ class OsGitToolTest extends munit.FunSuite:
     assert(msg.contains("?? untracked.txt"), msg)
     assert(msg.contains("missing tree fa29f13"), msg)
 
+  test("gitFailureMessage keeps a stderr line that starts with `|`"):
+    // A commit hook writes what it likes to git's stderr, markdown included.
+    val diag = OsGitTool.GitDiagnostics(status = "", fsck = "")
+    val msg =
+      OsGitTool.gitFailureMessage("commit -m x", "hook says:\n| no |", diag)
+    assert(msg.contains("\n| no |"), msg)
+
   test("gitFailureMessage shows '(clean)' / '(no issues reported)' when empty"):
     val diag = OsGitTool.GitDiagnostics(status = "", fsck = "")
     val msg = OsGitTool.gitFailureMessage("add -A", "boom", diag)

--- a/tools/src/test/scala/orca/tools/OsGitToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitToolTest.scala
@@ -898,7 +898,7 @@ class OsGitToolTest extends munit.FunSuite:
 
   test("fileAt refuses a blob past the whole-file limit"):
     withRepo: (git, dir) =>
-      os.write(dir / "big.bin", "x" * (OsGitTool.MaxReadBytes + 1))
+      os.write(dir / "big.bin", "x" * (OsGitTool.MaxFileAtBytes + 1))
       git.commit("add big").orThrow
       val failure = git.fileAt("HEAD", "big.bin").left.toOption.get
       assert(failure.getMessage.contains("whole-file read"), failure.getMessage)


### PR DESCRIPTION
Five fixes in the MCP servers and `GitTool`, plus nine follow-up commits from
two rounds of review.

## 1. The MCP output cap had no test, and nothing required it

`McpHost.bounded` capped a tool result at 60 000 chars, but deleting the call
from every call site left the whole suite green. That is why the same
unbounded-output defect landed twice: `RepoMcpServer` capped, `GitHubMcpServer`
did not.

A test alone would not have stopped a third instance, so the cap moved into the
one place every tool passes through. `McpHost.start` now wraps each tool's
logic, and that wrapper both bounds the result and turns a thrown exception
into a tool error. A tool cannot forget either. `GitHubMcpServer`'s hand-rolled
try/catch is gone with it.

The seam was clean: chimp's `ServerTool` is a plain case class with a `logic`
field, so wrapping it is a `copy`.

Both channels are bounded, not just the success one — an error string reaches
the model as tokens exactly like a result does.

**The wiring itself is pinned by a test over the wire.** The four unit tests
called `guarded` directly, so deleting it from `start` left the suite green —
and with the two servers' local guards now removed, that one line was all there
was. A `tools/call` against a real host for a handler that throws fails without
it: the exception reaches Netty and the agent gets a 500 rather than a readable
tool error. The thrown message is longer than the cap, so the same call pins
both guarantees — wiring in a catch-only wrapper does not satisfy it.

## 2. `git show` buffered its whole output before anything could cut it

`OsGitTool.show` went to `gitRead`, which does `result.out.text()` — the entire
diff landed on the heap before the MCP cap ran. A commit adding a 32 MB file
measured 32.4M chars.

Capped, rather than accepted. `gitRead` is the funnel for exactly the two reads
that take an agent-supplied revision (`show` and `fileAt`), so a guard there is
not a one-off — it is the boundary where an agent's choice sets the size. The
flow-driven reads (`reviewDiff`, `pendingChanges`) work on the tree the flow
just produced and are already capped by `BoundedDiff` before they reach a
prompt, so they are unchanged.

The cap is applied while reading, not before it. The obvious alternative — run
`--stat` first and refuse over a line threshold — does not bound anything: line
count says nothing about bytes, and one 32 MB minified line is one insertion.
So `QuietProc.callCapped` keeps the first 2 MiB and drains the rest. That needs
no size query and works whatever the content, and the child still runs to
completion, so its exit code is unchanged.

stderr is capped the same way. It is no more bounded than stdout — one
`git show` through a chatty `textconv` filter was measured retaining ~400 KB.

The bound is checked directly rather than inferred from the result. Every field
of `CappedResult` used to be recomputed from the full buffer, so a sink that
retained everything produced identical output and the cap — the point of the
whole change — had no regression protection. The sink is now a plain function a
test drives with no subprocess, and the result reads what the sink kept rather
than re-cutting, so an unbounded sink returns too much instead of the right
answer by luck.

`fileAt` keeps its `cat-file -s` check: there the size *is* known up front, and
that buys a refusal naming the file over a cut-off answer. The two limits have
separate names, since they answer different questions — a heap bound applied as
output arrives, and a refusal decided before the read. Splitting them made
`MaxFileAtBytes > MaxReadBytes` expressible, which would have let a file through
the size check for the read to cut, returning a prefix as though it were the
file. `fileAt` now refuses a cut read outright, so the worst that
misconfiguration costs is a refusal.

The cut marker only ever reaches a direct `GitTool` caller: `McpHost` cuts the
agent's copy at 60 000 chars, far below 2 MiB. So the byte cap bounds what orca
holds, not what the agent reads. The constant says so.

## 3. `rev` rejected the spellings its own tool description asks for

`GitRead.rev` refused `HEAD~1`, `HEAD^`, `@` and `HEAD@{1}`, while
`git_file_at`'s description tells the agent to read a file "as it was before
the change under review". `git show`'s default format prints no parent sha, so
there was no way to recover in-tool — the agent spent a call finding out.

The character class now admits `~ ^ @ { }`. Ranges stay out, and widening the
class added three spellings that had to be named explicitly, all written
entirely with characters a revision may contain, so neither the `..` guard nor
the dash guard caught them. Measured in a scratch repo: `git show HEAD^-` on a
merge printed 3 commits where `git show HEAD` printed 1, `HEAD^@` printed 2,
and `^HEAD` exited 0 having printed nothing at all — a blank answer the agent
cannot tell from a commit that changed nothing. (`x^{/text}` is admitted on
purpose: it searches history but resolves to one commit.)

Three tests here were passing for the wrong reason and are now load-bearing:

- the leading-dash test used `--upload-pack=touch pwned`, caught by the space
  rather than by the guard — it now uses `--all`;
- the character class had no test at all: mutating it to accept everything left
  the suite green, since every existing case was caught by another guard;
- the `HEAD@{1}` case asserted which commit it resolved to, which holds only
  because of how the fixture happens to move HEAD. It now asserts what the test
  is about — that the spelling survives validation.

## 4 and 5. Two `stripMargin` interpolation sites

- `GitHubMcpServer`: `${issue.body}` is arbitrary GitHub markdown, and a table
  row starts its line with `|`. The first body line survived; every later one
  lost its leading `|`. The same function already gets it right two lines down
  for comment bodies.
- `GitTool`'s failure message interpolates git's stderr — whatever git and any
  hook it ran wrote. The two diagnostic blocks only escaped because their lines
  are indented first, which is incidental.

Ninth and tenth instances of a class this repo has fixed in #46, #54, #66 and
#85.

## What this does not bound

The cap covers the two reads that take an agent-supplied revision. It is not a
general bound on `GitTool`. In particular `untrackedFileDiff` still renders a
whole untracked file through uncapped `gitProc`, and `undiffableReason` gates
only on symlink-to-directory and nested repositories with no size check at all
— on the routine `reviewDiff` / `pendingChanges` path, which is a larger
unbounded-heap exposure than the one fixed here. Pre-existing, not touched, and
worth its own change.

Deferred, both known and neither a regression:

- `guardedResult` logs nothing, and `boundary.Break` extends `RuntimeException`,
  so a stray `ox.either` break inside a tool handler would be caught as
  `NonFatal` and returned as a meaningless tool error. Worth a targeted
  exclusion plus a log line; it is a different concern from the cap.
- `gitRead` has no subprocess timeout. That matters more than it looks, because
  `git show` runs whatever `textconv` filter the repository configures.

## Checks

`sbt scalafmtCheckAll` clean, `sbt clean compile test` green with zero
warnings. Every new test was mutation-checked: apply the mutation, confirm
exactly the intended test fails, revert.
