### PR TITLE
Fix the cost pipeline

### DIFF
--- a/adr/0021-orca-shell.md
+++ b/adr/0021-orca-shell.md
@@ -687,8 +687,9 @@ resume is global, but the resumed context still references that directory):
 > asserts on `cost.total`, `cost.byRole` and `turns`, so its cost half moves to a
 > `runner` round trip against the cost file rather than being deleted. The
 > criterion is deliberately about `orca.runner.manifest` types and not "cost" in
-> general: `PriceList` stays in `RunManifestWriter.start`'s signature, since the
-> writer resolves each turn's cost.
+> general. (`PriceList` has since left `RunManifestWriter.start`'s signature:
+> each turn's cost is resolved once at the dispatch boundary and arrives on the
+> event, so the writer prices nothing.)
 >
 > **Enabled, not scheduled.** Recording each turn's `model` becomes cheap once
 > the cost file is additive, and there is a concrete question waiting for it: a

--- a/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
@@ -1,6 +1,6 @@
 package orca.tools.claude
 
-import orca.agents.{AutoApprove, BackendTag, AgentConfig}
+import orca.agents.{AutoApprove, BackendTag, AgentConfig, Model}
 import orca.AgentTurnFailed
 import orca.events.TurnDebit
 import orca.backend.{ApprovalDecision, ConversationEvent}
@@ -211,10 +211,14 @@ private[claude] class ClaudeConversation(
       wireId = result.sessionId,
       output = resultBody(result).getOrElse(""),
       usage = withApiCalls(result.usage),
-      // Fall back to the model claude announced in system.init when the
-      // result message omits it.
-      modelId = result.model.orElse(initModel)
+      modelId = turnModel(result)
     )
+
+  /** The turn's model: the one the `result` message reports, falling back to
+    * what claude announced in `system.init`.
+    */
+  private def turnModel(result: InboundMessage.Result): Option[String] =
+    result.model.orElse(initModel)
 
   /** Attaches the turn's API-call count to its usage and clears the tally, so
     * the next turn of a multi-turn conversation counts its own responses.
@@ -274,7 +278,7 @@ private[claude] class ClaudeConversation(
           s"session ${result.sessionId}): $message",
         TurnDebit.Observed(
           withApiCalls(result.usage),
-          result.model.orElse(initModel).map(orca.agents.Model.apply)
+          turnModel(result).map(Model.apply)
         )
       )
     )

--- a/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
@@ -2,6 +2,7 @@ package orca.tools.claude
 
 import orca.agents.{AutoApprove, BackendTag, AgentConfig}
 import orca.AgentTurnFailed
+import orca.events.TurnDebit
 import orca.backend.{ApprovalDecision, ConversationEvent}
 import orca.backend.{ForkedConversation, StreamSource}
 import orca.subprocess.PipedCliProcess
@@ -253,6 +254,12 @@ private[claude] class ClaudeConversation(
     * settling it here is what lets the failed turn's `usage` reach the cost
     * summary.
     */
+  /** Only the `result` message carries usage, and a turn that reaches it
+    * settles itself (with an `Observed` debit) rather than reaching the base's
+    * generic wrap — so what does reach it spent nothing orca can see.
+    */
+  override protected def failedTurnDebit: TurnDebit = TurnDebit.Unobserved
+
   private def handleResultError(result: InboundMessage.Result): Unit =
     val message = resultBody(result).getOrElse(
       s"claude reported is_error (subtype ${result.subtype})"
@@ -265,7 +272,10 @@ private[claude] class ClaudeConversation(
       new AgentTurnFailed(
         s"claude session failed (subtype ${result.subtype}, " +
           s"session ${result.sessionId}): $message",
-        usage = Some(withApiCalls(result.usage))
+        TurnDebit.Observed(
+          withApiCalls(result.usage),
+          result.model.orElse(initModel).map(orca.agents.Model.apply)
+        )
       )
     )
 

--- a/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
@@ -238,6 +238,12 @@ private[claude] class ClaudeConversation(
   private def resultBody(result: InboundMessage.Result): Option[String] =
     result.structuredOutput.orElse(result.output).filter(_.nonEmpty)
 
+  /** orca decodes usage only from the `result` message, and a turn that reaches
+    * one settles itself (with an `Observed` debit) rather than reaching the
+    * base's generic wrap.
+    */
+  override protected def failedTurnDebit: TurnDebit = TurnDebit.Unobserved
+
   /** Claude sets `is_error: true` for out-of-band failures (API errors, rate
     * limits, auth) at the CLI boundary rather than inside a turn. Treat these
     * as session-ending rather than feeding the error body into the response
@@ -254,12 +260,6 @@ private[claude] class ClaudeConversation(
     * settling it here is what lets the failed turn's `usage` reach the cost
     * summary.
     */
-  /** Only the `result` message carries usage, and a turn that reaches it
-    * settles itself (with an `Observed` debit) rather than reaching the base's
-    * generic wrap — so what does reach it spent nothing orca can see.
-    */
-  override protected def failedTurnDebit: TurnDebit = TurnDebit.Unobserved
-
   private def handleResultError(result: InboundMessage.Result): Unit =
     val message = resultBody(result).getOrElse(
       s"claude reported is_error (subtype ${result.subtype})"

--- a/claude/src/main/scala/orca/tools/claude/streamjson/InboundMessage.scala
+++ b/claude/src/main/scala/orca/tools/claude/streamjson/InboundMessage.scala
@@ -80,11 +80,7 @@ private[claude] object InboundMessage:
   private def parseResult(line: String): InboundMessage =
     val wire = readFromString[ResultWire](line)
     val u = wire.usage.getOrElse(UsageWire())
-    // Claude Code splits input across `input_tokens` (new this turn),
-    // `cache_creation_input_tokens`, and `cache_read_input_tokens` — three
-    // separate categories billed at three different rates, so the total input
-    // is their sum and the two cache categories stay on their own axes. The
-    // wire's "cache creation" is orca's cache write.
+    // The wire's "cache creation" is orca's cache write.
     val cacheWrite = u.cache_creation_input_tokens.getOrElse(0L)
     val cacheRead = u.cache_read_input_tokens.getOrElse(0L)
     // The result message's own `num_turns` looks like a call count and is not
@@ -97,12 +93,14 @@ private[claude] object InboundMessage:
       sessionId = wire.session_id,
       output = wire.result,
       structuredOutput = wire.structured_output.map(_.value),
-      usage = Usage(
-        inputTokens = u.input_tokens.getOrElse(0L) + cacheWrite + cacheRead,
-        outputTokens = u.output_tokens.getOrElse(0L),
-        cost = wire.total_cost_usd,
+      usage = Usage.exclusiveInput(
+        freshInputTokens = u.input_tokens.getOrElse(0L),
         cacheReadInputTokens = cacheRead,
-        cacheWriteInputTokens = cacheWrite
+        cacheWriteInputTokens = cacheWrite,
+        outputTokens = u.output_tokens.getOrElse(0L),
+        reasoningOutputTokens = 0L,
+        cost = wire.total_cost_usd,
+        apiCalls = None
       ),
       isError = wire.is_error.getOrElse(false),
       model = wire.model

--- a/claude/src/main/scala/orca/tools/claude/streamjson/InboundMessage.scala
+++ b/claude/src/main/scala/orca/tools/claude/streamjson/InboundMessage.scala
@@ -93,7 +93,7 @@ private[claude] object InboundMessage:
       sessionId = wire.session_id,
       output = wire.result,
       structuredOutput = wire.structured_output.map(_.value),
-      usage = Usage.exclusiveInput(
+      usage = Usage(
         freshInputTokens = u.input_tokens.getOrElse(0L),
         cacheReadInputTokens = cacheRead,
         cacheWriteInputTokens = cacheWrite,

--- a/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
@@ -1,8 +1,7 @@
 package orca.tools.claude
 
 import orca.agents.{AutoApprove, AgentConfig, Model}
-import orca.events.TurnDebit
-import orca.events.Usage
+import orca.events.{TurnDebit, Usage}
 import orca.testkit.Usages.usage
 import orca.{AgentTurnFailed, OrcaFlowException, OrcaInteractiveCancelled}
 import orca.backend.{

--- a/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
@@ -1,6 +1,7 @@
 package orca.tools.claude
 
-import orca.agents.{AutoApprove, AgentConfig}
+import orca.agents.{AutoApprove, AgentConfig, Model}
+import orca.events.TurnDebit
 import orca.testkit.Usages.usage
 import orca.{AgentTurnFailed, OrcaFlowException, OrcaInteractiveCancelled}
 import orca.backend.{
@@ -177,20 +178,23 @@ class ClaudeConversationTest extends munit.FunSuite:
 
   // The failing turn's tokens are on the wire in the same `result` frame; the
   // exception is the only way they can still reach the run's cost summary.
-  convTest("is_error carries the result's usage on the thrown failure"):
+  convTest("is_error carries the result's debit on the thrown failure"):
     val process = new FakePipedCliProcess()
     val conv = new ClaudeConversation(process, AgentConfig())
 
     process.enqueueStdout(
-      """{"type":"result","subtype":"error_during_execution","session_id":"sid-cost","is_error":true,"usage":{"input_tokens":11,"output_tokens":3,"cache_read_input_tokens":7},"total_cost_usd":0.25}"""
+      """{"type":"result","subtype":"error_during_execution","session_id":"sid-cost","is_error":true,"usage":{"input_tokens":11,"output_tokens":3,"cache_read_input_tokens":7},"total_cost_usd":0.25,"model":"claude-sonnet-4-6"}"""
     )
     process.closeStdout()
 
     val _ = conv.events.toList
     val failure = intercept[AgentTurnFailed](conv.awaitResult())
     assertEquals(
-      failure.usage,
-      Some(usage(18L, 3L, Some(BigDecimal("0.25")), cacheRead = 7L))
+      failure.debit,
+      TurnDebit.Observed(
+        usage(18L, 3L, Some(BigDecimal("0.25")), cacheRead = 7L),
+        Some(Model("claude-sonnet-4-6"))
+      )
     )
 
   convTest(

--- a/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
@@ -2,6 +2,7 @@ package orca.tools.claude
 
 import orca.agents.{AutoApprove, AgentConfig, Model}
 import orca.events.TurnDebit
+import orca.events.Usage
 import orca.testkit.Usages.usage
 import orca.{AgentTurnFailed, OrcaFlowException, OrcaInteractiveCancelled}
 import orca.backend.{
@@ -192,7 +193,17 @@ class ClaudeConversationTest extends munit.FunSuite:
     assertEquals(
       failure.debit,
       TurnDebit.Observed(
-        usage(18L, 3L, Some(BigDecimal("0.25")), cacheRead = 7L),
+        // The wire's counts, verbatim: claude's `input_tokens` excludes the
+        // cache categories, so it is the fresh axis.
+        Usage(
+          freshInputTokens = 11L,
+          cacheReadInputTokens = 7L,
+          cacheWriteInputTokens = 0L,
+          outputTokens = 3L,
+          reasoningOutputTokens = 0L,
+          cost = Some(BigDecimal("0.25")),
+          apiCalls = None
+        ),
         Some(Model("claude-sonnet-4-6"))
       )
     )

--- a/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
@@ -1,7 +1,7 @@
 package orca.tools.claude
 
 import orca.agents.{AutoApprove, AgentConfig}
-import orca.events.{Usage}
+import orca.testkit.Usages.usage
 import orca.{AgentTurnFailed, OrcaFlowException, OrcaInteractiveCancelled}
 import orca.backend.{
   ApprovalDecision,
@@ -58,7 +58,7 @@ class ClaudeConversationTest extends munit.FunSuite:
     val _ = conv.events.toList
     val Right(result) = conv.awaitResult(): @unchecked
     assertEquals(result.output, "done")
-    assertEquals(result.usage, Usage(5L, 7L, None))
+    assertEquals(result.usage, usage(5L, 7L))
 
   // Nothing on the wire reports how many requests a turn made. The CLI splits
   // one model response into several `assistant` messages sharing one id, and a
@@ -190,7 +190,7 @@ class ClaudeConversationTest extends munit.FunSuite:
     val failure = intercept[AgentTurnFailed](conv.awaitResult())
     assertEquals(
       failure.usage,
-      Some(Usage(18L, 3L, Some(BigDecimal("0.25")), 7L))
+      Some(usage(18L, 3L, Some(BigDecimal("0.25")), cacheRead = 7L))
     )
 
   convTest(

--- a/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
@@ -6,13 +6,15 @@ import orca.agents.{
   BackendTag,
   Enforcement,
   JsonData,
+  Model,
   AgentConfig,
   SessionId,
   StructuredOutputMode,
   ToolSet,
   WireSessionId
 }
-import orca.events.{OrcaListener, Usage}
+import orca.events.{OrcaEvent, OrcaListener, TurnDebit, Usage}
+import orca.testkit.Usages.usage
 
 import orca.backend.{
   Interaction,
@@ -410,7 +412,10 @@ class DefaultAgentCallTest extends munit.FunSuite:
           outputSchema: Option[String]
       ): AgentResult[BackendTag.ClaudeCode.type] =
         val _ = calls.incrementAndGet()
-        throw new AgentTurnFailed("Prompt is too long")
+        throw new AgentTurnFailed(
+          "Prompt is too long",
+          TurnDebit.Unobserved
+        )
     supervised:
       val ex = intercept[AgentTurnFailed]:
         makeCall(backend).autonomous.run("the original input")
@@ -498,6 +503,40 @@ class DefaultAgentCallTest extends munit.FunSuite:
         agentName = "claude"
       ).autonomous.run("anything")
       assertEquals(captured.get().flatMap(_.systemPrompt), Some("tool-prompt"))
+
+  // The autonomous path emits a failed turn's debit; the interactive one runs
+  // the same models against the same bills and used to report nothing.
+  test(
+    "an interactive turn failing after the model ran still emits TokensUsed"
+  ):
+    val seen = new AtomicReference[List[OrcaEvent]](Nil)
+    val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
+    val spent = usage(120L, 8L, Some(BigDecimal("0.0031")))
+    val failingInteraction: Interaction = new Interaction:
+      val listeners: List[OrcaListener] = Nil
+      def drive[B <: BackendTag](
+          conversation: orca.backend.Conversation[B]
+      )(using ox.Ox): AgentResult[B] =
+        throw new AgentTurnFailed(
+          "provider error",
+          TurnDebit.Observed(spent, Some(Model("claude-sonnet-5")))
+        )
+    supervised:
+      val _ = intercept[AgentTurnFailed]:
+        new DefaultAgentCall[BackendTag.ClaudeCode.type, Answer](
+          backend = new SequencedBackend(Nil),
+          effectiveConfig = cfg => cfg.getOrElse(AgentConfig()),
+          prompts = DefaultPrompts,
+          events = listener,
+          interaction = failingInteraction,
+          agentName = "claude"
+        ).interactive.run("anything")
+      assertEquals(
+        seen.get().collect { case t: OrcaEvent.TokensUsed =>
+          (t.usage, t.model)
+        },
+        List((spent, Some(Model("claude-sonnet-5"))))
+      )
 
   test("interactive.runWithSession registers the (clientSid, serverSid) map"):
     // The framework must call `backend.sessions.register(session, result.wireId)`

--- a/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
@@ -1,6 +1,6 @@
 package orca.tools.claude
 
-import orca.{AgentTurnFailed, OrcaFlowException}
+import orca.{AgentTurnFailed, OrcaFlowException, OrcaInteractiveCancelled}
 import orca.agents.{
   AutoApprove,
   BackendTag,
@@ -503,6 +503,35 @@ class DefaultAgentCallTest extends munit.FunSuite:
         agentName = "claude"
       ).autonomous.run("anything")
       assertEquals(captured.get().flatMap(_.systemPrompt), Some("tool-prompt"))
+
+  // Ctrl-C at an interactive prompt abandons a turn the user is still billed
+  // for; the conversation carries what it spent on the cancellation itself.
+  test("an interactive turn cancelled after the model ran emits TokensUsed"):
+    val seen = new AtomicReference[List[OrcaEvent]](Nil)
+    val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
+    val spent = usage(90L, 4L)
+    val cancellingInteraction: Interaction = new Interaction:
+      val listeners: List[OrcaListener] = Nil
+      def drive[B <: BackendTag](
+          conversation: orca.backend.Conversation[B]
+      )(using ox.Ox): AgentResult[B] =
+        throw new OrcaInteractiveCancelled(
+          TurnDebit.Observed(spent, Some(Model("claude-sonnet-5")))
+        )
+    supervised:
+      val _ = intercept[OrcaInteractiveCancelled]:
+        new DefaultAgentCall[BackendTag.ClaudeCode.type, Answer](
+          backend = new SequencedBackend(Nil),
+          effectiveConfig = cfg => cfg.getOrElse(AgentConfig()),
+          prompts = DefaultPrompts,
+          events = listener,
+          interaction = cancellingInteraction,
+          agentName = "claude"
+        ).interactive.run("anything")
+      assertEquals(
+        seen.get().collect { case t: OrcaEvent.TokensUsed => t.usage },
+        List(spent)
+      )
 
   // The autonomous path emits a failed turn's debit; the interactive one runs
   // the same models against the same bills and used to report nothing.

--- a/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
@@ -430,6 +430,77 @@ class DefaultAgentCallTest extends munit.FunSuite:
         s"expected the original AgentTurnFailed as cause; got: ${ex.getCause}"
       )
 
+  // `Unobserved` claims the protocol reported nothing, so nothing may be
+  // emitted: an all-zero TokensUsed would read as a turn measured at zero.
+  test("an Unobserved debit emits no TokensUsed"):
+    val seen = new AtomicReference[List[OrcaEvent]](Nil)
+    val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
+    val backend = new SequencedBackend(Nil):
+      override def runAutonomous(
+          prompt: String,
+          session: SessionId[BackendTag.ClaudeCode.type],
+          config: AgentConfig,
+          events: OrcaListener,
+          outputSchema: Option[String]
+      ): AgentResult[BackendTag.ClaudeCode.type] =
+        throw new AgentTurnFailed("no usage on the wire", TurnDebit.Unobserved)
+    supervised:
+      val _ = intercept[AgentTurnFailed]:
+        new DefaultAgentCall[BackendTag.ClaudeCode.type, Answer](
+          backend = backend,
+          effectiveConfig = cfg => cfg.getOrElse(AgentConfig()),
+          prompts = DefaultPrompts,
+          events = listener,
+          interaction = stubInteraction,
+          agentName = "claude"
+        ).autonomous.run("anything")
+      assertEquals(
+        seen.get().collect { case t: OrcaEvent.TokensUsed => t },
+        Nil
+      )
+
+  // The only failure route that does attempt arithmetic: a retry re-sends the
+  // prompt, so the failed second turn is attempt 2 and separable from the first.
+  test("a retry that fails after the model ran debits the second attempt"):
+    val seen = new AtomicReference[List[OrcaEvent]](Nil)
+    val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
+    val spent = usage(70L, 6L)
+    val calls = new AtomicInteger(0)
+    // Turn 1 runs and returns unparseable output; the corrective retry's turn
+    // runs too, then fails with what it spent.
+    val backend = new SequencedBackend(List("not json")):
+      override def runAutonomous(
+          prompt: String,
+          session: SessionId[BackendTag.ClaudeCode.type],
+          config: AgentConfig,
+          events: OrcaListener,
+          outputSchema: Option[String]
+      ): AgentResult[BackendTag.ClaudeCode.type] =
+        if calls.incrementAndGet() == 1 then
+          super.runAutonomous(prompt, session, config, events, outputSchema)
+        else
+          throw new AgentTurnFailed(
+            "provider error",
+            TurnDebit.Observed(spent, None)
+          )
+    supervised:
+      val _ = intercept[AgentTurnFailed]:
+        new DefaultAgentCall[BackendTag.ClaudeCode.type, Answer](
+          backend = backend,
+          effectiveConfig =
+            cfg => cfg.getOrElse(AgentConfig()).copy(retrySchedule = fastRetry),
+          prompts = DefaultPrompts,
+          events = listener,
+          interaction = stubInteraction,
+          agentName = "claude"
+        ).autonomous.run("anything")
+      assertEquals(
+        seen.get().reverse.collect { case t: OrcaEvent.TokensUsed =>
+          t.attempt
+        },
+        List(1, 2)
+      )
+
   test(
     "autonomous still retries a non-AgentTurnFailed backend failure"
   ):

--- a/claude/src/test/scala/orca/tools/claude/streamjson/InboundMessageTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/streamjson/InboundMessageTest.scala
@@ -63,11 +63,11 @@ class InboundMessageTest extends munit.FunSuite:
         // The wire's `input_tokens` excludes both cache categories, so it is
         // the fresh axis as it stands.
         freshInputTokens = 10L,
-        outputTokens = 20L,
-        cost = Some(BigDecimal("0.5")),
         cacheReadInputTokens = 4000L,
-        reasoningOutputTokens = 0L,
         cacheWriteInputTokens = 300L,
+        outputTokens = 20L,
+        reasoningOutputTokens = 0L,
+        cost = Some(BigDecimal("0.5")),
         apiCalls = None
       )
     )

--- a/claude/src/test/scala/orca/tools/claude/streamjson/InboundMessageTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/streamjson/InboundMessageTest.scala
@@ -1,6 +1,8 @@
 package orca.tools.claude.streamjson
 
-import orca.events.{Usage}
+import orca.events.Usage
+import orca.testkit.Usages.usage
+
 class InboundMessageTest extends munit.FunSuite:
 
   test("system/init carries the session id out of the envelope"):
@@ -48,7 +50,7 @@ class InboundMessageTest extends munit.FunSuite:
     val r = msg.asInstanceOf[InboundMessage.Result]
     assertEquals(r.sessionId, "sid-1")
     assertEquals(r.structuredOutput, Some("""{"answer":42}"""))
-    assertEquals(r.usage, Usage(10L, 20L, Some(BigDecimal("0.003"))))
+    assertEquals(r.usage, usage(10L, 20L, Some(BigDecimal("0.003"))))
     assertEquals(r.isError, false)
 
   test("result keeps cache creation and cache reads on separate axes"):
@@ -58,12 +60,15 @@ class InboundMessageTest extends munit.FunSuite:
     assertEquals(
       msg.asInstanceOf[InboundMessage.Result].usage,
       Usage(
-        // All three input categories are billed, so they sum into the total.
-        inputTokens = 4310L,
+        // The wire's `input_tokens` excludes both cache categories, so it is
+        // the fresh axis as it stands.
+        freshInputTokens = 10L,
         outputTokens = 20L,
         cost = Some(BigDecimal("0.5")),
         cacheReadInputTokens = 4000L,
-        cacheWriteInputTokens = 300L
+        reasoningOutputTokens = 0L,
+        cacheWriteInputTokens = 300L,
+        apiCalls = None
       )
     )
 
@@ -124,7 +129,7 @@ class InboundMessageTest extends munit.FunSuite:
     val r = msg.asInstanceOf[InboundMessage.Result]
     assertEquals(r.output, None)
     assertEquals(r.structuredOutput, None)
-    assertEquals(r.usage, Usage(0L, 0L, None))
+    assertEquals(r.usage, Usage.empty)
     assertEquals(r.isError, false)
 
   test("non-init system subtype is namespaced into Unknown"):

--- a/codex/src/main/scala/orca/tools/codex/CodexConversation.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexConversation.scala
@@ -2,7 +2,7 @@ package orca.tools.codex
 
 import orca.AgentTurnFailed
 import orca.agents.{BackendTag, Model}
-import orca.events.{Usage}
+import orca.events.{TurnDebit, Usage}
 import orca.backend.ConversationEvent
 import orca.backend.{
   StderrPipeline,
@@ -250,6 +250,12 @@ private[codex] class CodexConversation(
   private def mcpToolName(server: String, tool: String): String =
     s"$server.$tool"
 
+  /** ADR 0007: codex reports usage on `turn.completed` only — a `turn.failed`
+    * or a torn stream carries none, and there is no per-message counter to
+    * accrue along the way.
+    */
+  override protected def failedTurnDebit: TurnDebit = TurnDebit.Unobserved
+
   private def handleTurnCompleted(usage: Usage): Unit =
     settleSuccess(
       wireId = sessionId,
@@ -277,7 +283,12 @@ private[codex] class CodexConversation(
     */
   private def handleTurnFailed(message: String): Unit =
     lastProtocolError = Some(message)
-    failWith(new AgentTurnFailed(appendContext(s"codex turn failed: $message")))
+    failWith(
+      new AgentTurnFailed(
+        appendContext(s"codex turn failed: $message"),
+        failedTurnDebit
+      )
+    )
 
   private def toWire(c: FileChangeDetail): FileChangeWire =
     FileChangeWire(c.path, c.kind)

--- a/codex/src/main/scala/orca/tools/codex/jsonl/InboundEvent.scala
+++ b/codex/src/main/scala/orca/tools/codex/jsonl/InboundEvent.scala
@@ -121,21 +121,19 @@ private[codex] object InboundEvent:
     val wire = readFromString[TurnCompletedWire](line)
     val u = wire.usage.getOrElse(UsageWire())
     TurnCompleted(
-      Usage(
-        // In codex's wire shape `input_tokens` is the total billed input
-        // (cached + non-cached), and `output_tokens` is the total output
-        // (visible + reasoning) — `cached_input_tokens`,
-        // `cache_write_input_tokens` and `reasoning_output_tokens` are
-        // sub-breakdowns. Keep every axis: codex emits no cost, so the price
-        // table is the only cost signal, and on the GPT-5.6 family a cache
-        // write bills 1.25× input.
-        inputTokens = u.input_tokens.getOrElse(0L),
+      // Every axis is worth decoding here: codex emits no cost, so the price
+      // table is the only cost signal, and on the GPT-5.6 family a cache write
+      // bills 1.25× input.
+      Usage.inclusiveInput(
+        totalInputTokens = u.input_tokens.getOrElse(0L),
         cacheReadInputTokens = u.cached_input_tokens.getOrElse(0L),
         cacheWriteInputTokens = u.cache_write_input_tokens.getOrElse(0L),
         outputTokens = u.output_tokens.getOrElse(0L),
         reasoningOutputTokens = u.reasoning_output_tokens.getOrElse(0L),
-        // codex doesn't emit cost in the JSONL stream; left None.
-        cost = None
+        cost = None,
+        apiCalls = None,
+        // codex reports no all-token total to cross-check the axes against.
+        wireTotal = None
       )
     )
 

--- a/codex/src/test/scala/orca/tools/codex/CodexConversationTest.scala
+++ b/codex/src/test/scala/orca/tools/codex/CodexConversationTest.scala
@@ -1,7 +1,8 @@
 package orca.tools.codex
 
 import orca.agents.{Model, WireSessionId}
-import orca.events.{Usage}
+import orca.events.Usage
+import orca.testkit.Usages.usage
 import orca.{OrcaFlowException, OrcaInteractiveCancelled}
 import orca.backend.{ConversationEvent, ConversationEventConformance}
 import orca.subprocess.FakePipedCliProcess
@@ -36,14 +37,15 @@ class CodexConversationTest extends munit.FunSuite:
     assertEquals(
       result.usage,
       Usage(
-        // `input_tokens` is already the billed total; reads and writes are
-        // sub-breakdowns of it, so nothing is added on top.
-        inputTokens = 900L,
+        // `input_tokens` is already the billed total, so the fresh axis is
+        // what its two cache sub-breakdowns leave: 900 - 500 - 300.
+        freshInputTokens = 100L,
         outputTokens = 40L,
         cost = None,
         cacheReadInputTokens = 500L,
         reasoningOutputTokens = 12L,
-        cacheWriteInputTokens = 300L
+        cacheWriteInputTokens = 300L,
+        apiCalls = None
       )
     )
 
@@ -76,7 +78,7 @@ class CodexConversationTest extends munit.FunSuite:
     val Right(result) = conv.awaitResult(): @unchecked
     assertEquals(WireSessionId.value(result.wireId), "thr-1")
     assertEquals(result.output, "hello")
-    assertEquals(result.usage, Usage(10L, 3L, None))
+    assertEquals(result.usage, usage(10L, 3L))
 
   convTest(
     "usage attributes to the configured model when the wire omits it"

--- a/codex/src/test/scala/orca/tools/codex/CodexConversationTest.scala
+++ b/codex/src/test/scala/orca/tools/codex/CodexConversationTest.scala
@@ -40,11 +40,11 @@ class CodexConversationTest extends munit.FunSuite:
         // `input_tokens` is already the billed total, so the fresh axis is
         // what its two cache sub-breakdowns leave: 900 - 500 - 300.
         freshInputTokens = 100L,
-        outputTokens = 40L,
-        cost = None,
         cacheReadInputTokens = 500L,
-        reasoningOutputTokens = 12L,
         cacheWriteInputTokens = 300L,
+        outputTokens = 40L,
+        reasoningOutputTokens = 12L,
+        cost = None,
         apiCalls = None
       )
     )

--- a/flow/src/main/scala/orca/events/CostResolvingDispatcher.scala
+++ b/flow/src/main/scala/orca/events/CostResolvingDispatcher.scala
@@ -1,0 +1,18 @@
+package orca.events
+
+/** Resolves each turn's cost once, on the way into the listener fan-out, and
+  * hands every listener the same figure through [[OrcaEvent.TokensUsed.cost]].
+  *
+  * Wrapping the fan-out is what makes "the terminal summary, the on-disk cost
+  * log and a user's own listener show different dollars" unrepresentable: no
+  * listener holds a [[PriceList]], so there is nothing left to configure
+  * inconsistently.
+  */
+class CostResolvingDispatcher(pricing: PriceList, inner: OrcaListener)
+    extends OrcaListener:
+  def onEvent(event: OrcaEvent): Unit = event match
+    case turn: OrcaEvent.TokensUsed =>
+      inner.onEvent(
+        turn.copy(cost = Pricing.resolve(pricing.table, turn.model, turn.usage))
+      )
+    case other => inner.onEvent(other)

--- a/flow/src/main/scala/orca/events/CostTracker.scala
+++ b/flow/src/main/scala/orca/events/CostTracker.scala
@@ -2,7 +2,6 @@ package orca.events
 
 import orca.agents.Model
 
-import java.time.LocalDate
 import java.util.concurrent.atomic.AtomicReference
 
 /** Listener that accumulates `TokensUsed` events along three independent axes —
@@ -10,16 +9,16 @@ import java.util.concurrent.atomic.AtomicReference
   * so the tracker is safe to register across concurrent LLM calls.
   *
   * Cost comes off the event, resolved once for the whole run by
-  * [[CostResolvingDispatcher]]. Estimated figures are flagged, and the legend
-  * shows `ratesAsOf` so a stale snapshot is obvious.
+  * [[CostResolvingDispatcher]]; `pricing` is read for its `lastUpdated` alone,
+  * so the legend can't advertise a date from a different table than the one the
+  * run priced with.
   *
   * All axes share the same underlying calls, so summing any of the maps yields
   * the grand total. The `model` axis keys on `Option[Model]` because the
   * reported model isn't always present; the summary surfaces the missing case
   * as `(unknown)`.
   */
-class CostTracker(ratesAsOf: LocalDate = Pricing.default.lastUpdated)
-    extends OrcaListener:
+class CostTracker(pricing: PriceList = Pricing.default) extends OrcaListener:
 
   /** One bucket's running total. Keeping the usage and the cost of the same
     * calls in one value is what stops the two drifting apart per axis.
@@ -151,7 +150,7 @@ class CostTracker(ratesAsOf: LocalDate = Pricing.default.lastUpdated)
       val legend =
         if hasEstimate then
           s"\n\n* estimated from the pricing table " +
-            s"(rates as of $ratesAsOf — may be stale)"
+            s"(rates as of ${pricing.lastUpdated} — may be stale)"
         else ""
       s"""By agent:
          |${agentLines.mkString("\n")}

--- a/flow/src/main/scala/orca/events/CostTracker.scala
+++ b/flow/src/main/scala/orca/events/CostTracker.scala
@@ -2,36 +2,41 @@ package orca.events
 
 import orca.agents.Model
 
+import java.time.LocalDate
 import java.util.concurrent.atomic.AtomicReference
 
-/** Listener that accumulates `TokensUsed` events along two independent axes —
-  * by `agent` and by `model`. State is held in an `AtomicReference` so the
-  * tracker is safe to register across concurrent LLM calls.
+/** Listener that accumulates `TokensUsed` events along three independent axes —
+  * by `agent`, by `model` and by `role`. State is held in an `AtomicReference`
+  * so the tracker is safe to register across concurrent LLM calls.
   *
-  * Cost per event is either a reported figure (Claude CLI returns
-  * `total_cost_usd`) or estimated from the supplied [[PriceList]]. Estimated
-  * costs are flagged, and the legend shows the table's `lastUpdated` date so a
-  * stale snapshot is obvious; pass a custom `pricing` to override the rates.
+  * Cost comes off the event, resolved once for the whole run by
+  * [[CostResolvingDispatcher]]. Estimated figures are flagged, and the legend
+  * shows `ratesAsOf` so a stale snapshot is obvious.
   *
-  * Both axes share the same underlying calls, so summing either map yields the
-  * grand total. The `model` axis keys on `Option[Model]` because the reported
-  * model isn't always present; the summary surfaces the missing case as
-  * `(unknown)`.
+  * All axes share the same underlying calls, so summing any of the maps yields
+  * the grand total. The `model` axis keys on `Option[Model]` because the
+  * reported model isn't always present; the summary surfaces the missing case
+  * as `(unknown)`.
   */
-class CostTracker(pricing: PriceList = Pricing.default) extends OrcaListener:
+class CostTracker(ratesAsOf: LocalDate = Pricing.default.lastUpdated)
+    extends OrcaListener:
+
+  /** One bucket's running total. Keeping the usage and the cost of the same
+    * calls in one value is what stops the two drifting apart per axis.
+    */
+  private case class Tally(usage: Usage, cost: Option[Cost]):
+    def +(that: Tally): Tally =
+      Tally(usage + that.usage, (cost ++ that.cost).reduceOption(_ + _))
 
   private case class State(
-      byAgent: Map[String, Usage] = Map.empty,
-      byModel: Map[Option[Model], Usage] = Map.empty,
-      byAgentCost: Map[String, Cost] = Map.empty,
-      byModelCost: Map[Option[Model], Cost] = Map.empty,
+      byAgent: Map[String, Tally] = Map.empty,
+      byModel: Map[Option[Model], Tally] = Map.empty,
       /** The role last recorded for a given agent, for display/subtotal lookup.
         * `TokensUsed.role` is constant per agent in practice, so last-write and
         * first-write agree. See [[byRole]] for the subtotal axis.
         */
       agentRoles: Map[String, Option[String]] = Map.empty,
-      byRole: Map[Option[String], Usage] = Map.empty,
-      byRoleCost: Map[Option[String], Cost] = Map.empty
+      byRole: Map[Option[String], Tally] = Map.empty
   ):
     def record(
         agent: String,
@@ -39,69 +44,67 @@ class CostTracker(pricing: PriceList = Pricing.default) extends OrcaListener:
         usage: Usage,
         cost: Option[Cost],
         role: Option[String]
-    ): State = copy(
-      byAgent =
-        byAgent.updated(agent, byAgent.getOrElse(agent, Usage.empty) + usage),
-      byModel =
-        byModel.updated(model, byModel.getOrElse(model, Usage.empty) + usage),
-      byAgentCost = addCost(byAgentCost, agent, cost),
-      byModelCost = addCost(byModelCost, model, cost),
-      agentRoles = agentRoles.updated(agent, role),
-      byRole =
-        byRole.updated(role, byRole.getOrElse(role, Usage.empty) + usage),
-      byRoleCost = addCost(byRoleCost, role, cost)
-    )
+    ): State =
+      val tally = Tally(usage, cost)
+      copy(
+        byAgent = add(byAgent, agent, tally),
+        byModel = add(byModel, model, tally),
+        agentRoles = agentRoles.updated(agent, role),
+        byRole = add(byRole, role, tally)
+      )
 
-  /** Fold one optional cost into a per-key map. No-op when `cost` is `None`
-    * (the call had neither a reported nor estimable figure).
-    */
-  private def addCost[K](
-      map: Map[K, Cost],
-      key: K,
-      cost: Option[Cost]
-  ): Map[K, Cost] =
-    cost.fold(map)(c => map.updated(key, map.get(key).fold(c)(_ + c)))
+    private def add[K](
+        buckets: Map[K, Tally],
+        key: K,
+        tally: Tally
+    ): Map[K, Tally] =
+      buckets.updatedWith(key)(prev => Some(prev.fold(tally)(_ + tally)))
 
   private val state: AtomicReference[State] = AtomicReference(State())
 
   def onEvent(event: OrcaEvent): Unit = event match
     // `attempt` is ignored: a retry's tokens count toward the run's spend like
     // any other turn's.
-    case OrcaEvent.TokensUsed(agent, model, usage, role, _, _) =>
-      val cost = Pricing.resolve(pricing.table, model, usage)
+    case OrcaEvent.TokensUsed(agent, model, usage, role, _, _, cost) =>
       val _ = state.updateAndGet(_.record(agent, model, usage, cost, role))
     case _ => ()
 
   /** Usage accumulated across every call, regardless of axis. */
   def total: Usage =
-    state.get().byAgent.values.foldLeft(Usage.empty)(_ + _)
+    state.get().byAgent.values.foldLeft(Usage.empty)(_ + _.usage)
 
   /** Total cost across every call. `None` when no call surfaced a cost
     * (reported or estimable).
     */
   def totalCost: Option[Cost] =
-    state.get().byAgentCost.values.reduceOption(_ + _)
+    state.get().byAgent.values.flatMap(_.cost).reduceOption(_ + _)
 
   /** Per-agent usage breakdown — keyed by `Agent.name`. */
-  def perAgent: Map[String, Usage] = state.get().byAgent
+  def perAgent: Map[String, Usage] =
+    state.get().byAgent.view.mapValues(_.usage).toMap
 
   /** Per-agent cost breakdown. Missing entry means that agent's calls had
     * neither reported nor estimable cost.
     */
-  def perAgentCost: Map[String, Cost] = state.get().byAgentCost
+  def perAgentCost: Map[String, Cost] = costsOf(state.get().byAgent)
 
   /** Per-model usage breakdown. `None` collects calls whose model the backend
     * didn't report and the caller didn't pin in `AgentConfig`.
     */
-  def perModel: Map[Option[Model], Usage] = state.get().byModel
+  def perModel: Map[Option[Model], Usage] =
+    state.get().byModel.view.mapValues(_.usage).toMap
 
   /** Per-model cost breakdown. Same key semantics as [[perModel]]. */
-  def perModelCost: Map[Option[Model], Cost] = state.get().byModelCost
+  def perModelCost: Map[Option[Model], Cost] = costsOf(state.get().byModel)
 
   /** Per-role usage breakdown ([[Agent.role]], e.g. `Some("reviewer")`). `None`
     * collects calls from an agent with no role tag — the common case.
     */
-  def perRole: Map[Option[String], Usage] = state.get().byRole
+  def perRole: Map[Option[String], Usage] =
+    state.get().byRole.view.mapValues(_.usage).toMap
+
+  private def costsOf[K](buckets: Map[K, Tally]): Map[K, Cost] =
+    buckets.collect { case (key, Tally(_, Some(cost))) => key -> cost }
 
   /** Two or three sections — by-agent, by-model, and (only when at least one
     * call carried a [[orca.agents.Agent.role]] tag) by-role — each sorted
@@ -121,17 +124,17 @@ class CostTracker(pricing: PriceList = Pricing.default) extends OrcaListener:
     else
       val agentLines = s.byAgent.toList
         .sortBy((agent, _) => agentLabel(agent, s.agentRoles))
-        .map: (agent, u) =>
-          s"  ${agentLabel(agent, s.agentRoles)}: ${formatLine(u, s.byAgentCost.get(agent))}"
+        .map: (agent, t) =>
+          s"  ${agentLabel(agent, s.agentRoles)}: ${formatLine(t)}"
       val modelLines = s.byModel.toList
         .sortBy((model, _) => modelLabel(model))
-        .map: (model, u) =>
-          s"  ${modelLabel(model)}: ${formatLine(u, s.byModelCost.get(model))}"
+        .map: (model, t) =>
+          s"  ${modelLabel(model)}: ${formatLine(t)}"
       val roleLines = s.byRole.toList
-        .collect { case (Some(role), u) => (role, u) }
+        .collect { case (Some(role), t) => (role, t) }
         .sortBy(_._1)
-        .map: (role, u) =>
-          s"  $role: ${formatLine(u, s.byRoleCost.get(Some(role)))}"
+        .map: (role, t) =>
+          s"  $role: ${formatLine(t)}"
       val roleSection =
         if roleLines.isEmpty then ""
         else s"""
@@ -144,12 +147,11 @@ class CostTracker(pricing: PriceList = Pricing.default) extends OrcaListener:
         // total: $1.10*` reading like double-counting.
         val label = if c.estimated then "Estimated total" else "Total"
         s"\n\n$label: ${formatAmount(c)}"
-      val hasEstimate =
-        (s.byAgentCost.values ++ s.byModelCost.values).exists(_.estimated)
+      val hasEstimate = s.byAgent.values.flatMap(_.cost).exists(_.estimated)
       val legend =
         if hasEstimate then
           s"\n\n* estimated from the pricing table " +
-            s"(rates as of ${pricing.lastUpdated} — may be stale)"
+            s"(rates as of $ratesAsOf — may be stale)"
         else ""
       s"""By agent:
          |${agentLines.mkString("\n")}
@@ -175,9 +177,9 @@ class CostTracker(pricing: PriceList = Pricing.default) extends OrcaListener:
   ): String =
     agentRoles.get(agent).flatten.fold(agent)(role => s"$role: $agent")
 
-  private def formatLine(usage: Usage, cost: Option[Cost]): String =
-    val tokens = formatUsage(usage)
-    cost.fold(tokens)(c => s"$tokens (${formatCost(c)})")
+  private def formatLine(tally: Tally): String =
+    val tokens = formatUsage(tally.usage)
+    tally.cost.fold(tokens)(c => s"$tokens (${formatCost(c)})")
 
   /** Cache reads and cache writes share one parenthetical after the input
     * count, each part dropped when zero.

--- a/flow/src/main/scala/orca/events/CostTracker.scala
+++ b/flow/src/main/scala/orca/events/CostTracker.scala
@@ -64,8 +64,10 @@ class CostTracker(pricing: PriceList = Pricing.default) extends OrcaListener:
   def onEvent(event: OrcaEvent): Unit = event match
     // `attempt` is ignored: a retry's tokens count toward the run's spend like
     // any other turn's.
-    case OrcaEvent.TokensUsed(agent, model, usage, role, _, _, cost) =>
-      val _ = state.updateAndGet(_.record(agent, model, usage, cost, role))
+    case t: OrcaEvent.TokensUsed =>
+      val _ = state.updateAndGet(
+        _.record(t.agent, t.model, t.usage, t.cost, t.role)
+      )
     case _ => ()
 
   /** Usage accumulated across every call, regardless of axis. */

--- a/flow/src/main/scala/orca/events/Pricing.scala
+++ b/flow/src/main/scala/orca/events/Pricing.scala
@@ -62,6 +62,24 @@ object Pricing:
     */
   private val DateSuffix: Regex = """^-\d{8}$""".r
 
+  /** Suffixes that spell the SAME model at the SAME price, stripped so one row
+    * prices every spelling. Today just `[1m]`, the CLI's 1M-context spelling of
+    * a Claude model, which costs what the base row costs.
+    */
+  private val AliasSuffixes: List[String] = List("[1m]")
+
+  /** Anthropic's published ratios: cache read 0.10x input, output 5x, cache
+    * write 2x — the one-hour-TTL tier Claude Code requests (see the measured
+    * runs noted on [[default]]).
+    */
+  private def anthropic(inputUsdPerMillion: BigDecimal): ModelPricing =
+    ModelPricing(
+      inputUsdPerMillion = inputUsdPerMillion,
+      cacheReadUsdPerMillion = inputUsdPerMillion * BigDecimal("0.10"),
+      outputUsdPerMillion = inputUsdPerMillion * 5,
+      cacheWriteUsdPerMillion = inputUsdPerMillion * 2
+    )
+
   /** Resolve one call's cost: the figure the backend reported if there is one,
     * an [[estimate]] from `table` otherwise, `None` when neither is available.
     * The single home for the reported-vs-estimated decision.
@@ -103,7 +121,21 @@ object Pricing:
           BigDecimal(usage.outputTokens) * p.outputUsdPerMillion / million
         inputCost + cacheReadCost + cacheWriteCost + outputCost
 
+  /** Exact match, then the dated-snapshot prefix bridge, then the same lookup
+    * again on the alias-stripped id. The alias strip runs LAST so a future
+    * 1M-context model that prices differently wins with its own explicit row.
+    */
   private def lookup(
+      table: PricingTable,
+      model: Model
+  ): Option[ModelPricing] =
+    exactOrDated(table, model).orElse:
+      val stripped = AliasSuffixes.foldLeft(model.name)(_.stripSuffix(_))
+      Option
+        .when(stripped != model.name)(Model(stripped))
+        .flatMap(exactOrDated(table, _))
+
+  private def exactOrDated(
       table: PricingTable,
       model: Model
   ): Option[ModelPricing] =
@@ -126,98 +158,27 @@ object Pricing:
     table = Map(
       // --- Anthropic ---
       // Claude reports `total_cost_usd` from the CLI, so these are mostly
-      // safety nets for sessions that didn't surface the field. Cache-write
-      // rates are the one-hour-TTL tier (2× base input): Claude Code requests
-      // `ttl: "1h"`, and the CLI's own usage breakdown confirms it — across
-      // measured runs every cache-creation token landed in
+      // safety nets for sessions that didn't surface the field — and the CLI
+      // computes that figure at these same sticker rates. Anthropic's
+      // published introductory Sonnet $2/$10 ends 2026-08-31.
+      // Cache-write rates are the one-hour-TTL tier (2x base input): Claude
+      // Code requests `ttl: "1h"`, and the CLI's own usage breakdown confirms
+      // it — across measured runs every cache-creation token landed in
       // `cache_creation.ephemeral_1h_input_tokens` and none in the 5m bucket.
       // A backend that asks for the five-minute TTL instead (pi's default,
-      // unless PI_CACHE_RETENTION=long) bills 1.25× — $6.25 Opus, $3.75
-      // Sonnet, $1.25 Haiku, $12.50 Fable — so override the table for
+      // unless PI_CACHE_RETENTION=long) bills 1.25x, so override the table for
       // pi-heavy use.
-      Model("claude-fable-5") -> ModelPricing(
-        inputUsdPerMillion = 10,
-        cacheReadUsdPerMillion = 1.00,
-        outputUsdPerMillion = 50,
-        cacheWriteUsdPerMillion = 20
-      ),
-      // `[1m]` is the CLI's 1M-context spelling of the same model at the same
-      // price; the suffix isn't a date, so `lookup` won't bridge it — hence its
-      // own row.
-      Model("claude-opus-5") -> ModelPricing(
-        inputUsdPerMillion = 5,
-        cacheReadUsdPerMillion = 0.50,
-        outputUsdPerMillion = 25,
-        cacheWriteUsdPerMillion = 10
-      ),
-      Model("claude-opus-5[1m]") -> ModelPricing(
-        inputUsdPerMillion = 5,
-        cacheReadUsdPerMillion = 0.50,
-        outputUsdPerMillion = 25,
-        cacheWriteUsdPerMillion = 10
-      ),
-      Model("claude-opus-4-8") -> ModelPricing(
-        inputUsdPerMillion = 5,
-        cacheReadUsdPerMillion = 0.50,
-        outputUsdPerMillion = 25,
-        cacheWriteUsdPerMillion = 10
-      ),
-      Model("claude-opus-4-8[1m]") -> ModelPricing(
-        inputUsdPerMillion = 5,
-        cacheReadUsdPerMillion = 0.50,
-        outputUsdPerMillion = 25,
-        cacheWriteUsdPerMillion = 10
-      ),
-      Model("claude-opus-4-7") -> ModelPricing(
-        inputUsdPerMillion = 5,
-        cacheReadUsdPerMillion = 0.50,
-        outputUsdPerMillion = 25,
-        cacheWriteUsdPerMillion = 10
-      ),
-      Model("claude-opus-4-6") -> ModelPricing(
-        inputUsdPerMillion = 5,
-        cacheReadUsdPerMillion = 0.50,
-        outputUsdPerMillion = 25,
-        cacheWriteUsdPerMillion = 10
-      ),
-      Model("claude-opus-4-5") -> ModelPricing(
-        inputUsdPerMillion = 5,
-        cacheReadUsdPerMillion = 0.50,
-        outputUsdPerMillion = 25,
-        cacheWriteUsdPerMillion = 10
-      ),
-      Model("claude-opus-4-1") -> ModelPricing(
-        inputUsdPerMillion = 15,
-        cacheReadUsdPerMillion = 1.50,
-        outputUsdPerMillion = 75,
-        cacheWriteUsdPerMillion = 30
-      ),
-      // The CLI computes the `total_cost_usd` it reports at these sticker
-      // rates; Anthropic's published introductory $2/$10 ends 2026-08-31.
-      Model("claude-sonnet-5") -> ModelPricing(
-        inputUsdPerMillion = 3,
-        cacheReadUsdPerMillion = 0.30,
-        outputUsdPerMillion = 15,
-        cacheWriteUsdPerMillion = 6
-      ),
-      Model("claude-sonnet-4-6") -> ModelPricing(
-        inputUsdPerMillion = 3,
-        cacheReadUsdPerMillion = 0.30,
-        outputUsdPerMillion = 15,
-        cacheWriteUsdPerMillion = 6
-      ),
-      Model("claude-sonnet-4-5") -> ModelPricing(
-        inputUsdPerMillion = 3,
-        cacheReadUsdPerMillion = 0.30,
-        outputUsdPerMillion = 15,
-        cacheWriteUsdPerMillion = 6
-      ),
-      Model("claude-haiku-4-5") -> ModelPricing(
-        inputUsdPerMillion = 1,
-        cacheReadUsdPerMillion = 0.10,
-        outputUsdPerMillion = 5,
-        cacheWriteUsdPerMillion = 2
-      ),
+      Model("claude-fable-5") -> anthropic(10),
+      Model("claude-opus-5") -> anthropic(5),
+      Model("claude-opus-4-8") -> anthropic(5),
+      Model("claude-opus-4-7") -> anthropic(5),
+      Model("claude-opus-4-6") -> anthropic(5),
+      Model("claude-opus-4-5") -> anthropic(5),
+      Model("claude-opus-4-1") -> anthropic(15),
+      Model("claude-sonnet-5") -> anthropic(3),
+      Model("claude-sonnet-4-6") -> anthropic(3),
+      Model("claude-sonnet-4-5") -> anthropic(3),
+      Model("claude-haiku-4-5") -> anthropic(1),
       // --- OpenAI (codex, opencode) ---
       // The GPT-5.6 family prices cache writes separately, at 1.25× input;
       // earlier models have no write charge, so their rate is plain input.

--- a/flow/src/main/scala/orca/events/Pricing.scala
+++ b/flow/src/main/scala/orca/events/Pricing.scala
@@ -29,13 +29,6 @@ case class ModelPricing(
     cacheWriteUsdPerMillion: BigDecimal
 )
 
-/** A USD cost with a flag that propagates through addition: any aggregate
-  * mixing at least one estimated input is itself flagged as an estimate.
-  */
-case class Cost(amount: BigDecimal, estimated: Boolean):
-  def +(that: Cost): Cost =
-    Cost(amount + that.amount, estimated || that.estimated)
-
 /** Model id → per-million-token rates. */
 type PricingTable = Map[Model, ModelPricing]
 

--- a/flow/src/main/scala/orca/events/Pricing.scala
+++ b/flow/src/main/scala/orca/events/Pricing.scala
@@ -44,7 +44,14 @@ type PricingTable = Map[Model, ModelPricing]
   *   args,
   *   pricing = PriceList(
   *     Pricing.default.table ++
-  *       Map(Model("my-model") -> ModelPricing(2, 0.2, 10, 2.5)),
+  *       Map(
+  *         Model("my-model") -> ModelPricing(
+  *           inputUsdPerMillion = 2,
+  *           cacheReadUsdPerMillion = 0.2,
+  *           outputUsdPerMillion = 10,
+  *           cacheWriteUsdPerMillion = 2.5
+  *         )
+  *       ),
   *     lastUpdated = LocalDate.now
   *   )
   * ): ...

--- a/flow/src/main/scala/orca/events/Pricing.scala
+++ b/flow/src/main/scala/orca/events/Pricing.scala
@@ -62,11 +62,10 @@ object Pricing:
     */
   private val DateSuffix: Regex = """^-\d{8}$""".r
 
-  /** Suffixes that spell the SAME model at the SAME price, stripped so one row
-    * prices every spelling. Today just `[1m]`, the CLI's 1M-context spelling of
-    * a Claude model, which costs what the base row costs.
+  /** The CLI's 1M-context spelling of a Claude model, which costs what the base
+    * row costs — so one row prices both spellings.
     */
-  private val AliasSuffixes: List[String] = List("[1m]")
+  private val AliasSuffix: String = "[1m]"
 
   /** Anthropic's published ratios: cache read 0.10x input, output 5x, cache
     * write 2x — the one-hour-TTL tier Claude Code requests (see the measured
@@ -94,18 +93,22 @@ object Pricing:
       .orElse(estimate(table, model, usage).map(Cost(_, estimated = true)))
 
   /** Compute an estimated cost for one call from `usage` and the price for
-    * `model`. Returns `None` when `model` is missing or absent from `table`.
+    * `model`. Returns `None` when `model` is missing, absent from `table`, or
+    * the call spent no tokens at all — a zero estimate would be a `Cost` whose
+    * `estimated` flag relabels the whole run's total, having priced nothing.
     *
     * Looks up `model` exactly first, then falls back to the longest entry in
     * `table` that prefixes `model` — so a date-suffixed id like
     * `claude-sonnet-4-6-20251015` matches the `claude-sonnet-4-6` entry.
     */
-  def estimate(
+  private def estimate(
       table: PricingTable,
       model: Option[Model],
       usage: Usage
   ): Option[BigDecimal] =
-    model
+    Option
+      .when(usage.inputTokens > 0 || usage.outputTokens > 0)(model)
+      .flatten
       .flatMap(lookup(table, _))
       .map: p =>
         val million = BigDecimal(1_000_000)
@@ -130,9 +133,10 @@ object Pricing:
       model: Model
   ): Option[ModelPricing] =
     exactOrDated(table, model).orElse:
-      val stripped = AliasSuffixes.foldLeft(model.name)(_.stripSuffix(_))
       Option
-        .when(stripped != model.name)(Model(stripped))
+        .when(model.name.endsWith(AliasSuffix))(
+          Model(model.name.stripSuffix(AliasSuffix))
+        )
         .flatMap(exactOrDated(table, _))
 
   private def exactOrDated(

--- a/flow/src/main/scala/orca/events/Pricing.scala
+++ b/flow/src/main/scala/orca/events/Pricing.scala
@@ -98,13 +98,8 @@ object Pricing:
       .flatMap(lookup(table, _))
       .map: p =>
         val million = BigDecimal(1_000_000)
-        // Fresh input is what neither cache category claimed. The clamp keeps
-        // a backend that over-reports its cache axes from producing a negative
-        // charge.
-        val freshInput = (usage.inputTokens - usage.cacheReadInputTokens -
-          usage.cacheWriteInputTokens) max 0L
         val inputCost =
-          BigDecimal(freshInput) * p.inputUsdPerMillion / million
+          BigDecimal(usage.freshInputTokens) * p.inputUsdPerMillion / million
         val cacheReadCost =
           BigDecimal(usage.cacheReadInputTokens) * p.cacheReadUsdPerMillion /
             million

--- a/flow/src/main/scala/orca/events/Pricing.scala
+++ b/flow/src/main/scala/orca/events/Pricing.scala
@@ -11,11 +11,10 @@ import scala.util.matching.Regex
   *     `cache_read_input_tokens`, OpenAI `cached_input`).
   *   - `cacheWrite` bills tokens written into it (Claude
   *     `cache_creation_input_tokens`). Where a provider prices writes by cache
-  *     lifetime — Anthropic charges 1.25× base input at the five-minute TTL and
-  *     2× at the one-hour one — this is a single rate, because the CLI picks
-  *     the TTL per request and orca never sees which tier a given write used.
-  *     The shipped rates follow the tier the CLI in front of them actually
-  *     requests; set your own accordingly.
+  *     lifetime, this is still a single rate: the CLI picks the TTL per request
+  *     and orca never sees which tier a given write used. The shipped rates
+  *     follow the tier the CLI in front of them actually requests; set your own
+  *     accordingly.
   *   - `output` covers reasoning tokens too — both Anthropic and OpenAI bill
   *     reasoning at the output rate.
   *
@@ -67,9 +66,15 @@ object Pricing:
     */
   private val AliasSuffix: String = "[1m]"
 
-  /** Anthropic's published ratios: cache read 0.10x input, output 5x, cache
-    * write 2x — the one-hour-TTL tier Claude Code requests (see the measured
-    * runs noted on [[default]]).
+  /** An Anthropic row from its input rate alone: they all follow the published
+    * ratios — cache read 0.10× input, output 5×, cache write 2×.
+    *
+    * The 2× is the one-hour-TTL tier. Claude Code requests `ttl: "1h"`, and the
+    * CLI's own usage breakdown confirms it: across measured runs every
+    * cache-creation token landed in `cache_creation.ephemeral_1h_input_tokens`
+    * and none in the 5m bucket. A backend asking for the five-minute TTL
+    * instead (pi's default, unless `PI_CACHE_RETENTION=long`) bills 1.25×, so
+    * override the table for pi-heavy use.
     */
   private def anthropic(inputUsdPerMillion: BigDecimal): ModelPricing =
     ModelPricing(
@@ -160,18 +165,11 @@ object Pricing:
     */
   val default: PriceList = PriceList(
     table = Map(
-      // --- Anthropic ---
-      // Claude reports `total_cost_usd` from the CLI, so these are mostly
-      // safety nets for sessions that didn't surface the field — and the CLI
-      // computes that figure at these same sticker rates. Anthropic's
-      // published introductory Sonnet $2/$10 ends 2026-08-31.
-      // Cache-write rates are the one-hour-TTL tier (2x base input): Claude
-      // Code requests `ttl: "1h"`, and the CLI's own usage breakdown confirms
-      // it — across measured runs every cache-creation token landed in
-      // `cache_creation.ephemeral_1h_input_tokens` and none in the 5m bucket.
-      // A backend that asks for the five-minute TTL instead (pi's default,
-      // unless PI_CACHE_RETENTION=long) bills 1.25x, so override the table for
-      // pi-heavy use.
+      // --- Anthropic --- the argument is the input rate in USD per million;
+      // `anthropic` derives the other three. Claude reports `total_cost_usd`
+      // from the CLI, so these are mostly safety nets for sessions that didn't
+      // surface the field — and the CLI computes that figure at these same
+      // sticker rates.
       Model("claude-fable-5") -> anthropic(10),
       Model("claude-opus-5") -> anthropic(5),
       Model("claude-opus-4-8") -> anthropic(5),
@@ -179,6 +177,8 @@ object Pricing:
       Model("claude-opus-4-6") -> anthropic(5),
       Model("claude-opus-4-5") -> anthropic(5),
       Model("claude-opus-4-1") -> anthropic(15),
+      // Sonnet's sticker input rate. Anthropic's introductory $2/$10 promotion
+      // ends 2026-08-31, after which the standard $3/$15 encoded here applies.
       Model("claude-sonnet-5") -> anthropic(3),
       Model("claude-sonnet-4-6") -> anthropic(3),
       Model("claude-sonnet-4-5") -> anthropic(3),

--- a/flow/src/test/scala/orca/CostResolvingDispatcherTest.scala
+++ b/flow/src/test/scala/orca/CostResolvingDispatcherTest.scala
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 class CostResolvingDispatcherTest extends munit.FunSuite:
 
-  private val table = PriceList(
+  private val prices = PriceList(
     Map(Model("opus") -> ModelPricing(1, BigDecimal("0.10"), 5, 2)),
     lastUpdated = LocalDate.of(2026, 1, 15)
   )
@@ -32,7 +32,7 @@ class CostResolvingDispatcherTest extends munit.FunSuite:
     val first = AtomicReference[List[OrcaEvent]](Nil)
     val second = AtomicReference[List[OrcaEvent]](Nil)
     val dispatcher = new CostResolvingDispatcher(
-      table,
+      prices,
       new EventDispatcher(List(recorder(first), recorder(second)))
     )
     dispatcher.onEvent(
@@ -50,6 +50,6 @@ class CostResolvingDispatcherTest extends munit.FunSuite:
 
   test("an event that isn't a turn passes through untouched"):
     val seen = AtomicReference[List[OrcaEvent]](Nil)
-    val dispatcher = new CostResolvingDispatcher(table, recorder(seen))
+    val dispatcher = new CostResolvingDispatcher(prices, recorder(seen))
     dispatcher.onEvent(OrcaEvent.Step("hi"))
     assertEquals(seen.get(), List(OrcaEvent.Step("hi")))

--- a/flow/src/test/scala/orca/CostResolvingDispatcherTest.scala
+++ b/flow/src/test/scala/orca/CostResolvingDispatcherTest.scala
@@ -4,6 +4,7 @@ import orca.agents.Model
 import orca.events.{
   Cost,
   CostResolvingDispatcher,
+  EventDispatcher,
   ModelPricing,
   OrcaEvent,
   OrcaListener,
@@ -28,20 +29,23 @@ class CostResolvingDispatcherTest extends munit.FunSuite:
   // The point of resolving before the fan-out: two listeners can no longer
   // report different dollars for one turn, because neither prices anything.
   test("every listener receives the same resolved cost for one turn"):
-    val seen = AtomicReference[List[OrcaEvent]](Nil)
+    val first = AtomicReference[List[OrcaEvent]](Nil)
+    val second = AtomicReference[List[OrcaEvent]](Nil)
     val dispatcher = new CostResolvingDispatcher(
       table,
-      e => { recorder(seen).onEvent(e); recorder(seen).onEvent(e) }
+      new EventDispatcher(List(recorder(first), recorder(second)))
     )
     dispatcher.onEvent(
       OrcaEvent.TokensUsed("claude", Some(Model("opus")), usage(1_000_000L, 0L))
     )
+    val resolved = List(Some(Cost(BigDecimal("1.0"), estimated = true)))
     assertEquals(
-      seen.get().collect { case t: OrcaEvent.TokensUsed => t.cost },
-      List(
-        Some(Cost(BigDecimal("1.0"), estimated = true)),
-        Some(Cost(BigDecimal("1.0"), estimated = true))
-      )
+      first.get().collect { case t: OrcaEvent.TokensUsed => t.cost },
+      resolved
+    )
+    assertEquals(
+      second.get().collect { case t: OrcaEvent.TokensUsed => t.cost },
+      resolved
     )
 
   test("an event that isn't a turn passes through untouched"):

--- a/flow/src/test/scala/orca/CostResolvingDispatcherTest.scala
+++ b/flow/src/test/scala/orca/CostResolvingDispatcherTest.scala
@@ -1,0 +1,51 @@
+package orca
+
+import orca.agents.Model
+import orca.events.{
+  Cost,
+  CostResolvingDispatcher,
+  ModelPricing,
+  OrcaEvent,
+  OrcaListener,
+  PriceList
+}
+import orca.testkit.Usages.usage
+
+import java.time.LocalDate
+import java.util.concurrent.atomic.AtomicReference
+
+class CostResolvingDispatcherTest extends munit.FunSuite:
+
+  private val table = PriceList(
+    Map(Model("opus") -> ModelPricing(1, BigDecimal("0.10"), 5, 2)),
+    lastUpdated = LocalDate.of(2026, 1, 15)
+  )
+
+  private def recorder(
+      into: AtomicReference[List[OrcaEvent]]
+  ): OrcaListener = e => { val _ = into.updateAndGet(e :: _) }
+
+  // The point of resolving before the fan-out: two listeners can no longer
+  // report different dollars for one turn, because neither prices anything.
+  test("every listener receives the same resolved cost for one turn"):
+    val seen = AtomicReference[List[OrcaEvent]](Nil)
+    val dispatcher = new CostResolvingDispatcher(
+      table,
+      e => { recorder(seen).onEvent(e); recorder(seen).onEvent(e) }
+    )
+    dispatcher.onEvent(
+      OrcaEvent.TokensUsed("claude", Some(Model("opus")), usage(1_000_000L, 0L))
+    )
+    assertEquals(
+      seen.get().collect { case t: OrcaEvent.TokensUsed => t.cost },
+      List(
+        Some(Cost(BigDecimal("1.0"), estimated = true)),
+        Some(Cost(BigDecimal("1.0"), estimated = true))
+      )
+    )
+
+  test("an event that isn't a turn passes through untouched"):
+    val seen = AtomicReference[List[OrcaEvent]](Nil)
+    val dispatcher = new CostResolvingDispatcher(table, recorder(seen))
+    dispatcher.onEvent(OrcaEvent.Step("hi"))
+    assertEquals(seen.get(), List(OrcaEvent.Step("hi")))

--- a/flow/src/test/scala/orca/CostResolvingDispatcherTest.scala
+++ b/flow/src/test/scala/orca/CostResolvingDispatcherTest.scala
@@ -4,7 +4,6 @@ import orca.agents.Model
 import orca.events.{
   Cost,
   CostResolvingDispatcher,
-  EventDispatcher,
   ModelPricing,
   OrcaEvent,
   OrcaListener,
@@ -18,7 +17,14 @@ import java.util.concurrent.atomic.AtomicReference
 class CostResolvingDispatcherTest extends munit.FunSuite:
 
   private val prices = PriceList(
-    Map(Model("opus") -> ModelPricing(1, BigDecimal("0.10"), 5, 2)),
+    Map(
+      Model("opus") -> ModelPricing(
+        inputUsdPerMillion = 1,
+        cacheReadUsdPerMillion = BigDecimal("0.10"),
+        outputUsdPerMillion = 5,
+        cacheWriteUsdPerMillion = 2
+      )
+    ),
     lastUpdated = LocalDate.of(2026, 1, 15)
   )
 
@@ -26,26 +32,18 @@ class CostResolvingDispatcherTest extends munit.FunSuite:
       into: AtomicReference[List[OrcaEvent]]
   ): OrcaListener = e => { val _ = into.updateAndGet(e :: _) }
 
-  // The point of resolving before the fan-out: two listeners can no longer
-  // report different dollars for one turn, because neither prices anything.
-  test("every listener receives the same resolved cost for one turn"):
-    val first = AtomicReference[List[OrcaEvent]](Nil)
-    val second = AtomicReference[List[OrcaEvent]](Nil)
-    val dispatcher = new CostResolvingDispatcher(
-      prices,
-      new EventDispatcher(List(recorder(first), recorder(second)))
-    )
+  // Resolving before the fan-out is what stops two listeners reporting
+  // different dollars for one turn: the figure is settled by the time any of
+  // them sees the event, and none of them prices anything.
+  test("the fan-out receives the turn with its cost already resolved"):
+    val seen = AtomicReference[List[OrcaEvent]](Nil)
+    val dispatcher = new CostResolvingDispatcher(prices, recorder(seen))
     dispatcher.onEvent(
       OrcaEvent.TokensUsed("claude", Some(Model("opus")), usage(1_000_000L, 0L))
     )
-    val resolved = List(Some(Cost(BigDecimal("1.0"), estimated = true)))
     assertEquals(
-      first.get().collect { case t: OrcaEvent.TokensUsed => t.cost },
-      resolved
-    )
-    assertEquals(
-      second.get().collect { case t: OrcaEvent.TokensUsed => t.cost },
-      resolved
+      seen.get().collect { case t: OrcaEvent.TokensUsed => t.cost },
+      List(Some(Cost(BigDecimal("1.0"), estimated = true)))
     )
 
   test("an event that isn't a turn passes through untouched"):

--- a/flow/src/test/scala/orca/CostTrackerTest.scala
+++ b/flow/src/test/scala/orca/CostTrackerTest.scala
@@ -17,13 +17,24 @@ import java.time.temporal.ChronoUnit
 
 class CostTrackerTest extends munit.FunSuite:
 
+  /** Stands in for the run's [[CostResolvingDispatcher]]: the tracker reads
+    * cost off the event, so the test resolves it on the way in the same way.
+    */
   private def tokens(
       agent: String,
       model: Option[String],
       u: Usage,
-      role: Option[String] = None
+      role: Option[String] = None,
+      pricing: PriceList = testTable
   ): OrcaEvent.TokensUsed =
-    OrcaEvent.TokensUsed(agent, model.map(Model.apply), u, role)
+    val resolved = model.map(Model.apply)
+    OrcaEvent.TokensUsed(
+      agent,
+      resolved,
+      u,
+      role,
+      cost = Pricing.resolve(pricing.table, resolved, u)
+    )
 
   // Tiny price list so token math gives round dollar figures: a model at
   // $1/M input means 1,000,000 input tokens = $1. Each of the four rates is
@@ -66,7 +77,7 @@ class CostTrackerTest extends munit.FunSuite:
     assertEquals(tracker.perModel(None), usage(3L, 2L, None))
 
   test("reported cost from the backend is accumulated as non-estimated"):
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(
       tokens("claude", Some("opus"), usage(100L, 50L, Some(BigDecimal("0.42"))))
     )
@@ -76,7 +87,7 @@ class CostTrackerTest extends munit.FunSuite:
     )
 
   test("missing reported cost falls back to a price-table estimate"):
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     // 1M input @ $1/M + 500k output @ $5/M = $3.50
     tracker.onEvent(
       tokens("claude", Some("opus"), usage(1_000_000L, 500_000L, None))
@@ -86,7 +97,7 @@ class CostTrackerTest extends munit.FunSuite:
     assertEquals(c.amount, BigDecimal("3.5"))
 
   test("estimate bills cache reads at the read rate, not the input rate"):
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     // A backend that reports one undifferentiated cache number (gemini) leaves
     // the write axis at zero, so nothing is billed twice:
     // 1M input total, 800k of which are cache reads:
@@ -117,7 +128,7 @@ class CostTrackerTest extends munit.FunSuite:
     // Total: $0.76. Folding writes into reads (what the old single axis did)
     // would bill 900k @ $0.10/M = $0.09 and understate the turn by more
     // than half.
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(
       tokens(
         "claude",
@@ -136,7 +147,7 @@ class CostTrackerTest extends munit.FunSuite:
   test("a reported cost still renders a write-only cache parenthetical"):
     // A cold first turn writes the whole prompt and reads nothing, which is
     // the shape every fresh claude session starts with.
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(
       tokens(
         "claude",
@@ -191,7 +202,8 @@ class CostTrackerTest extends munit.FunSuite:
           cost = None,
           cacheRead = 155_848L,
           cacheWrite = 20_769L
-        )
+        ),
+        pricing = Pricing.default
       )
     )
     assertEquals(
@@ -200,7 +212,7 @@ class CostTrackerTest extends munit.FunSuite:
     )
 
   test("estimate ignores reasoning tokens (already inside output)"):
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     // Pin the invariant: reasoning is a sub-portion of outputTokens, not
     // an additional billable bucket. Adding 400k reasoning should leave
     // the estimate unchanged at 1M output @ $5/M = $5.00.
@@ -219,7 +231,7 @@ class CostTrackerTest extends munit.FunSuite:
     assertEquals(tracker.perAgentCost("claude").amount, BigDecimal("5.0"))
 
   test("price-table lookup falls back to a prefix match"):
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(
       tokens(
         "claude",
@@ -238,7 +250,7 @@ class CostTrackerTest extends munit.FunSuite:
     // from "opus", not a dated snapshot of it — unlike "opus-20251015" above,
     // the prefix fallback must not cross tiers just because one name prefixes
     // the other. Mirrors the real-world gemini-2.5-flash / -flash-lite risk.
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(
       tokens("claude", Some("opus-mini"), usage(1_000_000L, 0L, None))
     )
@@ -249,7 +261,7 @@ class CostTrackerTest extends munit.FunSuite:
     )
 
   test("mixed reported + estimated rolls up to an estimated aggregate"):
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(
       tokens("claude", Some("opus"), usage(0L, 0L, Some(BigDecimal("1.0"))))
     )
@@ -263,7 +275,7 @@ class CostTrackerTest extends munit.FunSuite:
   test(
     "summary formats per-line cost as $X.XXXX with an asterisk on estimates"
   ):
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(
       tokens("claude", Some("opus"), usage(10L, 5L, Some(BigDecimal("0.10"))))
     )
@@ -287,7 +299,7 @@ class CostTrackerTest extends munit.FunSuite:
       999_950L -> "1M" // rounds up into the next unit
     )
     cases.foreach: (n, expected) =>
-      val tracker = new CostTracker(pricing = testTable)
+      val tracker = new CostTracker(testTable.lastUpdated)
       tracker.onEvent(tokens("claude", Some("opus"), usage(n, 0L, None)))
       assert(
         tracker.summary.contains(s"claude: $expected in"),
@@ -295,7 +307,7 @@ class CostTrackerTest extends munit.FunSuite:
       )
 
   test("summary compacts the cache and reasoning parentheticals too"):
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(
       tokens(
         "claude",
@@ -319,7 +331,7 @@ class CostTrackerTest extends munit.FunSuite:
     )
 
   test("summary drops the cache-write part when a backend reports no writes"):
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(
       tokens(
         "codex",
@@ -341,7 +353,7 @@ class CostTrackerTest extends munit.FunSuite:
     // Sorting on the raw agent name would slot an unprefixed agent between
     // role-prefixed ones (`reviewer: lint` < main < `reviewer: readability`
     // by name); the reader sees labels, so labels drive the order.
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(
       tokens("lint", Some("opus"), usage(1L, 1L, None), role = Some("reviewer"))
     )
@@ -365,7 +377,7 @@ class CostTrackerTest extends munit.FunSuite:
     )
 
   test("summary lists By model lines alphabetically by model label"):
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(tokens("a", Some("opus"), usage(1L, 1L, None)))
     tracker.onEvent(tokens("b", Some("haiku"), usage(1L, 1L, None)))
     tracker.onEvent(tokens("c", None, usage(1L, 1L, None)))
@@ -380,14 +392,14 @@ class CostTrackerTest extends munit.FunSuite:
     )
 
   test("summary's estimate legend cites the price-list lastUpdated date"):
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(
       tokens("performance", Some("haiku"), usage(1_000_000L, 0L, None))
     )
     assert(tracker.summary.contains("rates as of 2026-01-15"), tracker.summary)
 
   test("summary omits the legend when every line was reported"):
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(
       tokens("claude", Some("opus"), usage(10L, 5L, Some(BigDecimal("0.10"))))
     )
@@ -397,7 +409,7 @@ class CostTrackerTest extends munit.FunSuite:
     assert(out.contains("Total: $0.1000"), out)
 
   test("perRole subtotals usage by role, with None as the untagged bucket"):
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(
       tokens(
         "performance",
@@ -426,7 +438,7 @@ class CostTrackerTest extends munit.FunSuite:
   ):
     // `agent` stays bare; the summary derives the "reviewer: <slug>" display
     // text purely from `role`, and adds a "By role:" subtotal section.
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(
       tokens(
         "performance",
@@ -449,7 +461,7 @@ class CostTrackerTest extends munit.FunSuite:
     assert(out.contains("  reviewer:"), out)
 
   test("summary omits the By role section when no event carried a role"):
-    val tracker = new CostTracker(pricing = testTable)
+    val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(tokens("claude", Some("opus"), usage(10L, 5L, None)))
     assert(!tracker.summary.contains("By role:"), tracker.summary)
 

--- a/flow/src/test/scala/orca/CostTrackerTest.scala
+++ b/flow/src/test/scala/orca/CostTrackerTest.scala
@@ -51,8 +51,18 @@ class CostTrackerTest extends munit.FunSuite:
   // intentionally distinct so a test can tell which one was applied.
   private val testTable = PriceList(
     table = Map(
-      Model("opus") -> ModelPricing(1, BigDecimal("0.10"), 5, 2),
-      Model("haiku") -> ModelPricing(1, BigDecimal("0.10"), 5, 2)
+      Model("opus") -> ModelPricing(
+        inputUsdPerMillion = 1,
+        cacheReadUsdPerMillion = BigDecimal("0.10"),
+        outputUsdPerMillion = 5,
+        cacheWriteUsdPerMillion = 2
+      ),
+      Model("haiku") -> ModelPricing(
+        inputUsdPerMillion = 1,
+        cacheReadUsdPerMillion = BigDecimal("0.10"),
+        outputUsdPerMillion = 5,
+        cacheWriteUsdPerMillion = 2
+      )
     ),
     lastUpdated = LocalDate.of(2026, 1, 15)
   )
@@ -273,19 +283,33 @@ class CostTrackerTest extends munit.FunSuite:
     // indistinguishable from an unknown model.
     val tracker = new CostTracker(testTable)
     tracker.onEvent(tokens("a", Some("opus[1m]"), usage(1_000_000L, 0L)))
+    assertEquals(tracker.perAgentCost("a").amount, BigDecimal("1.0"))
+
+  test("a dated [1m] spelling still reaches the base row"):
+    // Both bridges have to compose: strip the alias, then bridge the snapshot.
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(
-      tokens("b", Some("opus-20251015[1m]"), usage(1_000_000L, 0L))
+      tokens("a", Some("opus-20251015[1m]"), usage(1_000_000L, 0L))
     )
     assertEquals(tracker.perAgentCost("a").amount, BigDecimal("1.0"))
-    assertEquals(tracker.perAgentCost("b").amount, BigDecimal("1.0"))
 
   test("an explicit [1m] row outprices the alias strip"):
     // The alias strip encodes today's fact that the 1M spelling costs the same;
     // a row saying otherwise is the newer claim and must win.
     val split = PriceList(
       table = Map(
-        Model("opus") -> ModelPricing(1, BigDecimal("0.10"), 5, 2),
-        Model("opus[1m]") -> ModelPricing(2, BigDecimal("0.20"), 10, 4)
+        Model("opus") -> ModelPricing(
+          inputUsdPerMillion = 1,
+          cacheReadUsdPerMillion = BigDecimal("0.10"),
+          outputUsdPerMillion = 5,
+          cacheWriteUsdPerMillion = 2
+        ),
+        Model("opus[1m]") -> ModelPricing(
+          inputUsdPerMillion = 2,
+          cacheReadUsdPerMillion = BigDecimal("0.20"),
+          outputUsdPerMillion = 10,
+          cacheWriteUsdPerMillion = 4
+        )
       ),
       lastUpdated = LocalDate.of(2026, 1, 15)
     )

--- a/flow/src/test/scala/orca/CostTrackerTest.scala
+++ b/flow/src/test/scala/orca/CostTrackerTest.scala
@@ -87,7 +87,7 @@ class CostTrackerTest extends munit.FunSuite:
     assertEquals(tracker.perModel(None), usage(3L, 2L, None))
 
   test("reported cost from the backend is accumulated as non-estimated"):
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(
       tokens("claude", Some("opus"), usage(100L, 50L, Some(BigDecimal("0.42"))))
     )
@@ -97,7 +97,7 @@ class CostTrackerTest extends munit.FunSuite:
     )
 
   test("missing reported cost falls back to a price-table estimate"):
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     // 1M input @ $1/M + 500k output @ $5/M = $3.50
     tracker.onEvent(
       tokens("claude", Some("opus"), usage(1_000_000L, 500_000L, None))
@@ -107,7 +107,7 @@ class CostTrackerTest extends munit.FunSuite:
     assertEquals(c.amount, BigDecimal("3.5"))
 
   test("estimate bills cache reads at the read rate, not the input rate"):
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     // A backend that reports one undifferentiated cache number (gemini) leaves
     // the write axis at zero, so nothing is billed twice:
     // 1M input total, 800k of which are cache reads:
@@ -137,7 +137,7 @@ class CostTrackerTest extends munit.FunSuite:
     //   300k write @ $2/M    = $0.60
     // Total: $0.76. Folding writes into reads would bill 900k @ $0.10/M =
     // $0.09 and understate the turn by more than half.
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(
       tokens(
         "claude",
@@ -156,7 +156,7 @@ class CostTrackerTest extends munit.FunSuite:
   test("a reported cost still renders a write-only cache parenthetical"):
     // A cold first turn writes the whole prompt and reads nothing, which is
     // the shape every fresh claude session starts with.
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(
       tokens(
         "claude",
@@ -219,7 +219,7 @@ class CostTrackerTest extends munit.FunSuite:
     )
 
   test("estimate ignores reasoning tokens (already inside output)"):
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     // Pin the invariant: reasoning is a sub-portion of outputTokens, not
     // an additional billable bucket. Adding 400k reasoning should leave
     // the estimate unchanged at 1M output @ $5/M = $5.00.
@@ -238,7 +238,7 @@ class CostTrackerTest extends munit.FunSuite:
     assertEquals(tracker.perAgentCost("claude").amount, BigDecimal("5.0"))
 
   test("price-table lookup falls back to a prefix match"):
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(
       tokens(
         "claude",
@@ -257,7 +257,7 @@ class CostTrackerTest extends munit.FunSuite:
     // from "opus", not a dated snapshot of it — unlike "opus-20251015" above,
     // the prefix fallback must not cross tiers just because one name prefixes
     // the other. Mirrors the real-world gemini-2.5-flash / -flash-lite risk.
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(
       tokens("claude", Some("opus-mini"), usage(1_000_000L, 0L, None))
     )
@@ -271,7 +271,7 @@ class CostTrackerTest extends munit.FunSuite:
     // The 1M-context suffix isn't a date, so the snapshot bridge doesn't reach
     // it; without the alias strip such a run shows tokens against no dollars,
     // indistinguishable from an unknown model.
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(tokens("a", Some("opus[1m]"), usage(1_000_000L, 0L)))
     tracker.onEvent(
       tokens("b", Some("opus-20251015[1m]"), usage(1_000_000L, 0L))
@@ -289,14 +289,24 @@ class CostTrackerTest extends munit.FunSuite:
       ),
       lastUpdated = LocalDate.of(2026, 1, 15)
     )
-    val tracker = new CostTracker(split.lastUpdated)
+    val tracker = new CostTracker(split)
     tracker.onEvent(
       tokens("claude", Some("opus[1m]"), usage(1_000_000L, 0L), pricing = split)
     )
     assertEquals(tracker.perAgentCost("claude").amount, BigDecimal("2.0"))
 
+  // A turn that spent nothing has no cost to estimate; a Cost(0, estimated)
+  // would carry its flag into the run total and relabel exact spend.
+  test("a zero-token turn leaves the total unflagged"):
+    val tracker = new CostTracker(testTable)
+    tracker.onEvent(
+      tokens("claude", Some("opus"), usage(10L, 5L, Some(BigDecimal("0.10"))))
+    )
+    tracker.onEvent(tokens("idle", Some("opus"), usage(0L, 0L)))
+    assertEquals(tracker.totalCost.map(_.estimated), Some(false))
+
   test("mixed reported + estimated rolls up to an estimated aggregate"):
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(
       tokens("claude", Some("opus"), usage(0L, 0L, Some(BigDecimal("1.0"))))
     )
@@ -310,7 +320,7 @@ class CostTrackerTest extends munit.FunSuite:
   test(
     "summary formats per-line cost as $X.XXXX with an asterisk on estimates"
   ):
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(
       tokens("claude", Some("opus"), usage(10L, 5L, Some(BigDecimal("0.10"))))
     )
@@ -334,7 +344,7 @@ class CostTrackerTest extends munit.FunSuite:
       999_950L -> "1M" // rounds up into the next unit
     )
     cases.foreach: (n, expected) =>
-      val tracker = new CostTracker(testTable.lastUpdated)
+      val tracker = new CostTracker(testTable)
       tracker.onEvent(tokens("claude", Some("opus"), usage(n, 0L, None)))
       assert(
         tracker.summary.contains(s"claude: $expected in"),
@@ -342,7 +352,7 @@ class CostTrackerTest extends munit.FunSuite:
       )
 
   test("summary compacts the cache and reasoning parentheticals too"):
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(
       tokens(
         "claude",
@@ -366,7 +376,7 @@ class CostTrackerTest extends munit.FunSuite:
     )
 
   test("summary drops the cache-write part when a backend reports no writes"):
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(
       tokens(
         "codex",
@@ -388,7 +398,7 @@ class CostTrackerTest extends munit.FunSuite:
     // Sorting on the raw agent name would slot an unprefixed agent between
     // role-prefixed ones (`reviewer: lint` < main < `reviewer: readability`
     // by name); the reader sees labels, so labels drive the order.
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(
       tokens("lint", Some("opus"), usage(1L, 1L, None), role = Some("reviewer"))
     )
@@ -407,21 +417,21 @@ class CostTrackerTest extends munit.FunSuite:
     )
 
   test("summary lists By model lines alphabetically by model label"):
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(tokens("a", Some("opus"), usage(1L, 1L, None)))
     tracker.onEvent(tokens("b", Some("haiku"), usage(1L, 1L, None)))
     tracker.onEvent(tokens("c", None, usage(1L, 1L, None)))
     assertLabelsInOrder(tracker.summary, List("(unknown)", "haiku", "opus"))
 
   test("summary's estimate legend cites the price-list lastUpdated date"):
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(
       tokens("performance", Some("haiku"), usage(1_000_000L, 0L, None))
     )
     assert(tracker.summary.contains("rates as of 2026-01-15"), tracker.summary)
 
   test("summary omits the legend when every line was reported"):
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(
       tokens("claude", Some("opus"), usage(10L, 5L, Some(BigDecimal("0.10"))))
     )
@@ -431,7 +441,7 @@ class CostTrackerTest extends munit.FunSuite:
     assert(out.contains("Total: $0.1000"), out)
 
   test("perRole subtotals usage by role, with None as the untagged bucket"):
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(
       tokens(
         "performance",
@@ -460,7 +470,7 @@ class CostTrackerTest extends munit.FunSuite:
   ):
     // `agent` stays bare; the summary derives the "reviewer: <slug>" display
     // text purely from `role`, and adds a "By role:" subtotal section.
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(
       tokens(
         "performance",
@@ -483,7 +493,7 @@ class CostTrackerTest extends munit.FunSuite:
     assert(out.contains("  reviewer:"), out)
 
   test("summary omits the By role section when no event carried a role"):
-    val tracker = new CostTracker(testTable.lastUpdated)
+    val tracker = new CostTracker(testTable)
     tracker.onEvent(tokens("claude", Some("opus"), usage(10L, 5L, None)))
     assert(!tracker.summary.contains("By role:"), tracker.summary)
 

--- a/flow/src/test/scala/orca/CostTrackerTest.scala
+++ b/flow/src/test/scala/orca/CostTrackerTest.scala
@@ -10,6 +10,7 @@ import orca.events.{
   Usage
 }
 import orca.agents.Model
+import orca.testkit.Usages.usage
 
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
@@ -44,30 +45,30 @@ class CostTrackerTest extends munit.FunSuite:
 
   test("total sums every TokensUsed event regardless of agent or model"):
     val tracker = new CostTracker
-    tracker.onEvent(tokens("claude", Some("opus"), Usage(100L, 50L, None)))
-    tracker.onEvent(tokens("performance", Some("haiku"), Usage(30L, 20L, None)))
-    assertEquals(tracker.total, Usage(130L, 70L, None))
+    tracker.onEvent(tokens("claude", Some("opus"), usage(100L, 50L, None)))
+    tracker.onEvent(tokens("performance", Some("haiku"), usage(30L, 20L, None)))
+    assertEquals(tracker.total, usage(130L, 70L, None))
 
   test("perAgent groups by Agent name"):
     val tracker = new CostTracker
-    tracker.onEvent(tokens("claude", Some("opus"), Usage(10L, 5L, None)))
-    tracker.onEvent(tokens("performance", Some("opus"), Usage(20L, 15L, None)))
-    tracker.onEvent(tokens("claude", Some("haiku"), Usage(3L, 2L, None)))
-    assertEquals(tracker.perAgent("claude"), Usage(13L, 7L, None))
-    assertEquals(tracker.perAgent("performance"), Usage(20L, 15L, None))
+    tracker.onEvent(tokens("claude", Some("opus"), usage(10L, 5L, None)))
+    tracker.onEvent(tokens("performance", Some("opus"), usage(20L, 15L, None)))
+    tracker.onEvent(tokens("claude", Some("haiku"), usage(3L, 2L, None)))
+    assertEquals(tracker.perAgent("claude"), usage(13L, 7L, None))
+    assertEquals(tracker.perAgent("performance"), usage(20L, 15L, None))
 
   test("perModel groups by reported model id, with None as its own bucket"):
     val tracker = new CostTracker
-    tracker.onEvent(tokens("claude", Some("opus"), Usage(10L, 5L, None)))
-    tracker.onEvent(tokens("performance", Some("opus"), Usage(20L, 15L, None)))
-    tracker.onEvent(tokens("claude", None, Usage(3L, 2L, None)))
-    assertEquals(tracker.perModel(Some(Model("opus"))), Usage(30L, 20L, None))
-    assertEquals(tracker.perModel(None), Usage(3L, 2L, None))
+    tracker.onEvent(tokens("claude", Some("opus"), usage(10L, 5L, None)))
+    tracker.onEvent(tokens("performance", Some("opus"), usage(20L, 15L, None)))
+    tracker.onEvent(tokens("claude", None, usage(3L, 2L, None)))
+    assertEquals(tracker.perModel(Some(Model("opus"))), usage(30L, 20L, None))
+    assertEquals(tracker.perModel(None), usage(3L, 2L, None))
 
   test("reported cost from the backend is accumulated as non-estimated"):
     val tracker = new CostTracker(pricing = testTable)
     tracker.onEvent(
-      tokens("claude", Some("opus"), Usage(100L, 50L, Some(BigDecimal("0.42"))))
+      tokens("claude", Some("opus"), usage(100L, 50L, Some(BigDecimal("0.42"))))
     )
     assertEquals(
       tracker.perAgentCost("claude"),
@@ -78,7 +79,7 @@ class CostTrackerTest extends munit.FunSuite:
     val tracker = new CostTracker(pricing = testTable)
     // 1M input @ $1/M + 500k output @ $5/M = $3.50
     tracker.onEvent(
-      tokens("claude", Some("opus"), Usage(1_000_000L, 500_000L, None))
+      tokens("claude", Some("opus"), usage(1_000_000L, 500_000L, None))
     )
     val c = tracker.perAgentCost("claude")
     assertEquals(c.estimated, true)
@@ -98,11 +99,11 @@ class CostTrackerTest extends munit.FunSuite:
       tokens(
         "claude",
         Some("opus"),
-        Usage(
-          inputTokens = 1_000_000L,
-          outputTokens = 0L,
+        usage(
+          input = 1_000_000L,
+          output = 0L,
           cost = None,
-          cacheReadInputTokens = 800_000L
+          cacheRead = 800_000L
         )
       )
     )
@@ -121,38 +122,16 @@ class CostTrackerTest extends munit.FunSuite:
       tokens(
         "claude",
         Some("opus"),
-        Usage(
-          inputTokens = 1_000_000L,
-          outputTokens = 0L,
+        usage(
+          input = 1_000_000L,
+          output = 0L,
           cost = None,
-          cacheReadInputTokens = 600_000L,
-          cacheWriteInputTokens = 300_000L
+          cacheRead = 600_000L,
+          cacheWrite = 300_000L
         )
       )
     )
     assertEquals(tracker.perAgentCost("claude").amount, BigDecimal("0.76"))
-
-  test("cache axes over-reported past the input total never bill negatively"):
-    // The invariant says reads + writes <= inputTokens; a backend that breaks
-    // it must cost zero fresh input, not a negative charge that eats the rest
-    // of the estimate. Here fresh would be -50k: 300k read @ $0.10/M +
-    // 250k write @ $2/M = $0.53, with nothing subtracted for input. The two
-    // cache counts differ so a read/write rate swap can't pass.
-    val tracker = new CostTracker(pricing = testTable)
-    tracker.onEvent(
-      tokens(
-        "claude",
-        Some("opus"),
-        Usage(
-          inputTokens = 500_000L,
-          outputTokens = 0L,
-          cost = None,
-          cacheReadInputTokens = 300_000L,
-          cacheWriteInputTokens = 250_000L
-        )
-      )
-    )
-    assertEquals(tracker.perAgentCost("claude").amount, BigDecimal("0.53"))
 
   test("a reported cost still renders a write-only cache parenthetical"):
     // A cold first turn writes the whole prompt and reads nothing, which is
@@ -162,11 +141,11 @@ class CostTrackerTest extends munit.FunSuite:
       tokens(
         "claude",
         Some("opus"),
-        Usage(
-          inputTokens = 30_000L,
-          outputTokens = 500L,
+        usage(
+          input = 30_000L,
+          output = 500L,
           cost = Some(BigDecimal("0.42")),
-          cacheWriteInputTokens = 29_000L
+          cacheWrite = 29_000L
         )
       )
     )
@@ -206,12 +185,12 @@ class CostTrackerTest extends munit.FunSuite:
       tokens(
         "reviewer",
         Some("claude-sonnet-5"),
-        Usage(
-          inputTokens = 176_625L,
-          outputTokens = 1_083L,
+        usage(
+          input = 176_625L,
+          output = 1_083L,
           cost = None,
-          cacheReadInputTokens = 155_848L,
-          cacheWriteInputTokens = 20_769L
+          cacheRead = 155_848L,
+          cacheWrite = 20_769L
         )
       )
     )
@@ -229,11 +208,11 @@ class CostTrackerTest extends munit.FunSuite:
       tokens(
         "claude",
         Some("opus"),
-        Usage(
-          inputTokens = 0L,
-          outputTokens = 1_000_000L,
+        usage(
+          input = 0L,
+          output = 1_000_000L,
           cost = None,
-          reasoningOutputTokens = 400_000L
+          reasoning = 400_000L
         )
       )
     )
@@ -245,7 +224,7 @@ class CostTrackerTest extends munit.FunSuite:
       tokens(
         "claude",
         Some("opus-20251015"),
-        Usage(1_000_000L, 0L, None)
+        usage(1_000_000L, 0L, None)
       )
     )
     val c = tracker.perAgentCost("claude")
@@ -261,7 +240,7 @@ class CostTrackerTest extends munit.FunSuite:
     // the other. Mirrors the real-world gemini-2.5-flash / -flash-lite risk.
     val tracker = new CostTracker(pricing = testTable)
     tracker.onEvent(
-      tokens("claude", Some("opus-mini"), Usage(1_000_000L, 0L, None))
+      tokens("claude", Some("opus-mini"), usage(1_000_000L, 0L, None))
     )
     assert(
       tracker.perAgentCost.get("claude").isEmpty,
@@ -272,10 +251,10 @@ class CostTrackerTest extends munit.FunSuite:
   test("mixed reported + estimated rolls up to an estimated aggregate"):
     val tracker = new CostTracker(pricing = testTable)
     tracker.onEvent(
-      tokens("claude", Some("opus"), Usage(0L, 0L, Some(BigDecimal("1.0"))))
+      tokens("claude", Some("opus"), usage(0L, 0L, Some(BigDecimal("1.0"))))
     )
     tracker.onEvent(
-      tokens("claude", Some("opus"), Usage(1_000_000L, 0L, None))
+      tokens("claude", Some("opus"), usage(1_000_000L, 0L, None))
     )
     val c = tracker.totalCost.get
     assertEquals(c.estimated, true)
@@ -286,10 +265,10 @@ class CostTrackerTest extends munit.FunSuite:
   ):
     val tracker = new CostTracker(pricing = testTable)
     tracker.onEvent(
-      tokens("claude", Some("opus"), Usage(10L, 5L, Some(BigDecimal("0.10"))))
+      tokens("claude", Some("opus"), usage(10L, 5L, Some(BigDecimal("0.10"))))
     )
     tracker.onEvent(
-      tokens("performance", Some("haiku"), Usage(1_000_000L, 0L, None))
+      tokens("performance", Some("haiku"), usage(1_000_000L, 0L, None))
     )
     val out = tracker.summary
     assert(out.contains("claude: 10 in, 5 out ($0.1000)"), out)
@@ -309,7 +288,7 @@ class CostTrackerTest extends munit.FunSuite:
     )
     cases.foreach: (n, expected) =>
       val tracker = new CostTracker(pricing = testTable)
-      tracker.onEvent(tokens("claude", Some("opus"), Usage(n, 0L, None)))
+      tracker.onEvent(tokens("claude", Some("opus"), usage(n, 0L, None)))
       assert(
         tracker.summary.contains(s"claude: $expected in"),
         tracker.summary
@@ -321,13 +300,13 @@ class CostTrackerTest extends munit.FunSuite:
       tokens(
         "claude",
         Some("opus"),
-        Usage(
-          inputTokens = 50_000L,
-          outputTokens = 12_500L,
+        usage(
+          input = 50_000L,
+          output = 12_500L,
           cost = None,
-          cacheReadInputTokens = 40_000L,
-          reasoningOutputTokens = 1_200L,
-          cacheWriteInputTokens = 5_000L
+          cacheRead = 40_000L,
+          reasoning = 1_200L,
+          cacheWrite = 5_000L
         )
       )
     )
@@ -345,11 +324,11 @@ class CostTrackerTest extends munit.FunSuite:
       tokens(
         "codex",
         Some("opus"),
-        Usage(
-          inputTokens = 50_000L,
-          outputTokens = 100L,
+        usage(
+          input = 50_000L,
+          output = 100L,
           cost = None,
-          cacheReadInputTokens = 40_000L
+          cacheRead = 40_000L
         )
       )
     )
@@ -364,14 +343,14 @@ class CostTrackerTest extends munit.FunSuite:
     // by name); the reader sees labels, so labels drive the order.
     val tracker = new CostTracker(pricing = testTable)
     tracker.onEvent(
-      tokens("lint", Some("opus"), Usage(1L, 1L, None), role = Some("reviewer"))
+      tokens("lint", Some("opus"), usage(1L, 1L, None), role = Some("reviewer"))
     )
-    tracker.onEvent(tokens("main", Some("opus"), Usage(1L, 1L, None)))
+    tracker.onEvent(tokens("main", Some("opus"), usage(1L, 1L, None)))
     tracker.onEvent(
       tokens(
         "readability",
         Some("opus"),
-        Usage(1L, 1L, None),
+        usage(1L, 1L, None),
         role = Some("reviewer")
       )
     )
@@ -387,9 +366,9 @@ class CostTrackerTest extends munit.FunSuite:
 
   test("summary lists By model lines alphabetically by model label"):
     val tracker = new CostTracker(pricing = testTable)
-    tracker.onEvent(tokens("a", Some("opus"), Usage(1L, 1L, None)))
-    tracker.onEvent(tokens("b", Some("haiku"), Usage(1L, 1L, None)))
-    tracker.onEvent(tokens("c", None, Usage(1L, 1L, None)))
+    tracker.onEvent(tokens("a", Some("opus"), usage(1L, 1L, None)))
+    tracker.onEvent(tokens("b", Some("haiku"), usage(1L, 1L, None)))
+    tracker.onEvent(tokens("c", None, usage(1L, 1L, None)))
     val out = tracker.summary
     val labels = List("(unknown)", "haiku", "opus")
       .map(l => l -> out.indexOf(s"  $l:"))
@@ -403,14 +382,14 @@ class CostTrackerTest extends munit.FunSuite:
   test("summary's estimate legend cites the price-list lastUpdated date"):
     val tracker = new CostTracker(pricing = testTable)
     tracker.onEvent(
-      tokens("performance", Some("haiku"), Usage(1_000_000L, 0L, None))
+      tokens("performance", Some("haiku"), usage(1_000_000L, 0L, None))
     )
     assert(tracker.summary.contains("rates as of 2026-01-15"), tracker.summary)
 
   test("summary omits the legend when every line was reported"):
     val tracker = new CostTracker(pricing = testTable)
     tracker.onEvent(
-      tokens("claude", Some("opus"), Usage(10L, 5L, Some(BigDecimal("0.10"))))
+      tokens("claude", Some("opus"), usage(10L, 5L, Some(BigDecimal("0.10"))))
     )
     val out = tracker.summary
     assert(!out.contains("*"), out)
@@ -423,7 +402,7 @@ class CostTrackerTest extends munit.FunSuite:
       tokens(
         "performance",
         Some("opus"),
-        Usage(10L, 5L, None),
+        usage(10L, 5L, None),
         role = Some("reviewer")
       )
     )
@@ -431,16 +410,16 @@ class CostTrackerTest extends munit.FunSuite:
       tokens(
         "security",
         Some("opus"),
-        Usage(20L, 5L, None),
+        usage(20L, 5L, None),
         role = Some("reviewer")
       )
     )
-    tracker.onEvent(tokens("claude", Some("opus"), Usage(100L, 50L, None)))
+    tracker.onEvent(tokens("claude", Some("opus"), usage(100L, 50L, None)))
     assertEquals(
       tracker.perRole(Some("reviewer")),
-      Usage(30L, 10L, None)
+      usage(30L, 10L, None)
     )
-    assertEquals(tracker.perRole(None), Usage(100L, 50L, None))
+    assertEquals(tracker.perRole(None), usage(100L, 50L, None))
 
   test(
     "summary derives a display-only role prefix per agent and adds a By role subtotal section"
@@ -452,11 +431,11 @@ class CostTrackerTest extends munit.FunSuite:
       tokens(
         "performance",
         Some("opus"),
-        Usage(10L, 5L, None),
+        usage(10L, 5L, None),
         role = Some("reviewer")
       )
     )
-    tracker.onEvent(tokens("claude", Some("opus"), Usage(100L, 50L, None)))
+    tracker.onEvent(tokens("claude", Some("opus"), usage(100L, 50L, None)))
     val out = tracker.summary
     assert(
       out.contains("reviewer: performance:"),
@@ -471,7 +450,7 @@ class CostTrackerTest extends munit.FunSuite:
 
   test("summary omits the By role section when no event carried a role"):
     val tracker = new CostTracker(pricing = testTable)
-    tracker.onEvent(tokens("claude", Some("opus"), Usage(10L, 5L, None)))
+    tracker.onEvent(tokens("claude", Some("opus"), usage(10L, 5L, None)))
     assert(!tracker.summary.contains("By role:"), tracker.summary)
 
   test("summary is empty when nothing has been recorded"):

--- a/flow/src/test/scala/orca/CostTrackerTest.scala
+++ b/flow/src/test/scala/orca/CostTrackerTest.scala
@@ -36,6 +36,16 @@ class CostTrackerTest extends munit.FunSuite:
       cost = Pricing.resolve(pricing.table, resolved, u)
     )
 
+  /** Every label appears as a section line in `out`, in the order given. */
+  private def assertLabelsInOrder(out: String, labels: List[String]): Unit =
+    val placed = labels.map(l => l -> out.indexOf(s"  $l:"))
+    placed.foreach((l, at) => assert(at >= 0, s"missing line for $l:\n$out"))
+    assertEquals(
+      placed.map(_._1),
+      placed.sortBy(_._2).map(_._1),
+      s"lines must appear in this order; got:\n$out"
+    )
+
   // Tiny price list so token math gives round dollar figures: a model at
   // $1/M input means 1,000,000 input tokens = $1. Each of the four rates is
   // intentionally distinct so a test can tell which one was applied.
@@ -125,9 +135,8 @@ class CostTrackerTest extends munit.FunSuite:
     //   100k fresh @ $1/M    = $0.10
     //   600k read  @ $0.10/M = $0.06
     //   300k write @ $2/M    = $0.60
-    // Total: $0.76. Folding writes into reads (what the old single axis did)
-    // would bill 900k @ $0.10/M = $0.09 and understate the turn by more
-    // than half.
+    // Total: $0.76. Folding writes into reads would bill 900k @ $0.10/M =
+    // $0.09 and understate the turn by more than half.
     val tracker = new CostTracker(testTable.lastUpdated)
     tracker.onEvent(
       tokens(
@@ -161,9 +170,7 @@ class CostTrackerTest extends munit.FunSuite:
       )
     )
     assert(
-      tracker.summary.contains(
-        "claude: 30K in (29K cache write), 500 out ($0.4200)"
-      ),
+      tracker.summary.contains("claude: 30K in (29K cache write), 500 out"),
       tracker.summary
     )
 
@@ -259,6 +266,34 @@ class CostTrackerTest extends munit.FunSuite:
       s"expected no cost estimate for an unrelated tier; got: ${tracker.perAgentCost
           .get("claude")}"
     )
+
+  test("a [1m] context spelling prices from its base model's row"):
+    // The 1M-context suffix isn't a date, so the snapshot bridge doesn't reach
+    // it; without the alias strip such a run shows tokens against no dollars,
+    // indistinguishable from an unknown model.
+    val tracker = new CostTracker(testTable.lastUpdated)
+    tracker.onEvent(tokens("a", Some("opus[1m]"), usage(1_000_000L, 0L)))
+    tracker.onEvent(
+      tokens("b", Some("opus-20251015[1m]"), usage(1_000_000L, 0L))
+    )
+    assertEquals(tracker.perAgentCost("a").amount, BigDecimal("1.0"))
+    assertEquals(tracker.perAgentCost("b").amount, BigDecimal("1.0"))
+
+  test("an explicit [1m] row outprices the alias strip"):
+    // The alias strip encodes today's fact that the 1M spelling costs the same;
+    // a row saying otherwise is the newer claim and must win.
+    val split = PriceList(
+      table = Map(
+        Model("opus") -> ModelPricing(1, BigDecimal("0.10"), 5, 2),
+        Model("opus[1m]") -> ModelPricing(2, BigDecimal("0.20"), 10, 4)
+      ),
+      lastUpdated = LocalDate.of(2026, 1, 15)
+    )
+    val tracker = new CostTracker(split.lastUpdated)
+    tracker.onEvent(
+      tokens("claude", Some("opus[1m]"), usage(1_000_000L, 0L), pricing = split)
+    )
+    assertEquals(tracker.perAgentCost("claude").amount, BigDecimal("2.0"))
 
   test("mixed reported + estimated rolls up to an estimated aggregate"):
     val tracker = new CostTracker(testTable.lastUpdated)
@@ -366,14 +401,9 @@ class CostTrackerTest extends munit.FunSuite:
         role = Some("reviewer")
       )
     )
-    val out = tracker.summary
-    val labels = List("main", "reviewer: lint", "reviewer: readability")
-      .map(l => l -> out.indexOf(s"  $l:"))
-    labels.foreach((l, i) => assert(i >= 0, s"missing agent line $l:\n$out"))
-    assertEquals(
-      labels.map(_._1),
-      labels.sortBy(_._2).map(_._1),
-      s"agent lines must be alphabetical by label; got:\n$out"
+    assertLabelsInOrder(
+      tracker.summary,
+      List("main", "reviewer: lint", "reviewer: readability")
     )
 
   test("summary lists By model lines alphabetically by model label"):
@@ -381,15 +411,7 @@ class CostTrackerTest extends munit.FunSuite:
     tracker.onEvent(tokens("a", Some("opus"), usage(1L, 1L, None)))
     tracker.onEvent(tokens("b", Some("haiku"), usage(1L, 1L, None)))
     tracker.onEvent(tokens("c", None, usage(1L, 1L, None)))
-    val out = tracker.summary
-    val labels = List("(unknown)", "haiku", "opus")
-      .map(l => l -> out.indexOf(s"  $l:"))
-    labels.foreach((l, i) => assert(i >= 0, s"missing model line $l:\n$out"))
-    assertEquals(
-      labels.map(_._1),
-      labels.sortBy(_._2).map(_._1),
-      s"model lines must be alphabetical; got:\n$out"
-    )
+    assertLabelsInOrder(tracker.summary, List("(unknown)", "haiku", "opus"))
 
   test("summary's estimate legend cites the price-list lastUpdated date"):
     val tracker = new CostTracker(testTable.lastUpdated)

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiConversation.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiConversation.scala
@@ -1,7 +1,7 @@
 package orca.tools.gemini
 
-import orca.agents.BackendTag
-import orca.events.Usage
+import orca.agents.{BackendTag, Model}
+import orca.events.{TurnDebit, Usage}
 import orca.AgentTurnFailed
 import orca.backend.{
   StderrPipeline,
@@ -107,6 +107,12 @@ private[gemini] class GeminiConversation(
     * gemini exited 0 — tagged `AgentTurnFailed` so the autonomous retry loop
     * doesn't reopen the now-registered session id.
     */
+  /** Only the terminal `result` event carries stats, and a turn that reaches it
+    * settles itself (with an `Observed` debit) rather than reaching the base's
+    * generic wrap.
+    */
+  override protected def failedTurnDebit: TurnDebit = TurnDebit.Unobserved
+
   private def handleResult(usage: Usage, status: ToolStatus): Unit =
     status match
       case ToolStatus.Success =>
@@ -123,7 +129,10 @@ private[gemini] class GeminiConversation(
           if raw.isEmpty then "a missing status" else s"status '$raw'"
         failWith(
           new AgentTurnFailed(
-            appendContext(s"gemini turn ended with $description")
+            appendContext(s"gemini turn ended with $description"),
+            // The failed `result` frame carries the turn's stats; without them
+            // a quota- or max-turns-killed turn spends invisibly.
+            TurnDebit.Observed(usage, model.map(Model.apply))
           )
         )
 

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiConversation.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiConversation.scala
@@ -101,18 +101,18 @@ private[gemini] class GeminiConversation(
       // silently rather than rendering an error.
       ()
 
-  /** Settle the conversation outcome at the terminal `result` event. Only an
-    * explicit `"success"` is success ([[ToolStatus.isSuccess]]); any other
-    * status is a failed turn that must NOT be reported as success even though
-    * gemini exited 0 — tagged `AgentTurnFailed` so the autonomous retry loop
-    * doesn't reopen the now-registered session id.
-    */
   /** Only the terminal `result` event carries stats, and a turn that reaches it
     * settles itself (with an `Observed` debit) rather than reaching the base's
     * generic wrap.
     */
   override protected def failedTurnDebit: TurnDebit = TurnDebit.Unobserved
 
+  /** Settle the conversation outcome at the terminal `result` event. Only an
+    * explicit `"success"` is success ([[ToolStatus.isSuccess]]); any other
+    * status is a failed turn that must NOT be reported as success even though
+    * gemini exited 0 — tagged `AgentTurnFailed` so the autonomous retry loop
+    * doesn't reopen the now-registered session id.
+    */
   private def handleResult(usage: Usage, status: ToolStatus): Unit =
     status match
       case ToolStatus.Success =>

--- a/gemini/src/main/scala/orca/tools/gemini/jsonl/InboundEvent.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/jsonl/InboundEvent.scala
@@ -124,15 +124,19 @@ private[gemini] object InboundEvent:
     val w = readFromString[ResultWire](line)
     val s = w.stats.getOrElse(StatsWire())
     Result(
-      Usage(
-        inputTokens = s.input_tokens.getOrElse(0L),
-        outputTokens = s.output_tokens.getOrElse(0L),
-        cost = None, // gemini doesn't emit cost on the wire
-        // cache sub-count is `cached` (older/forward shapes use
+      Usage.inclusiveInput(
+        totalInputTokens = s.input_tokens.getOrElse(0L),
+        // The cache sub-count is `cached` (older/forward shapes use
         // `cached_input_tokens`), and it counts reads only — gemini reports no
-        // cache-write counter, so `cacheWriteInputTokens` stays zero.
+        // cache-write counter.
         cacheReadInputTokens =
-          s.cached.orElse(s.cached_input_tokens).getOrElse(0L)
+          s.cached.orElse(s.cached_input_tokens).getOrElse(0L),
+        cacheWriteInputTokens = 0L,
+        outputTokens = s.output_tokens.getOrElse(0L),
+        reasoningOutputTokens = 0L,
+        cost = None, // gemini doesn't emit cost on the wire
+        apiCalls = None,
+        wireTotal = s.total_tokens
       ),
       status = ToolStatus.of(w.status)
     )
@@ -170,11 +174,14 @@ private[gemini] object InboundEvent:
   private case class ErrorWire(message: Option[String] = None)
       derives ConfiguredJsonValueCodec
 
+  // `total_tokens` is decoded only as the cross-check `Usage.inclusiveInput`
+  // runs against the axes above; no orca axis is derived from it.
   private case class StatsWire(
       input_tokens: Option[Long] = None,
       output_tokens: Option[Long] = None,
       cached: Option[Long] = None,
-      cached_input_tokens: Option[Long] = None
+      cached_input_tokens: Option[Long] = None,
+      total_tokens: Option[Long] = None
   ) derives ConfiguredJsonValueCodec
 
   private case class ResultWire(

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiConversationTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiConversationTest.scala
@@ -1,7 +1,7 @@
 package orca.tools.gemini
 
 import orca.agents.WireSessionId
-import orca.events.Usage
+import orca.testkit.Usages.usage
 import orca.{OrcaFlowException, OrcaInteractiveCancelled}
 import orca.backend.{ConversationEvent, ConversationEventConformance}
 import orca.subprocess.FakePipedCliProcess
@@ -51,7 +51,7 @@ class GeminiConversationTest extends munit.FunSuite:
     val Right(r) = conv.awaitResult(): @unchecked
     assertEquals(WireSessionId.value(r.wireId), "sess-1")
     assertEquals(r.output, "hello")
-    assertEquals(r.usage, Usage(10L, 3L, None))
+    assertEquals(r.usage, usage(10L, 3L))
     assertEquals(r.model.map(_.name), Some("gemini-2.5-pro"))
 
   convTest("a user-role message is ignored (prompt echo, not agent output)"):

--- a/gemini/src/test/scala/orca/tools/gemini/GeminiConversationTest.scala
+++ b/gemini/src/test/scala/orca/tools/gemini/GeminiConversationTest.scala
@@ -1,6 +1,7 @@
 package orca.tools.gemini
 
-import orca.agents.WireSessionId
+import orca.agents.{Model, WireSessionId}
+import orca.events.TurnDebit
 import orca.testkit.Usages.usage
 import orca.{OrcaFlowException, OrcaInteractiveCancelled}
 import orca.backend.{ConversationEvent, ConversationEventConformance}
@@ -409,6 +410,28 @@ class GeminiConversationTest extends munit.FunSuite:
     assert(
       ex.getMessage.contains("error"),
       s"expected the failing status in the message; got: ${ex.getMessage}"
+    )
+
+  // gemini's failing `result` frame carries the turn's stats, and the estimate
+  // from them is the only cost signal gemini ever gives.
+  convTest("a failed result frame carries its stats as the turn's debit"):
+    val process = new FakePipedCliProcess()
+    val conv = new GeminiConversation(process)
+
+    process.enqueueStdout(
+      """{"type":"init","session_id":"s","model":"gemini-2.5-pro"}"""
+    )
+    process.enqueueStdout(
+      """{"type":"result","status":"error","stats":{"input_tokens":90,"output_tokens":7}}"""
+    )
+    process.closeStdout()
+    process.closeStderr()
+
+    val _ = conv.events.toList
+    val ex = intercept[orca.AgentTurnFailed](conv.awaitResult())
+    assertEquals(
+      ex.debit,
+      TurnDebit.Observed(usage(90L, 7L), Some(Model("gemini-2.5-pro")))
     )
 
   convTest(

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeConversation.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeConversation.scala
@@ -155,9 +155,20 @@ private[opencode] class OpencodeConversation(
     settleSuccess(
       wireId = session,
       output = structured.getOrElse(turnState.text.mkString),
-      usage = info.flatMap(usageOf).getOrElse(Usage.empty),
+      usage = settledUsage(info),
       modelId = info.flatMap(_.modelID)
     )
+
+  /** What a COMPLETED turn reports. Unlike [[failedTurnDebit]] there is no
+    * "nothing measured" case to represent: every completed turn owes a
+    * `TokensUsed`, since the cost log keeps one line per turn and the attempt
+    * index counts them. A message that carried no `tokens` settles at zero —
+    * still carrying any cost opencode reported alongside them.
+    */
+  private def settledUsage(info: Option[AssistantInfo]): Usage =
+    info
+      .flatMap(usageOf)
+      .getOrElse(Usage.empty.copy(cost = info.flatMap(_.cost)))
 
   /** The assistant message is refreshed by every `message.updated` frame, so a
     * turn that errors part-way still carries whatever it had spent by then.

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeConversation.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeConversation.scala
@@ -168,7 +168,7 @@ private[opencode] class OpencodeConversation(
 
   private def usageOf(info: AssistantInfo): Usage =
     val tokens = info.tokens
-    Usage.exclusiveInput(
+    Usage(
       freshInputTokens = tokens.map(_.input).getOrElse(0L),
       cacheReadInputTokens = tokens.map(_.cache.read).getOrElse(0L),
       cacheWriteInputTokens = tokens.map(_.cache.write).getOrElse(0L),

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeConversation.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeConversation.scala
@@ -8,8 +8,8 @@ import orca.backend.{
   ForkedConversation,
   StreamSource
 }
-import orca.events.Usage
-import orca.agents.BackendTag
+import orca.events.{TurnDebit, Usage}
+import orca.agents.{BackendTag, Model}
 import orca.tools.opencode.OpencodeApi.{
   AssistantInfo,
   PermissionReply,
@@ -143,7 +143,7 @@ private[opencode] class OpencodeConversation(
         else settleResult()
 
   private def failTurn(message: String): Unit =
-    failWith(AgentTurnFailed(message))
+    failWith(AgentTurnFailed(message, failedTurnDebit))
 
   /** Settle the turn with the synthesised result: in structured mode the
     * validated object, otherwise the accrued assistant text. Usage and model
@@ -155,19 +155,26 @@ private[opencode] class OpencodeConversation(
     settleSuccess(
       wireId = session,
       output = structured.getOrElse(turnState.text.mkString),
-      usage = usageOf(info),
+      usage = info.fold(Usage.empty)(usageOf),
       modelId = info.flatMap(_.modelID)
     )
 
-  private def usageOf(info: Option[AssistantInfo]): Usage =
-    val tokens = info.flatMap(_.tokens)
+  /** The assistant message is refreshed by every `message.updated` frame, so a
+    * turn that errors part-way still carries whatever it had spent by then.
+    */
+  override protected def failedTurnDebit: TurnDebit =
+    turnState.info.fold(TurnDebit.Unobserved): info =>
+      TurnDebit.Observed(usageOf(info), info.modelID.map(Model.apply))
+
+  private def usageOf(info: AssistantInfo): Usage =
+    val tokens = info.tokens
     Usage.exclusiveInput(
       freshInputTokens = tokens.map(_.input).getOrElse(0L),
       cacheReadInputTokens = tokens.map(_.cache.read).getOrElse(0L),
       cacheWriteInputTokens = tokens.map(_.cache.write).getOrElse(0L),
       outputTokens = tokens.map(_.output).getOrElse(0L),
       reasoningOutputTokens = tokens.map(_.reasoning).getOrElse(0L),
-      cost = info.flatMap(_.cost),
+      cost = info.cost,
       apiCalls = None
     )
 

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeConversation.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeConversation.scala
@@ -155,28 +155,33 @@ private[opencode] class OpencodeConversation(
     settleSuccess(
       wireId = session,
       output = structured.getOrElse(turnState.text.mkString),
-      usage = info.fold(Usage.empty)(usageOf),
+      usage = info.flatMap(usageOf).getOrElse(Usage.empty),
       modelId = info.flatMap(_.modelID)
     )
 
   /** The assistant message is refreshed by every `message.updated` frame, so a
     * turn that errors part-way still carries whatever it had spent by then.
+    * Keyed on the token counts, not on the message: an assistant message that
+    * arrived without any is nothing measured, and an all-zero `TokensUsed`
+    * would read as a measured zero.
     */
   override protected def failedTurnDebit: TurnDebit =
-    turnState.info.fold(TurnDebit.Unobserved): info =>
-      TurnDebit.Observed(usageOf(info), info.modelID.map(Model.apply))
+    turnState.info
+      .flatMap(info => usageOf(info).map((_, info.modelID)))
+      .fold(TurnDebit.Unobserved): (usage, modelID) =>
+        TurnDebit.Observed(usage, modelID.map(Model.apply))
 
-  private def usageOf(info: AssistantInfo): Usage =
-    val tokens = info.tokens
-    Usage(
-      freshInputTokens = tokens.map(_.input).getOrElse(0L),
-      cacheReadInputTokens = tokens.map(_.cache.read).getOrElse(0L),
-      cacheWriteInputTokens = tokens.map(_.cache.write).getOrElse(0L),
-      outputTokens = tokens.map(_.output).getOrElse(0L),
-      reasoningOutputTokens = tokens.map(_.reasoning).getOrElse(0L),
-      cost = info.cost,
-      apiCalls = None
-    )
+  private def usageOf(info: AssistantInfo): Option[Usage] =
+    info.tokens.map: tokens =>
+      Usage(
+        freshInputTokens = tokens.input,
+        cacheReadInputTokens = tokens.cache.read,
+        cacheWriteInputTokens = tokens.cache.write,
+        outputTokens = tokens.output,
+        reasoningOutputTokens = tokens.reasoning,
+        cost = info.cost,
+        apiCalls = None
+      )
 
   private def questionText(req: QuestionRequest): String =
     req.questions.headOption.map(_.question).getOrElse("")

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeConversation.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeConversation.scala
@@ -161,17 +161,14 @@ private[opencode] class OpencodeConversation(
 
   private def usageOf(info: Option[AssistantInfo]): Usage =
     val tokens = info.flatMap(_.tokens)
-    Usage(
-      // `input` is the non-cached input; cache read/write are billed separately
-      // and at different rates, so the total input axis sums all three and each
-      // cache category keeps its own axis.
-      inputTokens =
-        tokens.map(t => t.input + t.cache.read + t.cache.write).getOrElse(0L),
-      outputTokens = tokens.map(_.output).getOrElse(0L),
-      cost = info.flatMap(_.cost),
+    Usage.exclusiveInput(
+      freshInputTokens = tokens.map(_.input).getOrElse(0L),
       cacheReadInputTokens = tokens.map(_.cache.read).getOrElse(0L),
+      cacheWriteInputTokens = tokens.map(_.cache.write).getOrElse(0L),
+      outputTokens = tokens.map(_.output).getOrElse(0L),
       reasoningOutputTokens = tokens.map(_.reasoning).getOrElse(0L),
-      cacheWriteInputTokens = tokens.map(_.cache.write).getOrElse(0L)
+      cost = info.flatMap(_.cost),
+      apiCalls = None
     )
 
   private def questionText(req: QuestionRequest): String =

--- a/opencode/src/test/scala/orca/tools/opencode/DefaultOpencodeToolTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/DefaultOpencodeToolTest.scala
@@ -38,7 +38,7 @@ class DefaultOpencodeAgentTest extends munit.FunSuite:
         outputSchema: Option[String]
     ): AgentResult[BackendTag.Opencode.type] =
       lastConfig = Some(config)
-      AgentResult(session.onWire, "ok", Usage(0L, 0L, None))
+      AgentResult(session.onWire, "ok", Usage.empty)
     def runInteractive(
         prompt: String,
         session: SessionId[BackendTag.Opencode.type],

--- a/opencode/src/test/scala/orca/tools/opencode/OpencodeConversationTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/OpencodeConversationTest.scala
@@ -1,6 +1,8 @@
 package orca.tools.opencode
 
 import orca.AgentTurnFailed
+import orca.agents.Model
+import orca.events.{TurnDebit, Usage}
 import orca.backend.{
   ApprovalDecision,
   ConversationEvent,
@@ -251,6 +253,48 @@ class OpencodeConversationTest extends munit.FunSuite:
     )
     conv.events.foreach(_ => ())
     intercept[AgentTurnFailed](conv.awaitResult())
+
+  // An assistant message with no `tokens` measured nothing; an all-zero debit
+  // would be indistinguishable from a turn measured at zero.
+  convTest("a failed turn whose message reported no tokens debits nothing"):
+    val (conv, _) = conversation(
+      List(
+        data(
+          """{"type":"message.updated","properties":{"info":{"role":"assistant","sessionID":"ses_A","modelID":"gpt-4o-mini","error":{"message":"model exploded"}}}}"""
+        ),
+        data("""{"type":"session.idle","properties":{"sessionID":"ses_A"}}""")
+      )
+    )
+    conv.events.foreach(_ => ())
+    val failure = intercept[AgentTurnFailed](conv.awaitResult())
+    assertEquals(failure.debit, TurnDebit.Unobserved)
+
+  convTest("a failed turn debits the tokens its message did report"):
+    val (conv, _) = conversation(
+      List(
+        data(
+          """{"type":"message.updated","properties":{"info":{"role":"assistant","sessionID":"ses_A","modelID":"gpt-4o-mini","tokens":{"input":10,"output":2,"reasoning":0,"cache":{"read":1,"write":3}},"error":{"message":"model exploded"}}}}"""
+        ),
+        data("""{"type":"session.idle","properties":{"sessionID":"ses_A"}}""")
+      )
+    )
+    conv.events.foreach(_ => ())
+    val failure = intercept[AgentTurnFailed](conv.awaitResult())
+    assertEquals(
+      failure.debit,
+      TurnDebit.Observed(
+        Usage(
+          freshInputTokens = 10L,
+          cacheReadInputTokens = 1L,
+          cacheWriteInputTokens = 3L,
+          outputTokens = 2L,
+          reasoningOutputTokens = 0L,
+          cost = None,
+          apiCalls = None
+        ),
+        Some(Model("gpt-4o-mini"))
+      )
+    )
 
   convTest(
     "a failure settle after assistant activity still emits AssistantTurnEnd"

--- a/opencode/src/test/scala/orca/tools/opencode/OpencodeConversationTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/OpencodeConversationTest.scala
@@ -233,6 +233,22 @@ class OpencodeConversationTest extends munit.FunSuite:
     assertEquals(result.usage.outputTokens, 0L)
     assertEquals(result.model, None)
 
+  // `tokens` and `cost` are independent fields on the assistant message, so a
+  // turn can report money without counts — which must still reach the summary.
+  convTest("a completed turn keeps a reported cost when tokens are absent"):
+    val (conv, _) = conversation(
+      List(
+        data(
+          """{"type":"message.updated","properties":{"info":{"role":"assistant","sessionID":"ses_A","cost":0.25,"finish":"stop"}}}"""
+        ),
+        data("""{"type":"session.idle","properties":{"sessionID":"ses_A"}}""")
+      )
+    )
+    conv.events.foreach(_ => ())
+    val result = conv.awaitResult().toOption.get
+    assertEquals(result.usage.cost, Some(BigDecimal("0.25")))
+    assertEquals(result.usage.inputTokens, 0L)
+
   convTest("idle with no assistant message at all fails the turn"):
     val (conv, _) = conversation(
       List(

--- a/pi/src/main/scala/orca/tools/pi/PiConversation.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiConversation.scala
@@ -1,7 +1,7 @@
 package orca.tools.pi
 
-import orca.events.Usage
-import orca.agents.{BackendTag, SessionId}
+import orca.events.{TurnDebit, Usage}
+import orca.agents.{BackendTag, Model, SessionId}
 import orca.{OrcaFlowException}
 import orca.backend.ConversationEvent
 import orca.backend.{StderrPipeline, ForkedConversation, StreamSource}
@@ -47,7 +47,7 @@ private[pi] class PiConversation(
     */
   private case class TurnState(
       lastAssistantMessage: String = "",
-      usage: Usage = Usage.empty,
+      usage: Option[Usage] = None,
       model: Option[String] = None,
       textStreamedThisMessage: Boolean = false
   )
@@ -83,6 +83,13 @@ private[pi] class PiConversation(
     resources.foreach(closeQuietly)
 
   override protected def terminalMessageNoun: String = "an agent_end event"
+
+  /** A pi turn runs many assistant messages, each carrying its own usage, so a
+    * late RPC failure would otherwise discard everything already accrued.
+    */
+  override protected def failedTurnDebit: TurnDebit =
+    turnState.usage.fold(TurnDebit.Unobserved): usage =>
+      TurnDebit.Observed(usage, turnState.model.map(Model.apply))
 
   private def handle(event: InboundEvent): Unit = event match
     case InboundEvent.Response(_, command, success, error) =>
@@ -138,7 +145,7 @@ private[pi] class PiConversation(
       val fallbackText = message.text.nonEmpty && !streamed
       turnState = turnState.copy(
         lastAssistantMessage = message.text,
-        usage = message.usage.fold(turnState.usage)(turnState.usage + _),
+        usage = (turnState.usage ++ message.usage).reduceOption(_ + _),
         model = message.model.orElse(turnState.model),
         textStreamedThisMessage = false // reset for the next message
       )
@@ -155,7 +162,7 @@ private[pi] class PiConversation(
     settleSuccess(
       wireId = clientSession.value,
       output = turnState.lastAssistantMessage,
-      usage = turnState.usage,
+      usage = turnState.usage.getOrElse(Usage.empty),
       modelId = turnState.model
     )
 

--- a/pi/src/main/scala/orca/tools/pi/rpc/InboundEvent.scala
+++ b/pi/src/main/scala/orca/tools/pi/rpc/InboundEvent.scala
@@ -192,23 +192,20 @@ private[pi] object InboundEvent:
       cacheWrite: Option[Long] = None,
       cost: Option[CostWire] = None
   ) derives ConfiguredJsonValueCodec:
-    // pi normalises `input` to the FRESH prompt only, disjoint from
-    // `cacheRead`/`cacheWrite` — it forwards Anthropic's `input_tokens` (which
-    // excludes both cache categories) and subtracts cached tokens on providers
-    // that include them, then reports `totalTokens` as the sum of all four
-    // axes. The total prompt is therefore the sum of the three input axes, as
-    // for claude and opencode. pi also reports `cacheWrite1h`, the 1h-TTL
-    // subset of `cacheWrite` — unparsed here, since `ModelPricing` carries one
-    // write rate; it is what a per-tier split would key on.
+    // pi subtracts cached tokens from `input` on providers that include them,
+    // so `input` is the fresh prompt on every provider it fronts. It also
+    // reports `cacheWrite1h`, the 1h-TTL subset of `cacheWrite` — unparsed
+    // here, since `ModelPricing` carries one write rate; it is what a per-tier
+    // split would key on.
     def toUsage: Usage =
-      val read = cacheRead.getOrElse(0L)
-      val write = cacheWrite.getOrElse(0L)
-      Usage(
-        inputTokens = input.getOrElse(0L) + read + write,
+      Usage.exclusiveInput(
+        freshInputTokens = input.getOrElse(0L),
+        cacheReadInputTokens = cacheRead.getOrElse(0L),
+        cacheWriteInputTokens = cacheWrite.getOrElse(0L),
         outputTokens = output.getOrElse(0L),
+        reasoningOutputTokens = 0L,
         cost = cost.flatMap(_.total),
-        cacheReadInputTokens = read,
-        cacheWriteInputTokens = write
+        apiCalls = None
       )
 
   private case class CostWire(total: Option[BigDecimal] = None)

--- a/pi/src/main/scala/orca/tools/pi/rpc/InboundEvent.scala
+++ b/pi/src/main/scala/orca/tools/pi/rpc/InboundEvent.scala
@@ -198,7 +198,7 @@ private[pi] object InboundEvent:
     // here, since `ModelPricing` carries one write rate; it is what a per-tier
     // split would key on.
     def toUsage: Usage =
-      Usage.exclusiveInput(
+      Usage(
         freshInputTokens = input.getOrElse(0L),
         cacheReadInputTokens = cacheRead.getOrElse(0L),
         cacheWriteInputTokens = cacheWrite.getOrElse(0L),

--- a/pi/src/test/scala/orca/tools/pi/PiBackendTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiBackendTest.scala
@@ -2,7 +2,7 @@ package orca.tools.pi
 
 import orca.OrcaDir
 import orca.backend.SystemPromptComposer
-import orca.events.Usage
+import orca.testkit.Usages.usage
 import orca.agents.{
   BackendTag,
   AgentConfig,
@@ -59,7 +59,7 @@ class PiBackendTest extends munit.FunSuite:
     val wire: WireSessionId[BackendTag.Pi.type] = sid.onWire
     assertEquals(result.wireId, wire)
     assertEquals(result.output, "answer")
-    assertEquals(result.usage, Usage(10L, 5L, None))
+    assertEquals(result.usage, usage(10L, 5L))
     assertEquals(result.model.map(_.name), Some("pi-model"))
 
     val call = runner.spawnCalls.head

--- a/pi/src/test/scala/orca/tools/pi/PiConversationTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiConversationTest.scala
@@ -1,10 +1,11 @@
 package orca.tools.pi
 
 import orca.backend.{ConversationEvent, ConversationEventConformance}
-import orca.events.Usage
-import orca.agents.{BackendTag, SessionId, WireSessionId, onWire}
-import orca.{OrcaFlowException, OrcaInteractiveCancelled}
+import orca.events.{TurnDebit, Usage}
+import orca.agents.{BackendTag, Model, SessionId, WireSessionId, onWire}
+import orca.{AgentTurnFailed, OrcaFlowException, OrcaInteractiveCancelled}
 import orca.subprocess.FakePipedCliProcess
+import orca.testkit.Usages.usage
 import ox.{Ox, supervised}
 
 class PiConversationTest extends munit.FunSuite:
@@ -208,6 +209,26 @@ class PiConversationTest extends munit.FunSuite:
     ConversationEventConformance.assertGrammar(events, completedNormally = true)
     val ex = intercept[OrcaFlowException](conv.awaitResult())
     assert(ex.getMessage.contains("model unavailable"))
+
+  // A pi turn runs many assistant messages; a late RPC failure would otherwise
+  // discard every message_end's usage already accrued for the turn.
+  convTest("a failed response debits the usage accrued earlier in the turn"):
+    val process = new FakePipedCliProcess()
+    val conv = new PiConversation(process, sid)
+
+    process.enqueueStdout(
+      """{"type":"message_end","message":{"role":"assistant","model":"anthropic/claude-sonnet","content":[{"type":"text","text":"first"}],"usage":{"input":40,"output":9}}}"""
+    )
+    process.enqueueStdout(
+      """{"type":"response","id":"orca-prompt","command":"prompt","success":false,"error":"model unavailable"}"""
+    )
+
+    val _ = conv.events.toList
+    val ex = intercept[AgentTurnFailed](conv.awaitResult())
+    assertEquals(
+      ex.debit,
+      TurnDebit.Observed(usage(40L, 9L), Some(Model("anthropic/claude-sonnet")))
+    )
 
   convTest(
     "extension UI input request becomes UserQuestion and writes response"

--- a/pi/src/test/scala/orca/tools/pi/PiConversationTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiConversationTest.scala
@@ -255,6 +255,31 @@ class PiConversationTest extends munit.FunSuite:
       case other =>
         fail(s"expected cancellation after test cleanup, got $other")
 
+  // Ctrl-C at an interactive prompt abandons a turn that has already been
+  // billed for every assistant message it ran.
+  convTest("a cancelled turn carries the usage accrued before the cancel"):
+    val process = new FakePipedCliProcess()
+    val conv = new PiConversation(process, sid)
+
+    process.enqueueStdout(
+      """{"type":"message_end","message":{"role":"assistant","model":"anthropic/claude-sonnet","content":[{"type":"text","text":"partial"}],"usage":{"input":60,"output":4}}}"""
+    )
+    assertEquals(
+      conv.events.next(),
+      ConversationEvent.AssistantTextDelta("partial")
+    )
+    conv.cancel()
+    conv.awaitResult() match
+      case Left(cancelled) =>
+        assertEquals(
+          cancelled.debit,
+          TurnDebit.Observed(
+            usage(60L, 4L),
+            Some(Model("anthropic/claude-sonnet"))
+          )
+        )
+      case other => fail(s"expected cancellation, got $other")
+
   convTest("fire-and-forget extension UI requests are ignored"):
     val process = new FakePipedCliProcess()
     val conv = new PiConversation(process, sid)

--- a/pi/src/test/scala/orca/tools/pi/PiConversationTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiConversationTest.scala
@@ -50,12 +50,14 @@ class PiConversationTest extends munit.FunSuite:
     assertEquals(
       result.usage,
       Usage(
-        // pi's `input` counts only the fresh prompt, so the total is 10+1+2.
-        inputTokens = 13L,
+        // pi's `input` counts only the fresh prompt.
+        freshInputTokens = 10L,
         outputTokens = 3L,
         cost = Some(BigDecimal("0.01")),
         cacheReadInputTokens = 1L,
-        cacheWriteInputTokens = 2L
+        reasoningOutputTokens = 0L,
+        cacheWriteInputTokens = 2L,
+        apiCalls = None
       )
     )
     assertEquals(process.sigIntCount, 1)
@@ -178,11 +180,13 @@ class PiConversationTest extends munit.FunSuite:
       result.usage,
       Usage(
         // (1 fresh + 3 read) + (4 fresh + 6 write)
-        inputTokens = 14L,
+        freshInputTokens = 5L,
         outputTokens = 7L,
         cost = None,
         cacheReadInputTokens = 3L,
-        cacheWriteInputTokens = 6L
+        reasoningOutputTokens = 0L,
+        cacheWriteInputTokens = 6L,
+        apiCalls = None
       )
     )
 

--- a/pi/src/test/scala/orca/tools/pi/PiConversationTest.scala
+++ b/pi/src/test/scala/orca/tools/pi/PiConversationTest.scala
@@ -53,11 +53,11 @@ class PiConversationTest extends munit.FunSuite:
       Usage(
         // pi's `input` counts only the fresh prompt.
         freshInputTokens = 10L,
-        outputTokens = 3L,
-        cost = Some(BigDecimal("0.01")),
         cacheReadInputTokens = 1L,
-        reasoningOutputTokens = 0L,
         cacheWriteInputTokens = 2L,
+        outputTokens = 3L,
+        reasoningOutputTokens = 0L,
+        cost = Some(BigDecimal("0.01")),
         apiCalls = None
       )
     )
@@ -182,11 +182,11 @@ class PiConversationTest extends munit.FunSuite:
       Usage(
         // (1 fresh + 3 read) + (4 fresh + 6 write)
         freshInputTokens = 5L,
-        outputTokens = 7L,
-        cost = None,
         cacheReadInputTokens = 3L,
-        reasoningOutputTokens = 0L,
         cacheWriteInputTokens = 6L,
+        outputTokens = 7L,
+        reasoningOutputTokens = 0L,
+        cost = None,
         apiCalls = None
       )
     )

--- a/runner/src/main/scala/orca/flow.scala
+++ b/runner/src/main/scala/orca/flow.scala
@@ -153,7 +153,7 @@ def flow(
   // with no diagnostic; this leaves a trail on the console and in the trace.
   installUncaughtExceptionHandler()
   // Tally token usage and print the summary on exit (success or failure).
-  val costTracker = new CostTracker(pricing.lastUpdated)
+  val costTracker = new CostTracker(pricing)
   // `try/finally` so the cost summary always lands — even when a fatal
   // throwable (OOM, StackOverflow) escapes the NonFatal catch below. See
   // `FlowOutcome`'s scaladoc for why this is one ADT, not two booleans.

--- a/runner/src/main/scala/orca/flow.scala
+++ b/runner/src/main/scala/orca/flow.scala
@@ -2,6 +2,7 @@ package orca
 
 import orca.backend.{AgentWiring, Interaction}
 import orca.events.{
+  CostResolvingDispatcher,
   CostTracker,
   EventDispatcher,
   OrcaEvent,
@@ -152,7 +153,7 @@ def flow(
   // with no diagnostic; this leaves a trail on the console and in the trace.
   installUncaughtExceptionHandler()
   // Tally token usage and print the summary on exit (success or failure).
-  val costTracker = new CostTracker(pricing)
+  val costTracker = new CostTracker(pricing.lastUpdated)
   // `try/finally` so the cost summary always lands — even when a fatal
   // throwable (OOM, StackOverflow) escapes the NonFatal catch below. See
   // `FlowOutcome`'s scaladoc for why this is one ADT, not two booleans.
@@ -172,7 +173,6 @@ def flow(
       workDir,
       OrcaBanner.version,
       flowName,
-      pricing,
       () => java.time.Instant.now()
     )
     try
@@ -190,6 +190,7 @@ def flow(
           returnToStartBranch = returnToStartBranch,
           progressStore = progressStore,
           flowName = flowName,
+          pricing = pricing,
           wiring = FlowWiring(
             claude = claude,
             codex = codex,
@@ -261,7 +262,8 @@ private[orca] def runFlow(
     // `sys.env` reading; `None` for every other caller (tests, a nested
     // `flow()` invocation with nothing of its own to report).
     flowName: Option[String] = None,
-    wiring: FlowWiring = FlowWiring()
+    wiring: FlowWiring = FlowWiring(),
+    pricing: PriceList = Pricing.default
 )(body: FlowControl ?=> Unit): Unit =
   val debug = OrcaDebug.enabled || args.verbose.value
   // Acquire both guards before `supervised:` (neither needs an `Ox` scope) so a
@@ -279,10 +281,16 @@ private[orca] def runFlow(
           TerminalInteraction.start(workDir = Some(workDir))
         )
         try
-          val dispatcher = new EventDispatcher(
-            effectiveInteraction.listeners ++ List(
-              new LoggingListener
-            ) ++ extraListeners
+          // Cost is resolved on the way in, so the terminal summary, the
+          // on-disk cost log and any listener a caller added all read one
+          // figure — none of them holds a price table of its own.
+          val dispatcher: OrcaListener = new CostResolvingDispatcher(
+            pricing,
+            new EventDispatcher(
+              effectiveInteraction.listeners ++ List(
+                new LoggingListener
+              ) ++ extraListeners
+            )
           )
           val store =
             progressStore.getOrElse(
@@ -364,7 +372,7 @@ private def buildContext(
     reviewAgent: Option[AgentSet => Agent[?]],
     globalSettingsPath: os.Path,
     branchNaming: Option[BranchNamingStrategy],
-    dispatcher: EventDispatcher,
+    dispatcher: OrcaListener,
     agents: WiredAgents,
     gitTool: GitTool,
     ghTool: GitHubTool,

--- a/runner/src/main/scala/orca/runner/DefaultFlowContext.scala
+++ b/runner/src/main/scala/orca/runner/DefaultFlowContext.scala
@@ -4,7 +4,7 @@ import orca.{FlowControl, StackSettings}
 import orca.progress.ProgressStore
 import orca.tools.{FsTool, GitHubTool, GitTool}
 import orca.agents.{Agent, BackendTag}
-import orca.events.{EventDispatcher, OrcaEvent}
+import orca.events.{OrcaEvent, OrcaListener}
 
 import ox.discard
 
@@ -21,7 +21,7 @@ private[orca] class DefaultFlowContext[
 ](
     val userPrompt: String,
     val workDir: os.Path,
-    dispatcher: EventDispatcher,
+    dispatcher: OrcaListener,
     // The three role agents (ADR 0020), resolved by `runFlow`. Each is
     // concretely typed via its own tag parameter so the role type members pin
     // them and sessions thread.

--- a/runner/src/main/scala/orca/runner/LoggingListener.scala
+++ b/runner/src/main/scala/orca/runner/LoggingListener.scala
@@ -33,14 +33,23 @@ private[orca] class LoggingListener extends OrcaListener:
         "structured result: {}",
         summary.filter(_.nonEmpty).getOrElse(raw)
       )
-    case OrcaEvent.TokensUsed(agent, model, usage, role, attempt, session) =>
+    case OrcaEvent.TokensUsed(
+          agent,
+          model,
+          usage,
+          role,
+          attempt,
+          session,
+          cost
+        ) =>
       log.debug(
-        "tokens: agent={} role={} model={} attempt={} session={} usage={}",
+        "tokens: agent={} role={} model={} attempt={} session={} cost={} usage={}",
         agent,
         role.getOrElse("(none)"),
         model.map(_.name).getOrElse("(unknown)"),
         attempt,
         session.getOrElse("(none)"),
+        cost.map(_.amount).getOrElse("(unknown)"),
         usage
       )
     case OrcaEvent.Error(message) => log.error("error: {}", message)

--- a/runner/src/main/scala/orca/runner/LoggingListener.scala
+++ b/runner/src/main/scala/orca/runner/LoggingListener.scala
@@ -33,24 +33,16 @@ private[orca] class LoggingListener extends OrcaListener:
         "structured result: {}",
         summary.filter(_.nonEmpty).getOrElse(raw)
       )
-    case OrcaEvent.TokensUsed(
-          agent,
-          model,
-          usage,
-          role,
-          attempt,
-          session,
-          cost
-        ) =>
+    case t: OrcaEvent.TokensUsed =>
       log.debug(
         "tokens: agent={} role={} model={} attempt={} session={} cost={} usage={}",
-        agent,
-        role.getOrElse("(none)"),
-        model.map(_.name).getOrElse("(unknown)"),
-        attempt,
-        session.getOrElse("(none)"),
-        cost.fold("(none)")(_.amount.toString),
-        usage
+        t.agent,
+        t.role.getOrElse("(none)"),
+        t.model.map(_.name).getOrElse("(unknown)"),
+        t.attempt,
+        t.session.getOrElse("(none)"),
+        t.cost.fold("(none)")(_.amount.toString),
+        t.usage
       )
     case OrcaEvent.Error(message) => log.error("error: {}", message)
     case OrcaEvent.SessionCommitted(harness, clientId, wireId, agent, role) =>

--- a/runner/src/main/scala/orca/runner/LoggingListener.scala
+++ b/runner/src/main/scala/orca/runner/LoggingListener.scala
@@ -49,7 +49,7 @@ private[orca] class LoggingListener extends OrcaListener:
         model.map(_.name).getOrElse("(unknown)"),
         attempt,
         session.getOrElse("(none)"),
-        cost.map(_.amount).getOrElse("(unknown)"),
+        cost.fold("(none)")(_.amount.toString),
         usage
       )
     case OrcaEvent.Error(message) => log.error("error: {}", message)

--- a/runner/src/main/scala/orca/runner/manifest/CostLog.scala
+++ b/runner/src/main/scala/orca/runner/manifest/CostLog.scala
@@ -13,14 +13,16 @@ import orca.events.{Cost, Usage}
 import java.nio.charset.StandardCharsets
 import scala.util.control.NonFatal
 
-/** The persisted projection of [[orca.events.Usage]]'s token axes, sharing its
-  * normalisation contract — including that cache reads and cache writes are
-  * disjoint sub-portions of `inputTokens`, carried separately because they bill
-  * at opposite ends of base input.
+/** The persisted projection of [[orca.events.Usage]]'s token axes.
   *
   * The field names are `Usage`'s, verbatim, and so are the JSON keys: every
   * axis persisted here has to be traceable to the one it mirrors, or the two
-  * drift and a reader silently reports the wrong money.
+  * drift and a reader silently reports the wrong money. `RunManifestTest` pins
+  * that correspondence against `Usage`'s own field list, so an axis added there
+  * fails a test instead of silently vanishing from the log.
+  *
+  * `apiCalls` is the one axis of `Usage` that isn't here: it lives on
+  * [[CostRecord.Turn]], beside the attribution fields.
   *
   * Deliberately carries no money, unlike `Usage`: `Usage.cost` is only the
   * portion backends reported, and an unlabelled figure next to a resolved

--- a/runner/src/main/scala/orca/runner/manifest/CostLog.scala
+++ b/runner/src/main/scala/orca/runner/manifest/CostLog.scala
@@ -15,14 +15,16 @@ import scala.util.control.NonFatal
 
 /** The persisted projection of [[orca.events.Usage]]'s token axes.
   *
-  * The field names are `Usage`'s, verbatim, and so are the JSON keys: every
-  * axis persisted here has to be traceable to the one it mirrors, or the two
-  * drift and a reader silently reports the wrong money. `RunManifestTest` pins
-  * that correspondence against `Usage`'s own field list, so an axis added there
+  * The field names are `Usage`'s and so are the JSON keys: every axis persisted
+  * here has to be traceable to the one it mirrors, or the two drift and a
+  * reader silently reports the wrong money. `RunManifestTest` pins that
+  * correspondence against `Usage`'s own field list, so an axis added there
   * fails a test instead of silently vanishing from the log.
   *
-  * `apiCalls` is the one axis of `Usage` that isn't here: it lives on
-  * [[CostRecord.Turn]], beside the attribution fields.
+  * `inputTokens` is the one name that isn't a field of `Usage`: it is the TOTAL
+  * prompt, `cacheReadInputTokens` and `cacheWriteInputTokens` INCLUDED, so
+  * adding the three double counts. `apiCalls`, an axis of `Usage`, isn't here
+  * at all: it lives on [[CostRecord.Turn]], beside the attribution fields.
   *
   * Deliberately carries no money, unlike `Usage`: `Usage.cost` is only the
   * portion backends reported, and an unlabelled figure next to a resolved

--- a/runner/src/main/scala/orca/runner/manifest/CostLog.scala
+++ b/runner/src/main/scala/orca/runner/manifest/CostLog.scala
@@ -53,8 +53,8 @@ private[orca] enum CostRecord:
   /** Written once, before the first turn. `orcaVersion` and `flow` have nowhere
     * else to live for a run that spends tokens without ever committing a
     * session, since such a run writes no [[RunManifest]] at all. `workDir` is
-    * recoverable from the file's own path, and repeated anyway because a cost
-    * log routinely gets copied out of its directory into a research note.
+    * recoverable from the file's own path; repeated so the log is
+    * self-contained when copied.
     */
   case Run(orcaVersion: String, flow: Option[String], workDir: String)
 
@@ -81,8 +81,7 @@ private[orca] enum CostRecord:
 
   /** Written by `RunManifestWriter.finish`. Distinguishes a succeeded run from
     * a failed one for a turn-only run, whose `outcome` has no other home — a
-    * distinction that changes how the run's spend reads. (Whether a run ended
-    * at all is answerable without this, from the pid in the filename.)
+    * distinction that changes how the run's spend reads.
     */
   case Finish(at: String, outcome: String)
 

--- a/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
@@ -6,7 +6,7 @@ import com.github.plokhotnyuk.jsoniter_scala.core.{
 }
 import orca.OrcaDir
 import orca.agents.JsonData
-import orca.events.{OrcaEvent, OrcaListener, PriceList, Pricing}
+import orca.events.{OrcaEvent, OrcaListener}
 import orca.progress.ProgressLog
 import org.slf4j.LoggerFactory
 import ox.Ox
@@ -57,11 +57,10 @@ private[orca] object RunManifestWriter:
       workDir: os.Path,
       orcaVersion: String,
       flowName: Option[String],
-      pricing: PriceList,
       clock: () => Instant
   )(using Ox, BufferCapacity): RunManifestWriter =
     val state =
-      new RunManifestWriterState(workDir, orcaVersion, flowName, pricing, clock)
+      new RunManifestWriterState(workDir, orcaVersion, flowName, clock)
     new ActorRunManifestWriter(Actor.create(state))
 
 /** Actor-backed [[RunManifestWriter]]. `onEvent` is a `tell`; `finish` is an
@@ -98,7 +97,6 @@ private[runner] class RunManifestWriterState(
     workDir: os.Path,
     orcaVersion: String,
     flowName: Option[String],
-    pricing: PriceList,
     clock: () => Instant
 ) extends RunManifestWriter:
 
@@ -186,7 +184,7 @@ private[runner] class RunManifestWriterState(
           upsertSession(harness, clientId, wireId, agent, role)
         )
       if hasCommittedSession then safeWrite()
-    case OrcaEvent.TokensUsed(agent, model, usage, role, attempt, session) =>
+    case OrcaEvent.TokensUsed(agent, _, usage, role, attempt, session, cost) =>
       if !state.anyTurnRecorded then
         guarded("cost log header"):
           costLog.append(
@@ -204,7 +202,7 @@ private[runner] class RunManifestWriterState(
             attempt = attempt,
             apiCalls = usage.apiCalls,
             usage = ManifestUsage.of(usage),
-            cost = Pricing.resolve(pricing.table, model, usage),
+            cost = cost,
             session = session
           )
         )

--- a/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
@@ -183,7 +183,7 @@ private[runner] class RunManifestWriterState(
           upsertSession(harness, clientId, wireId, agent, role)
         )
       if hasCommittedSession then safeWrite()
-    case OrcaEvent.TokensUsed(agent, _, usage, role, attempt, session, cost) =>
+    case t: OrcaEvent.TokensUsed =>
       if !state.anyTurnRecorded then
         guarded("cost log header"):
           costLog.append(
@@ -195,14 +195,14 @@ private[runner] class RunManifestWriterState(
         costLog.append(
           CostRecord.Turn(
             at = clock().toString,
-            agent = agent,
-            role = role,
+            agent = t.agent,
+            role = t.role,
             stage = state.stageStack.headOption,
-            attempt = attempt,
-            apiCalls = usage.apiCalls,
-            usage = ManifestUsage.of(usage),
-            cost = cost,
-            session = session
+            attempt = t.attempt,
+            apiCalls = t.usage.apiCalls,
+            usage = ManifestUsage.of(t.usage),
+            cost = t.cost,
+            session = t.session
           )
         )
     case _ => ()

--- a/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
@@ -76,13 +76,12 @@ private class ActorRunManifestWriter(actor: ActorRef[RunManifestWriterState])
 /** Mutable manifest-building state — not thread-safe in isolation.
   * [[ActorRunManifestWriter]] serialises every call onto one actor thread:
   * `onEvent` is a `tell` (fire-and-forget, though a full mailbox blocks the
-  * emitter — every event now writes, but turns arrive seconds apart and an
-  * append is one small write, so the queue still drains far faster than it
-  * fills) and `finish` is an `ask` (its write must land before `flow()` moves
-  * on to the cost summary). Every write is guarded internally ([[safeWrite]])
-  * so a transient failure can't quarantine the writer or throw out of a
-  * `tell`'s handler. Tests construct this directly and drive events
-  * synchronously.
+  * emitter — every event writes, but turns arrive seconds apart and an append
+  * is one small write, so the queue still drains far faster than it fills) and
+  * `finish` is an `ask` (its write must land before `flow()` moves on to the
+  * cost summary). Every write is guarded internally ([[safeWrite]]) so a
+  * transient failure can't quarantine the writer or throw out of a `tell`'s
+  * handler. Tests construct this directly and drive events synchronously.
   *
   * The two files have separate creation gates: the manifest appears on the
   * first `SessionCommitted` (a session-less run offers nothing to continue —

--- a/runner/src/test/scala/flowtests/FlowCompilesTest.scala
+++ b/runner/src/test/scala/flowtests/FlowCompilesTest.scala
@@ -225,8 +225,8 @@ object FlowCanary:
         val tracker = new CostTracker()
         val _: Option[Cost] = tracker.totalCost
         val listener: OrcaListener =
-          case OrcaEvent.TokensUsed(_, _, usage, _, _, _, _) =>
-            val _: Usage = usage
+          case t: OrcaEvent.TokensUsed =>
+            val _: Usage = t.usage
           case _ => ()
         val _ = listener
         val ignored: IgnoredIssues = fixLoop(

--- a/runner/src/test/scala/flowtests/FlowCompilesTest.scala
+++ b/runner/src/test/scala/flowtests/FlowCompilesTest.scala
@@ -225,7 +225,7 @@ object FlowCanary:
         val tracker = new CostTracker()
         val _: Option[Cost] = tracker.totalCost
         val listener: OrcaListener =
-          case OrcaEvent.TokensUsed(_, _, usage, _, _, _) =>
+          case OrcaEvent.TokensUsed(_, _, usage, _, _, _, _) =>
             val _: Usage = usage
           case _ => ()
         val _ = listener

--- a/runner/src/test/scala/orca/runner/OpencodeFlowTest.scala
+++ b/runner/src/test/scala/orca/runner/OpencodeFlowTest.scala
@@ -108,7 +108,7 @@ class OpencodeFlowTest extends munit.FunSuite:
         events: OrcaListener,
         outputSchema: Option[String]
     ): AgentResult[BackendTag.Opencode.type] =
-      AgentResult(session.onWire, json, Usage(0L, 0L, None))
+      AgentResult(session.onWire, json, Usage.empty)
     def runInteractive(
         prompt: String,
         session: SessionId[BackendTag.Opencode.type],

--- a/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
+++ b/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
@@ -251,8 +251,8 @@ class OrcaOverridesTest extends munit.FunSuite:
     // agent's "wired" event must be among them.
     var seen: List[String] = Nil
     val recorder: OrcaListener =
-      case OrcaEvent.TokensUsed(agent, _, _, _, _, _) => seen = agent :: seen
-      case _                                          => ()
+      case OrcaEvent.TokensUsed(agent, _, _, _, _, _, _) => seen = agent :: seen
+      case _                                             => ()
     supervised:
       val interaction = TerminalInteraction.start(
         out = new PrintStream(new ByteArrayOutputStream()),

--- a/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
+++ b/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
@@ -293,9 +293,14 @@ class OrcaOverridesTest extends munit.FunSuite:
         summon[FlowContext].emit(
           OrcaEvent.TokensUsed(
             "test-agent",
-            Some(Model("test-model")),
+            // A model the shipped table prices, so the cost below is the run's
+            // own resolution rather than an absent figure.
+            Some(Model("claude-haiku-4-5")),
             usage(10L, 5L)
           )
         )
     // TerminalInteraction ignores TokensUsed; CostTracker should accumulate.
     assertEquals(tracker.total, usage(10L, 5L))
+    // The tracker prices nothing itself: a cost here means the run resolved it
+    // on the way into the fan-out.
+    assert(tracker.totalCost.nonEmpty, tracker.summary)

--- a/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
+++ b/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
@@ -251,8 +251,8 @@ class OrcaOverridesTest extends munit.FunSuite:
     // agent's "wired" event must be among them.
     var seen: List[String] = Nil
     val recorder: OrcaListener =
-      case OrcaEvent.TokensUsed(agent, _, _, _, _, _, _) => seen = agent :: seen
-      case _                                             => ()
+      case t: OrcaEvent.TokensUsed => seen = t.agent :: seen
+      case _                       => ()
     supervised:
       val interaction = TerminalInteraction.start(
         out = new PrintStream(new ByteArrayOutputStream()),

--- a/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
+++ b/runner/src/test/scala/orca/runner/OrcaOverridesTest.scala
@@ -17,7 +17,8 @@ import orca.agents.{
   SessionId,
   ToolSet
 }
-import orca.events.{CostTracker, OrcaEvent, OrcaListener, Usage}
+import orca.events.{CostTracker, OrcaEvent, OrcaListener}
+import orca.testkit.Usages.usage
 import orca.tools.opencode.OpencodeAgents
 import _root_.orca.runner.terminal.TerminalInteraction
 import ox.supervised
@@ -240,7 +241,7 @@ class OrcaOverridesTest extends munit.FunSuite:
               OrcaEvent.TokensUsed(
                 "wired",
                 Some(Model("wired-model")),
-                Usage(7L, 3L, None)
+                usage(7L, 3L)
               )
             )
             s"ok: $p"
@@ -293,8 +294,8 @@ class OrcaOverridesTest extends munit.FunSuite:
           OrcaEvent.TokensUsed(
             "test-agent",
             Some(Model("test-model")),
-            Usage(10L, 5L, None)
+            usage(10L, 5L)
           )
         )
     // TerminalInteraction ignores TokensUsed; CostTracker should accumulate.
-    assertEquals(tracker.total, Usage(10L, 5L, None))
+    assertEquals(tracker.total, usage(10L, 5L))

--- a/runner/src/test/scala/orca/runner/manifest/CostLogTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/CostLogTest.scala
@@ -2,8 +2,9 @@ package orca.runner.manifest
 
 import orca.OrcaDir
 import orca.agents.Model
-import orca.events.{Cost, OrcaEvent, PriceList, Pricing, Usage}
+import orca.events.{Cost, OrcaEvent, PriceList, Pricing}
 import orca.testkit.TempDirs
+import orca.testkit.Usages.usage
 
 import java.time.Instant
 
@@ -40,7 +41,7 @@ class CostLogTest extends munit.FunSuite:
   test("a turn-only run writes a cost log and no session manifest"):
     val workDir = TempDirs.dir()
     val writer = newWriter(workDir)
-    writer.onEvent(OrcaEvent.TokensUsed("claude", None, Usage(10, 1, None)))
+    writer.onEvent(OrcaEvent.TokensUsed("claude", None, usage(10, 1, None)))
     writer.finish(RunOutcome.Succeeded)
     assertEquals(
       os.list(OrcaDir.cacheRunsPath(workDir)).filter(_.ext == "json").toList,
@@ -69,8 +70,8 @@ class CostLogTest extends munit.FunSuite:
   test("the cost log opens with one run header carrying the run's identity"):
     val workDir = TempDirs.dir()
     val writer = newWriter(workDir)
-    writer.onEvent(OrcaEvent.TokensUsed("claude", None, Usage(10, 1, None)))
-    writer.onEvent(OrcaEvent.TokensUsed("claude", None, Usage(20, 2, None)))
+    writer.onEvent(OrcaEvent.TokensUsed("claude", None, usage(10, 1, None)))
+    writer.onEvent(OrcaEvent.TokensUsed("claude", None, usage(20, 2, None)))
     assertEquals(
       costRecords(workDir).collect { case r: CostRecord.Run => r },
       List(
@@ -81,7 +82,7 @@ class CostLogTest extends munit.FunSuite:
   test("finish appends the outcome as the log's last record"):
     val workDir = TempDirs.dir()
     val writer = newWriter(workDir)
-    writer.onEvent(OrcaEvent.TokensUsed("claude", None, Usage(10, 1, None)))
+    writer.onEvent(OrcaEvent.TokensUsed("claude", None, usage(10, 1, None)))
     writer.finish(RunOutcome.Failed)
     assertEquals(
       costRecords(workDir).last,
@@ -94,7 +95,7 @@ class CostLogTest extends munit.FunSuite:
   test("a run that never finishes leaves the log without a trailer"):
     val workDir = TempDirs.dir()
     val writer = newWriter(workDir)
-    writer.onEvent(OrcaEvent.TokensUsed("claude", None, Usage(10, 1, None)))
+    writer.onEvent(OrcaEvent.TokensUsed("claude", None, usage(10, 1, None)))
     assert(
       !costRecords(workDir).exists(_.isInstanceOf[CostRecord.Finish]),
       costRecords(workDir).toString
@@ -112,7 +113,7 @@ class CostLogTest extends munit.FunSuite:
       OrcaEvent.TokensUsed(
         "claude",
         None,
-        Usage(107_000, 500, None, apiCalls = Some(3L)),
+        usage(107_000, 500, None, apiCalls = Some(3L)),
         None,
         session = Some("wire-1")
       )
@@ -124,7 +125,7 @@ class CostLogTest extends munit.FunSuite:
       OrcaEvent.TokensUsed(
         "reviewer",
         None,
-        Usage(0, 0, None),
+        usage(0, 0, None),
         Some("reviewer"),
         attempt = 2
       )
@@ -151,12 +152,12 @@ class CostLogTest extends munit.FunSuite:
       OrcaEvent.TokensUsed(
         agent = "claude",
         model = Some(Model("claude-sonnet-5")),
-        usage = Usage(
-          inputTokens = 120_000,
-          outputTokens = 900,
+        usage = usage(
+          input = 120_000,
+          output = 900,
           cost = None,
-          cacheReadInputTokens = 107_000,
-          cacheWriteInputTokens = 8_000
+          cacheRead = 107_000,
+          cacheWrite = 8_000
         ),
         role = None
       )
@@ -187,7 +188,7 @@ class CostLogTest extends munit.FunSuite:
       OrcaEvent.TokensUsed(
         agent = "claude",
         model = Some(Model("claude-sonnet-5")),
-        usage = Usage(120_000, 900, None, cacheReadInputTokens = 107_000),
+        usage = usage(120_000, 900, None, cacheRead = 107_000),
         role = None
       )
     )
@@ -195,7 +196,7 @@ class CostLogTest extends munit.FunSuite:
       OrcaEvent.TokensUsed(
         agent = "reviewer",
         model = Some(Model("claude-haiku-4-5")),
-        usage = Usage(5_000, 100, Some(BigDecimal("0.0123"))),
+        usage = usage(5_000, 100, Some(BigDecimal("0.0123"))),
         role = Some("reviewer")
       )
     )
@@ -246,7 +247,7 @@ class CostLogTest extends munit.FunSuite:
   test("a second finish does not append a second trailer"):
     val workDir = TempDirs.dir()
     val writer = newWriter(workDir)
-    writer.onEvent(OrcaEvent.TokensUsed("claude", None, Usage(10, 1, None)))
+    writer.onEvent(OrcaEvent.TokensUsed("claude", None, usage(10, 1, None)))
     writer.finish(RunOutcome.Succeeded)
     writer.finish(RunOutcome.Failed)
     assertEquals(

--- a/runner/src/test/scala/orca/runner/manifest/CostLogTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/CostLogTest.scala
@@ -2,7 +2,7 @@ package orca.runner.manifest
 
 import orca.OrcaDir
 import orca.agents.Model
-import orca.events.{Cost, OrcaEvent, PriceList, Pricing}
+import orca.events.{Cost, OrcaEvent}
 import orca.testkit.TempDirs
 import orca.testkit.Usages.usage
 
@@ -15,15 +15,11 @@ class CostLogTest extends munit.FunSuite:
 
   private def fixedClock(at: Instant): () => Instant = () => at
 
-  private def newWriter(
-      workDir: os.Path,
-      pricing: PriceList = Pricing.default
-  ): RunManifestWriterState =
+  private def newWriter(workDir: os.Path): RunManifestWriterState =
     new RunManifestWriterState(
       workDir,
       "0.0.test",
       Some("review-pr.sc"),
-      pricing,
       fixedClock(Instant.parse("2026-07-18T10:00:00Z"))
     )
 
@@ -142,12 +138,13 @@ class CostLogTest extends munit.FunSuite:
 
   /** Every axis is carried per turn, because the aggregates are folds over
     * these lines and nothing else persists them. The cache-read and cache-write
-    * figures are non-zero and unequal so both survive the projection, and a
-    * write is billed at the write rate rather than folded into base input.
+    * figures are non-zero and unequal so both survive the projection. Cost is
+    * whatever the dispatcher already resolved — the writer prices nothing.
     */
-  test("a turn carries every usage axis and its resolved cost"):
+  test("a turn carries every usage axis and the cost the event arrived with"):
     val workDir = TempDirs.dir()
     val writer = newWriter(workDir)
+    val resolved = Cost(BigDecimal("0.1086"), estimated = true)
     writer.onEvent(
       OrcaEvent.TokensUsed(
         agent = "claude",
@@ -159,7 +156,8 @@ class CostLogTest extends munit.FunSuite:
           cacheRead = 107_000,
           cacheWrite = 8_000
         ),
-        role = None
+        role = None,
+        cost = Some(resolved)
       )
     )
     val turn = turns(workDir).head
@@ -173,9 +171,7 @@ class CostLogTest extends munit.FunSuite:
         reasoningOutputTokens = 0
       )
     )
-    // 13k fresh at $3/M + 107k cache-read at $0.30/M + 8k cache-write at $6/M +
-    // 900 out at $15/M.
-    assertEquals(turn.cost, Some(Cost(BigDecimal("0.1086"), estimated = true)))
+    assertEquals(turn.cost, Some(resolved))
 
   /** The run total is a read-time fold, so this pins that the lines carry
     * enough to compute one — including `estimated` surviving the addition, so a
@@ -189,7 +185,8 @@ class CostLogTest extends munit.FunSuite:
         agent = "claude",
         model = Some(Model("claude-sonnet-5")),
         usage = usage(120_000, 900, None, cacheRead = 107_000),
-        role = None
+        role = None,
+        cost = Some(Cost(BigDecimal("0.0846"), estimated = true))
       )
     )
     writer.onEvent(
@@ -197,13 +194,12 @@ class CostLogTest extends munit.FunSuite:
         agent = "reviewer",
         model = Some(Model("claude-haiku-4-5")),
         usage = usage(5_000, 100, Some(BigDecimal("0.0123"))),
-        role = Some("reviewer")
+        role = Some("reviewer"),
+        cost = Some(Cost(BigDecimal("0.0123"), estimated = false))
       )
     )
     val recorded = turns(workDir)
     assertEquals(recorded.map(_.usage.inputTokens).sum, 125_000L)
-    // 13k fresh at $3/M + 107k cache-read at $0.30/M + 900 out at $15/M =
-    // $0.0846, plus the second turn's reported $0.0123.
     assertEquals(
       recorded.flatMap(_.cost).reduce(_ + _),
       Cost(BigDecimal("0.0969"), estimated = true)

--- a/runner/src/test/scala/orca/runner/manifest/RunManifestTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/RunManifestTest.scala
@@ -7,16 +7,15 @@ class RunManifestTest extends munit.FunSuite:
   // Guards the invariant ManifestUsage's scaladoc states: it mirrors every one
   // of Usage's token axes. Without this, an axis ADDED to Usage leaves
   // `ManifestUsage.of` compiling untouched and the cost log silently
-  // under-records spend — which is exactly how the cache-write axis went
-  // missing. Only the rename that came with it turned that into a compile
-  // error; a plain addition would have shipped. Every aggregate is now a fold
-  // over these lines, so an unrecorded axis is unrecoverable rather than
-  // recomputable.
+  // under-records spend. Every aggregate is a fold over these lines, so an
+  // unrecorded axis is unrecoverable rather than recomputable.
   test("ManifestUsage mirrors every token axis of Usage"):
     assertEquals(
       ManifestUsage.of(Usage.empty).productElementNames.toSet,
-      // Usage's two non-token fields, deliberately not carried here: `cost` at
-      // all (see ManifestUsage's scaladoc), and `apiCalls` beside the usage on
-      // each turn line rather than inside it.
-      Usage.empty.productElementNames.toSet - "cost" - "apiCalls"
+      // Three of Usage's fields take another route: `freshInputTokens` is
+      // persisted through the `inputTokens` total it feeds, `cost` is not
+      // carried at all (see ManifestUsage's scaladoc), and `apiCalls` sits
+      // beside the usage on each turn line rather than inside it.
+      Usage.empty.productElementNames.toSet
+        - "freshInputTokens" + "inputTokens" - "cost" - "apiCalls"
     )

--- a/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
@@ -3,7 +3,7 @@ package orca.runner.manifest
 import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
 import orca.OrcaDir
 import orca.WorkspaceWrite
-import orca.events.{OrcaEvent, PriceList, Pricing}
+import orca.events.OrcaEvent
 import orca.testkit.Usages.usage
 import orca.progress.{BranchMode, ProgressHeader, ProgressStore, SessionRecord}
 import orca.testkit.TempDirs
@@ -31,10 +31,9 @@ class RunManifestWriterTest extends munit.FunSuite:
   private def newWriter(
       workDir: os.Path,
       clock: () => Instant,
-      flowName: Option[String] = None,
-      pricing: PriceList = Pricing.default
+      flowName: Option[String] = None
   ): RunManifestWriterState =
-    new RunManifestWriterState(workDir, "0.0.test", flowName, pricing, clock)
+    new RunManifestWriterState(workDir, "0.0.test", flowName, clock)
 
   private def manifestFiles(workDir: os.Path): List[os.Path] =
     os.list(OrcaDir.cacheRunsPath(workDir)).filter(_.ext == "json").toList
@@ -443,7 +442,6 @@ class RunManifestWriterTest extends munit.FunSuite:
         workDir,
         "0.0.test",
         None,
-        Pricing.default,
         () => Instant.now()
       )
       val threads = (0 until 2).map: t =>

--- a/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/RunManifestWriterTest.scala
@@ -3,7 +3,8 @@ package orca.runner.manifest
 import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
 import orca.OrcaDir
 import orca.WorkspaceWrite
-import orca.events.{OrcaEvent, PriceList, Pricing, Usage}
+import orca.events.{OrcaEvent, PriceList, Pricing}
+import orca.testkit.Usages.usage
 import orca.progress.{BranchMode, ProgressHeader, ProgressStore, SessionRecord}
 import orca.testkit.TempDirs
 import ox.channels.BufferCapacity
@@ -339,7 +340,7 @@ class RunManifestWriterTest extends munit.FunSuite:
     for i <- 1 to 25 do os.write(runsDir / f"1000000000$i%03d-1.json", "{}")
     val writer =
       newWriter(workDir, fixedClock(Instant.parse("2026-07-18T10:00:00Z")))
-    writer.onEvent(OrcaEvent.TokensUsed("claude", None, Usage(10, 1, None)))
+    writer.onEvent(OrcaEvent.TokensUsed("claude", None, usage(10, 1)))
     assert(
       !os.exists(runsDir / "1000000000001-1.json"),
       "the oldest of 25 seeded runs must be gone"
@@ -358,7 +359,7 @@ class RunManifestWriterTest extends munit.FunSuite:
       os.write(runsDir / f"1000000000$i%03d-1-cost.jsonl", "")
     val writer =
       newWriter(workDir, fixedClock(Instant.parse("2026-07-18T10:00:00Z")))
-    writer.onEvent(OrcaEvent.TokensUsed("claude", None, Usage(10, 1, None)))
+    writer.onEvent(OrcaEvent.TokensUsed("claude", None, usage(10, 1)))
     assertEquals(manifestFiles(workDir).size, 20)
 
   /** Keeping every manifest-less run newer than the oldest kept manifest would
@@ -373,7 +374,7 @@ class RunManifestWriterTest extends munit.FunSuite:
       os.write(runsDir / f"1000000000$i%03d-1-cost.jsonl", "")
     val writer =
       newWriter(workDir, fixedClock(Instant.parse("2026-07-18T10:00:00Z")))
-    writer.onEvent(OrcaEvent.TokensUsed("claude", None, Usage(10, 1, None)))
+    writer.onEvent(OrcaEvent.TokensUsed("claude", None, usage(10, 1)))
     assertEquals(costLogFiles(workDir).size, 20)
 
   /** The upsert reads `.orca/` to name the session, and its failure is

--- a/runner/src/test/scala/orca/runner/terminal/ConversationRendererTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/ConversationRendererTest.scala
@@ -79,7 +79,7 @@ class ConversationRendererTest extends munit.FunSuite:
     AgentResult(
       wireId = WireSessionId[BackendTag.ClaudeCode.type]("sid"),
       output = """{"ok":true}""",
-      usage = Usage(0L, 0L, None)
+      usage = Usage.empty
     )
 
   test("UserMessage renders as one truncated line, not the full prompt"):

--- a/runner/src/test/scala/orca/runner/terminal/ConversationRendererTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/ConversationRendererTest.scala
@@ -1,7 +1,7 @@
 package orca.runner.terminal
 
 import orca.agents.{BackendTag, WireSessionId}
-import orca.events.{Usage}
+import orca.events.{TurnDebit, Usage}
 import orca.{OrcaInteractiveCancelled}
 import orca.backend.{
   ApprovalDecision,
@@ -165,7 +165,7 @@ class ConversationRendererTest extends munit.FunSuite:
 
   test("render surfaces awaitResult's Left as-is"):
     val buf = new ByteArrayOutputStream()
-    val cancelled = new OrcaInteractiveCancelled()
+    val cancelled = new OrcaInteractiveCancelled(TurnDebit.Unobserved)
     val conv = new ScriptedConversation(Nil, Left(cancelled))
     assertEquals(supervised(renderer(buf).render(conv)), Left(cancelled))
 

--- a/runner/src/test/scala/orca/runner/terminal/TerminalEventListenerTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/TerminalEventListenerTest.scala
@@ -1,6 +1,7 @@
 package orca.runner.terminal
 
-import orca.events.{OrcaEvent, Usage}
+import orca.events.OrcaEvent
+import orca.testkit.Usages.usage
 import orca.agents.Model
 import java.io.{ByteArrayOutputStream, PrintStream}
 
@@ -212,7 +213,7 @@ class TerminalEventListenerTest extends munit.FunSuite:
         OrcaEvent.TokensUsed(
           "claude",
           Some(Model("opus")),
-          Usage(10L, 5L, None)
+          usage(10L, 5L)
         )
       )
     )

--- a/shell/src/test/scala/orca/shell/sessions/ManifestRoundTripTest.scala
+++ b/shell/src/test/scala/orca/shell/sessions/ManifestRoundTripTest.scala
@@ -1,7 +1,8 @@
 package orca.shell.sessions
 
 import orca.WorkspaceWrite
-import orca.events.{OrcaEvent, Pricing, Usage}
+import orca.events.{OrcaEvent, Pricing}
+import orca.testkit.Usages.usage
 import orca.progress.{BranchMode, ProgressHeader, ProgressStore, SessionRecord}
 import orca.runner.manifest.{RunManifestWriter, RunOutcome}
 import orca.testkit.TempDirs
@@ -60,7 +61,7 @@ class ManifestRoundTripTest extends munit.FunSuite:
         OrcaEvent.TokensUsed(
           "claude",
           None,
-          Usage(1_000, 200, Some(BigDecimal("0.5"))),
+          usage(1_000, 200, Some(BigDecimal("0.5"))),
           Some("reviewer")
         )
       )

--- a/shell/src/test/scala/orca/shell/sessions/ManifestRoundTripTest.scala
+++ b/shell/src/test/scala/orca/shell/sessions/ManifestRoundTripTest.scala
@@ -1,7 +1,7 @@
 package orca.shell.sessions
 
 import orca.WorkspaceWrite
-import orca.events.{OrcaEvent, Pricing}
+import orca.events.OrcaEvent
 import orca.testkit.Usages.usage
 import orca.progress.{BranchMode, ProgressHeader, ProgressStore, SessionRecord}
 import orca.runner.manifest.{RunManifestWriter, RunOutcome}
@@ -44,7 +44,6 @@ class ManifestRoundTripTest extends munit.FunSuite:
         workDir,
         "0.0.test",
         Some("a-flow.sc"),
-        Pricing.default,
         () => Instant.now()
       )
       writer.onEvent(OrcaEvent.StageStarted("code"))

--- a/tools/src/main/scala/orca/OrcaFlowException.scala
+++ b/tools/src/main/scala/orca/OrcaFlowException.scala
@@ -22,8 +22,13 @@ class OrcaFlowException(message: String) extends RuntimeException(message)
   * policy — cannot produce this (see
   * [[orca.backend.Conversations.drainAutonomous]]), so subtyping never causes a
   * cancellation to be retried.
+  *
+  * `debit` is what the abandoned turn had spent, on the same terms as
+  * [[AgentTurnFailed.debit]]: a user who Ctrl-Cs a long interactive turn is
+  * billed for it, so the run's cost summary has to see it.
   */
 class OrcaInteractiveCancelled(
+    val debit: orca.events.TurnDebit,
     message: String = "interactive session cancelled"
 ) extends OrcaFlowException(message)
 

--- a/tools/src/main/scala/orca/OrcaFlowException.scala
+++ b/tools/src/main/scala/orca/OrcaFlowException.scala
@@ -42,15 +42,15 @@ class OrcaInteractiveCancelled(
   * (stack trace, exact type) for `--verbose`/debug inspection rather than being
   * flattened into the message string.
   *
-  * `usage` carries what the turn spent before failing, when the backend reports
-  * it on the terminal error frame (claude's `result` message does). Without it
-  * a failed turn's tokens would never reach `OrcaEvent.TokensUsed` — the
-  * success path is the only other emitter — and the run's cost summary would
-  * understate spend. `None` for backends whose failure frame carries no usage.
+  * `debit` is what the turn spent before failing. It has no default: the
+  * success path is the only other `OrcaEvent.TokensUsed` emitter, so a driver
+  * that skipped the question would silently drop the failed turn from the run's
+  * cost summary. A driver whose protocol reports nothing on its failure frame
+  * says so with [[orca.events.TurnDebit.Unobserved]].
   */
 class AgentTurnFailed(
     message: String,
-    cause: Throwable | Null = null,
-    val usage: Option[orca.events.Usage] = None
+    val debit: orca.events.TurnDebit,
+    cause: Throwable | Null = null
 ) extends OrcaFlowException(message):
   if cause != null then initCause(cause): Unit

--- a/tools/src/main/scala/orca/agents/AgentCall.scala
+++ b/tools/src/main/scala/orca/agents/AgentCall.scala
@@ -202,6 +202,8 @@ class DefaultAgentCall[B <: BackendTag, O](
       * can drive a corrective re-prompt loop around repeated calls to this.
       */
     def attemptOnce(): O =
+      // This attempt's turn index, whether it ends in a debit or a result.
+      val thisTurn = turnsRecorded + 1
       val promptText = lastFailure match
         case Some(f) =>
           val corrective = prompts.retry(f.response, f.parserError)
@@ -220,7 +222,7 @@ class DefaultAgentCall[B <: BackendTag, O](
         catch
           // Fires at most once per call — `AgentTurnFailed` is never retried.
           case e: AgentTurnFailed =>
-            accounting.failedAfterModelRan(e.debit, turnsRecorded + 1)
+            accounting.failedAfterModelRan(e.debit, thisTurn)
             throw e
       // Fire as soon as the backend drain commits — before the fallible
       // parse below — so a session that later exhausts its retries (parse
@@ -229,8 +231,8 @@ class DefaultAgentCall[B <: BackendTag, O](
       // session re-fires with the same payload; listeners dedup on
       // (backend, clientId, wireId) per the event's scaladoc.
       accounting.sessionCommitted()
-      turnsRecorded += 1
-      accounting.succeeded(result, turnsRecorded)
+      turnsRecorded = thisTurn
+      accounting.succeeded(result, thisTurn)
       try
         val parsed = ResponseParser.parse[O](result.output)
         emitStructuredResult(result.output, parsed)
@@ -283,9 +285,9 @@ class DefaultAgentCall[B <: BackendTag, O](
     // into this Ox, `drive` consumes them, and `cancel` (in the `finally`) tears
     // the conversation down before the scope joins — so a cancelled turn never
     // leaks the subprocess/forks. On cancel `drive` throws, skipping the
-    // register / TokensUsed bookkeeping below; a turn that failed after the
-    // model ran still reports its spend through `recording`.
-    val result = accounting.recording(TurnAccounting.OnlyTurn):
+    // register / session bookkeeping below; `recording` still reports what the
+    // abandoned turn spent.
+    val result = accounting.recording:
       ox.supervised:
         val rawConversation = backend.runInteractive(
           prompt,
@@ -310,9 +312,6 @@ class DefaultAgentCall[B <: BackendTag, O](
     // thread. No-op for backends whose session id IS the client UUID (claude).
     backend.sessions.register(session, result.wireId)
     accounting.sessionCommitted()
-    // A mid-session cancel throws out of `drive` before this line, and the wire
-    // protocols don't always carry partial usage, so a cancelled turn reports
-    // nothing.
     accounting.succeeded(result, TurnAccounting.OnlyTurn)
     val parsed = ResponseParser.parse[O](result.output)
     emitStructuredResult(result.output, parsed)

--- a/tools/src/main/scala/orca/agents/AgentCall.scala
+++ b/tools/src/main/scala/orca/agents/AgentCall.scala
@@ -2,7 +2,7 @@ package orca.agents
 
 import orca.AgentTurnFailed
 import orca.backend.{Conversations, Interaction, AgentBackend}
-import orca.events.{OrcaEvent, OrcaListener, Usage}
+import orca.events.{OrcaEvent, OrcaListener}
 import orca.util.JsonSchemaGen
 import ox.resilience.{ResultPolicy, RetryConfig, retry}
 
@@ -123,15 +123,6 @@ class DefaultAgentCall[B <: BackendTag, O](
     */
   private val outputSchema: String = JsonSchemaGen[O]
 
-  /** The use-after-close guard's second gate: `resultAs[O]` refuses
-    * construction on a closed agent, but a gateway built before the flow ended
-    * and stored across the close boundary would still reach the backend — this
-    * per-call check closes that gap.
-    */
-  private def checkNotClosed(): Unit =
-    if backend.isClosed then
-      throw new orca.OrcaFlowException(AgentBackend.ClosedMessage)
-
   val autonomous: AutonomousAgentCall[B, O] = new AutonomousAgentCall[B, O]:
     private[orca] def runWithSession[I: AgentInput](
         input: I,
@@ -139,7 +130,10 @@ class DefaultAgentCall[B <: BackendTag, O](
         config: Option[AgentConfig],
         emitPrompt: Boolean
     )(using orca.InStage): O =
-      checkNotClosed()
+      // `resultAs[O]` refuses construction on a closed agent, but a gateway
+      // built before the flow ended and stored across the close boundary would
+      // still reach the backend — this per-call check closes that gap.
+      backend.checkNotClosed()
       runAutonomousWithRetry(input, config, session, emitPrompt)
 
   val interactive: InteractiveAgentCall[B, O] = new InteractiveAgentCall[B, O]:
@@ -148,7 +142,7 @@ class DefaultAgentCall[B <: BackendTag, O](
         session: SessionId[B],
         config: Option[AgentConfig]
     )(using orca.InStage): O =
-      checkNotClosed()
+      backend.checkNotClosed()
       runInteractiveOnce(input, config, session)
 
   /** Emit a `StructuredResult` event carrying the raw payload and the
@@ -160,23 +154,6 @@ class DefaultAgentCall[B <: BackendTag, O](
       case _: Announce.NoSpecific[?] => None
       case specific                  => specific.message(value).orElse(Some(""))
     events.onEvent(OrcaEvent.StructuredResult(raw, summary))
-
-  /** Fires once a session's first turn commits (ADR 0021 §8). Read
-    * `backend.sessions.persistableWireId` directly (rather than through
-    * `Agent.resumeWireId`, which needs an `Agent` instance this class doesn't
-    * hold) — the same underlying lookup a `BaseAgent`-backed tool's
-    * `resumeWireId` resolves to.
-    */
-  private def emitSessionCommitted(session: SessionId[B]): Unit =
-    events.onEvent(
-      OrcaEvent.SessionCommitted(
-        backend.tag.wireName,
-        session.value,
-        backend.sessions.persistableWireId(session).map(_.value),
-        agentName,
-        agentRole
-      )
-    )
 
   /** THE retry policy — the only place that decides whether an autonomous-turn
     * failure gets retried: parse failures (corrective re-prompt, same session
@@ -203,6 +180,8 @@ class DefaultAgentCall[B <: BackendTag, O](
     // schema-wrapped form the agent sees): listeners want the question.
     if emitPrompt then events.onEvent(OrcaEvent.UserPrompt(serialized))
 
+    val accounting = turnAccounting(effective, session)
+
     // Carries a parse failure into the next attempt's corrective prompt. Local
     // contract: written only in the `MalformedAgentOutputException` catch below,
     // read only at the top of the next `attemptOnce` call, which `retry`
@@ -215,19 +194,6 @@ class DefaultAgentCall[B <: BackendTag, O](
     // turn that is actually paid for as a retry. Same sequential-write contract
     // as `lastFailure` above.
     var turnsRecorded = 0
-
-    def recordTurn(model: Option[Model], usage: Usage): Unit =
-      turnsRecorded += 1
-      events.onEvent(
-        OrcaEvent.TokensUsed(
-          agentName,
-          model,
-          usage,
-          agentRole,
-          turnsRecorded,
-          Some(backend.sessions.sessionKey(session))
-        )
-      )
 
     /** One attempt: build this iteration's prompt (the initial one, or a
       * corrective re-prompt carrying the prior parse failure), run the turn,
@@ -252,12 +218,9 @@ class DefaultAgentCall[B <: BackendTag, O](
             outputSchema = Some(outputSchema)
           )
         catch
-          // A turn that failed after the model ran still spent tokens; the
-          // success path below is the only other emitter, so without this they
-          // never reach the cost summary. Fires at most once per call —
-          // `AgentTurnFailed` is never retried.
+          // Fires at most once per call — `AgentTurnFailed` is never retried.
           case e: AgentTurnFailed =>
-            e.usage.foreach(recordTurn(effective.model, _))
+            accounting.failedAfterModelRan(e.debit, turnsRecorded + 1)
             throw e
       // Fire as soon as the backend drain commits — before the fallible
       // parse below — so a session that later exhausts its retries (parse
@@ -265,8 +228,9 @@ class DefaultAgentCall[B <: BackendTag, O](
       // announced as durably resumable (ADR 0021 §8). Every attempt on this
       // session re-fires with the same payload; listeners dedup on
       // (backend, clientId, wireId) per the event's scaladoc.
-      emitSessionCommitted(session)
-      recordTurn(result.model.orElse(effective.model), result.usage)
+      accounting.sessionCommitted()
+      turnsRecorded += 1
+      accounting.succeeded(result, turnsRecorded)
       try
         val parsed = ResponseParser.parse[O](result.output)
         emitStructuredResult(result.output, parsed)
@@ -297,8 +261,8 @@ class DefaultAgentCall[B <: BackendTag, O](
         throw new AgentTurnFailed(
           s"agent '$agentName' turn failed " +
             s"(this turn's input ≈${serialized.length} chars): ${e.getMessage}",
-          e,
-          e.usage
+          e.debit,
+          e
         )
 
   /** Interactive variant. No retry: the user is steering the session and a
@@ -314,49 +278,57 @@ class DefaultAgentCall[B <: BackendTag, O](
     val serialized = ai.serialize(input)
     val effective = effectiveConfig(config)
     val prompt = prompts.interactive(serialized, outputSchema, effective)
+    val accounting = turnAccounting(effective, session)
     // Per-turn structured-concurrency scope: `runInteractive` forks its workers
     // into this Ox, `drive` consumes them, and `cancel` (in the `finally`) tears
     // the conversation down before the scope joins — so a cancelled turn never
     // leaks the subprocess/forks. On cancel `drive` throws, skipping the
-    // register / TokensUsed bookkeeping below.
-    val result = ox.supervised:
-      val rawConversation = backend.runInteractive(
-        prompt,
-        session,
-        displayPrompt = serialized,
-        effective,
-        Some(outputSchema)
-      )(using summon[ox.Ox])
-      // Withhold the closing structured-payload turn from every `Interaction`
-      // impl uniformly (parallel to `Conversations.TurnBuffer` on the
-      // autonomous drain) rather than leaving each renderer to reinvent it.
-      val conversation = Conversations.withholdInteractiveProse(
-        rawConversation,
-        events
-      )
-      try interaction.drive(conversation)
-      finally
-        conversation.cancel()
-        orca.sweep.EnvCookieSweep.afterTurn(conversation.envCookie, events)
+    // register / TokensUsed bookkeeping below; a turn that failed after the
+    // model ran still reports its spend through `recording`.
+    val result = accounting.recording(TurnAccounting.OnlyTurn):
+      ox.supervised:
+        val rawConversation = backend.runInteractive(
+          prompt,
+          session,
+          displayPrompt = serialized,
+          effective,
+          Some(outputSchema)
+        )(using summon[ox.Ox])
+        // Withhold the closing structured-payload turn from every `Interaction`
+        // impl uniformly (parallel to `Conversations.TurnBuffer` on the
+        // autonomous drain) rather than leaving each renderer to reinvent it.
+        val conversation = Conversations.withholdInteractiveProse(
+          rawConversation,
+          events
+        )
+        try interaction.drive(conversation)
+        finally
+          conversation.cancel()
+          orca.sweep.EnvCookieSweep.afterTurn(conversation.envCookie, events)
     // Codex mints its server thread id inside the drain (not at spawn); surface
     // it back so a follow-up call with the same `session` resumes the right
     // thread. No-op for backends whose session id IS the client UUID (claude).
     backend.sessions.register(session, result.wireId)
-    emitSessionCommitted(session)
-    // Normal path only: on mid-session cancel `drive` throws before this line,
-    // and the wire protocols don't always carry partial usage, so there's
-    // nothing authoritative to emit at cancel time.
-    events.onEvent(
-      OrcaEvent.TokensUsed(
-        agentName,
-        result.model.orElse(effective.model),
-        result.usage,
-        agentRole,
-        session = Some(backend.sessions.sessionKey(session))
-      )
-    )
+    accounting.sessionCommitted()
+    // A mid-session cancel throws out of `drive` before this line, and the wire
+    // protocols don't always carry partial usage, so a cancelled turn reports
+    // nothing.
+    accounting.succeeded(result, TurnAccounting.OnlyTurn)
     val parsed = ResponseParser.parse[O](result.output)
     emitStructuredResult(result.output, parsed)
     parsed
+
+  private def turnAccounting(
+      effective: AgentConfig,
+      session: SessionId[B]
+  ): TurnAccounting[B] =
+    new TurnAccounting[B](
+      events,
+      agentName,
+      agentRole,
+      backend,
+      session,
+      effective.model
+    )
 
 private case class FailedAttempt(response: String, parserError: String)

--- a/tools/src/main/scala/orca/agents/BaseAgent.scala
+++ b/tools/src/main/scala/orca/agents/BaseAgent.scala
@@ -1,7 +1,6 @@
 package orca.agents
 
-import orca.{AgentTurnFailed, OrcaFlowException}
-import orca.backend.{Interaction, AgentBackend, AgentResult}
+import orca.backend.{Interaction, AgentBackend}
 import orca.events.{OrcaEvent, OrcaListener}
 
 /** Skeleton shared by all backends' default tools. Centralises the
@@ -81,15 +80,6 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
     backend.closedFlag
   )
 
-  /** Gates [[autonomous]]`.run` and [[resultAs]]'s gateway construction on the
-    * backend's closed latch, so a leaked agent handle used after its flow ended
-    * can't silently emit to a closed run's dispatcher. The latch lives on the
-    * shared `backend`, so every `copyTool`-derived sibling is covered too.
-    */
-  private def checkNotClosed(): Unit =
-    if backend.isClosed then
-      throw new OrcaFlowException(AgentBackend.ClosedMessage)
-
   /** Latches the shared backend closed first (so a `run`/`resultAs` call racing
     * this close never sees a live-looking agent whose backend is torn down),
     * then delegates resource teardown.
@@ -106,14 +96,14 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
           callConfig: Option[AgentConfig],
           emitPrompt: Boolean
       )(using orca.InStage): String =
-        checkNotClosed()
+        backend.checkNotClosed()
         val effective = effectiveConfig(callConfig)
         if emitPrompt then events.onEvent(OrcaEvent.UserPrompt(prompt))
-        val result =
-          runAccountingForFailure(effective, session):
-            backend.runAutonomous(prompt, session, effective, events)
-        emitTokens(effective, session, result)
-        emitSessionCommitted(session)
+        val accounting = turnAccounting(effective, session)
+        val result = accounting.recording(TurnAccounting.OnlyTurn):
+          backend.runAutonomous(prompt, session, effective, events)
+        accounting.succeeded(result, TurnAccounting.OnlyTurn)
+        accounting.sessionCommitted()
         result.output
 
   /** See [[Agent.quietTextTurn]]: the turn runs against a filtered event sink
@@ -124,26 +114,21 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
   override private[orca] def quietTextTurn(prompt: String)(using
       orca.InStage
   ): String =
-    checkNotClosed()
+    backend.checkNotClosed()
     val effective = effectiveConfig(None)
     val quietEvents: OrcaListener = (e: OrcaEvent) =>
       e match
         case _: OrcaEvent.AssistantMessage | _: OrcaEvent.ToolUse => ()
         case other => events.onEvent(other)
     val session = SessionId.fresh[B]
-    val result =
-      runAccountingForFailure(effective, session):
-        backend.runAutonomous(
-          prompt,
-          session,
-          effective,
-          quietEvents
-        )
-    emitTokens(effective, session, result)
+    val accounting = turnAccounting(effective, session)
+    val result = accounting.recording(TurnAccounting.OnlyTurn):
+      backend.runAutonomous(prompt, session, effective, quietEvents)
+    accounting.succeeded(result, TurnAccounting.OnlyTurn)
     result.output
 
   def resultAs[O: JsonData: Announce]: AgentCall[B, O] =
-    checkNotClosed()
+    backend.checkNotClosed()
     new DefaultAgentCall[B, O](
       backend,
       effectiveConfig,
@@ -154,64 +139,11 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
       agentRole = role
     )
 
-  /** Run a backend turn, emitting the spend of a turn that fails after the
-    * model already ran ([[AgentTurnFailed.usage]]) before re-raising —
-    * otherwise only the success path reports tokens and a failed turn is
-    * invisible in the cost summary. The failure frame carries no model id, so
-    * the bucket key is whatever the caller pinned.
-    */
-  private def runAccountingForFailure(
+  private def turnAccounting(
       effective: AgentConfig,
       session: SessionId[B]
-  )(turn: => AgentResult[B]): AgentResult[B] =
-    try turn
-    catch
-      case e: AgentTurnFailed =>
-        e.usage.foreach: usage =>
-          events.onEvent(
-            OrcaEvent.TokensUsed(
-              name,
-              effective.model,
-              usage,
-              role,
-              session = Some(backend.sessions.sessionKey(session))
-            )
-          )
-        throw e
-
-  /** `model` prefers the response-reported model (most precise), falling back
-    * to whatever the caller pinned in config, `None` when neither is known.
-    */
-  private def emitTokens(
-      effective: AgentConfig,
-      session: SessionId[B],
-      result: AgentResult[B]
-  ): Unit =
-    val model = result.model.orElse(effective.model)
-    events.onEvent(
-      OrcaEvent.TokensUsed(
-        name,
-        model,
-        result.usage,
-        role,
-        session = Some(backend.sessions.sessionKey(session))
-      )
-    )
-
-  /** Fires once a session's first turn commits (ADR 0021 §8): reads
-    * `resumeWireId` after `backend.runAutonomous` returns, so `wireId` reflects
-    * whatever this call just committed.
-    */
-  private def emitSessionCommitted(session: SessionId[B]): Unit =
-    events.onEvent(
-      OrcaEvent.SessionCommitted(
-        backend.tag.wireName,
-        session.value,
-        resumeWireId(session).map(_.value),
-        name,
-        role
-      )
-    )
+  ): TurnAccounting[B] =
+    new TurnAccounting[B](events, name, role, backend, session, effective.model)
 
   /** `None` (the caller omitted the per-call `config` arg) falls back to the
     * tool-level config. An explicit `Some(...)` from the call site wholly

--- a/tools/src/main/scala/orca/agents/BaseAgent.scala
+++ b/tools/src/main/scala/orca/agents/BaseAgent.scala
@@ -4,9 +4,9 @@ import orca.backend.{Interaction, AgentBackend}
 import orca.events.{OrcaEvent, OrcaListener}
 
 /** Skeleton shared by all backends' default tools. Centralises the
-  * autonomous-text path (delegation to `backend.runAutonomous` plus
-  * `TokensUsed` emission), the `resultAs[O]` factory, and the `withConfig` /
-  * `withSystemPrompt` / `withName` builders.
+  * autonomous-text path (delegation to `backend.runAutonomous`, with
+  * [[TurnAccounting]] emitting), the `resultAs[O]` factory, and the
+  * `withConfig` / `withSystemPrompt` / `withName` builders.
   *
   * Concrete subclasses provide:
   *   - the `Self` type bound (their own `Agent` subtype) so the builders return
@@ -100,7 +100,7 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
         val effective = effectiveConfig(callConfig)
         if emitPrompt then events.onEvent(OrcaEvent.UserPrompt(prompt))
         val accounting = turnAccounting(effective, session)
-        val result = accounting.recording(TurnAccounting.OnlyTurn):
+        val result = accounting.recording:
           backend.runAutonomous(prompt, session, effective, events)
         accounting.succeeded(result, TurnAccounting.OnlyTurn)
         accounting.sessionCommitted()
@@ -122,7 +122,7 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
         case other => events.onEvent(other)
     val session = SessionId.fresh[B]
     val accounting = turnAccounting(effective, session)
-    val result = accounting.recording(TurnAccounting.OnlyTurn):
+    val result = accounting.recording:
       backend.runAutonomous(prompt, session, effective, quietEvents)
     accounting.succeeded(result, TurnAccounting.OnlyTurn)
     result.output

--- a/tools/src/main/scala/orca/agents/TurnAccounting.scala
+++ b/tools/src/main/scala/orca/agents/TurnAccounting.scala
@@ -1,0 +1,88 @@
+package orca.agents
+
+import orca.backend.{AgentBackend, AgentResult}
+import orca.events.{OrcaEvent, OrcaListener, TurnDebit, Usage}
+
+/** Attributes one call's turns — which agent, which model, which role, which
+  * session, which attempt — and emits the resulting events.
+  *
+  * Built once per call, so no emission site assembles the attribution itself
+  * and a path that forgets the session key or the model fallback can't exist.
+  *
+  * @param pinned
+  *   the model the caller configured, used wherever the turn itself reports
+  *   none.
+  */
+private[orca] class TurnAccounting[B <: BackendTag](
+    events: OrcaListener,
+    agentName: String,
+    role: Option[String],
+    backend: AgentBackend[B],
+    session: SessionId[B],
+    pinned: Option[Model]
+):
+
+  // Resolved per emission, not once at construction: for a server-minted id the
+  // key only becomes the wire id once the turn commits it, and a turn must name
+  // the same key `SessionCommitted` is deduplicated under.
+  private def sessionKey: Option[String] = Some(
+    backend.sessions.sessionKey(session)
+  )
+
+  /** `attempt` is the turn's 1-based position among the turns of this call; a
+    * path that never retries passes 1.
+    */
+  def succeeded(result: AgentResult[B], attempt: Int): Unit =
+    emit(result.model, result.usage, attempt)
+
+  /** A turn that failed after the model ran still spent tokens, and the success
+    * path is the only other emitter. An `Unobserved` debit emits nothing.
+    */
+  def failedAfterModelRan(debit: TurnDebit, attempt: Int): Unit = debit match
+    case TurnDebit.Observed(usage, model) => emit(model, usage, attempt)
+    case TurnDebit.Unobserved             => ()
+
+  /** Run `turn`, recording the debit of a failure that happened after the model
+    * ran, then re-raising it.
+    */
+  def recording(attempt: Int)(turn: => AgentResult[B]): AgentResult[B] =
+    try turn
+    catch
+      case e: orca.AgentTurnFailed =>
+        failedAfterModelRan(e.debit, attempt)
+        throw e
+
+  /** Fires once a session's first turn commits (ADR 0021 §8). Call after the
+    * backend drain returns, so the wire id reflects what that turn committed.
+    */
+  def sessionCommitted(): Unit =
+    events.onEvent(
+      OrcaEvent.SessionCommitted(
+        backend.tag.wireName,
+        session.value,
+        backend.sessions.persistableWireId(session).map(_.value),
+        agentName,
+        role
+      )
+    )
+
+  private def emit(
+      reported: Option[Model],
+      usage: Usage,
+      attempt: Int
+  ): Unit =
+    events.onEvent(
+      OrcaEvent.TokensUsed(
+        agentName,
+        reported.orElse(pinned),
+        usage,
+        role,
+        attempt,
+        sessionKey
+      )
+    )
+
+private[orca] object TurnAccounting:
+  /** The attempt number of a call shape that runs one turn and never retries.
+    */
+  val OnlyTurn: Int = 1

--- a/tools/src/main/scala/orca/agents/TurnAccounting.scala
+++ b/tools/src/main/scala/orca/agents/TurnAccounting.scala
@@ -73,12 +73,12 @@ private[orca] class TurnAccounting[B <: BackendTag](
   ): Unit =
     events.onEvent(
       OrcaEvent.TokensUsed(
-        agentName,
-        reported.orElse(pinned),
-        usage,
-        role,
-        attempt,
-        sessionKey
+        agent = agentName,
+        model = reported.orElse(pinned),
+        usage = usage,
+        role = role,
+        attempt = attempt,
+        session = sessionKey
       )
     )
 

--- a/tools/src/main/scala/orca/agents/TurnAccounting.scala
+++ b/tools/src/main/scala/orca/agents/TurnAccounting.scala
@@ -2,7 +2,6 @@ package orca.agents
 
 import orca.backend.{AgentBackend, AgentResult}
 import orca.events.{OrcaEvent, OrcaListener, TurnDebit, Usage}
-import orca.agents.TurnAccounting.OnlyTurn
 
 /** Attributes one call's turns — which agent, which model, which role, which
   * session, which attempt — and emits the resulting events.
@@ -49,10 +48,10 @@ private[orca] class TurnAccounting[B <: BackendTag](
     try turn
     catch
       case e: orca.AgentTurnFailed =>
-        failedAfterModelRan(e.debit, OnlyTurn)
+        failedAfterModelRan(e.debit, TurnAccounting.OnlyTurn)
         throw e
       case e: orca.OrcaInteractiveCancelled =>
-        failedAfterModelRan(e.debit, OnlyTurn)
+        failedAfterModelRan(e.debit, TurnAccounting.OnlyTurn)
         throw e
 
   /** Fires once a session's first turn commits (ADR 0021 §8). Call after the

--- a/tools/src/main/scala/orca/agents/TurnAccounting.scala
+++ b/tools/src/main/scala/orca/agents/TurnAccounting.scala
@@ -26,9 +26,7 @@ private[orca] class TurnAccounting[B <: BackendTag](
   // Resolved per emission, not once at construction: for a server-minted id the
   // key only becomes the wire id once the turn commits it, and a turn must name
   // the same key `SessionCommitted` is deduplicated under.
-  private def sessionKey: Option[String] = Some(
-    backend.sessions.sessionKey(session)
-  )
+  private def sessionKey: String = backend.sessions.sessionKey(session)
 
   /** `attempt` is the turn's 1-based position among the turns of this call; a
     * path that never retries passes 1.
@@ -83,7 +81,7 @@ private[orca] class TurnAccounting[B <: BackendTag](
         usage = usage,
         role = role,
         attempt = attempt,
-        session = sessionKey
+        session = Some(sessionKey)
       )
     )
 

--- a/tools/src/main/scala/orca/agents/TurnAccounting.scala
+++ b/tools/src/main/scala/orca/agents/TurnAccounting.scala
@@ -2,6 +2,7 @@ package orca.agents
 
 import orca.backend.{AgentBackend, AgentResult}
 import orca.events.{OrcaEvent, OrcaListener, TurnDebit, Usage}
+import orca.agents.TurnAccounting.OnlyTurn
 
 /** Attributes one call's turns — which agent, which model, which role, which
   * session, which attempt — and emits the resulting events.
@@ -42,14 +43,18 @@ private[orca] class TurnAccounting[B <: BackendTag](
     case TurnDebit.Observed(usage, model) => emit(model, usage, attempt)
     case TurnDebit.Unobserved             => ()
 
-  /** Run `turn`, recording the debit of a failure that happened after the model
-    * ran, then re-raising it.
+  /** Run `turn`, recording the debit of a turn that ended after the model ran —
+    * failed or cancelled by the user — then re-raising it. For the call shapes
+    * that run one turn and never retry, hence [[TurnAccounting.OnlyTurn]].
     */
-  def recording(attempt: Int)(turn: => AgentResult[B]): AgentResult[B] =
+  def recording(turn: => AgentResult[B]): AgentResult[B] =
     try turn
     catch
       case e: orca.AgentTurnFailed =>
-        failedAfterModelRan(e.debit, attempt)
+        failedAfterModelRan(e.debit, OnlyTurn)
+        throw e
+      case e: orca.OrcaInteractiveCancelled =>
+        failedAfterModelRan(e.debit, OnlyTurn)
         throw e
 
   /** Fires once a session's first turn commits (ADR 0021 §8). Call after the

--- a/tools/src/main/scala/orca/backend/AgentBackend.scala
+++ b/tools/src/main/scala/orca/backend/AgentBackend.scala
@@ -153,6 +153,15 @@ trait AgentBackend[B <: BackendTag](
     */
   private[orca] final def isClosed: Boolean = closedFlag.get()
 
+  /** Refuse a run against a backend whose flow has ended, so a leaked agent
+    * handle can't emit to a closed run's dispatcher. Gates both the agent
+    * surface (`BaseAgent`) and the structured gateway (`DefaultAgentCall`),
+    * which holds no agent of its own.
+    */
+  private[orca] final def checkNotClosed(): Unit =
+    if isClosed then
+      throw new orca.OrcaFlowException(AgentBackend.ClosedMessage)
+
 object AgentBackend:
   /** The use-after-close guard's user-facing message, thrown by every
     * `isClosed` gate so a leaked-handle failure reads identically no matter

--- a/tools/src/main/scala/orca/backend/ForkedConversation.scala
+++ b/tools/src/main/scala/orca/backend/ForkedConversation.scala
@@ -250,8 +250,9 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
       Ox
   ): Either[OrcaInteractiveCancelled, AgentResult[B]] =
     ensureStarted().reader.join() match
-      case Outcome.Success(r)  => Right(r)
-      case Outcome.Cancelled() => Left(new OrcaInteractiveCancelled())
+      case Outcome.Success(r) => Right(r)
+      case Outcome.Cancelled() =>
+        Left(new OrcaInteractiveCancelled(failedTurnDebit))
       case Outcome.Failed(e: AgentTurnFailed) => throw e
       case Outcome.Failed(e) =>
         throw new AgentTurnFailed(
@@ -340,14 +341,16 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
 
   // --- Hooks for backend implementations ---
 
-  /** What this turn had spent by the time it failed, for the failures
-    * [[awaitResult]] wraps rather than the driver settling them itself — a
-    * mid-stream read error, a non-zero exit, a clean exit with no result. Read
-    * after the reader fork has joined, so accrued turn state is published.
+  /** What this turn had spent by the time it ended badly. [[awaitResult]] reads
+    * it for the endings it diagnoses itself — a mid-stream read error, a bad
+    * exit, a user cancel — and drivers settling their own failures may reuse
+    * it. It must therefore hold at any point in the stream, not only at the
+    * end; drivers accrue turn state on the reader thread, which the reader's
+    * join publishes.
     *
     * Abstract with no default so a new driver has to answer the question: a
     * body of [[TurnDebit.Unobserved]] is the visible claim that the protocol
-    * reports nothing at that point.
+    * reports nothing to accrue.
     */
   protected def failedTurnDebit: TurnDebit
 
@@ -505,6 +508,11 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
       // depending on it runs first. Idempotent.
       askUser.foreach(_.close())
 
+  /** Diagnose a stream that ended without a settle. `None` is not a cancel — a
+    * genuine one is caught by the `cancelled` check ahead of this — but a
+    * stream that ended with the process still running, which is a failed turn
+    * like the others rather than something to retry against a locked session.
+    */
   private def outcomeFromExit(exitCode: Option[Int]): Outcome[B] =
     exitCode match
       case Some(0) => Outcome.failed[B](cleanExitWithoutResult())
@@ -514,7 +522,15 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
             appendContext(s"$backendName exited with code $code")
           )
         )
-      case None => Outcome.cancelled[B]
+      case None =>
+        Outcome.failed[B](
+          new OrcaFlowException(
+            appendContext(
+              s"$backendName's output ended without $terminalMessageNoun, " +
+                "while the process was still running"
+            )
+          )
+        )
 
   /** Single-consumer iterator over the event channel; `done` ends it. */
   private val channelIterator: Iterator[ConversationEvent] =

--- a/tools/src/main/scala/orca/backend/ForkedConversation.scala
+++ b/tools/src/main/scala/orca/backend/ForkedConversation.scala
@@ -2,7 +2,7 @@ package orca.backend
 
 import orca.backend.mcp.{AskUserBridge, AskUserSession}
 import orca.agents.{BackendTag, Model, WireSessionId}
-import orca.events.Usage
+import orca.events.{TurnDebit, Usage}
 import orca.util.OrcaDebug
 import orca.{AgentTurnFailed, OrcaFlowException, OrcaInteractiveCancelled}
 
@@ -256,6 +256,7 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
       case Outcome.Failed(e) =>
         throw new AgentTurnFailed(
           Option(e.getMessage).filter(_.nonEmpty).getOrElse(e.toString),
+          failedTurnDebit,
           e
         )
 
@@ -338,6 +339,17 @@ private[orca] abstract class ForkedConversation[B <: BackendTag](
     if turnIsOpen then eventQueue.enqueue(ConversationEvent.AssistantTurnEnd)
 
   // --- Hooks for backend implementations ---
+
+  /** What this turn had spent by the time it failed, for the failures
+    * [[awaitResult]] wraps rather than the driver settling them itself — a
+    * mid-stream read error, a non-zero exit, a clean exit with no result. Read
+    * after the reader fork has joined, so accrued turn state is published.
+    *
+    * Abstract with no default so a new driver has to answer the question: a
+    * body of [[TurnDebit.Unobserved]] is the visible claim that the protocol
+    * reports nothing at that point.
+    */
+  protected def failedTurnDebit: TurnDebit
 
   /** Process a single line of stdout. Implementations parse the protocol
     * message and translate to [[ConversationEvent]] enqueues (and/or

--- a/tools/src/main/scala/orca/events/Cost.scala
+++ b/tools/src/main/scala/orca/events/Cost.scala
@@ -1,0 +1,12 @@
+package orca.events
+
+/** A USD cost with a flag that propagates through addition: any aggregate
+  * mixing at least one estimated input is itself flagged as an estimate.
+  *
+  * Lives here rather than beside `Pricing` (which resolves it) so
+  * [[OrcaEvent.TokensUsed]] can carry one — `tools` holds no price table and
+  * doesn't depend on the flow module.
+  */
+case class Cost(amount: BigDecimal, estimated: Boolean):
+  def +(that: Cost): Cost =
+    Cost(amount + that.amount, estimated || that.estimated)

--- a/tools/src/main/scala/orca/events/OrcaEvent.scala
+++ b/tools/src/main/scala/orca/events/OrcaEvent.scala
@@ -49,6 +49,11 @@ enum OrcaEvent:
     * emits no event, so it doesn't shift the index of the turn that follows.
     * Emission sites that never retry leave the default.
     *
+    * `cost` is this turn's resolved spend, filled in once at the dispatch
+    * boundary so every listener reads the same figure. Emitters leave it unset:
+    * pricing lives in the flow module, and a listener that priced the event
+    * itself could disagree with the printed summary and the on-disk cost log.
+    *
     * `session` is [[OrcaEvent.sessionKey]] for the conversation this turn ran
     * in — the same key [[SessionCommitted]] is deduplicated under, so turns and
     * sessions join on it. Two turns of one session carry the same value; the
@@ -61,7 +66,8 @@ enum OrcaEvent:
       usage: Usage,
       role: Option[String] = None,
       attempt: Int = 1,
-      session: Option[String] = None
+      session: Option[String] = None,
+      cost: Option[Cost] = None
   )
 
   /** The agent's final structured payload, after parsing succeeded. `raw` is

--- a/tools/src/main/scala/orca/events/TurnDebit.scala
+++ b/tools/src/main/scala/orca/events/TurnDebit.scala
@@ -1,0 +1,15 @@
+package orca.events
+
+import orca.agents.Model
+
+/** What a turn that failed after the model ran had spent by the time it failed,
+  * as the driver that saw the wire observed it.
+  *
+  * `Unobserved` is a claim, not a fallback: the protocol gave this driver
+  * nothing to report on its failure frame (codex — ADR 0007 puts usage on
+  * `turn.completed` only). It emits no `TokensUsed`, because an all-zero event
+  * would be indistinguishable from a measured zero.
+  */
+enum TurnDebit:
+  case Observed(usage: Usage, model: Option[Model])
+  case Unobserved

--- a/tools/src/main/scala/orca/events/Usage.scala
+++ b/tools/src/main/scala/orca/events/Usage.scala
@@ -1,58 +1,53 @@
 package orca.events
 
+import org.slf4j.LoggerFactory
+
 /** Token + cost accounting for one or more LLM calls.
   *
-  * **Normalisation contract.** All backends map onto the same axes so summing
-  * `Usage` across calls and backends is apples-to-apples:
+  * The prompt is stored as three disjoint parts — `freshInputTokens`,
+  * `cacheReadInputTokens` (served FROM the prompt cache),
+  * `cacheWriteInputTokens` (written INTO it; Anthropic spells this "cache
+  * creation") — and [[Usage.inputTokens]] is their sum. They are separate axes
+  * because they bill at opposite ends of base input: a write costs more, a read
+  * far less, and folding them together understates a cache-heavy run badly.
+  * `reasoningOutputTokens` is the internal-reasoning sub-portion of
+  * `outputTokens` (codex / o-series), so it is the one axis that is NOT
+  * disjoint from its sibling.
   *
-  *   - `inputTokens` is the TOTAL prompt tokens, **inclusive** of any served
-  *     from prompt cache or written into it. `outputTokens` is the total
-  *     completion tokens.
-  *   - `cacheReadInputTokens` (tokens served FROM the prompt cache) and
-  *     `cacheWriteInputTokens` (tokens written INTO it — Anthropic spells this
-  *     "cache creation") are DISJOINT sub-portions of `inputTokens`, so
-  *     `cacheReadInputTokens + cacheWriteInputTokens <= inputTokens`. They are
-  *     separate axes because they bill at opposite ends of base input — a write
-  *     costs more, a read far less — and folding them together understates a
-  *     cache-heavy run badly.
-  *   - `reasoningOutputTokens` is the internal-reasoning sub-portion of
-  *     `outputTokens` (codex / o-series).
-  *   - `apiCalls` is how many model requests the token counts above cover. A
-  *     turn that runs a tool makes at least two, and every one of them re-sends
-  *     the whole prompt — so it is what turns a prompt size into a bill. `None`
-  *     means the backend does not report it, which is not the same as one: an
-  *     inferred count would be indistinguishable from a measured one
-  *     downstream, so backends that cannot count leave it unset.
+  * `apiCalls` is how many model requests the token counts above cover. A turn
+  * that runs a tool makes at least two, and every one of them re-sends the
+  * whole prompt — so it is what turns a prompt size into a bill. `None` means
+  * the backend does not report it, which is not the same as one: an inferred
+  * count would be indistinguishable from a measured one downstream, so backends
+  * that cannot count leave it unset.
   *
-  * All three token breakdowns are non-cumulative, so callers can report
-  * cache-hit, cache-write and reasoning ratios directly.
+  * Decoders build one through [[Usage.exclusiveInput]] or
+  * [[Usage.inclusiveInput]], whichever names their wire's convention.
   *
-  * A new backend must fold cache-read and cache-written tokens INTO
-  * `inputTokens` rather than report them alongside it, and leave
-  * `cacheWriteInputTokens` at zero when the protocol has no write counter
-  * (gemini). The per-backend arithmetic is documented at each driver's
-  * `Usage(...)` construction site.
-  *
-  * Destructure by name (`case Usage(inputTokens = in) =>`): the axis list grows
-  * as backends start reporting finer breakdowns, and a positional pattern
+  * Destructure by name (`case Usage(outputTokens = out) =>`): the axis list
+  * grows as backends start reporting finer breakdowns, and a positional pattern
   * silently rebinds or stops compiling when it does.
   */
 case class Usage(
-    inputTokens: Long,
+    freshInputTokens: Long,
     outputTokens: Long,
     cost: Option[BigDecimal],
-    cacheReadInputTokens: Long = 0L,
-    reasoningOutputTokens: Long = 0L,
-    cacheWriteInputTokens: Long = 0L,
-    apiCalls: Option[Long] = None
+    cacheReadInputTokens: Long,
+    reasoningOutputTokens: Long,
+    cacheWriteInputTokens: Long,
+    apiCalls: Option[Long]
 ):
+  /** Total prompt tokens, cache categories included. */
+  def inputTokens: Long =
+    freshInputTokens + cacheReadInputTokens + cacheWriteInputTokens
+
   /** Combine two usages; `cost` and `apiCalls` are `Some` iff at least one side
     * reports them, so a sum that mixes a reporting backend with a silent one
     * under-counts rather than dropping the half that was measured.
     */
   def +(that: Usage): Usage =
     Usage(
-      inputTokens = inputTokens + that.inputTokens,
+      freshInputTokens = freshInputTokens + that.freshInputTokens,
       outputTokens = outputTokens + that.outputTokens,
       cost = (cost ++ that.cost).reduceOption(_ + _),
       cacheReadInputTokens = cacheReadInputTokens + that.cacheReadInputTokens,
@@ -64,4 +59,67 @@ case class Usage(
     )
 
 object Usage:
+  private val log = LoggerFactory.getLogger("orca.events")
+
   val empty: Usage = Usage(0L, 0L, None, 0L, 0L, 0L, None)
+
+  /** Build a usage from a wire whose input counter EXCLUDES the cache
+    * categories (claude, pi, opencode): the three input axes are already
+    * disjoint and are stored as they arrive.
+    */
+  def exclusiveInput(
+      freshInputTokens: Long,
+      cacheReadInputTokens: Long,
+      cacheWriteInputTokens: Long,
+      outputTokens: Long,
+      reasoningOutputTokens: Long,
+      cost: Option[BigDecimal],
+      apiCalls: Option[Long]
+  ): Usage = Usage(
+    freshInputTokens = freshInputTokens,
+    outputTokens = outputTokens,
+    cost = cost,
+    cacheReadInputTokens = cacheReadInputTokens,
+    reasoningOutputTokens = reasoningOutputTokens,
+    cacheWriteInputTokens = cacheWriteInputTokens,
+    apiCalls = apiCalls
+  )
+
+  /** Build a usage from a wire whose input counter INCLUDES the cache
+    * categories (codex, gemini): the fresh part is the remainder, clamped at
+    * zero so a backend over-reporting a cache axis can't produce a negative
+    * charge.
+    *
+    * `wireTotal` is the backend's own all-token total where it reports one. A
+    * non-zero residue against the axes decoded here means the wire carries a
+    * counter this decoder drops — a renamed or newly added one announces itself
+    * in the debug log instead of vanishing into a smaller bill.
+    */
+  def inclusiveInput(
+      totalInputTokens: Long,
+      cacheReadInputTokens: Long,
+      cacheWriteInputTokens: Long,
+      outputTokens: Long,
+      reasoningOutputTokens: Long,
+      cost: Option[BigDecimal],
+      apiCalls: Option[Long],
+      wireTotal: Option[Long]
+  ): Usage =
+    val usage = Usage(
+      freshInputTokens =
+        (totalInputTokens - cacheReadInputTokens - cacheWriteInputTokens) max 0L,
+      outputTokens = outputTokens,
+      cost = cost,
+      cacheReadInputTokens = cacheReadInputTokens,
+      reasoningOutputTokens = reasoningOutputTokens,
+      cacheWriteInputTokens = cacheWriteInputTokens,
+      apiCalls = apiCalls
+    )
+    wireTotal.foreach: total =>
+      val decoded = usage.inputTokens + usage.outputTokens
+      if total != decoded then
+        log.debug(
+          s"Usage residue ${total - decoded}: the wire reports $total " +
+            s"tokens, the decoded axes sum to $decoded"
+        )
+    usage

--- a/tools/src/main/scala/orca/events/Usage.scala
+++ b/tools/src/main/scala/orca/events/Usage.scala
@@ -21,20 +21,22 @@ import org.slf4j.LoggerFactory
   * count would be indistinguishable from a measured one downstream, so backends
   * that cannot count leave it unset.
   *
-  * Decoders build one through [[Usage.exclusiveInput]] or
-  * [[Usage.inclusiveInput]], whichever names their wire's convention.
+  * A wire whose input counter EXCLUDES the cache categories (claude, pi,
+  * opencode) maps straight onto this constructor; one that INCLUDES them
+  * (codex, gemini) goes through [[Usage.inclusiveInput]], which splits it.
   *
-  * Destructure by name (`case Usage(outputTokens = out) =>`): the axis list
-  * grows as backends start reporting finer breakdowns, and a positional pattern
-  * silently rebinds or stops compiling when it does.
+  * Construct and destructure by name (`Usage(outputTokens = 3L, …)`): the axis
+  * list grows as backends start reporting finer breakdowns, and a positional
+  * argument or pattern silently rebinds when it does — invisibly, since every
+  * axis is money.
   */
 case class Usage(
     freshInputTokens: Long,
-    outputTokens: Long,
-    cost: Option[BigDecimal],
     cacheReadInputTokens: Long,
-    reasoningOutputTokens: Long,
     cacheWriteInputTokens: Long,
+    outputTokens: Long,
+    reasoningOutputTokens: Long,
+    cost: Option[BigDecimal],
     apiCalls: Option[Long]
 ):
   /** Total prompt tokens, cache categories included. */
@@ -48,41 +50,27 @@ case class Usage(
   def +(that: Usage): Usage =
     Usage(
       freshInputTokens = freshInputTokens + that.freshInputTokens,
-      outputTokens = outputTokens + that.outputTokens,
-      cost = (cost ++ that.cost).reduceOption(_ + _),
       cacheReadInputTokens = cacheReadInputTokens + that.cacheReadInputTokens,
-      reasoningOutputTokens =
-        reasoningOutputTokens + that.reasoningOutputTokens,
       cacheWriteInputTokens =
         cacheWriteInputTokens + that.cacheWriteInputTokens,
+      outputTokens = outputTokens + that.outputTokens,
+      reasoningOutputTokens =
+        reasoningOutputTokens + that.reasoningOutputTokens,
+      cost = (cost ++ that.cost).reduceOption(_ + _),
       apiCalls = (apiCalls ++ that.apiCalls).reduceOption(_ + _)
     )
 
 object Usage:
   private val log = LoggerFactory.getLogger("orca.events")
 
-  val empty: Usage = Usage(0L, 0L, None, 0L, 0L, 0L, None)
-
-  /** Build a usage from a wire whose input counter EXCLUDES the cache
-    * categories (claude, pi, opencode): the three input axes are already
-    * disjoint and are stored as they arrive.
-    */
-  def exclusiveInput(
-      freshInputTokens: Long,
-      cacheReadInputTokens: Long,
-      cacheWriteInputTokens: Long,
-      outputTokens: Long,
-      reasoningOutputTokens: Long,
-      cost: Option[BigDecimal],
-      apiCalls: Option[Long]
-  ): Usage = Usage(
-    freshInputTokens = freshInputTokens,
-    outputTokens = outputTokens,
-    cost = cost,
-    cacheReadInputTokens = cacheReadInputTokens,
-    reasoningOutputTokens = reasoningOutputTokens,
-    cacheWriteInputTokens = cacheWriteInputTokens,
-    apiCalls = apiCalls
+  val empty: Usage = Usage(
+    freshInputTokens = 0L,
+    cacheReadInputTokens = 0L,
+    cacheWriteInputTokens = 0L,
+    outputTokens = 0L,
+    reasoningOutputTokens = 0L,
+    cost = None,
+    apiCalls = None
   )
 
   /** Build a usage from a wire whose input counter INCLUDES the cache
@@ -108,11 +96,11 @@ object Usage:
     val usage = Usage(
       freshInputTokens =
         (totalInputTokens - cacheReadInputTokens - cacheWriteInputTokens) max 0L,
-      outputTokens = outputTokens,
-      cost = cost,
       cacheReadInputTokens = cacheReadInputTokens,
-      reasoningOutputTokens = reasoningOutputTokens,
       cacheWriteInputTokens = cacheWriteInputTokens,
+      outputTokens = outputTokens,
+      reasoningOutputTokens = reasoningOutputTokens,
+      cost = cost,
       apiCalls = apiCalls
     )
     wireTotal.foreach: total =>

--- a/tools/src/test/scala/orca/ConversationEventTest.scala
+++ b/tools/src/test/scala/orca/ConversationEventTest.scala
@@ -1,6 +1,7 @@
 package orca
 
 import orca.backend.{ApprovalDecision, ConversationEvent}
+import orca.events.TurnDebit
 
 import java.util.concurrent.atomic.AtomicReference
 
@@ -39,6 +40,6 @@ class ConversationEventTest extends munit.FunSuite:
     assertEquals(ApprovalDecision.Deny().reason, None)
 
   test("OrcaInteractiveCancelled is an OrcaFlowException"):
-    val cancelled = new OrcaInteractiveCancelled()
+    val cancelled = new OrcaInteractiveCancelled(TurnDebit.Unobserved)
     assert(cancelled.isInstanceOf[OrcaFlowException])
     assertEquals(cancelled.getMessage, "interactive session cancelled")

--- a/tools/src/test/scala/orca/agents/BaseAgentTest.scala
+++ b/tools/src/test/scala/orca/agents/BaseAgentTest.scala
@@ -10,7 +10,7 @@ import orca.backend.{
   IdScheme,
   SessionSupport
 }
-import orca.events.{OrcaEvent, OrcaListener, Usage}
+import orca.events.{OrcaEvent, OrcaListener, TurnDebit, Usage}
 import orca.testkit.Usages.usage
 import ox.scheduling.Schedule
 
@@ -185,7 +185,10 @@ class BaseAgentTest extends munit.FunSuite:
     val spent = usage(120L, 8L, Some(BigDecimal("0.0031")))
     val tool = new StubTool(
       new FailingBackend(
-        new orca.AgentTurnFailed("claude session failed", usage = Some(spent))
+        new orca.AgentTurnFailed(
+          "claude session failed",
+          TurnDebit.Observed(spent, None)
+        )
       ),
       listener = listener
     )

--- a/tools/src/test/scala/orca/agents/BaseAgentTest.scala
+++ b/tools/src/test/scala/orca/agents/BaseAgentTest.scala
@@ -11,6 +11,7 @@ import orca.backend.{
   SessionSupport
 }
 import orca.events.{OrcaEvent, OrcaListener, Usage}
+import orca.testkit.Usages.usage
 import ox.scheduling.Schedule
 
 import scala.concurrent.duration.DurationInt
@@ -181,7 +182,7 @@ class BaseAgentTest extends munit.FunSuite:
     val seen =
       new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
     val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
-    val spent = Usage(120L, 8L, Some(BigDecimal("0.0031")))
+    val spent = usage(120L, 8L, Some(BigDecimal("0.0031")))
     val tool = new StubTool(
       new FailingBackend(
         new orca.AgentTurnFailed("claude session failed", usage = Some(spent))

--- a/tools/src/test/scala/orca/backend/ConversationTeardownTest.scala
+++ b/tools/src/test/scala/orca/backend/ConversationTeardownTest.scala
@@ -1,6 +1,7 @@
 package orca.backend
 
 import orca.agents.BackendTag
+import orca.events.TurnDebit
 import orca.subprocess.OsProcCliRunner
 import orca.testkit.ProcessProbe.{alive, awaitDead}
 
@@ -22,6 +23,7 @@ class ConversationTeardownTest extends munit.FunSuite:
         backendName = "fake"
       ):
     val outputSchema: Option[String] = None
+    protected def failedTurnDebit: TurnDebit = TurnDebit.Unobserved
     protected def handleLine(line: String): Unit =
       eventQueue.enqueue(ConversationEvent.AssistantTextDelta(line))
 

--- a/tools/src/test/scala/orca/backend/ConversationsTest.scala
+++ b/tools/src/test/scala/orca/backend/ConversationsTest.scala
@@ -169,7 +169,7 @@ class ConversationsTest extends munit.FunSuite:
     assertEquals(conv.drained.get(), 2)
 
   test("drainAutonomous throws OrcaInteractiveCancelled on Left outcome"):
-    val cancelled = new OrcaInteractiveCancelled()
+    val cancelled = new OrcaInteractiveCancelled(TurnDebit.Unobserved)
     val conv = new ScriptedConversation(Nil, Left(cancelled))
     val thrown = intercept[OrcaInteractiveCancelled]:
       supervised(Conversations.drainAutonomous(conv))

--- a/tools/src/test/scala/orca/backend/ConversationsTest.scala
+++ b/tools/src/test/scala/orca/backend/ConversationsTest.scala
@@ -81,7 +81,7 @@ class ConversationsTest extends munit.FunSuite:
   private val sampleResult = AgentResult[BackendTag.Codex.type](
     wireId = WireSessionId[BackendTag.Codex.type]("sid"),
     output = "out",
-    usage = Usage(0L, 0L, None)
+    usage = Usage.empty
   )
 
   test(

--- a/tools/src/test/scala/orca/backend/ConversationsTest.scala
+++ b/tools/src/test/scala/orca/backend/ConversationsTest.scala
@@ -1,7 +1,7 @@
 package orca.backend
 
 import orca.{AgentTurnFailed, OrcaFlowException, OrcaInteractiveCancelled}
-import orca.events.{OrcaEvent, OrcaListener, Usage}
+import orca.events.{OrcaEvent, OrcaListener, TurnDebit, Usage}
 import orca.agents.{BackendTag, SessionId, WireSessionId}
 
 import ox.{Ox, supervised}
@@ -490,7 +490,7 @@ class ConversationsTest extends munit.FunSuite:
     val client = SessionId.fresh[BackendTag.Codex.type]
     val support = SessionSupport
       .durable[BackendTag.Codex.type](IdScheme.ServerMinted, _ => false)
-    val failure = new AgentTurnFailed("turn blew up")
+    val failure = new AgentTurnFailed("turn blew up", TurnDebit.Unobserved)
     val conv = new FailingConversation(failure)
     val thrown = intercept[AgentTurnFailed]:
       Conversations.runAutonomous(

--- a/tools/src/test/scala/orca/backend/TurnGrammarTest.scala
+++ b/tools/src/test/scala/orca/backend/TurnGrammarTest.scala
@@ -1,7 +1,7 @@
 package orca.backend
 
 import orca.agents.{BackendTag, WireSessionId}
-import orca.events.Usage
+import orca.events.{TurnDebit, Usage}
 import orca.OrcaFlowException
 import orca.subprocess.FakePipedCliProcess
 import ox.supervised
@@ -26,6 +26,7 @@ class TurnGrammarTest extends munit.FunSuite:
         backendName = "fake"
       ):
     val outputSchema: Option[String] = None
+    protected def failedTurnDebit: TurnDebit = TurnDebit.Unobserved
 
     protected def handleLine(line: String): Unit =
       line match
@@ -157,6 +158,7 @@ class TurnGrammarTest extends munit.FunSuite:
         backendName = "fake"
       ):
     val outputSchema: Option[String] = None
+    protected def failedTurnDebit: TurnDebit = TurnDebit.Unobserved
     var cancelRequests: Int = 0
     override protected def onCancelRequested(): Unit = cancelRequests += 1
     protected def handleLine(line: String): Unit =
@@ -205,6 +207,7 @@ class TurnGrammarTest extends munit.FunSuite:
         backendName = "fake"
       ):
     val outputSchema: Option[String] = None
+    protected def failedTurnDebit: TurnDebit = TurnDebit.Unobserved
     protected def handleLine(line: String): Unit =
       line match
         case "succeed" =>

--- a/tools/src/test/scala/orca/events/UsageTest.scala
+++ b/tools/src/test/scala/orca/events/UsageTest.scala
@@ -5,33 +5,41 @@ class UsageTest extends munit.FunSuite:
   test("+ adds every axis independently across usages from different backends"):
     // A run mixes backends reporting different axis subsets. Every axis must
     // add independently, whatever order the events arrive in.
-    val withWrites = Usage(
-      inputTokens = 1_000L,
-      outputTokens = 100L,
-      cost = Some(BigDecimal("0.10")),
+    val withWrites = Usage.exclusiveInput(
+      freshInputTokens = 100L,
       cacheReadInputTokens = 600L,
       cacheWriteInputTokens = 300L,
+      outputTokens = 100L,
+      reasoningOutputTokens = 0L,
+      cost = Some(BigDecimal("0.10")),
       apiCalls = Some(2L)
     )
-    val fewerWrites = Usage(
-      inputTokens = 500L,
-      outputTokens = 50L,
-      cost = None,
+    val fewerWrites = Usage.exclusiveInput(
+      freshInputTokens = 210L,
       cacheReadInputTokens = 200L,
-      reasoningOutputTokens = 20L,
       // non-zero, and different from `withWrites`, so a keep-one-side `+`
       // can't produce the expected total on this axis either
       cacheWriteInputTokens = 90L,
+      outputTokens = 50L,
+      reasoningOutputTokens = 20L,
+      cost = None,
       // Unset, as a backend that cannot count its API calls leaves it — the
       // total below must still keep the two counts that were measured.
       apiCalls = None
     )
-    val plain =
-      Usage(7L, 3L, Some(BigDecimal("0.01")), apiCalls = Some(5L))
+    val plain = Usage.exclusiveInput(
+      freshInputTokens = 7L,
+      cacheReadInputTokens = 0L,
+      cacheWriteInputTokens = 0L,
+      outputTokens = 3L,
+      reasoningOutputTokens = 0L,
+      cost = Some(BigDecimal("0.01")),
+      apiCalls = Some(5L)
+    )
     assertEquals(
       (withWrites + fewerWrites) + plain,
       Usage(
-        inputTokens = 1_507L,
+        freshInputTokens = 317L,
         outputTokens = 153L,
         cost = Some(BigDecimal("0.11")),
         cacheReadInputTokens = 800L,
@@ -46,3 +54,37 @@ class UsageTest extends munit.FunSuite:
     val u = Usage(10L, 5L, Some(BigDecimal("0.02")), 4L, 1L, 3L, Some(2L))
     assertEquals(Usage.empty + u, u)
     assertEquals(u + Usage.empty, u)
+
+  test("inputTokens totals the three disjoint input axes"):
+    val u = Usage(10L, 0L, None, 4L, 0L, 3L, None)
+    assertEquals(u.inputTokens, 17L)
+
+  test("inclusiveInput splits the wire total into its fresh remainder"):
+    val u = Usage.inclusiveInput(
+      totalInputTokens = 1_000L,
+      cacheReadInputTokens = 600L,
+      cacheWriteInputTokens = 300L,
+      outputTokens = 0L,
+      reasoningOutputTokens = 0L,
+      cost = None,
+      apiCalls = None,
+      wireTotal = None
+    )
+    assertEquals(u.freshInputTokens, 100L)
+
+  /** A backend whose cache axes over-report past its own input total must cost
+    * zero fresh input, not a negative charge eating the rest of the estimate.
+    */
+  test("inclusiveInput clamps fresh input at zero"):
+    val u = Usage.inclusiveInput(
+      totalInputTokens = 500_000L,
+      cacheReadInputTokens = 300_000L,
+      cacheWriteInputTokens = 250_000L,
+      outputTokens = 0L,
+      reasoningOutputTokens = 0L,
+      cost = None,
+      apiCalls = None,
+      wireTotal = None
+    )
+    assertEquals(u.freshInputTokens, 0L)
+    assertEquals(u.inputTokens, 550_000L)

--- a/tools/src/test/scala/orca/events/UsageTest.scala
+++ b/tools/src/test/scala/orca/events/UsageTest.scala
@@ -5,7 +5,7 @@ class UsageTest extends munit.FunSuite:
   test("+ adds every axis independently across usages from different backends"):
     // A run mixes backends reporting different axis subsets. Every axis must
     // add independently, whatever order the events arrive in.
-    val withWrites = Usage.exclusiveInput(
+    val withWrites = Usage(
       freshInputTokens = 100L,
       cacheReadInputTokens = 600L,
       cacheWriteInputTokens = 300L,
@@ -14,7 +14,7 @@ class UsageTest extends munit.FunSuite:
       cost = Some(BigDecimal("0.10")),
       apiCalls = Some(2L)
     )
-    val fewerWrites = Usage.exclusiveInput(
+    val fewerWrites = Usage(
       freshInputTokens = 210L,
       cacheReadInputTokens = 200L,
       // non-zero, and different from `withWrites`, so a keep-one-side `+`
@@ -27,7 +27,7 @@ class UsageTest extends munit.FunSuite:
       // total below must still keep the two counts that were measured.
       apiCalls = None
     )
-    val plain = Usage.exclusiveInput(
+    val plain = Usage(
       freshInputTokens = 7L,
       cacheReadInputTokens = 0L,
       cacheWriteInputTokens = 0L,
@@ -40,23 +40,39 @@ class UsageTest extends munit.FunSuite:
       (withWrites + fewerWrites) + plain,
       Usage(
         freshInputTokens = 317L,
-        outputTokens = 153L,
-        cost = Some(BigDecimal("0.11")),
         cacheReadInputTokens = 800L,
-        reasoningOutputTokens = 20L,
         cacheWriteInputTokens = 390L,
+        outputTokens = 153L,
+        reasoningOutputTokens = 20L,
+        cost = Some(BigDecimal("0.11")),
         apiCalls = Some(7L)
       )
     )
     assertEquals(fewerWrites + withWrites, withWrites + fewerWrites)
 
   test("empty is the identity of +"):
-    val u = Usage(10L, 5L, Some(BigDecimal("0.02")), 4L, 1L, 3L, Some(2L))
+    val u = Usage(
+      freshInputTokens = 10L,
+      cacheReadInputTokens = 4L,
+      cacheWriteInputTokens = 3L,
+      outputTokens = 5L,
+      reasoningOutputTokens = 1L,
+      cost = Some(BigDecimal("0.02")),
+      apiCalls = Some(2L)
+    )
     assertEquals(Usage.empty + u, u)
     assertEquals(u + Usage.empty, u)
 
   test("inputTokens totals the three disjoint input axes"):
-    val u = Usage(10L, 0L, None, 4L, 0L, 3L, None)
+    val u = Usage(
+      freshInputTokens = 10L,
+      cacheReadInputTokens = 4L,
+      cacheWriteInputTokens = 3L,
+      outputTokens = 0L,
+      reasoningOutputTokens = 0L,
+      cost = None,
+      apiCalls = None
+    )
     assertEquals(u.inputTokens, 17L)
 
   test("inclusiveInput splits the wire total into its fresh remainder"):

--- a/tools/src/test/scala/orca/testkit/Usages.scala
+++ b/tools/src/test/scala/orca/testkit/Usages.scala
@@ -1,0 +1,31 @@
+package orca.testkit
+
+import orca.events.Usage
+
+/** Builds a [[Usage]] from the axes a test cares about, leaving the others at
+  * zero.
+  *
+  * `input` is the whole prompt, cache axes included — the way a cost summary
+  * reads it, and the reason the cache arguments can be raised without also
+  * raising `input`.
+  */
+object Usages:
+  def usage(
+      input: Long,
+      output: Long,
+      cost: Option[BigDecimal] = None,
+      cacheRead: Long = 0L,
+      cacheWrite: Long = 0L,
+      reasoning: Long = 0L,
+      apiCalls: Option[Long] = None
+  ): Usage =
+    Usage.inclusiveInput(
+      totalInputTokens = input,
+      cacheReadInputTokens = cacheRead,
+      cacheWriteInputTokens = cacheWrite,
+      outputTokens = output,
+      reasoningOutputTokens = reasoning,
+      cost = cost,
+      apiCalls = apiCalls,
+      wireTotal = None
+    )


### PR DESCRIPTION
- `Usage` now stores the three input parts (fresh, cache read, cache write) and derives the total, so the "cache counts are inside input" rule can't be got wrong. Each backend picks `Usage.exclusiveInput` or `Usage.inclusiveInput` by name; the clamp in `Pricing.estimate` is gone.
- gemini's `total_tokens` is now decoded and cross-checked against the axes orca reads; a mismatch is logged, so a wire counter orca drops announces itself.
- A failed turn now always states what it spent: `AgentTurnFailed` carries a `TurnDebit` (`Observed` or `Unobserved`) with no default, and drivers that had the numbers in hand (gemini, opencode, pi) stopped throwing them away. The interactive path reports failed turns too.
- Turn attribution (agent, model fallback, role, session key, attempt) lives in one `TurnAccounting` instead of four copies.
- Cost is resolved once, at the dispatch boundary, and rides on `TokensUsed`. No listener holds a price table anymore, so the summary, the cost log and a user's own listener can't disagree.
- `CostTracker` keeps one `Tally` per bucket instead of a usage map and a cost map per axis; the pricing table encodes Anthropic's ratios and the `[1m]` alias instead of repeating rows.

Skipped: gemini thinking-token wire capture (needs a live probe).