### PR TITLE
Fix the agent-isolation findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,8 +180,9 @@ most easily broken:
   paste the block it prints. Per-cell rationale (why gemini's read-only cells
   are `PromptOnly`, what claude's `Hard` covers, why codex loses its sandbox on
   resume) lives in each backend's `*Args.enforcementCell`. When a turn's tier
-  isn't mechanically enforced, `EnforcementNotice` says so once per run — a
-  `Step` plus a WARN.
+  isn't mechanically enforced, `EnforcementNotice` says so — a `Step` plus a
+  WARN — once per backend instance and answer, so a second backend of the same
+  kind gets its own notice.
 
 - **Conversation events.** The event grammar (turn boundaries, `Option` tool
   names) is specified on `ConversationEvent`'s scaladoc and pinned per backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,17 +176,17 @@ most easily broken:
   | Full, Only(_) / Only() | Hard       | SandboxApprox | Ignored  | Ignored    | Ignored    |
 
   A resumed turn is classified the same, except:
-  - Codex, ReadOnly, *: PromptOnly, not Hard
   - Codex, Full, Only(_) / Only(): Ignored, not SandboxApprox
 
   Per-cell rationale (why gemini's read-only cells are `PromptOnly`, what
-  claude's `Hard` covers, why codex loses its sandbox on resume) lives in each
-  backend's `*Args.enforcementCell`. When a turn asks for a restriction the
-  backend can't apply mechanically — a read-only tier, or an `AutoApprove.Only`
-  list — `EnforcementNotice` says so in plain words as a `Step`, with the
-  rationale behind it as a WARN. Once per backend and distinct sentence: a
-  second backend of the same kind gets its own notice, and a changed answer
-  (codex's read-only turns once resumed) gets a new one.
+  claude's `Hard` covers, what a resumed codex turn re-applies) lives in each
+  backend's `*Args.enforcementCell`, with the CLI version and date of any probe
+  behind it. When a turn asks for a restriction the backend can't apply
+  mechanically — a read-only tier, or an `AutoApprove.Only` list —
+  `EnforcementNotice` says so in plain words as a `Step`, with the rationale
+  behind it as a WARN. Once per backend and distinct sentence: a second backend
+  of the same kind gets its own notice, and a changed answer (codex's `Full` +
+  `Only` once resumed) gets a new one.
 
 - **Conversation events.** The event grammar (turn boundaries, `Option` tool
   names) is specified on `ConversationEvent`'s scaladoc and pinned per backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,8 +160,8 @@ most easily broken:
 - **Tool enforcement.** `AgentConfig.tools: ToolSet` (ReadOnly/NetworkOnly/Full)
   and `autoApprove: AutoApprove` (All/Only) request a restriction, but each
   backend enforces it differently. `AgentBackend.enforcementCell(tools,
-  autoApprove)` answers with the guarantee actually achieved plus the reason —
-  see `Enforcement`'s scaladoc for what the levels mean:
+  autoApprove, dispatch)` answers with the guarantee actually achieved plus the
+  reason — see `Enforcement`'s scaladoc for what the levels mean:
 
   | tools, approve         | ClaudeCode | Codex         | Opencode | Pi         | Gemini     |
   |------------------------|------------|---------------|----------|------------|------------|
@@ -170,12 +170,18 @@ most easily broken:
   | Full, All              | Hard       | Hard          | Ignored  | Ignored    | Hard       |
   | Full, Only(_) / Only() | Hard       | SandboxApprox | Ignored  | Ignored    | Ignored    |
 
-  That table is RENDERED from the declared cells by
+  A resumed turn is classified the same, except:
+  - Codex, ReadOnly, *: PromptOnly, not Hard
+  - Codex, Full, Only(_) / Only(): Ignored, not SandboxApprox
+
+  That block is RENDERED from the declared cells by
   `runner/src/test/scala/orca/runner/EnforcementTableTest.scala`, which walks
-  the full (backend × ToolSet × AutoApprove) product — when it fails, paste the
-  block it prints. Per-cell rationale (why gemini's read-only cells are
-  `PromptOnly`, what claude's `Hard` covers) lives in each backend's
-  `*Args.enforcementCell`.
+  the full (backend × ToolSet × AutoApprove × dispatch) product — when it fails,
+  paste the block it prints. Per-cell rationale (why gemini's read-only cells
+  are `PromptOnly`, what claude's `Hard` covers, why codex loses its sandbox on
+  resume) lives in each backend's `*Args.enforcementCell`. When a turn's tier
+  isn't mechanically enforced, `EnforcementNotice` says so once per run — a
+  `Step` plus a WARN.
 
 - **Conversation events.** The event grammar (turn boundaries, `Option` tool
   names) is specified on `ConversationEvent`'s scaladoc and pinned per backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,10 +179,12 @@ most easily broken:
   the full (backend × ToolSet × AutoApprove × dispatch) product — when it fails,
   paste the block it prints. Per-cell rationale (why gemini's read-only cells
   are `PromptOnly`, what claude's `Hard` covers, why codex loses its sandbox on
-  resume) lives in each backend's `*Args.enforcementCell`. When a turn's tier
-  isn't mechanically enforced, `EnforcementNotice` says so — a `Step` plus a
-  WARN — once per backend instance and answer, so a second backend of the same
-  kind gets its own notice.
+  resume) lives in each backend's `*Args.enforcementCell`. When a turn asks for
+  a restriction the backend can't apply mechanically — a read-only tier, or an
+  `AutoApprove.Only` list — `EnforcementNotice` says so in plain words as a
+  `Step`, with the rationale behind it as a WARN. Once per backend and distinct
+  sentence: a second backend of the same kind gets its own notice, and a
+  changed answer (codex's read-only turns once resumed) gets a new one.
 
 - **Conversation events.** The event grammar (turn boundaries, `Option` tool
   names) is specified on `ConversationEvent`'s scaladoc and pinned per backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,28 +159,23 @@ most easily broken:
 
 - **Tool enforcement.** `AgentConfig.tools: ToolSet` (ReadOnly/NetworkOnly/Full)
   and `autoApprove: AutoApprove` (All/Only) request a restriction, but each
-  backend enforces it differently. `AgentBackend.enforcement(tools, autoApprove)`
-  surfaces the actual guarantee as the `Enforcement` enum — **Hard** (mechanically
-  blocked: permission mode / sandbox / allowlist), **SandboxApprox** (a coarser
-  sandbox, semantics widened), **PromptOnly** (only the prompt forbids it), or
-  **Ignored** (not encoded; depends on backend/server config outside orca):
+  backend enforces it differently. `AgentBackend.enforcementCell(tools,
+  autoApprove)` answers with the guarantee actually achieved plus the reason —
+  see `Enforcement`'s scaladoc for what the levels mean:
 
-  | tools, approve  | claude | codex         | gemini     | opencode | pi        |
-  |-----------------|--------|---------------|------------|----------|-----------|
-  | ReadOnly, *     | Hard   | Hard          | PromptOnly | Hard     | Hard      |
-  | NetworkOnly, *  | Hard   | PromptOnly    | PromptOnly | Hard     | PromptOnly|
-  | Full, All       | Hard   | Hard          | Hard       | Ignored  | Ignored   |
-  | Full, Only(_)   | Hard   | SandboxApprox | Ignored    | Ignored  | Ignored   |
+  | tools, approve         | ClaudeCode | Codex         | Opencode | Pi         | Gemini     |
+  |------------------------|------------|---------------|----------|------------|------------|
+  | ReadOnly, *            | Hard       | Hard          | Hard     | Hard       | PromptOnly |
+  | NetworkOnly, *         | Hard       | PromptOnly    | Hard     | PromptOnly | PromptOnly |
+  | Full, All              | Hard       | Hard          | Ignored  | Ignored    | Hard       |
+  | Full, Only(_) / Only() | Hard       | SandboxApprox | Ignored  | Ignored    | Ignored    |
 
-  gemini's read-only cells are `PromptOnly` because its `--approval-mode plan`
-  is **unmeasured**, not because it is known weak: no headless `plan` turn has
-  been run against a write attempt, and gemini downgrades `plan` to `default`
-  in untrusted folders, which is where orca runs agents.
-
-  The matrix is machine-checked in
-  `runner/src/test/scala/orca/runner/EnforcementTableTest.scala` (the source of
-  truth) — keep this table in sync with `EnforcementTableTest`; per-cell
-  rationale lives in each backend's `*Args.enforcement`.
+  That table is RENDERED from the declared cells by
+  `runner/src/test/scala/orca/runner/EnforcementTableTest.scala`, which walks
+  the full (backend × ToolSet × AutoApprove) product — when it fails, paste the
+  block it prints. Per-cell rationale (why gemini's read-only cells are
+  `PromptOnly`, what claude's `Hard` covers) lives in each backend's
+  `*Args.enforcementCell`.
 
 - **Conversation events.** The event grammar (turn boundaries, `Option` tool
   names) is specified on `ConversationEvent`'s scaladoc and pinned per backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,12 @@ most easily broken:
   and `autoApprove: AutoApprove` (All/Only) request a restriction, but each
   backend enforces it differently. `AgentBackend.enforcementCell(tools,
   autoApprove, dispatch)` answers with the guarantee actually achieved plus the
-  reason — see `Enforcement`'s scaladoc for what the levels mean:
+  reason — see `Enforcement`'s scaladoc for what the levels mean.
+
+  The block below is RENDERED — a fresh-turn table, then the resumed turns that
+  differ — by `runner/src/test/scala/orca/runner/EnforcementTableTest.scala`,
+  which walks the full (backend × ToolSet × AutoApprove × dispatch) product.
+  Don't hand-edit it: when the test fails, paste the block it prints.
 
   | tools, approve         | ClaudeCode | Codex         | Opencode | Pi         | Gemini     |
   |------------------------|------------|---------------|----------|------------|------------|
@@ -174,17 +179,14 @@ most easily broken:
   - Codex, ReadOnly, *: PromptOnly, not Hard
   - Codex, Full, Only(_) / Only(): Ignored, not SandboxApprox
 
-  That block is RENDERED from the declared cells by
-  `runner/src/test/scala/orca/runner/EnforcementTableTest.scala`, which walks
-  the full (backend × ToolSet × AutoApprove × dispatch) product — when it fails,
-  paste the block it prints. Per-cell rationale (why gemini's read-only cells
-  are `PromptOnly`, what claude's `Hard` covers, why codex loses its sandbox on
-  resume) lives in each backend's `*Args.enforcementCell`. When a turn asks for
-  a restriction the backend can't apply mechanically — a read-only tier, or an
-  `AutoApprove.Only` list — `EnforcementNotice` says so in plain words as a
-  `Step`, with the rationale behind it as a WARN. Once per backend and distinct
-  sentence: a second backend of the same kind gets its own notice, and a
-  changed answer (codex's read-only turns once resumed) gets a new one.
+  Per-cell rationale (why gemini's read-only cells are `PromptOnly`, what
+  claude's `Hard` covers, why codex loses its sandbox on resume) lives in each
+  backend's `*Args.enforcementCell`. When a turn asks for a restriction the
+  backend can't apply mechanically — a read-only tier, or an `AutoApprove.Only`
+  list — `EnforcementNotice` says so in plain words as a `Step`, with the
+  rationale behind it as a WARN. Once per backend and distinct sentence: a
+  second backend of the same kind gets its own notice, and a changed answer
+  (codex's read-only turns once resumed) gets a new one.
 
 - **Conversation events.** The event grammar (turn boundaries, `Option` tool
   names) is specified on `ConversationEvent`'s scaladoc and pinned per backend

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -8,7 +8,8 @@ import orca.agents.{
   Enforcement,
   EnforcementCell,
   WireSessionId,
-  ToolSet
+  ToolSet,
+  TurnDispatch
 }
 
 /** Maps AgentConfig fields to Claude Code CLI flags. `systemPrompt` is consumed
@@ -167,28 +168,32 @@ private[claude] object ClaudeArgs:
   /** How strongly claude enforces each `(tools, autoApprove)` combination — see
     * [[permissionArgs]] for the flags this classifies.
     *
-    * Written as an exhaustive match rather than a bare constant so a future
-    * `ToolSet`/`AutoApprove` case fails compilation here.
+    * Every axis is matched exhaustively rather than answered with a constant,
+    * so a future `ToolSet`/`AutoApprove`/`TurnDispatch` case fails compilation
+    * here.
     */
   def enforcementCell(
       tools: ToolSet,
-      autoApprove: AutoApprove
-  ): EnforcementCell =
-    tools match
-      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
-        EnforcementCell(
-          Enforcement.Hard,
-          "`--tools` confines the turn to the read-only names, so the write and shell tools are not on offer"
-        )
-      case ToolSet.Full =>
-        autoApprove match
-          case AutoApprove.All =>
-            EnforcementCell(
-              Enforcement.Hard,
-              "`--permission-mode bypassPermissions` approves everything, which is what `All` asks for"
-            )
-          case AutoApprove.Only(_) =>
-            EnforcementCell(
-              Enforcement.Hard,
-              "`--allowedTools` is a mechanical gate, but an ADDITIVE one: the approved set is claude's default permission mode ∪ the `Only` list, and only what falls outside that union is gated"
-            )
+      autoApprove: AutoApprove,
+      dispatch: TurnDispatch
+  ): EnforcementCell = dispatch match
+    // Same either way: [[streamJson]] emits `permissionArgs` on `--resume` too.
+    case TurnDispatch.Fresh | TurnDispatch.Resumed =>
+      tools match
+        case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+          EnforcementCell(
+            Enforcement.Hard,
+            "`--tools` confines the turn to the read-only names, so the write and shell tools are not on offer"
+          )
+        case ToolSet.Full =>
+          autoApprove match
+            case AutoApprove.All =>
+              EnforcementCell(
+                Enforcement.Hard,
+                "`--permission-mode bypassPermissions` approves everything, which is what `All` asks for"
+              )
+            case AutoApprove.Only(_) =>
+              EnforcementCell(
+                Enforcement.Hard,
+                "`--allowedTools` is a mechanical gate, but an ADDITIVE one: the approved set is claude's default permission mode ∪ the `Only` list, and only what falls outside that union is gated"
+              )

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -6,6 +6,7 @@ import orca.agents.{
   BackendTag,
   AgentConfig,
   Enforcement,
+  EnforcementCell,
   WireSessionId,
   ToolSet
 }
@@ -164,16 +165,30 @@ private[claude] object ClaudeArgs:
     else Seq("--allowedTools", tools.mkString(","))
 
   /** How strongly claude enforces each `(tools, autoApprove)` combination — see
-    * [[permissionArgs]] for the flags this classifies. Every one of them is a
-    * mechanical gate, hence `Hard` throughout.
+    * [[permissionArgs]] for the flags this classifies.
     *
     * Written as an exhaustive match rather than a bare constant so a future
     * `ToolSet`/`AutoApprove` case fails compilation here.
     */
-  def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
+  def enforcementCell(
+      tools: ToolSet,
+      autoApprove: AutoApprove
+  ): EnforcementCell =
     tools match
-      case ToolSet.ReadOnly | ToolSet.NetworkOnly => Enforcement.Hard
+      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+        EnforcementCell(
+          Enforcement.Hard,
+          "`--tools` confines the turn to the read-only names, so the write and shell tools are not on offer"
+        )
       case ToolSet.Full =>
         autoApprove match
-          case AutoApprove.All     => Enforcement.Hard
-          case AutoApprove.Only(_) => Enforcement.Hard
+          case AutoApprove.All =>
+            EnforcementCell(
+              Enforcement.Hard,
+              "`--permission-mode bypassPermissions` approves everything, which is what `All` asks for"
+            )
+          case AutoApprove.Only(_) =>
+            EnforcementCell(
+              Enforcement.Hard,
+              "`--allowedTools` is a mechanical gate, but an ADDITIVE one: the approved set is claude's default permission mode ∪ the `Only` list, and only what falls outside that union is gated"
+            )

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -190,6 +190,14 @@ private[claude] object ClaudeArgs:
                 Enforcement.Hard,
                 "`--permission-mode bypassPermissions` approves everything, which is what `All` asks for"
               )
+            // Split as [[permissionArgs]] splits it: an empty `Only` emits no
+            // flag at all, so naming `--allowedTools` here would describe a
+            // gate that branch never builds.
+            case AutoApprove.Only(names) if names.isEmpty =>
+              EnforcementCell(
+                Enforcement.Hard,
+                "no flag: the turn runs in claude's default permission mode, which is the gate and approves nothing beyond its own defaults"
+              )
             case AutoApprove.Only(_) =>
               EnforcementCell(
                 Enforcement.Hard,

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -201,5 +201,5 @@ private[claude] object ClaudeArgs:
             case AutoApprove.Only(_) =>
               EnforcementCell(
                 Enforcement.Hard,
-                "`--allowedTools` is a mechanical gate, but an ADDITIVE one: the approved set is claude's default permission mode ∪ the `Only` list, and only what falls outside that union is gated"
+                "`--allowedTools` is a mechanical gate, but an ADDITIVE one: the auto-approved set is claude's default permission mode ∪ the `Only` list, and everything outside that union is denied. Probed 2026-08-07, claude 2.1.224: with only `Bash(echo *)` allowlisted a `Read` still ran unprompted, so the defaults survive the flag; the defaults seen to auto-approve are workspace reads and read-only `Bash`, while `Write` and mutating `Bash` were denied. The gate is hard; its boundary is a documented superset of the request"
               )

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -144,13 +144,11 @@ private[claude] object ClaudeArgs:
             Seq("--allowedTools", tools.toSeq.sorted.mkString(","))
 
   /** Whether a tier's `--tools` list withholds `Bash`, and so needs the host to
-    * hand back the reads it would otherwise shell out for. Matched exhaustively
-    * so a new `ToolSet` case has to answer the question here rather than
-    * silently defaulting.
+    * hand back the reads it would otherwise shell out for. Exactly the tiers
+    * with no write primitive, since claude's write tools and `Bash` are dropped
+    * by the same allowlist.
     */
-  private[claude] def losesShell(tools: ToolSet): Boolean = tools match
-    case ToolSet.ReadOnly | ToolSet.NetworkOnly => true
-    case ToolSet.Full                           => false
+  private[claude] def losesShell(tools: ToolSet): Boolean = !tools.writeCapable
 
   /** Grants `tools` on a read-only turn. `--tools` only advertises: the turn
     * stays in the default permission mode, where `WebFetch` and MCP tools are

--- a/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
@@ -217,7 +217,7 @@ private[orca] class ClaudeBackend(
     val repoReads: Option[McpHost] =
       Option.when(ClaudeArgs.losesShell(config.tools))(RepoMcpServer.start(git))
     val githubReads: Option[McpHost] =
-      Option.when(config.tools == ToolSet.NetworkOnly):
+      Option.when(config.tools.hasScopedNetwork):
         GitHubMcpServer.start(new OsGitHubTool(cli, workDir))
     val mcpConfig = Option
       .when(askUser.isDefined || repoReads.isDefined || githubReads.isDefined):

--- a/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
@@ -12,6 +12,7 @@ import orca.agents.{
   SessionId,
   StructuredOutputMode,
   ToolSet,
+  TurnDispatch,
   onWire
 }
 import orca.backend.{
@@ -111,9 +112,10 @@ private[orca] class ClaudeBackend(
 
   override def enforcementCell(
       tools: ToolSet,
-      autoApprove: AutoApprove
+      autoApprove: AutoApprove,
+      dispatch: TurnDispatch
   ): EnforcementCell =
-    ClaudeArgs.enforcementCell(tools, autoApprove)
+    ClaudeArgs.enforcementCell(tools, autoApprove, dispatch)
 
   /** `--json-schema` (passed whenever a structured call supplies a schema — see
     * [[runAutonomous]]) makes the CLI inject a StructuredOutput tool whose

--- a/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
@@ -9,6 +9,7 @@ import orca.agents.{
   BackendTag,
   AgentConfig,
   EnforcementCell,
+  EnforcementNotice,
   SessionId,
   StructuredOutputMode,
   ToolSet,
@@ -60,12 +61,17 @@ private[orca] class ClaudeBackend(
       * bare/test construction; the runtime passes the flow's real `workDir`.
       */
     override val workDir: os.Path = os.pwd,
-    /** Threaded into [[AgentBackend]]'s `closedFlag`. Bare construction gets a
-      * fresh flag; [[withNetworkTools]] passes THIS instance's flag so the
-      * sibling shares one latch with its parent — see `AgentBackend` for why.
+    /** Threaded into [[AgentBackend]]'s `closedFlag` and `enforcementNotice`.
+      * Bare construction gets fresh ones; [[withNetworkTools]] passes THIS
+      * instance's, so the sibling shares one close latch and one notice log
+      * with its parent — see `AgentBackend` for why each must be shared.
       */
-    sharedClosedFlag: AtomicBoolean = new AtomicBoolean(false)
-) extends AgentBackend[BackendTag.ClaudeCode.type](sharedClosedFlag):
+    sharedClosedFlag: AtomicBoolean = new AtomicBoolean(false),
+    sharedNotice: EnforcementNotice = new EnforcementNotice
+) extends AgentBackend[BackendTag.ClaudeCode.type](
+      sharedClosedFlag,
+      sharedNotice
+    ):
 
   /** Return a sibling backend that, on [[ToolSet.NetworkOnly]] turns, adds
     * `tools` to the read-only `--tools` allowlist. Lives on the backend, not
@@ -77,15 +83,23 @@ private[orca] class ClaudeBackend(
     * exit 0, no warning. Without this check a flow script carrying the old
     * syntax would keep compiling, keep running, and grant nothing.
     *
-    * Shares `closedFlag` with `this`: the sibling is a genuinely different
-    * `AgentBackend` instance, so without threading the SAME flag through, a
-    * handle derived here and leaked past flow-end would bypass the
-    * use-after-close guard.
+    * Shares `closedFlag` and `enforcementNotice` with `this`: the sibling is a
+    * genuinely different `AgentBackend` instance, so without threading the SAME
+    * values through, a handle derived here and leaked past flow-end would
+    * bypass the use-after-close guard, and every enforcement notice would be
+    * given a second time.
     */
   def withNetworkTools(tools: Seq[String]): ClaudeBackend =
     tools.filterNot(ClaudeBackend.BareToolName.matches) match
       case Nil =>
-        new ClaudeBackend(cli, tools, projectsDir, workDir, closedFlag)
+        new ClaudeBackend(
+          cli,
+          tools,
+          projectsDir,
+          workDir,
+          closedFlag,
+          enforcementNotice
+        )
       case bad =>
         throw new IllegalArgumentException(
           s"withNetworkTools takes bare claude tool names; these are not: " +

--- a/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
@@ -8,7 +8,7 @@ import orca.agents.{
   AutoApprove,
   BackendTag,
   AgentConfig,
-  Enforcement,
+  EnforcementCell,
   SessionId,
   StructuredOutputMode,
   ToolSet,
@@ -109,11 +109,11 @@ private[orca] class ClaudeBackend(
     */
   private val git: GitTool = new OsGitTool(workDir)
 
-  override def enforcement(
+  override def enforcementCell(
       tools: ToolSet,
       autoApprove: AutoApprove
-  ): Enforcement =
-    ClaudeArgs.enforcement(tools, autoApprove)
+  ): EnforcementCell =
+    ClaudeArgs.enforcementCell(tools, autoApprove)
 
   /** `--json-schema` (passed whenever a structured call supplies a schema — see
     * [[runAutonomous]]) makes the CLI inject a StructuredOutput tool whose

--- a/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
@@ -220,7 +220,7 @@ private[orca] class ClaudeBackend(
     val mcpConfig = Option
       .when(askUser.isDefined || repoReads.isDefined || githubReads.isDefined):
         writeMcpConfig(askUser.map(_.server), repoReads, githubReads, session)
-    val systemPromptFile = writeSystemPromptIfPresent(
+    val systemPromptFile = writeSystemPrompt(
       config,
       includeAskUserHint = askUser.isDefined,
       includeRepoHint = repoReads.isDefined,
@@ -233,7 +233,7 @@ private[orca] class ClaudeBackend(
     val perTurn: List[AutoCloseable] =
       repoReads.toList ++ githubReads.toList ++
         mcpConfig.map(SubprocessSpawn.deleteFileResource) ++
-        systemPromptFile.map(SubprocessSpawn.deleteFileResource)
+        List(SubprocessSpawn.deleteFileResource(systemPromptFile))
     SubprocessSpawn.open("claude stream-json", askUser.toList ++ perTurn) {
       // `autoApproveAlso` reaches `--allowedTools` only on `Full`; the
       // read-only tiers ignore `autoApprove` entirely, so the name also goes
@@ -249,7 +249,7 @@ private[orca] class ClaudeBackend(
       // `agent.chat()`.
       val args = ClaudeArgs.streamJson(
         effectiveConfig,
-        systemPromptFile,
+        Some(systemPromptFile),
         dispatch = sessions.dispatchFor(session),
         outputSchema,
         mcpConfig = mcpConfig,
@@ -322,20 +322,22 @@ private[orca] class ClaudeBackend(
     * (auto-cleaned on exit) rather than the user's workDir — it's purely an IPC
     * mechanism, read once via `--append-system-prompt-file`.
     */
-  private def writeSystemPromptIfPresent(
+  private def writeSystemPrompt(
       config: AgentConfig,
       includeAskUserHint: Boolean,
       includeRepoHint: Boolean,
       includeGitHubHint: Boolean
-  ): Option[os.Path] =
+  ): os.Path =
     val hints =
       Option.when(includeAskUserHint)(AskUserMcpServer.Hint) ++
         Option.when(includeRepoHint)(RepoMcpServer.Hint) ++
         Option.when(includeGitHubHint)(GitHubMcpServer.Hint)
-    SystemPromptComposer
-      .combine(config, hints.reduceOption(_ + "\n\n" + _))
-      .map: text =>
-        os.temp(prefix = "orca-system-prompt-", suffix = ".md", contents = text)
+    os.temp(
+      prefix = "orca-system-prompt-",
+      suffix = ".md",
+      contents =
+        SystemPromptComposer.combine(config, hints.reduceOption(_ + "\n\n" + _))
+    )
 
 object ClaudeBackend:
 

--- a/claude/src/test/scala/orca/tools/claude/ClaudeBackendTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeBackendTest.scala
@@ -279,6 +279,18 @@ class ClaudeBackendTest extends munit.FunSuite:
       derived.run("prompt")
     assertEquals(thrown.getMessage, orca.backend.AgentBackend.ClosedMessage)
 
+  test("a withNetworkTools sibling shares the parent's enforcement notices"):
+    // The same rule as the closed latch above, for the other value a sibling
+    // must not get its own copy of: with a fresh log it would repeat every
+    // notice the parent already gave. Pinned structurally rather than by
+    // running a turn — claude's cells are `Hard` throughout, so no claude turn
+    // can make the notice fire at all.
+    val backend = new ClaudeBackend(new SpawnStubCliRunner(Nil))
+    assert(
+      backend.withNetworkTools(Seq("WebFetch")).enforcementNotice eq
+        backend.enforcementNotice
+    )
+
   test("claude declares Tool structured-output mode"):
     // The declaration behind the prompt's delivery instruction: --json-schema
     // (asserted below) makes the CLI inject a StructuredOutput tool, so the

--- a/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
@@ -6,6 +6,7 @@ import orca.agents.{
   BackendTag,
   Enforcement,
   EnforcementCell,
+  TurnDispatch,
   JsonData,
   AgentConfig,
   SessionId,
@@ -71,9 +72,10 @@ class SequencedBackend(
   val workDir: os.Path = os.pwd
   def enforcementCell(
       tools: ToolSet,
-      autoApprove: AutoApprove
+      autoApprove: AutoApprove,
+      dispatch: TurnDispatch
   ): EnforcementCell =
-    EnforcementCell(Enforcement.Ignored, "test double")
+    EnforcementCell(Enforcement.Hard, "test double: nothing to report")
   def structuredOutputMode: StructuredOutputMode = mode
 
   def runAutonomous(

--- a/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
@@ -1,10 +1,10 @@
 package orca.tools.claude
 
+import orca.testkit.StubEnforcement
 import orca.{AgentTurnFailed, OrcaFlowException}
 import orca.agents.{
   AutoApprove,
   BackendTag,
-  Enforcement,
   EnforcementCell,
   TurnDispatch,
   JsonData,
@@ -75,7 +75,7 @@ class SequencedBackend(
       autoApprove: AutoApprove,
       dispatch: TurnDispatch
   ): EnforcementCell =
-    EnforcementCell(Enforcement.Hard, "test double: nothing to report")
+    StubEnforcement.cell
   def structuredOutputMode: StructuredOutputMode = mode
 
   def runAutonomous(

--- a/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
@@ -5,6 +5,7 @@ import orca.agents.{
   AutoApprove,
   BackendTag,
   Enforcement,
+  EnforcementCell,
   JsonData,
   AgentConfig,
   SessionId,
@@ -68,8 +69,11 @@ class SequencedBackend(
 
   val tag: BackendTag.ClaudeCode.type = BackendTag.ClaudeCode
   val workDir: os.Path = os.pwd
-  def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
-    Enforcement.Ignored
+  def enforcementCell(
+      tools: ToolSet,
+      autoApprove: AutoApprove
+  ): EnforcementCell =
+    EnforcementCell(Enforcement.Ignored, "test double")
   def structuredOutputMode: StructuredOutputMode = mode
 
   def runAutonomous(

--- a/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
@@ -9,7 +9,8 @@ import orca.agents.{
   Enforcement,
   EnforcementCell,
   WireSessionId,
-  ToolSet
+  ToolSet,
+  TurnDispatch
 }
 
 /** Maps `AgentConfig` fields to `codex exec` CLI flags. `systemPrompt` is not
@@ -150,9 +151,24 @@ private[codex] object CodexArgs:
       case ToolSet.ReadOnly | ToolSet.Full => Nil
 
   /** How strongly codex enforces each `(tools, autoApprove)` combination — see
-    * [[sandboxArgs]] / [[networkConfigArgs]] for the flags this classifies.
+    * [[sandboxArgs]] / [[networkConfigArgs]] for the flags a fresh turn gets
+    * and [[resumeSandboxArgs]] for the (much smaller) set a resumed one gets.
+    *
+    * codex is the one backend whose answer depends on the dispatch: `exec
+    * resume` accepts no sandbox flag but the bypass, so on every other tier a
+    * resumed turn runs in whatever sandbox its session was created with, which
+    * this classification cannot know. It reports what orca can stand behind for
+    * THIS turn, which is the folded-in prompt.
     */
   def enforcementCell(
+      tools: ToolSet,
+      autoApprove: AutoApprove,
+      dispatch: TurnDispatch
+  ): EnforcementCell = dispatch match
+    case TurnDispatch.Fresh   => freshCell(tools, autoApprove)
+    case TurnDispatch.Resumed => resumedCell(tools, autoApprove)
+
+  private def freshCell(
       tools: ToolSet,
       autoApprove: AutoApprove
   ): EnforcementCell =
@@ -178,4 +194,27 @@ private[codex] object CodexArgs:
             EnforcementCell(
               Enforcement.SandboxApprox,
               "no per-tool allowlist, so the requested subset becomes `--full-auto`, a whole-sandbox approximation wider than what was asked"
+            )
+
+  private def resumedCell(
+      tools: ToolSet,
+      autoApprove: AutoApprove
+  ): EnforcementCell =
+    tools match
+      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+        EnforcementCell(
+          Enforcement.PromptOnly,
+          "`exec resume` takes no sandbox flag, so the tier's restriction reaches this turn only as the read-only rule folded into its prompt"
+        )
+      case ToolSet.Full =>
+        autoApprove match
+          case AutoApprove.All =>
+            EnforcementCell(
+              Enforcement.Hard,
+              "`--dangerously-bypass-approvals-and-sandbox` is the one flag `exec resume` accepts, and it is re-asserted every turn"
+            )
+          case AutoApprove.Only(_) =>
+            EnforcementCell(
+              Enforcement.Ignored,
+              "`exec resume` takes no sandbox flag, so the requested subset is encoded nowhere and the turn keeps the sandbox its session was created with"
             )

--- a/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
@@ -54,10 +54,17 @@ private[codex] object CodexArgs:
     *     validation falls to the prompt template + post-hoc parser; the
     *     retry-with-corrective-prompt loop in `DefaultAgentCall` handles parse
     *     failures.
-    *   - rejects `--sandbox <mode>` and `--full-auto` ("unexpected argument"):
-    *     a resumed session inherits the sandbox it was created with. Only
-    *     `--dangerously-bypass-approvals-and-sandbox` is still accepted, so
-    *     [[resumeSandboxArgs]] keeps that one and drops the rest.
+    *   - rejects `--sandbox <mode>` ("unexpected argument"), which is why the
+    *     tier's sandbox is re-applied through [[resumeSandboxModeArgs]]' `-c`
+    *     override instead. `--full-auto` is accepted but deprecated, and
+    *     omitted for that reason rather than because resume refuses it.
+    *
+    * A resumed session INHERITS the sandbox it was created with — probed
+    * 2026-08-07 against codex-cli 0.145.0: a flagless resume of a `--full-auto`
+    * session wrote a file, while a flagless fresh turn was blocked read-only.
+    * So the tier has to be re-asserted per turn; without that, a session
+    * created `NetworkOnly` and resumed `ReadOnly` (which `Plan.reviewed` does)
+    * would keep workspace write.
     *
     * codex also rejects resuming a session started with `--ephemeral`; the
     * backend never passes `--ephemeral`, so resume always finds a rollout.
@@ -70,6 +77,7 @@ private[codex] object CodexArgs:
   ): Seq[String] =
     Seq("codex") ++
       mcpServerArgs(mcpServerUrl) ++
+      resumeSandboxModeArgs(config) ++
       networkConfigArgs(config) ++
       Seq("exec", "resume", "--json", WireSessionId.value(sessionId)) ++
       resumeSandboxArgs(config) ++
@@ -77,11 +85,28 @@ private[codex] object CodexArgs:
       Seq("--skip-git-repo-check") ++
       Seq(prompt)
 
-  /** Sandbox flags accepted by `exec resume` (a subset of [[sandboxArgs]]).
-    * Only `--dangerously-bypass-approvals-and-sandbox` (Full +
-    * [[AutoApprove.All]]) is accepted, re-asserted each turn to keep approvals
-    * off; the other tiers map to no flag since the resumed session inherits its
-    * sandbox from creation.
+  /** Re-applies the read-only tiers' sandbox on a resumed turn, through the
+    * global `-c` slot `exec resume` does accept — the `--sandbox` flag it
+    * doesn't. Verified to narrow an already-widened session: resuming a
+    * `--full-auto` session with `-c sandbox_mode="read-only"` blocked the write
+    * (probed 2026-08-07, codex-cli 0.145.0).
+    *
+    * `Full` is absent because its two shapes are already handled after the
+    * subcommand — [[AutoApprove.All]] by the bypass flag in
+    * [[resumeSandboxArgs]], and `Only` by neither, matching what a resumed
+    * `Only` turn can be held to.
+    */
+  private def resumeSandboxModeArgs(config: AgentConfig): Seq[String] =
+    // Values are TOML, hence the embedded quotes.
+    config.tools match
+      case ToolSet.ReadOnly    => Seq("-c", "sandbox_mode=\"read-only\"")
+      case ToolSet.NetworkOnly => Seq("-c", "sandbox_mode=\"workspace-write\"")
+      case ToolSet.Full        => Nil
+
+  /** Sandbox flags accepted by `exec resume` AFTER the subcommand (a subset of
+    * [[sandboxArgs]]): only `--dangerously-bypass-approvals-and-sandbox` (Full
+    * + [[AutoApprove.All]]), re-asserted each turn to keep approvals off. The
+    * read-only tiers go through [[resumeSandboxModeArgs]] instead.
     */
   private def resumeSandboxArgs(config: AgentConfig): Seq[String] =
     config.tools match
@@ -151,14 +176,14 @@ private[codex] object CodexArgs:
       case ToolSet.ReadOnly | ToolSet.Full => Nil
 
   /** How strongly codex enforces each `(tools, autoApprove)` combination — see
-    * [[sandboxArgs]] / [[networkConfigArgs]] for the flags a fresh turn gets
-    * and [[resumeSandboxArgs]] for the (much smaller) set a resumed one gets.
+    * [[sandboxArgs]] / [[networkConfigArgs]] for the flags a fresh turn gets,
+    * and [[resumeSandboxModeArgs]] / [[resumeSandboxArgs]] for a resumed one.
     *
-    * codex is the one backend whose answer depends on the dispatch: `exec
-    * resume` accepts no sandbox flag but the bypass, so on every other tier a
-    * resumed turn runs in whatever sandbox its session was created with, which
-    * this classification cannot know. Each resumed cell therefore reports only
-    * what orca can still stand behind for THIS turn.
+    * codex is the one backend whose answer still depends on the dispatch, and
+    * now in one cell only: the read-only tiers get their sandbox re-applied per
+    * turn, so they answer the same either way, while a resumed `Full` +
+    * [[AutoApprove.Only]] turn keeps whatever sandbox its session was created
+    * with — which this classification cannot know.
     */
   def enforcementCell(
       tools: ToolSet,
@@ -176,7 +201,7 @@ private[codex] object CodexArgs:
       case ToolSet.ReadOnly =>
         EnforcementCell(
           Enforcement.Hard,
-          "`--sandbox read-only` blocks writes at the sandbox"
+          "the `read-only` sandbox blocks writes, and a resumed turn re-applies it rather than inheriting the session's (probed 2026-08-07, codex-cli 0.145.0)"
         )
       case ToolSet.NetworkOnly =>
         EnforcementCell(
@@ -201,20 +226,19 @@ private[codex] object CodexArgs:
       autoApprove: AutoApprove
   ): EnforcementCell =
     tools match
+      // The read-only tiers answer exactly as a fresh turn does, because
+      // `resumeSandboxModeArgs` re-applies the same sandbox.
       case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
-        EnforcementCell(
-          Enforcement.PromptOnly,
-          "`exec resume` takes no sandbox flag, so the tier's restriction reaches this turn only as the read-only rule folded into its prompt"
-        )
+        freshCell(tools, autoApprove)
       case ToolSet.Full =>
         autoApprove match
           case AutoApprove.All =>
             EnforcementCell(
               Enforcement.Hard,
-              "`--dangerously-bypass-approvals-and-sandbox` is the one flag `exec resume` accepts, and it is re-asserted every turn"
+              "`--dangerously-bypass-approvals-and-sandbox` is re-asserted on every resumed turn, and `exec resume --help` lists it (probed 2026-08-07, codex-cli 0.145.0)"
             )
           case AutoApprove.Only(_) =>
             EnforcementCell(
               Enforcement.Ignored,
-              "`exec resume` takes no sandbox flag, so the requested subset is encoded nowhere and the turn keeps the sandbox its session was created with"
+              "the requested subset has no sandbox of its own to re-apply, so a resumed turn keeps whichever sandbox its session was created with — inheritance confirmed by probing a flagless resume of a `--full-auto` session (2026-08-07, codex-cli 0.145.0)"
             )

--- a/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
@@ -157,8 +157,8 @@ private[codex] object CodexArgs:
     * codex is the one backend whose answer depends on the dispatch: `exec
     * resume` accepts no sandbox flag but the bypass, so on every other tier a
     * resumed turn runs in whatever sandbox its session was created with, which
-    * this classification cannot know. It reports what orca can stand behind for
-    * THIS turn, which is the folded-in prompt.
+    * this classification cannot know. Each resumed cell therefore reports only
+    * what orca can still stand behind for THIS turn.
     */
   def enforcementCell(
       tools: ToolSet,

--- a/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
@@ -7,6 +7,7 @@ import orca.agents.{
   BackendTag,
   AgentConfig,
   Enforcement,
+  EnforcementCell,
   WireSessionId,
   ToolSet
 }
@@ -123,11 +124,9 @@ private[codex] object CodexArgs:
 
   /** Maps [[AgentConfig.tools]] to codex's sandbox flags (placed after the
     * `exec` subcommand). codex has no per-tool CLI allowlist, so
-    * [[AutoApprove.Only]] is approximated with the coarser `--full-auto`.
-    *
-    * `NetworkOnly` has no read-only-with-network sandbox on codex: network
-    * needs `workspace-write` (via `--full-auto`), which also permits writes, so
-    * its no-edit guarantee is prompt-only.
+    * [[AutoApprove.Only]] is approximated with the coarser `--full-auto`, and
+    * `NetworkOnly` has to take `workspace-write` too — codex has no
+    * read-only-with-network sandbox.
     */
   private def sandboxArgs(config: AgentConfig): Seq[String] =
     config.tools match
@@ -152,19 +151,31 @@ private[codex] object CodexArgs:
 
   /** How strongly codex enforces each `(tools, autoApprove)` combination — see
     * [[sandboxArgs]] / [[networkConfigArgs]] for the flags this classifies.
-    *
-    *   - `ReadOnly` → `Hard`: `--sandbox read-only` mechanically blocks writes.
-    *   - `NetworkOnly` → `PromptOnly`: no read-only-with-network sandbox, so
-    *     the no-edit guarantee rests only on the planner prompt.
-    *   - `Full` + `AutoApprove.All` → `Hard`: bypass flag approves everything.
-    *   - `Full` + `AutoApprove.Only(_)` → `SandboxApprox`: no per-tool
-    *     allowlist, so `--full-auto` is wider than the requested subset.
     */
-  def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
+  def enforcementCell(
+      tools: ToolSet,
+      autoApprove: AutoApprove
+  ): EnforcementCell =
     tools match
-      case ToolSet.ReadOnly    => Enforcement.Hard
-      case ToolSet.NetworkOnly => Enforcement.PromptOnly
+      case ToolSet.ReadOnly =>
+        EnforcementCell(
+          Enforcement.Hard,
+          "`--sandbox read-only` blocks writes at the sandbox"
+        )
+      case ToolSet.NetworkOnly =>
+        EnforcementCell(
+          Enforcement.PromptOnly,
+          "network needs the `workspace-write` sandbox, which also permits writes, so only the prompt withholds edits"
+        )
       case ToolSet.Full =>
         autoApprove match
-          case AutoApprove.All     => Enforcement.Hard
-          case AutoApprove.Only(_) => Enforcement.SandboxApprox
+          case AutoApprove.All =>
+            EnforcementCell(
+              Enforcement.Hard,
+              "`--dangerously-bypass-approvals-and-sandbox` approves everything, which is what `All` asks for"
+            )
+          case AutoApprove.Only(_) =>
+            EnforcementCell(
+              Enforcement.SandboxApprox,
+              "no per-tool allowlist, so the requested subset becomes `--full-auto`, a whole-sandbox approximation wider than what was asked"
+            )

--- a/codex/src/main/scala/orca/tools/codex/CodexBackend.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexBackend.scala
@@ -5,7 +5,7 @@ import orca.agents.{
   AutoApprove,
   BackendTag,
   AgentConfig,
-  Enforcement,
+  EnforcementCell,
   SessionId,
   StructuredOutputMode,
   ToolSet
@@ -71,11 +71,11 @@ private[orca] class CodexBackend(
     */
   val tag: BackendTag.Codex.type = BackendTag.Codex
 
-  override def enforcement(
+  override def enforcementCell(
       tools: ToolSet,
       autoApprove: AutoApprove
-  ): Enforcement =
-    CodexArgs.enforcement(tools, autoApprove)
+  ): EnforcementCell =
+    CodexArgs.enforcementCell(tools, autoApprove)
 
   /** `--output-schema` constrains the FINAL MESSAGE text — the reply text is
     * still the JSON value orca parses; there is no structured-output tool.

--- a/codex/src/main/scala/orca/tools/codex/CodexBackend.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexBackend.scala
@@ -8,7 +8,8 @@ import orca.agents.{
   EnforcementCell,
   SessionId,
   StructuredOutputMode,
-  ToolSet
+  ToolSet,
+  TurnDispatch
 }
 import orca.backend.{
   Conversation,
@@ -73,9 +74,10 @@ private[orca] class CodexBackend(
 
   override def enforcementCell(
       tools: ToolSet,
-      autoApprove: AutoApprove
+      autoApprove: AutoApprove,
+      dispatch: TurnDispatch
   ): EnforcementCell =
-    CodexArgs.enforcementCell(tools, autoApprove)
+    CodexArgs.enforcementCell(tools, autoApprove, dispatch)
 
   /** `--output-schema` constrains the FINAL MESSAGE text — the reply text is
     * still the JSON value orca parses; there is no structured-output tool.

--- a/codex/src/test/scala/orca/tools/codex/CodexArgsTest.scala
+++ b/codex/src/test/scala/orca/tools/codex/CodexArgsTest.scala
@@ -162,11 +162,11 @@ class CodexArgsTest extends munit.FunSuite:
     assert(!args.contains("-C"))
     assert(!args.contains("--output-schema"))
 
-  test(
-    "execResume omits --sandbox/--full-auto (exec resume rejects them; inherited)"
-  ):
-    // Regression: `codex exec resume` errors with "unexpected argument
-    // '--sandbox'"; the resumed session inherits its sandbox from creation.
+  test("execResume omits --sandbox and --full-auto"):
+    // `--sandbox` is a hard regression: `codex exec resume` errors with
+    // "unexpected argument". `--full-auto` is accepted but deprecated as of
+    // codex-cli 0.145.0 (probed 2026-08-07), and omitted for that reason —
+    // the tier travels through `-c sandbox_mode` instead.
     val sid = WireSessionId[BackendTag.Codex.type]("sid")
     val readOnly =
       CodexArgs.execResume(
@@ -188,6 +188,37 @@ class CodexArgsTest extends munit.FunSuite:
       AgentConfig().copy(autoApprove = AutoApprove.Only(Set("Bash")))
     )
     assert(!fullOnly.contains("--full-auto"), fullOnly)
+
+  test(
+    "execResume re-applies the read-only tiers' sandbox before the subcommand"
+  ):
+    // A resumed session inherits the sandbox it was created with, so without
+    // this a NetworkOnly-created session resumed ReadOnly (what `Plan.reviewed`
+    // does) would still be write-capable. The `-c` override goes in codex's
+    // global slot, hence before `exec`.
+    val sid = WireSessionId[BackendTag.Codex.type]("sid")
+    val readOnly = CodexArgs.execResume(
+      sid,
+      "x",
+      AgentConfig().copy(tools = ToolSet.ReadOnly)
+    )
+    assert(
+      readOnly.containsSlice(Seq("-c", "sandbox_mode=\"read-only\"")),
+      readOnly
+    )
+    assert(
+      readOnly.indexOf("sandbox_mode=\"read-only\"") < readOnly.indexOf("exec"),
+      readOnly
+    )
+    val networkOnly = CodexArgs.execResume(
+      sid,
+      "x",
+      AgentConfig().copy(tools = ToolSet.NetworkOnly)
+    )
+    assert(
+      networkOnly.containsSlice(Seq("-c", "sandbox_mode=\"workspace-write\"")),
+      networkOnly
+    )
 
   test(
     "execResume keeps --dangerously-bypass-approvals-and-sandbox (Full + All)"

--- a/codex/src/test/scala/orca/tools/codex/CodexBackendTest.scala
+++ b/codex/src/test/scala/orca/tools/codex/CodexBackendTest.scala
@@ -195,11 +195,12 @@ class CodexBackendTest extends munit.FunSuite:
       assert(secondArgs.contains("resume"), secondArgs)
       assert(secondArgs.contains("thr-server-1"), secondArgs)
 
-  // A resumed codex turn gets no sandbox flag, so the read-only rule in its
-  // prompt IS the restriction — the whole basis for classifying that cell
-  // PromptOnly rather than Hard. Asserted on the wire, since a composer that
-  // stopped folding it in would leave the resumed turn restricted by nothing.
-  test("a resumed read-only turn still carries the read-only rule"):
+  // Both halves of a resumed read-only turn's restriction, on the wire: the
+  // re-applied sandbox (without which the turn would inherit whatever its
+  // session was created with) and the prompt rule that backs it up.
+  test(
+    "a resumed read-only turn re-applies the sandbox and the read-only rule"
+  ):
     val runner = new SpawnStubCliRunner(
       List(
         successfulProcess("thr-server-1"),
@@ -214,6 +215,10 @@ class CodexBackendTest extends munit.FunSuite:
       // Asserted here rather than relied on from the resume test above, so this
       // one still fails if the second call stops being a resume.
       assert(resumedArgs.contains("resume"), resumedArgs)
+      assert(
+        resumedArgs.containsSlice(Seq("-c", "sandbox_mode=\"read-only\"")),
+        resumedArgs
+      )
       assert(
         resumedArgs.last.contains(SystemPromptComposer.ReadOnlyTurn),
         resumedArgs.last

--- a/codex/src/test/scala/orca/tools/codex/CodexBackendTest.scala
+++ b/codex/src/test/scala/orca/tools/codex/CodexBackendTest.scala
@@ -195,6 +195,27 @@ class CodexBackendTest extends munit.FunSuite:
       assert(secondArgs.contains("resume"), secondArgs)
       assert(secondArgs.contains("thr-server-1"), secondArgs)
 
+  // A resumed codex turn gets no sandbox flag, so the read-only rule in its
+  // prompt IS the restriction — the whole basis for classifying that cell
+  // PromptOnly rather than Hard. Asserted on the wire, since a composer that
+  // stopped folding it in would leave the resumed turn restricted by nothing.
+  test("a resumed read-only turn still carries the read-only rule"):
+    val runner = new SpawnStubCliRunner(
+      List(
+        successfulProcess("thr-server-1"),
+        successfulProcess("thr-server-1")
+      )
+    )
+    withBackend(runner): backend =>
+      val readOnly = AgentConfig(tools = ToolSet.ReadOnly)
+      val _ = backend.runAutonomous("first", clientSid, readOnly)
+      val _ = backend.runAutonomous("again", clientSid, readOnly)
+      val resumedPrompt = runner.calls(1).last
+      assert(
+        resumedPrompt.contains(SystemPromptComposer.ReadOnlyTurn),
+        resumedPrompt
+      )
+
   test(
     "registerSession after an interactive call lets a follow-up autonomous call resume"
   ):

--- a/codex/src/test/scala/orca/tools/codex/CodexBackendTest.scala
+++ b/codex/src/test/scala/orca/tools/codex/CodexBackendTest.scala
@@ -210,10 +210,13 @@ class CodexBackendTest extends munit.FunSuite:
       val readOnly = AgentConfig(tools = ToolSet.ReadOnly)
       val _ = backend.runAutonomous("first", clientSid, readOnly)
       val _ = backend.runAutonomous("again", clientSid, readOnly)
-      val resumedPrompt = runner.calls(1).last
+      val resumedArgs = runner.calls(1)
+      // Asserted here rather than relied on from the resume test above, so this
+      // one still fails if the second call stops being a resume.
+      assert(resumedArgs.contains("resume"), resumedArgs)
       assert(
-        resumedPrompt.contains(SystemPromptComposer.ReadOnlyTurn),
-        resumedPrompt
+        resumedArgs.last.contains(SystemPromptComposer.ReadOnlyTurn),
+        resumedArgs.last
       )
 
   test(

--- a/flow/src/main/scala/orca/review/Reviewers.scala
+++ b/flow/src/main/scala/orca/review/Reviewers.scala
@@ -133,6 +133,11 @@ def minimalReviewers[B <: BackendTag](base: Agent[B]): List[Agent[B]] =
   * and could edit files mid-review. Reads stay available so the agent can
   * verify claims beyond the diff.
   *
+  * How strongly that gate holds is per backend — `Hard` on most, `PromptOnly`
+  * on gemini (see AGENTS.md's enforcement table). The run says so once when it
+  * is not mechanical (`EnforcementNotice`), and the read-only rule is in every
+  * such turn's prompt either way.
+  *
   * Public so a flow can build agents from a custom [[Reviewer]] list rather
   * than being limited to the [[allReviewers]] / [[minimalReviewers]] presets.
   */

--- a/flow/src/main/scala/orca/review/Reviewers.scala
+++ b/flow/src/main/scala/orca/review/Reviewers.scala
@@ -133,10 +133,10 @@ def minimalReviewers[B <: BackendTag](base: Agent[B]): List[Agent[B]] =
   * and could edit files mid-review. Reads stay available so the agent can
   * verify claims beyond the diff.
   *
-  * How strongly that gate holds is per backend — `Hard` on most, `PromptOnly`
-  * on gemini (see AGENTS.md's enforcement table). The run says so once when it
-  * is not mechanical (`EnforcementNotice`), and the read-only rule is in every
-  * such turn's prompt either way.
+  * How strongly that gate holds is per backend and per turn — AGENTS.md's
+  * enforcement table is the answer. The run says so when it isn't mechanical
+  * (`EnforcementNotice`), and the read-only rule is in every such turn's prompt
+  * either way.
   *
   * Public so a flow can build agents from a custom [[Reviewer]] list rather
   * than being limited to the [[allReviewers]] / [[minimalReviewers]] presets.

--- a/flow/src/test/scala/orca/review/FixOutcomeAnnounceTest.scala
+++ b/flow/src/test/scala/orca/review/FixOutcomeAnnounceTest.scala
@@ -1,12 +1,12 @@
 package orca.review
 
+import orca.testkit.StubEnforcement
 import orca.agents.{
   AgentConfig,
   AutoApprove,
   BackendTag,
   DefaultAgentCall,
   DefaultPrompts,
-  Enforcement,
   EnforcementCell,
   TurnDispatch,
   SessionId,
@@ -46,7 +46,7 @@ private class CannedBackend(output: String)
       autoApprove: AutoApprove,
       dispatch: TurnDispatch
   ): EnforcementCell =
-    EnforcementCell(Enforcement.Hard, "test double: nothing to report")
+    StubEnforcement.cell
   def structuredOutputMode: StructuredOutputMode = StructuredOutputMode.RawText
   def runAutonomous(
       prompt: String,

--- a/flow/src/test/scala/orca/review/FixOutcomeAnnounceTest.scala
+++ b/flow/src/test/scala/orca/review/FixOutcomeAnnounceTest.scala
@@ -7,6 +7,7 @@ import orca.agents.{
   DefaultAgentCall,
   DefaultPrompts,
   Enforcement,
+  EnforcementCell,
   SessionId,
   StructuredOutputMode,
   ToolSet,
@@ -39,8 +40,11 @@ private class CannedBackend(output: String)
   val sessions: SessionSupport[BackendTag.Pi.type] =
     SessionSupport.ephemeral(IdScheme.ClientClaimed)
   val tag: BackendTag.Pi.type = BackendTag.Pi
-  def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
-    Enforcement.Ignored
+  def enforcementCell(
+      tools: ToolSet,
+      autoApprove: AutoApprove
+  ): EnforcementCell =
+    EnforcementCell(Enforcement.Ignored, "test double")
   def structuredOutputMode: StructuredOutputMode = StructuredOutputMode.RawText
   def runAutonomous(
       prompt: String,

--- a/flow/src/test/scala/orca/review/FixOutcomeAnnounceTest.scala
+++ b/flow/src/test/scala/orca/review/FixOutcomeAnnounceTest.scala
@@ -8,6 +8,7 @@ import orca.agents.{
   DefaultPrompts,
   Enforcement,
   EnforcementCell,
+  TurnDispatch,
   SessionId,
   StructuredOutputMode,
   ToolSet,
@@ -42,9 +43,10 @@ private class CannedBackend(output: String)
   val tag: BackendTag.Pi.type = BackendTag.Pi
   def enforcementCell(
       tools: ToolSet,
-      autoApprove: AutoApprove
+      autoApprove: AutoApprove,
+      dispatch: TurnDispatch
   ): EnforcementCell =
-    EnforcementCell(Enforcement.Ignored, "test double")
+    EnforcementCell(Enforcement.Hard, "test double: nothing to report")
   def structuredOutputMode: StructuredOutputMode = StructuredOutputMode.RawText
   def runAutonomous(
       prompt: String,

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
@@ -8,7 +8,8 @@ import orca.agents.{
   Enforcement,
   EnforcementCell,
   WireSessionId,
-  ToolSet
+  ToolSet,
+  TurnDispatch
 }
 
 /** Maps `AgentConfig` fields to `gemini` headless CLI flags. `systemPrompt` is
@@ -93,23 +94,26 @@ private[gemini] object GeminiArgs:
     */
   def enforcementCell(
       tools: ToolSet,
-      autoApprove: AutoApprove
-  ): EnforcementCell =
-    tools match
-      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
-        EnforcementCell(
-          Enforcement.PromptOnly,
-          "`--approval-mode plan` is UNMEASURED, not known weak: no headless `plan` turn has been run against a write attempt. The same class of mechanism on claude — `--permission-mode plan` — was measured and removes no tools (`docs/research/run-cost/09-diff-vs-coordinates.md` §2), and gemini downgrades `plan` to `default` in untrusted folders, which is where orca runs agents. Raise this cell when a probe establishes more."
-        )
-      case ToolSet.Full =>
-        autoApprove match
-          case AutoApprove.All =>
-            EnforcementCell(
-              Enforcement.Hard,
-              "`yolo` honours \"approve everything\" verbatim"
-            )
-          case AutoApprove.Only(_) =>
-            EnforcementCell(
-              Enforcement.Ignored,
-              "no per-tool allowlist, so any `Only` set is widened to `yolo` — the requested subset reaches the CLI nowhere"
-            )
+      autoApprove: AutoApprove,
+      dispatch: TurnDispatch
+  ): EnforcementCell = dispatch match
+    // Same either way: [[resume]] carries `approvalArgs` as [[headless]] does.
+    case TurnDispatch.Fresh | TurnDispatch.Resumed =>
+      tools match
+        case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+          EnforcementCell(
+            Enforcement.PromptOnly,
+            "`--approval-mode plan` is UNMEASURED, not known weak: no headless `plan` turn has been run against a write attempt. The same class of mechanism on claude — `--permission-mode plan` — was measured and removes no tools (`docs/research/run-cost/09-diff-vs-coordinates.md` §2), and gemini downgrades `plan` to `default` in untrusted folders, which is where orca runs agents. Raise this cell when a probe establishes more."
+          )
+        case ToolSet.Full =>
+          autoApprove match
+            case AutoApprove.All =>
+              EnforcementCell(
+                Enforcement.Hard,
+                "`yolo` honours \"approve everything\" verbatim"
+              )
+            case AutoApprove.Only(_) =>
+              EnforcementCell(
+                Enforcement.Ignored,
+                "no per-tool allowlist, so any `Only` set is widened to `yolo` — the requested subset reaches the CLI nowhere"
+              )

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
@@ -6,6 +6,7 @@ import orca.agents.{
   BackendTag,
   AgentConfig,
   Enforcement,
+  EnforcementCell,
   WireSessionId,
   ToolSet
 }
@@ -68,10 +69,6 @@ private[gemini] object GeminiArgs:
     * per-tool CLI allowlist, and in headless mode `auto_edit` blocks on shell
     * approvals no one can answer, so both [[AutoApprove.All]] and
     * [[AutoApprove.Only]] map to `yolo` (the `Only` widening: ADR 0015).
-    *
-    *   - `ReadOnly` → `--approval-mode plan`
-    *   - `NetworkOnly` → `--approval-mode plan --allowed-tools <web tools>`
-    *   - `Full` + `AutoApprove.All` / `Only(_)` → `--approval-mode yolo`
     */
   private def approvalArgs(config: AgentConfig): Seq[String] =
     config.tools match
@@ -89,28 +86,30 @@ private[gemini] object GeminiArgs:
             Seq("--approval-mode", "yolo")
 
   /** How strongly gemini enforces each `(tools, autoApprove)` combination — see
-    * [[approvalArgs]] for the flags this classifies.
-    *
-    *   - `ReadOnly` / `NetworkOnly` → `PromptOnly`. `plan` was assumed to make
-    *     writes and shell mechanically unavailable, but nothing has measured
-    *     it: no headless `plan` turn has been run against a write attempt on
-    *     any host orca is developed on. The same class of mechanism on claude —
-    *     `--permission-mode plan` — was measured and removes no tools
-    *     (`docs/research/run-cost/09-diff-vs-coordinates.md` §2), and gemini
-    *     additionally downgrades `plan` to `default` in untrusted folders,
-    *     which is where orca runs agents. `PromptOnly` records the guarantee
-    *     orca can actually stand behind; raise it when a probe establishes
-    *     more.
-    *   - `Full` + `AutoApprove.All` → `Hard`: `yolo` honours "approve
-    *     everything" verbatim.
-    *   - `Full` + `AutoApprove.Only(_)` → `Ignored`: no per-tool allowlist, so
-    *     any `Only` set is widened to `yolo` (ADR 0015) — the requested subset
-    *     is not encoded.
+    * [[approvalArgs]] for the flags this classifies. The read-only cells are
+    * the one place in the matrix where a level records what orca can stand
+    * behind rather than what a flag was assumed to do, so their rationale
+    * carries the whole argument — this is its only home.
     */
-  def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
+  def enforcementCell(
+      tools: ToolSet,
+      autoApprove: AutoApprove
+  ): EnforcementCell =
     tools match
-      case ToolSet.ReadOnly | ToolSet.NetworkOnly => Enforcement.PromptOnly
+      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+        EnforcementCell(
+          Enforcement.PromptOnly,
+          "`--approval-mode plan` is UNMEASURED, not known weak: no headless `plan` turn has been run against a write attempt. The same class of mechanism on claude — `--permission-mode plan` — was measured and removes no tools (`docs/research/run-cost/09-diff-vs-coordinates.md` §2), and gemini downgrades `plan` to `default` in untrusted folders, which is where orca runs agents. Raise this cell when a probe establishes more."
+        )
       case ToolSet.Full =>
         autoApprove match
-          case AutoApprove.All     => Enforcement.Hard
-          case AutoApprove.Only(_) => Enforcement.Ignored
+          case AutoApprove.All =>
+            EnforcementCell(
+              Enforcement.Hard,
+              "`yolo` honours \"approve everything\" verbatim"
+            )
+          case AutoApprove.Only(_) =>
+            EnforcementCell(
+              Enforcement.Ignored,
+              "no per-tool allowlist, so any `Only` set is widened to `yolo` — the requested subset reaches the CLI nowhere"
+            )

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
@@ -87,10 +87,9 @@ private[gemini] object GeminiArgs:
             Seq("--approval-mode", "yolo")
 
   /** How strongly gemini enforces each `(tools, autoApprove)` combination — see
-    * [[approvalArgs]] for the flags this classifies. The read-only cells are
-    * the one place in the matrix where a level records what orca can stand
-    * behind rather than what a flag was assumed to do, so their rationale
-    * carries the whole argument — this is its only home.
+    * [[approvalArgs]] for the flags this classifies. The read-only cells record
+    * what orca can stand behind rather than what a flag was assumed to do, so
+    * their rationale carries the whole argument — this is its only home.
     */
   def enforcementCell(
       tools: ToolSet,
@@ -103,7 +102,7 @@ private[gemini] object GeminiArgs:
         case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
           EnforcementCell(
             Enforcement.PromptOnly,
-            "`--approval-mode plan` is UNMEASURED, not known weak: no headless `plan` turn has been run against a write attempt. The same class of mechanism on claude — `--permission-mode plan` — was measured and removes no tools (`docs/research/run-cost/09-diff-vs-coordinates.md` §2), and gemini downgrades `plan` to `default` in untrusted folders, which is where orca runs agents. Raise this cell when a probe establishes more."
+            "`--approval-mode plan` is UNMEASURED, not known weak: no headless `plan` turn has been run against a write attempt. The same class of mechanism on claude — `--permission-mode plan` — was measured and removes no tools (`docs/research/run-cost/09-diff-vs-coordinates.md` §2). Raise this cell when a probe establishes more."
           )
         case ToolSet.Full =>
           autoApprove match

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
@@ -5,7 +5,7 @@ import orca.agents.{
   AutoApprove,
   BackendTag,
   AgentConfig,
-  Enforcement,
+  EnforcementCell,
   SessionId,
   StructuredOutputMode,
   ToolSet
@@ -66,11 +66,11 @@ private[orca] class GeminiBackend(
     */
   val tag: BackendTag.Gemini.type = BackendTag.Gemini
 
-  override def enforcement(
+  override def enforcementCell(
       tools: ToolSet,
       autoApprove: AutoApprove
-  ): Enforcement =
-    GeminiArgs.enforcement(tools, autoApprove)
+  ): EnforcementCell =
+    GeminiArgs.enforcementCell(tools, autoApprove)
 
   /** The gemini CLI has no output-schema flag (see [[runAutonomous]]) —
     * enforcement is prompt-only and the reply text is the JSON value.

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
@@ -8,7 +8,8 @@ import orca.agents.{
   EnforcementCell,
   SessionId,
   StructuredOutputMode,
-  ToolSet
+  ToolSet,
+  TurnDispatch
 }
 import orca.subprocess.CliResult
 import orca.backend.{
@@ -68,9 +69,10 @@ private[orca] class GeminiBackend(
 
   override def enforcementCell(
       tools: ToolSet,
-      autoApprove: AutoApprove
+      autoApprove: AutoApprove,
+      dispatch: TurnDispatch
   ): EnforcementCell =
-    GeminiArgs.enforcementCell(tools, autoApprove)
+    GeminiArgs.enforcementCell(tools, autoApprove, dispatch)
 
   /** The gemini CLI has no output-schema flag (see [[runAutonomous]]) —
     * enforcement is prompt-only and the reply text is the JSON value.

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
@@ -55,7 +55,7 @@ private[opencode] object OpencodeArgs:
     MessageBody(
       parts = List(MessagePart("text", prompt)),
       model = config.model.map(toModelRef),
-      system = SystemPromptComposer.combine(config),
+      system = Some(SystemPromptComposer.combine(config)),
       // orca never targets a specific opencode agent profile — omitted so the
       // server's default applies.
       agent = None,

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
@@ -1,7 +1,14 @@
 package orca.tools.opencode
 
 import orca.backend.{ConversationMode, SystemPromptComposer}
-import orca.agents.{AgentConfig, AutoApprove, Enforcement, Model, ToolSet}
+import orca.agents.{
+  AgentConfig,
+  AutoApprove,
+  Enforcement,
+  EnforcementCell,
+  Model,
+  ToolSet
+}
 import orca.tools.opencode.OpencodeApi.{
   MessageBody,
   MessagePart,
@@ -15,9 +22,8 @@ import orca.util.RawJson
   *
   * Unlike the subprocess backends, almost everything travels in the request
   * body rather than on a CLI flag: model, system prompt, output schema, and the
-  * per-tool gate all live on [[MessageBody]]. `autoApprove` is an
-  * approval-policy concern handled at the permission layer (the
-  * `permission.asked` reply), not encoded here.
+  * per-tool gate all live on [[MessageBody]]. `autoApprove` is not encoded at
+  * all — see [[enforcementCell]].
   */
 private[opencode] object OpencodeArgs:
 
@@ -98,16 +104,21 @@ private[opencode] object OpencodeArgs:
 
   /** How strongly opencode enforces each `(tools, autoApprove)` combination —
     * see [[toolFlags]] for the gate this classifies.
-    *
-    *   - `ReadOnly` / `NetworkOnly` → `Hard`: the write tools are disabled on
-    *     the message body, a mechanical no-edit gate.
-    *   - `Full` → `Ignored`: `autoApprove` is never encoded here — the approval
-    *     policy is whatever the user's `opencode` server config says via the
-    *     `permission.asked` reply, outside orca's control (ADR 0014 risk).
     */
-  def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
+  def enforcementCell(
+      tools: ToolSet,
+      autoApprove: AutoApprove
+  ): EnforcementCell =
     tools match
-      case ToolSet.ReadOnly | ToolSet.NetworkOnly => Enforcement.Hard
+      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+        EnforcementCell(
+          Enforcement.Hard,
+          "the message body disables the write tools, so the server never offers them"
+        )
       case ToolSet.Full =>
         autoApprove match
-          case AutoApprove.All | AutoApprove.Only(_) => Enforcement.Ignored
+          case AutoApprove.All | AutoApprove.Only(_) =>
+            EnforcementCell(
+              Enforcement.Ignored,
+              "the approval policy is whatever the user's `opencode` server config answers a `permission.asked` with, outside orca's control (ADR 0014 risk)"
+            )

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
@@ -7,7 +7,8 @@ import orca.agents.{
   Enforcement,
   EnforcementCell,
   Model,
-  ToolSet
+  ToolSet,
+  TurnDispatch
 }
 import orca.tools.opencode.OpencodeApi.{
   MessageBody,
@@ -107,18 +108,21 @@ private[opencode] object OpencodeArgs:
     */
   def enforcementCell(
       tools: ToolSet,
-      autoApprove: AutoApprove
-  ): EnforcementCell =
-    tools match
-      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
-        EnforcementCell(
-          Enforcement.Hard,
-          "the message body disables the write tools, so the server never offers them"
-        )
-      case ToolSet.Full =>
-        autoApprove match
-          case AutoApprove.All | AutoApprove.Only(_) =>
-            EnforcementCell(
-              Enforcement.Ignored,
-              "the approval policy is whatever the user's `opencode` server config answers a `permission.asked` with, outside orca's control (ADR 0014 risk)"
-            )
+      autoApprove: AutoApprove,
+      dispatch: TurnDispatch
+  ): EnforcementCell = dispatch match
+    // Same either way: the gate rides on [[message]], which every turn sends.
+    case TurnDispatch.Fresh | TurnDispatch.Resumed =>
+      tools match
+        case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+          EnforcementCell(
+            Enforcement.Hard,
+            "the message body disables the write tools, so the server never offers them"
+          )
+        case ToolSet.Full =>
+          autoApprove match
+            case AutoApprove.All | AutoApprove.Only(_) =>
+              EnforcementCell(
+                Enforcement.Ignored,
+                "the approval policy is whatever the user's `opencode` server config answers a `permission.asked` with, outside orca's control (ADR 0014 risk)"
+              )

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
@@ -117,7 +117,7 @@ private[opencode] object OpencodeArgs:
         case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
           EnforcementCell(
             Enforcement.Hard,
-            "the message body disables the write tools, so the server never offers them"
+            "the message body disables `write`, `edit`, `bash` and `patch` by name, so the server offers none of those four — unlike an allowlist, this stays exact only while opencode ships no fifth writing tool"
           )
         case ToolSet.Full =>
           autoApprove match

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeBackend.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeBackend.scala
@@ -20,7 +20,7 @@ import orca.agents.{
   AutoApprove,
   BackendTag,
   AgentConfig,
-  Enforcement,
+  EnforcementCell,
   SessionId,
   StructuredOutputMode,
   ToolSet,
@@ -126,11 +126,11 @@ private[orca] class OpencodeBackend(
 
   val tag: BackendTag.Opencode.type = BackendTag.Opencode
 
-  override def enforcement(
+  override def enforcementCell(
       tools: ToolSet,
       autoApprove: AutoApprove
-  ): Enforcement =
-    OpencodeArgs.enforcement(tools, autoApprove)
+  ): EnforcementCell =
+    OpencodeArgs.enforcementCell(tools, autoApprove)
 
   /** The `format: json_schema` message field is a response-format constraint —
     * the model still emits the JSON as its reply text (the server parses it

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeBackend.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeBackend.scala
@@ -24,6 +24,7 @@ import orca.agents.{
   SessionId,
   StructuredOutputMode,
   ToolSet,
+  TurnDispatch,
   WireSessionId
 }
 import orca.subprocess.CliRunner
@@ -128,9 +129,10 @@ private[orca] class OpencodeBackend(
 
   override def enforcementCell(
       tools: ToolSet,
-      autoApprove: AutoApprove
+      autoApprove: AutoApprove,
+      dispatch: TurnDispatch
   ): EnforcementCell =
-    OpencodeArgs.enforcementCell(tools, autoApprove)
+    OpencodeArgs.enforcementCell(tools, autoApprove, dispatch)
 
   /** The `format: json_schema` message field is a response-format constraint —
     * the model still emits the JSON as its reply text (the server parses it

--- a/opencode/src/test/scala/orca/tools/opencode/DefaultOpencodeToolTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/DefaultOpencodeToolTest.scala
@@ -1,5 +1,6 @@
 package orca.tools.opencode
 
+import orca.testkit.StubEnforcement
 import orca.backend.{
   Conversation,
   Interaction,
@@ -14,7 +15,6 @@ import orca.agents.{
   BackendTag,
   DefaultPrompts,
   AgentConfig,
-  Enforcement,
   EnforcementCell,
   TurnDispatch,
   OpencodeAgent,
@@ -57,7 +57,7 @@ class DefaultOpencodeAgentTest extends munit.FunSuite:
         autoApprove: AutoApprove,
         dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
+      StubEnforcement.cell
     def structuredOutputMode: orca.agents.StructuredOutputMode =
       orca.agents.StructuredOutputMode.RawText
 

--- a/opencode/src/test/scala/orca/tools/opencode/DefaultOpencodeToolTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/DefaultOpencodeToolTest.scala
@@ -15,6 +15,7 @@ import orca.agents.{
   DefaultPrompts,
   AgentConfig,
   Enforcement,
+  EnforcementCell,
   OpencodeAgent,
   SessionId,
   ToolSet,
@@ -50,8 +51,11 @@ class DefaultOpencodeAgentTest extends munit.FunSuite:
     val sessions: SessionSupport[BackendTag.Opencode.type] =
       SessionSupport.ephemeral(IdScheme.ClientClaimed)
     val tag: BackendTag.Opencode.type = BackendTag.Opencode
-    def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
-      Enforcement.Ignored
+    def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove
+    ): EnforcementCell =
+      EnforcementCell(Enforcement.Ignored, "test double")
     def structuredOutputMode: orca.agents.StructuredOutputMode =
       orca.agents.StructuredOutputMode.RawText
 

--- a/opencode/src/test/scala/orca/tools/opencode/DefaultOpencodeToolTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/DefaultOpencodeToolTest.scala
@@ -16,6 +16,7 @@ import orca.agents.{
   AgentConfig,
   Enforcement,
   EnforcementCell,
+  TurnDispatch,
   OpencodeAgent,
   SessionId,
   ToolSet,
@@ -53,9 +54,10 @@ class DefaultOpencodeAgentTest extends munit.FunSuite:
     val tag: BackendTag.Opencode.type = BackendTag.Opencode
     def enforcementCell(
         tools: ToolSet,
-        autoApprove: AutoApprove
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Ignored, "test double")
+      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
     def structuredOutputMode: orca.agents.StructuredOutputMode =
       orca.agents.StructuredOutputMode.RawText
 

--- a/pi/src/main/scala/orca/tools/pi/PiArgs.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiArgs.scala
@@ -6,7 +6,8 @@ import orca.agents.{
   AutoApprove,
   Enforcement,
   EnforcementCell,
-  ToolSet
+  ToolSet,
+  TurnDispatch
 }
 
 /** Maps Orca backend configuration to Pi CLI arguments; the argv carries only
@@ -74,23 +75,26 @@ private[pi] object PiArgs:
     */
   def enforcementCell(
       tools: ToolSet,
-      autoApprove: AutoApprove
-  ): EnforcementCell =
-    tools match
-      case ToolSet.ReadOnly =>
-        EnforcementCell(
-          Enforcement.Hard,
-          "the `--tools` allowlist excludes every writable tool"
-        )
-      case ToolSet.NetworkOnly =>
-        EnforcementCell(
-          Enforcement.PromptOnly,
-          "the allowlist has to include `bash` to reach the network, and `bash` also writes, so only the prompt withholds edits"
-        )
-      case ToolSet.Full =>
-        autoApprove match
-          case AutoApprove.All | AutoApprove.Only(_) =>
-            EnforcementCell(
-              Enforcement.Ignored,
-              "pi RPC never prompts, and the argv encodes no approval policy"
-            )
+      autoApprove: AutoApprove,
+      dispatch: TurnDispatch
+  ): EnforcementCell = dispatch match
+    // Same either way: [[rpc]] emits `toolsArgs` alongside `--continue`.
+    case TurnDispatch.Fresh | TurnDispatch.Resumed =>
+      tools match
+        case ToolSet.ReadOnly =>
+          EnforcementCell(
+            Enforcement.Hard,
+            "the `--tools` allowlist excludes every writable tool"
+          )
+        case ToolSet.NetworkOnly =>
+          EnforcementCell(
+            Enforcement.PromptOnly,
+            "the allowlist has to include `bash` to reach the network, and `bash` also writes, so only the prompt withholds edits"
+          )
+        case ToolSet.Full =>
+          autoApprove match
+            case AutoApprove.All | AutoApprove.Only(_) =>
+              EnforcementCell(
+                Enforcement.Ignored,
+                "pi RPC never prompts, and the argv encodes no approval policy"
+              )

--- a/pi/src/main/scala/orca/tools/pi/PiArgs.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiArgs.scala
@@ -1,7 +1,13 @@
 package orca.tools.pi
 
 import orca.backend.CliArgs
-import orca.agents.{AgentConfig, AutoApprove, Enforcement, ToolSet}
+import orca.agents.{
+  AgentConfig,
+  AutoApprove,
+  Enforcement,
+  EnforcementCell,
+  ToolSet
+}
 
 /** Maps Orca backend configuration to Pi CLI arguments; the argv carries only
   * process/session/configuration flags, since prompts go over stdin.
@@ -17,8 +23,7 @@ private[pi] object PiArgs:
 
   /** Pi has no web/fetch tool, so the only network path is the general `bash`
     * tool — which also permits writes. Added on [[ToolSet.NetworkOnly]] turns;
-    * the no-edit guarantee is then prompt-only (the planner prompts forbid
-    * edits), not enforced by the allowlist.
+    * see [[enforcementCell]] for what that costs the tier's guarantee.
     */
   val NetworkTool: String = "bash"
 
@@ -64,19 +69,28 @@ private[pi] object PiArgs:
   private def extensionArgs(file: Option[os.Path]): Seq[String] =
     CliArgs.flag("--extension", file)(_.toString)
 
-  /** How strongly pi enforces each `(tools, autoApprove)` combination:
-    *   - `ReadOnly` → `Hard`: the `--tools` allowlist mechanically excludes
-    *     every writable tool.
-    *   - `NetworkOnly` → `PromptOnly`: network arrives only via the general
-    *     `bash` tool, which also permits writes, so the no-edit guarantee rests
-    *     on the planner prompt.
-    *   - `Full` + `AutoApprove.All` / `Only(_)` → `Ignored`: pi RPC never
-    *     prompts and the argv encodes no approval policy.
+  /** How strongly pi enforces each `(tools, autoApprove)` combination — see
+    * [[toolsArgs]] for the flags this classifies.
     */
-  def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
+  def enforcementCell(
+      tools: ToolSet,
+      autoApprove: AutoApprove
+  ): EnforcementCell =
     tools match
-      case ToolSet.ReadOnly    => Enforcement.Hard
-      case ToolSet.NetworkOnly => Enforcement.PromptOnly
+      case ToolSet.ReadOnly =>
+        EnforcementCell(
+          Enforcement.Hard,
+          "the `--tools` allowlist excludes every writable tool"
+        )
+      case ToolSet.NetworkOnly =>
+        EnforcementCell(
+          Enforcement.PromptOnly,
+          "the allowlist has to include `bash` to reach the network, and `bash` also writes, so only the prompt withholds edits"
+        )
       case ToolSet.Full =>
         autoApprove match
-          case AutoApprove.All | AutoApprove.Only(_) => Enforcement.Ignored
+          case AutoApprove.All | AutoApprove.Only(_) =>
+            EnforcementCell(
+              Enforcement.Ignored,
+              "pi RPC never prompts, and the argv encodes no approval policy"
+            )

--- a/pi/src/main/scala/orca/tools/pi/PiBackend.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiBackend.scala
@@ -137,13 +137,13 @@ private[orca] class PiBackend private[pi] (
     // Write the system prompt file before allocating any resource, so a
     // temp-write failure can't leak the ask-user extension: with nothing
     // allocated yet, there's nothing to tear down.
-    val systemPromptFile = writeSystemPromptIfPresent(config, extraHint)
+    val systemPromptFile = writeSystemPrompt(config, extraHint)
 
     val askUserExtension =
       Option.when(mode.isInteractive)(PiAskUserExtension.allocate())
 
     val resources: List[AutoCloseable] =
-      askUserExtension.toList ++ systemPromptFile.toList
+      askUserExtension.toList ++ List(systemPromptFile)
 
     SubprocessSpawn.open("pi RPC", resources) {
       val resume = sessions.dispatchFor(session) match
@@ -157,7 +157,7 @@ private[orca] class PiBackend private[pi] (
           OrcaDir.ensurePiSessions(workDir) / SessionId.value(session),
         resume = resume,
         config = config,
-        systemPromptFile = systemPromptFile.map(_.file),
+        systemPromptFile = Some(systemPromptFile.file),
         askUserExtension = askUserExtension.map(_.file)
       )
       cli.spawnPiped(args, cwd = workDir, pipeStderr = true)
@@ -174,18 +174,15 @@ private[orca] class PiBackend private[pi] (
       conversation
     }
 
-  private def writeSystemPromptIfPresent(
+  private def writeSystemPrompt(
       config: AgentConfig,
       extraHint: Option[String]
-  ): Option[TempFileResource] =
-    SystemPromptComposer
-      .combine(config, extraHint)
-      .map: text =>
-        val dir =
-          os.temp.dir(prefix = "orca-pi-system-prompt-", deleteOnExit = true)
-        val file = dir / "system-prompt.md"
-        os.write(file, text)
-        TempFileResource(dir, file)
+  ): TempFileResource =
+    val dir =
+      os.temp.dir(prefix = "orca-pi-system-prompt-", deleteOnExit = true)
+    val file = dir / "system-prompt.md"
+    os.write(file, SystemPromptComposer.combine(config, extraHint))
+    TempFileResource(dir, file)
 
   private case class TempFileResource(dir: os.Path, file: os.Path)
       extends AutoCloseable:

--- a/pi/src/main/scala/orca/tools/pi/PiBackend.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiBackend.scala
@@ -9,7 +9,8 @@ import orca.agents.{
   EnforcementCell,
   SessionId,
   StructuredOutputMode,
-  ToolSet
+  ToolSet,
+  TurnDispatch
 }
 import orca.backend.{
   Conversation,
@@ -78,9 +79,10 @@ private[orca] class PiBackend private[pi] (
 
   override def enforcementCell(
       tools: ToolSet,
-      autoApprove: AutoApprove
+      autoApprove: AutoApprove,
+      dispatch: TurnDispatch
   ): EnforcementCell =
-    PiArgs.enforcementCell(tools, autoApprove)
+    PiArgs.enforcementCell(tools, autoApprove, dispatch)
 
   /** Pi has no native structured-output / JSON-schema flag (see
     * [[PiConversation]]) — the reply text is the JSON value.

--- a/pi/src/main/scala/orca/tools/pi/PiBackend.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiBackend.scala
@@ -6,7 +6,7 @@ import orca.agents.{
   AutoApprove,
   BackendTag,
   AgentConfig,
-  Enforcement,
+  EnforcementCell,
   SessionId,
   StructuredOutputMode,
   ToolSet
@@ -76,11 +76,11 @@ private[orca] class PiBackend private[pi] (
 
   val tag: BackendTag.Pi.type = BackendTag.Pi
 
-  override def enforcement(
+  override def enforcementCell(
       tools: ToolSet,
       autoApprove: AutoApprove
-  ): Enforcement =
-    PiArgs.enforcement(tools, autoApprove)
+  ): EnforcementCell =
+    PiArgs.enforcementCell(tools, autoApprove)
 
   /** Pi has no native structured-output / JSON-schema flag (see
     * [[PiConversation]]) — the reply text is the JSON value.

--- a/runner/src/test/scala/orca/runner/EnforcementTableTest.scala
+++ b/runner/src/test/scala/orca/runner/EnforcementTableTest.scala
@@ -139,29 +139,26 @@ class EnforcementTableTest extends munit.FunSuite:
         fullOnlyResumed
     )
 
-  test("every backend tag has a backend wired into the matrix"):
-    withDeclared: declared =>
-      assertEquals(declared.keySet.map(_._1), BackendTag.values.toSet)
-
   test("every cell of the product matches what its backend declares"):
     withDeclared: declared =>
-      // Collect every divergence and fail once with the full list, so one run
-      // surfaces all of them rather than stopping at the first.
+      // Both sides are looked up the same way, so an unenumerated cell and an
+      // unwired backend are named rather than skipped. Every divergence is
+      // collected and reported at once, so one run surfaces all of them.
       val problems = for
         tag <- BackendTag.values.toList
         tools <- ToolSet.values.toList
         shape <- ApproveShape.values.toList
         dispatch <- TurnDispatch.values.toList
         where = s"$tag / $tools / ${shape.label} / $dispatch"
-        problem <- expected
-          .get((tools, shape, dispatch))
-          .flatMap(_.get(tag)) match
-          case None => Some(s"$where: no expectation")
-          case Some(want) =>
-            declared
-              .get((tag, tools, shape, dispatch))
-              .filter(_ != want)
-              .map(got => s"$where: want $want, got $got")
+        problem <- (
+          expected.get((tools, shape, dispatch)).flatMap(_.get(tag)),
+          declared.get((tag, tools, shape, dispatch))
+        ) match
+          case (None, _) => Some(s"$where: no expectation declared")
+          case (_, None) => Some(s"$where: no backend wired")
+          case (Some(want), Some(got)) if want != got =>
+            Some(s"$where: want $want, got $got")
+          case _ => None
       yield problem
       assert(problems.isEmpty, problems.mkString("\n"))
 

--- a/runner/src/test/scala/orca/runner/EnforcementTableTest.scala
+++ b/runner/src/test/scala/orca/runner/EnforcementTableTest.scala
@@ -1,6 +1,6 @@
 package orca.runner
 
-import orca.agents.{AutoApprove, BackendTag, Enforcement, ToolSet}
+import orca.agents.{AutoApprove, BackendTag, Enforcement, ToolSet, TurnDispatch}
 import orca.backend.AgentBackend
 import orca.subprocess.StubCliRunner
 import orca.tools.claude.ClaudeBackend
@@ -22,14 +22,14 @@ private enum ApproveShape(val label: String, val sample: AutoApprove):
   case OnlyEmpty extends ApproveShape("Only()", AutoApprove.Only(Set.empty))
 
 /** Machine-checked source of truth for the per-backend enforcement matrix (the
-  * `Enforcement` a `(ToolSet, AutoApprove)` combination gets on each backend),
-  * and the renderer of the table AGENTS.md carries.
+  * `Enforcement` a `(ToolSet, AutoApprove, TurnDispatch)` combination gets on
+  * each backend), and the renderer of the block AGENTS.md carries.
   *
   * The expectations below are deliberately a second, hand-written copy of what
   * the backends declare: editing a backend's cell without editing its row here
-  * fails. The product is walked in full, so a new `BackendTag`, `ToolSet`, or
-  * approve shape fails the moment its enum grows rather than going silently
-  * unchecked.
+  * fails. The product is walked in full, so a new `BackendTag`, `ToolSet`,
+  * approve shape, or dispatch fails the moment its enum grows rather than going
+  * silently unchecked.
   *
   * Every backend's `enforcementCell` is a pure function delegating to its
   * `*Args`, so construction is cheap: a [[StubCliRunner]] the method never
@@ -58,7 +58,7 @@ class EnforcementTableTest extends munit.FunSuite:
       BackendTag.Pi -> pi
     )
 
-  private val readOnlyRow: Map[BackendTag, Enforcement] = row(
+  private val readOnlyFresh: Map[BackendTag, Enforcement] = row(
     claude = Hard,
     codex = Hard,
     gemini = PromptOnly,
@@ -66,7 +66,18 @@ class EnforcementTableTest extends munit.FunSuite:
     pi = Hard
   )
 
-  private val networkOnlyRow: Map[BackendTag, Enforcement] = row(
+  /** codex `exec resume` takes no sandbox flag, so its read-only tiers fall
+    * back to the prompt on a resumed turn.
+    */
+  private val readOnlyResumed: Map[BackendTag, Enforcement] = row(
+    claude = Hard,
+    codex = PromptOnly,
+    gemini = PromptOnly,
+    opencode = Hard,
+    pi = Hard
+  )
+
+  private val networkOnly: Map[BackendTag, Enforcement] = row(
     claude = Hard,
     codex = PromptOnly,
     gemini = PromptOnly,
@@ -74,7 +85,15 @@ class EnforcementTableTest extends munit.FunSuite:
     pi = PromptOnly
   )
 
-  private val fullOnlyRow: Map[BackendTag, Enforcement] = row(
+  private val fullAll: Map[BackendTag, Enforcement] = row(
+    claude = Hard,
+    codex = Hard,
+    gemini = Hard,
+    opencode = Ignored,
+    pi = Ignored
+  )
+
+  private val fullOnlyFresh: Map[BackendTag, Enforcement] = row(
     claude = Hard,
     codex = SandboxApprox,
     gemini = Ignored,
@@ -82,40 +101,47 @@ class EnforcementTableTest extends munit.FunSuite:
     pi = Ignored
   )
 
-  private val expected
-      : Map[(ToolSet, ApproveShape), Map[BackendTag, Enforcement]] =
-    Map(
-      // ReadOnly / NetworkOnly ignore autoApprove on every backend, so their
-      // three rows agree by construction — pinned, not assumed.
-      (ToolSet.ReadOnly, ApproveShape.All) ->
-        readOnlyRow,
-      (ToolSet.ReadOnly, ApproveShape.OnlySome) ->
-        readOnlyRow,
-      (ToolSet.ReadOnly, ApproveShape.OnlyEmpty) ->
-        readOnlyRow,
-      (ToolSet.NetworkOnly, ApproveShape.All) ->
-        networkOnlyRow,
-      (ToolSet.NetworkOnly, ApproveShape.OnlySome) ->
-        networkOnlyRow,
-      (ToolSet.NetworkOnly, ApproveShape.OnlyEmpty) ->
-        networkOnlyRow,
-      (ToolSet.Full, ApproveShape.All) -> row(
-        claude = Hard,
-        codex = Hard,
-        gemini = Hard,
-        opencode = Ignored,
-        pi = Ignored
-      ),
-      (ToolSet.Full, ApproveShape.OnlySome) ->
-        fullOnlyRow,
-      (ToolSet.Full, ApproveShape.OnlyEmpty) ->
-        fullOnlyRow
+  private val fullOnlyResumed: Map[BackendTag, Enforcement] = row(
+    claude = Hard,
+    codex = Ignored,
+    gemini = Ignored,
+    opencode = Ignored,
+    pi = Ignored
+  )
+
+  private val expected: Map[
+    (ToolSet, ApproveShape, TurnDispatch),
+    Map[BackendTag, Enforcement]
+  ] =
+    (for
+      shape <- ApproveShape.values.toList
+      // The read-only tiers ignore autoApprove on every backend, so one row
+      // stands for all three shapes — pinned by the product walk, not assumed.
+      entry <- List(
+        (ToolSet.ReadOnly, shape, TurnDispatch.Fresh) -> readOnlyFresh,
+        (ToolSet.ReadOnly, shape, TurnDispatch.Resumed) -> readOnlyResumed,
+        (ToolSet.NetworkOnly, shape, TurnDispatch.Fresh) -> networkOnly,
+        (ToolSet.NetworkOnly, shape, TurnDispatch.Resumed) -> networkOnly
+      )
+    yield entry).toMap ++ Map(
+      (ToolSet.Full, ApproveShape.All, TurnDispatch.Fresh) -> fullAll,
+      (ToolSet.Full, ApproveShape.All, TurnDispatch.Resumed) -> fullAll,
+      (
+        ToolSet.Full,
+        ApproveShape.OnlySome,
+        TurnDispatch.Fresh
+      ) -> fullOnlyFresh,
+      (ToolSet.Full, ApproveShape.OnlySome, TurnDispatch.Resumed) ->
+        fullOnlyResumed,
+      (ToolSet.Full, ApproveShape.OnlyEmpty, TurnDispatch.Fresh) ->
+        fullOnlyFresh,
+      (ToolSet.Full, ApproveShape.OnlyEmpty, TurnDispatch.Resumed) ->
+        fullOnlyResumed
     )
 
   test("every backend tag has a backend wired into the matrix"):
     withDeclared: declared =>
-      val wired = declared.keySet.map(_._1)
-      assertEquals(wired, BackendTag.values.toSet)
+      assertEquals(declared.keySet.map(_._1), BackendTag.values.toSet)
 
   test("every cell of the product matches what its backend declares"):
     withDeclared: declared =>
@@ -125,29 +151,34 @@ class EnforcementTableTest extends munit.FunSuite:
         tag <- BackendTag.values.toList
         tools <- ToolSet.values.toList
         shape <- ApproveShape.values.toList
-        problem <- expected.get((tools, shape)).flatMap(_.get(tag)) match
-          case None => Some(s"$tag / $tools / ${shape.label}: no expectation")
+        dispatch <- TurnDispatch.values.toList
+        where = s"$tag / $tools / ${shape.label} / $dispatch"
+        problem <- expected
+          .get((tools, shape, dispatch))
+          .flatMap(_.get(tag)) match
+          case None => Some(s"$where: no expectation")
           case Some(want) =>
             declared
-              .get((tag, tools, shape))
+              .get((tag, tools, shape, dispatch))
               .filter(_ != want)
-              .map(got =>
-                s"$tag / $tools / ${shape.label}: want $want, got $got"
-              )
+              .map(got => s"$where: want $want, got $got")
       yield problem
       assert(problems.isEmpty, problems.mkString("\n"))
 
-  test("AGENTS.md carries the table rendered from the declared cells"):
+  test("AGENTS.md carries the block rendered from the declared cells"):
     withDeclared: declared =>
-      val table = renderTable(declared)
+      val block = renderBlock(declared)
       assert(
-        agentsMd.contains(table),
-        s"AGENTS.md's enforcement table is stale — replace it with:\n\n$table"
+        agentsMd.contains(block),
+        s"AGENTS.md's enforcement block is stale — replace it with:\n\n$block"
       )
 
-  /** The declared level for every (backend, tools, approve shape). */
+  /** The declared level for every (backend, tools, approve shape, dispatch). */
   private def withDeclared[A](
-      use: Map[(BackendTag, ToolSet, ApproveShape), Enforcement] => A
+      use: Map[
+        (BackendTag, ToolSet, ApproveShape, TurnDispatch),
+        Enforcement
+      ] => A
   ): A =
     supervised:
       val cli = new StubCliRunner()
@@ -163,37 +194,66 @@ class EnforcementTableTest extends munit.FunSuite:
           backend <- backends
           tools <- ToolSet.values.toList
           shape <- ApproveShape.values.toList
-        yield (backend.tag, tools, shape) ->
-          backend.enforcementCell(tools, shape.sample).level).toMap
+          dispatch <- TurnDispatch.values.toList
+        yield (backend.tag, tools, shape, dispatch) ->
+          backend.enforcementCell(tools, shape.sample, dispatch).level).toMap
       )
 
-  /** Renders the matrix as the markdown block AGENTS.md carries: one column per
-    * backend, one row per run of approve shapes that classify identically on
-    * every backend (`*` when all of them do, which is why the read-only tiers
-    * are one row each). Indented two spaces to sit inside AGENTS.md's bullet.
+  /** Renders the markdown block AGENTS.md carries: the fresh-turn table, then
+    * the resumed turns that classify differently. Indented two spaces, which is
+    * where it sits inside AGENTS.md's bullet.
+    *
+    * Table rows collapse approve shapes that classify identically on every
+    * backend AND both dispatches (`*` when all of them do), so a shape that
+    * only differs on resume can't hide inside a merged row.
     */
-  private def renderTable(
-      declared: Map[(BackendTag, ToolSet, ApproveShape), Enforcement]
+  private def renderBlock(
+      declared: Map[
+        (BackendTag, ToolSet, ApproveShape, TurnDispatch),
+        Enforcement
+      ]
   ): String =
-    def levels(tools: ToolSet, shape: ApproveShape): List[String] =
-      BackendTag.values.toList.map(tag =>
-        declared((tag, tools, shape)).toString
-      )
+    def levels(
+        tools: ToolSet,
+        shape: ApproveShape,
+        dispatch: TurnDispatch
+    ): List[String] =
+      BackendTag.values.toList.map(declared(_, tools, shape, dispatch).toString)
+    def bothDispatches(tools: ToolSet, shape: ApproveShape): List[String] =
+      TurnDispatch.values.toList.flatMap(levels(tools, shape, _))
+
+    val runs = for
+      tools <- ToolSet.values.toList
+      run <- shapeRuns(tools, bothDispatches)
+    yield (tools, run)
 
     val header = "tools, approve" :: BackendTag.values.toList.map(_.wireName)
-    val body = for
-      tools <- ToolSet.values.toList
-      group <- shapeRuns(tools, levels)
-    yield s"$tools, ${runLabel(group)}" :: levels(tools, group.head)
-
+    val body = runs.map: (tools, run) =>
+      s"$tools, ${runLabel(run)}" ::
+        levels(tools, run.head, TurnDispatch.Fresh)
     val widths = (header :: body).transpose.map(_.map(_.length).max)
     def line(cells: List[String]) =
       cells
         .zip(widths)
-        .map((c, w) => c.padTo(w, ' '))
+        .map((cell, width) => cell.padTo(width, ' '))
         .mkString("  | ", " | ", " |")
     val separator = widths.map(w => "-" * (w + 2)).mkString("  |", "|", "|")
-    (line(header) :: separator :: body.map(line)).mkString("\n")
+    val table = (line(header) :: separator :: body.map(line)).mkString("\n")
+
+    val deltas = for
+      (tools, run) <- runs
+      tag <- BackendTag.values.toList
+      fresh = declared((tag, tools, run.head, TurnDispatch.Fresh))
+      resumed = declared((tag, tools, run.head, TurnDispatch.Resumed))
+      if fresh != resumed
+    yield s"  - ${tag.wireName}, $tools, ${runLabel(run)}: $resumed, not $fresh"
+    val note =
+      if deltas.isEmpty then "  A resumed turn is classified the same."
+      else
+        ("  A resumed turn is classified the same, except:" :: deltas)
+          .mkString("\n")
+
+    s"$table\n\n$note"
 
   /** Consecutive approve shapes whose whole row of levels is identical, so the
     * rendered table collapses them into one row.

--- a/runner/src/test/scala/orca/runner/EnforcementTableTest.scala
+++ b/runner/src/test/scala/orca/runner/EnforcementTableTest.scala
@@ -1,6 +1,6 @@
 package orca.runner
 
-import orca.agents.{AutoApprove, Enforcement, ToolSet}
+import orca.agents.{AutoApprove, BackendTag, Enforcement, ToolSet}
 import orca.backend.AgentBackend
 import orca.subprocess.StubCliRunner
 import orca.tools.claude.ClaudeBackend
@@ -12,77 +12,214 @@ import orca.tools.pi.PiBackend
 import ox.supervised
 import orca.testkit.TempDirs
 
+/** The [[AutoApprove]] values the matrix distinguishes. `Only` is split by
+  * emptiness because "pre-approve nothing" is a shape some backends encode as
+  * no flag at all, and it would otherwise go untested.
+  */
+private enum ApproveShape(val label: String, val sample: AutoApprove):
+  case All extends ApproveShape("All", AutoApprove.All)
+  case OnlySome extends ApproveShape("Only(_)", AutoApprove.Only(Set("Read")))
+  case OnlyEmpty extends ApproveShape("Only()", AutoApprove.Only(Set.empty))
+
 /** Machine-checked source of truth for the per-backend enforcement matrix (the
-  * `Enforcement` a `(ToolSet, AutoApprove)` combination gets on each backend).
-  * The rendered table lives in `AGENTS.md`; this test is what keeps it honest.
+  * `Enforcement` a `(ToolSet, AutoApprove)` combination gets on each backend),
+  * and the renderer of the table AGENTS.md carries.
   *
-  * Every backend's `enforcement` is a pure function delegating to its
-  * `*Args.enforcement`, so construction is cheap: a [[StubCliRunner]] the
-  * method never touches. opencode builds its server object eagerly but the
-  * process spawn stays lazy, so the [[StubCliRunner]] is never spawned.
+  * The expectations below are deliberately a second, hand-written copy of what
+  * the backends declare: editing a backend's cell without editing its row here
+  * fails. The product is walked in full, so a new `BackendTag`, `ToolSet`, or
+  * approve shape fails the moment its enum grows rather than going silently
+  * unchecked.
+  *
+  * Every backend's `enforcementCell` is a pure function delegating to its
+  * `*Args`, so construction is cheap: a [[StubCliRunner]] the method never
+  * touches. opencode builds its server object eagerly but the process spawn
+  * stays lazy, so the [[StubCliRunner]] is never spawned.
   */
 class EnforcementTableTest extends munit.FunSuite:
 
-  private val onlyEmpty: AutoApprove = AutoApprove.Only(Set.empty)
-  private val onlySome: AutoApprove = AutoApprove.Only(Set("Read"))
+  import Enforcement.*
 
-  test("every backend maps (tools, autoApprove) to the documented enforcement"):
+  /** One expected row, by backend. Named arguments at the call sites, and a
+    * signature a sixth backend has to widen, keep the columns from drifting.
+    */
+  private def row(
+      claude: Enforcement,
+      codex: Enforcement,
+      gemini: Enforcement,
+      opencode: Enforcement,
+      pi: Enforcement
+  ): Map[BackendTag, Enforcement] =
+    Map(
+      BackendTag.ClaudeCode -> claude,
+      BackendTag.Codex -> codex,
+      BackendTag.Gemini -> gemini,
+      BackendTag.Opencode -> opencode,
+      BackendTag.Pi -> pi
+    )
+
+  private val readOnlyRow: Map[BackendTag, Enforcement] = row(
+    claude = Hard,
+    codex = Hard,
+    gemini = PromptOnly,
+    opencode = Hard,
+    pi = Hard
+  )
+
+  private val networkOnlyRow: Map[BackendTag, Enforcement] = row(
+    claude = Hard,
+    codex = PromptOnly,
+    gemini = PromptOnly,
+    opencode = Hard,
+    pi = PromptOnly
+  )
+
+  private val fullOnlyRow: Map[BackendTag, Enforcement] = row(
+    claude = Hard,
+    codex = SandboxApprox,
+    gemini = Ignored,
+    opencode = Ignored,
+    pi = Ignored
+  )
+
+  private val expected
+      : Map[(ToolSet, ApproveShape), Map[BackendTag, Enforcement]] =
+    Map(
+      // ReadOnly / NetworkOnly ignore autoApprove on every backend, so their
+      // three rows agree by construction — pinned, not assumed.
+      (ToolSet.ReadOnly, ApproveShape.All) ->
+        readOnlyRow,
+      (ToolSet.ReadOnly, ApproveShape.OnlySome) ->
+        readOnlyRow,
+      (ToolSet.ReadOnly, ApproveShape.OnlyEmpty) ->
+        readOnlyRow,
+      (ToolSet.NetworkOnly, ApproveShape.All) ->
+        networkOnlyRow,
+      (ToolSet.NetworkOnly, ApproveShape.OnlySome) ->
+        networkOnlyRow,
+      (ToolSet.NetworkOnly, ApproveShape.OnlyEmpty) ->
+        networkOnlyRow,
+      (ToolSet.Full, ApproveShape.All) -> row(
+        claude = Hard,
+        codex = Hard,
+        gemini = Hard,
+        opencode = Ignored,
+        pi = Ignored
+      ),
+      (ToolSet.Full, ApproveShape.OnlySome) ->
+        fullOnlyRow,
+      (ToolSet.Full, ApproveShape.OnlyEmpty) ->
+        fullOnlyRow
+    )
+
+  test("every backend tag has a backend wired into the matrix"):
+    withDeclared: declared =>
+      val wired = declared.keySet.map(_._1)
+      assertEquals(wired, BackendTag.values.toSet)
+
+  test("every cell of the product matches what its backend declares"):
+    withDeclared: declared =>
+      // Collect every divergence and fail once with the full list, so one run
+      // surfaces all of them rather than stopping at the first.
+      val problems = for
+        tag <- BackendTag.values.toList
+        tools <- ToolSet.values.toList
+        shape <- ApproveShape.values.toList
+        problem <- expected.get((tools, shape)).flatMap(_.get(tag)) match
+          case None => Some(s"$tag / $tools / ${shape.label}: no expectation")
+          case Some(want) =>
+            declared
+              .get((tag, tools, shape))
+              .filter(_ != want)
+              .map(got =>
+                s"$tag / $tools / ${shape.label}: want $want, got $got"
+              )
+      yield problem
+      assert(problems.isEmpty, problems.mkString("\n"))
+
+  test("AGENTS.md carries the table rendered from the declared cells"):
+    withDeclared: declared =>
+      val table = renderTable(declared)
+      assert(
+        agentsMd.contains(table),
+        s"AGENTS.md's enforcement table is stale — replace it with:\n\n$table"
+      )
+
+  /** The declared level for every (backend, tools, approve shape). */
+  private def withDeclared[A](
+      use: Map[(BackendTag, ToolSet, ApproveShape), Enforcement] => A
+  ): A =
     supervised:
       val cli = new StubCliRunner()
-      val backends: List[(String, AgentBackend[?])] = List(
-        "claude" -> new ClaudeBackend(cli),
-        "codex" -> new CodexBackend(cli),
-        "gemini" -> new GeminiBackend(cli),
-        "opencode" -> OpencodeBackend(cli, TempDirs.dir()),
-        "pi" -> PiBackend.forInspection(cli)
+      val backends = List[AgentBackend[?]](
+        new ClaudeBackend(cli),
+        new CodexBackend(cli),
+        new GeminiBackend(cli),
+        OpencodeBackend(cli, TempDirs.dir()),
+        PiBackend.forInspection(cli)
       )
-      def get(name: String): AgentBackend[?] =
-        backends.collectFirst { case (n, b) if n == name => b }.get
+      use(
+        (for
+          backend <- backends
+          tools <- ToolSet.values.toList
+          shape <- ApproveShape.values.toList
+        yield (backend.tag, tools, shape) ->
+          backend.enforcementCell(tools, shape.sample).level).toMap
+      )
 
-      import Enforcement.*
-      import AutoApprove.All
-      // (backend, tools, autoApprove, expected)
-      val cases: List[(String, ToolSet, AutoApprove, Enforcement)] = List(
-        // ReadOnly, * — hard no-edit everywhere except gemini, whose plan mode
-        // has never been measured against a write attempt.
-        ("claude", ToolSet.ReadOnly, All, Hard),
-        ("codex", ToolSet.ReadOnly, All, Hard),
-        ("gemini", ToolSet.ReadOnly, All, PromptOnly),
-        ("opencode", ToolSet.ReadOnly, All, Hard),
-        ("pi", ToolSet.ReadOnly, All, Hard),
-        // NetworkOnly, * — codex/pi grant network via a writable shell.
-        ("claude", ToolSet.NetworkOnly, All, Hard),
-        ("codex", ToolSet.NetworkOnly, All, PromptOnly),
-        ("gemini", ToolSet.NetworkOnly, All, PromptOnly),
-        ("opencode", ToolSet.NetworkOnly, All, Hard),
-        ("pi", ToolSet.NetworkOnly, All, PromptOnly),
-        // Full, All
-        ("claude", ToolSet.Full, All, Hard),
-        ("codex", ToolSet.Full, All, Hard),
-        ("gemini", ToolSet.Full, All, Hard),
-        ("opencode", ToolSet.Full, All, Ignored),
-        ("pi", ToolSet.Full, All, Ignored),
-        // Full, Only(_)
-        ("claude", ToolSet.Full, onlySome, Hard),
-        ("codex", ToolSet.Full, onlySome, SandboxApprox),
-        ("gemini", ToolSet.Full, onlySome, Ignored),
-        ("opencode", ToolSet.Full, onlySome, Ignored),
-        ("pi", ToolSet.Full, onlySome, Ignored),
-        // Full, Only(empty) — same tier as Only(_).
-        ("claude", ToolSet.Full, onlyEmpty, Hard),
-        ("codex", ToolSet.Full, onlyEmpty, SandboxApprox),
-        ("gemini", ToolSet.Full, onlyEmpty, Ignored),
-        ("opencode", ToolSet.Full, onlyEmpty, Ignored),
-        ("pi", ToolSet.Full, onlyEmpty, Ignored)
+  /** Renders the matrix as the markdown block AGENTS.md carries: one column per
+    * backend, one row per run of approve shapes that classify identically on
+    * every backend (`*` when all of them do, which is why the read-only tiers
+    * are one row each). Indented two spaces to sit inside AGENTS.md's bullet.
+    */
+  private def renderTable(
+      declared: Map[(BackendTag, ToolSet, ApproveShape), Enforcement]
+  ): String =
+    def levels(tools: ToolSet, shape: ApproveShape): List[String] =
+      BackendTag.values.toList.map(tag =>
+        declared((tag, tools, shape)).toString
       )
-      // Collect every mismatched cell and fail once with the full list, so one
-      // run surfaces all divergences rather than stopping at the first.
-      val mismatches = cases.flatMap: (name, tools, approve, expected) =>
-        val actual = get(name).enforcement(tools, approve)
-        Option.when(actual != expected)(
-          s"$name / $tools / $approve: expected $expected, got $actual"
-        )
-      assert(
-        mismatches.isEmpty,
-        s"enforcement matrix mismatches:\n${mismatches.mkString("\n")}"
-      )
+
+    val header = "tools, approve" :: BackendTag.values.toList.map(_.wireName)
+    val body = for
+      tools <- ToolSet.values.toList
+      group <- shapeRuns(tools, levels)
+    yield s"$tools, ${runLabel(group)}" :: levels(tools, group.head)
+
+    val widths = (header :: body).transpose.map(_.map(_.length).max)
+    def line(cells: List[String]) =
+      cells
+        .zip(widths)
+        .map((c, w) => c.padTo(w, ' '))
+        .mkString("  | ", " | ", " |")
+    val separator = widths.map(w => "-" * (w + 2)).mkString("  |", "|", "|")
+    (line(header) :: separator :: body.map(line)).mkString("\n")
+
+  /** Consecutive approve shapes whose whole row of levels is identical, so the
+    * rendered table collapses them into one row.
+    */
+  private def shapeRuns(
+      tools: ToolSet,
+      levels: (ToolSet, ApproveShape) => List[String]
+  ): List[List[ApproveShape]] =
+    ApproveShape.values.toList.foldLeft(List.empty[List[ApproveShape]]):
+      (runs, shape) =>
+        runs.lastOption match
+          case Some(run) if levels(tools, run.head) == levels(tools, shape) =>
+            runs.init :+ (run :+ shape)
+          case _ => runs :+ List(shape)
+
+  private def runLabel(run: List[ApproveShape]): String =
+    if run.sizeIs == ApproveShape.values.length then "*"
+    else run.map(_.label).mkString(" / ")
+
+  /** AGENTS.md's text. sbt forks tests with the module directory as the working
+    * directory, so the repository root is found by walking up.
+    */
+  private def agentsMd: String =
+    val root = Iterator
+      .iterate(os.pwd)(_ / os.up)
+      .takeWhile(_ != os.root)
+      .find(dir => os.exists(dir / "AGENTS.md"))
+      .getOrElse(fail(s"no AGENTS.md above ${os.pwd}"))
+    os.read(root / "AGENTS.md")

--- a/runner/src/test/scala/orca/runner/EnforcementTableTest.scala
+++ b/runner/src/test/scala/orca/runner/EnforcementTableTest.scala
@@ -58,20 +58,9 @@ class EnforcementTableTest extends munit.FunSuite:
       BackendTag.Pi -> pi
     )
 
-  private val readOnlyFresh: Map[BackendTag, Enforcement] = row(
+  private val readOnly: Map[BackendTag, Enforcement] = row(
     claude = Hard,
     codex = Hard,
-    gemini = PromptOnly,
-    opencode = Hard,
-    pi = Hard
-  )
-
-  /** codex `exec resume` takes no sandbox flag, so its read-only tiers fall
-    * back to the prompt on a resumed turn.
-    */
-  private val readOnlyResumed: Map[BackendTag, Enforcement] = row(
-    claude = Hard,
-    codex = PromptOnly,
     gemini = PromptOnly,
     opencode = Hard,
     pi = Hard
@@ -117,9 +106,11 @@ class EnforcementTableTest extends munit.FunSuite:
       shape <- ApproveShape.values.toList
       // The read-only tiers ignore autoApprove on every backend, so one row
       // stands for all three shapes — pinned by the product walk, not assumed.
+      // Both read-only tiers now answer the same on either dispatch: codex
+      // re-applies their sandbox on resume rather than inheriting one.
       entry <- List(
-        (ToolSet.ReadOnly, shape, TurnDispatch.Fresh) -> readOnlyFresh,
-        (ToolSet.ReadOnly, shape, TurnDispatch.Resumed) -> readOnlyResumed,
+        (ToolSet.ReadOnly, shape, TurnDispatch.Fresh) -> readOnly,
+        (ToolSet.ReadOnly, shape, TurnDispatch.Resumed) -> readOnly,
         (ToolSet.NetworkOnly, shape, TurnDispatch.Fresh) -> networkOnly,
         (ToolSet.NetworkOnly, shape, TurnDispatch.Resumed) -> networkOnly
       )

--- a/runner/src/test/scala/orca/runner/LeadAgentIdentityTest.scala
+++ b/runner/src/test/scala/orca/runner/LeadAgentIdentityTest.scala
@@ -10,6 +10,7 @@ import orca.agents.{
   ClaudeAgent,
   CodexAgent,
   Enforcement,
+  EnforcementCell,
   AgentCall,
   GeminiAgent,
   JsonData,
@@ -299,8 +300,11 @@ class LeadAgentIdentityTest extends munit.FunSuite:
     val sessions: SessionSupport[BackendTag.Pi.type] =
       SessionSupport.ephemeral(IdScheme.ClientClaimed)
     val tag: BackendTag.Pi.type = BackendTag.Pi
-    def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
-      Enforcement.Ignored
+    def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove
+    ): EnforcementCell =
+      EnforcementCell(Enforcement.Ignored, "test double")
     def structuredOutputMode: orca.agents.StructuredOutputMode =
       orca.agents.StructuredOutputMode.RawText
 

--- a/runner/src/test/scala/orca/runner/LeadAgentIdentityTest.scala
+++ b/runner/src/test/scala/orca/runner/LeadAgentIdentityTest.scala
@@ -11,6 +11,7 @@ import orca.agents.{
   CodexAgent,
   Enforcement,
   EnforcementCell,
+  TurnDispatch,
   AgentCall,
   GeminiAgent,
   JsonData,
@@ -302,9 +303,10 @@ class LeadAgentIdentityTest extends munit.FunSuite:
     val tag: BackendTag.Pi.type = BackendTag.Pi
     def enforcementCell(
         tools: ToolSet,
-        autoApprove: AutoApprove
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Ignored, "test double")
+      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
     def structuredOutputMode: orca.agents.StructuredOutputMode =
       orca.agents.StructuredOutputMode.RawText
 

--- a/runner/src/test/scala/orca/runner/LeadAgentIdentityTest.scala
+++ b/runner/src/test/scala/orca/runner/LeadAgentIdentityTest.scala
@@ -1,5 +1,6 @@
 package orca.runner
 
+import orca.testkit.StubEnforcement
 import orca.{AgentSet, OrcaArgs, StackSettings, flow, runFlow}
 import orca.agents.{
   AgentConfig,
@@ -9,7 +10,6 @@ import orca.agents.{
   BackendTag,
   ClaudeAgent,
   CodexAgent,
-  Enforcement,
   EnforcementCell,
   TurnDispatch,
   AgentCall,
@@ -306,7 +306,7 @@ class LeadAgentIdentityTest extends munit.FunSuite:
         autoApprove: AutoApprove,
         dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
+      StubEnforcement.cell
     def structuredOutputMode: orca.agents.StructuredOutputMode =
       orca.agents.StructuredOutputMode.RawText
 

--- a/runner/src/test/scala/orca/runner/OpencodeFlowTest.scala
+++ b/runner/src/test/scala/orca/runner/OpencodeFlowTest.scala
@@ -1,5 +1,6 @@
 package orca.runner
 
+import orca.testkit.StubEnforcement
 import orca.{FlowContext, OrcaArgs, StackSettings, flow}
 import orca.backend.{
   Conversation,
@@ -18,7 +19,6 @@ import orca.agents.{
   AutoApprove,
   BackendTag,
   DefaultPrompts,
-  Enforcement,
   EnforcementCell,
   TurnDispatch,
   InteractiveAgentCall,
@@ -127,7 +127,7 @@ class OpencodeFlowTest extends munit.FunSuite:
         autoApprove: AutoApprove,
         dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
+      StubEnforcement.cell
     def structuredOutputMode: orca.agents.StructuredOutputMode =
       orca.agents.StructuredOutputMode.RawText
 

--- a/runner/src/test/scala/orca/runner/OpencodeFlowTest.scala
+++ b/runner/src/test/scala/orca/runner/OpencodeFlowTest.scala
@@ -20,6 +20,7 @@ import orca.agents.{
   DefaultPrompts,
   Enforcement,
   EnforcementCell,
+  TurnDispatch,
   InteractiveAgentCall,
   JsonData,
   AgentCall,
@@ -123,9 +124,10 @@ class OpencodeFlowTest extends munit.FunSuite:
     val tag: BackendTag.Opencode.type = BackendTag.Opencode
     def enforcementCell(
         tools: ToolSet,
-        autoApprove: AutoApprove
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Ignored, "test double")
+      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
     def structuredOutputMode: orca.agents.StructuredOutputMode =
       orca.agents.StructuredOutputMode.RawText
 

--- a/runner/src/test/scala/orca/runner/OpencodeFlowTest.scala
+++ b/runner/src/test/scala/orca/runner/OpencodeFlowTest.scala
@@ -19,6 +19,7 @@ import orca.agents.{
   BackendTag,
   DefaultPrompts,
   Enforcement,
+  EnforcementCell,
   InteractiveAgentCall,
   JsonData,
   AgentCall,
@@ -120,8 +121,11 @@ class OpencodeFlowTest extends munit.FunSuite:
     val sessions: SessionSupport[BackendTag.Opencode.type] =
       SessionSupport.ephemeral(IdScheme.ClientClaimed)
     val tag: BackendTag.Opencode.type = BackendTag.Opencode
-    def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
-      Enforcement.Ignored
+    def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove
+    ): EnforcementCell =
+      EnforcementCell(Enforcement.Ignored, "test double")
     def structuredOutputMode: orca.agents.StructuredOutputMode =
       orca.agents.StructuredOutputMode.RawText
 

--- a/tools/src/main/resources/orca/backend/prompts/readonly-turn.md
+++ b/tools/src/main/resources/orca/backend/prompts/readonly-turn.md
@@ -1,0 +1,1 @@
+This turn is read-only: do not create, edit, or delete files, and do not run commands that modify state — read, analyse, and report your findings instead.

--- a/tools/src/main/scala/orca/agents/AgentCall.scala
+++ b/tools/src/main/scala/orca/agents/AgentCall.scala
@@ -151,6 +151,21 @@ class DefaultAgentCall[B <: BackendTag, O](
       checkNotClosed()
       runInteractiveOnce(input, config, session)
 
+  /** Structured turns reach the backend here rather than through `BaseAgent`,
+    * so the notice has to be raised on this path too; the deduplication is
+    * shared, since both read the same backend instance.
+    */
+  private def announceEnforcementShortfall(
+      effective: AgentConfig,
+      session: SessionId[B]
+  ): Unit =
+    EnforcementNotice.announceShortfall(
+      backend,
+      effective,
+      backend.sessions.dispatchFor(session).turn,
+      events
+    )
+
   /** Emit a `StructuredResult` event carrying the raw payload and the
     * `Announce[O]`-derived summary — tri-state per
     * [[orca.events.OrcaEvent.StructuredResult]].
@@ -192,6 +207,7 @@ class DefaultAgentCall[B <: BackendTag, O](
   )(using ai: AgentInput[I]): O =
     val serialized = ai.serialize(input)
     val effective = effectiveConfig(config)
+    announceEnforcementShortfall(effective, session)
     val initialPrompt = prompts.autonomous(
       serialized,
       outputSchema,
@@ -313,6 +329,7 @@ class DefaultAgentCall[B <: BackendTag, O](
   )(using ai: AgentInput[I]): O =
     val serialized = ai.serialize(input)
     val effective = effectiveConfig(config)
+    announceEnforcementShortfall(effective, session)
     val prompt = prompts.interactive(serialized, outputSchema, effective)
     // Per-turn structured-concurrency scope: `runInteractive` forks its workers
     // into this Ox, `drive` consumes them, and `cancel` (in the `finally`) tears

--- a/tools/src/main/scala/orca/agents/AgentCall.scala
+++ b/tools/src/main/scala/orca/agents/AgentCall.scala
@@ -151,21 +151,6 @@ class DefaultAgentCall[B <: BackendTag, O](
       checkNotClosed()
       runInteractiveOnce(input, config, session)
 
-  /** Structured turns reach the backend here rather than through `BaseAgent`,
-    * so the notice has to be raised on this path too; the deduplication is
-    * shared, since both read the same backend instance.
-    */
-  private def announceEnforcementShortfall(
-      effective: AgentConfig,
-      session: SessionId[B]
-  ): Unit =
-    EnforcementNotice.announceShortfall(
-      backend,
-      effective,
-      backend.sessions.dispatchFor(session).asTurnDispatch,
-      events
-    )
-
   /** Emit a `StructuredResult` event carrying the raw payload and the
     * `Announce[O]`-derived summary — tri-state per
     * [[orca.events.OrcaEvent.StructuredResult]].
@@ -254,7 +239,7 @@ class DefaultAgentCall[B <: BackendTag, O](
       // Per attempt, not once per call: the first attempt commits the session,
       // so a corrective re-prompt runs as `Resumed` — which is a different
       // guarantee on codex.
-      announceEnforcementShortfall(effective, session)
+      backend.announceEnforcementShortfall(effective, session, events)
       val promptText = lastFailure match
         case Some(f) =>
           val corrective = prompts.retry(f.response, f.parserError)
@@ -332,7 +317,7 @@ class DefaultAgentCall[B <: BackendTag, O](
   )(using ai: AgentInput[I]): O =
     val serialized = ai.serialize(input)
     val effective = effectiveConfig(config)
-    announceEnforcementShortfall(effective, session)
+    backend.announceEnforcementShortfall(effective, session, events)
     val prompt = prompts.interactive(serialized, outputSchema, effective)
     // Per-turn structured-concurrency scope: `runInteractive` forks its workers
     // into this Ox, `drive` consumes them, and `cancel` (in the `finally`) tears

--- a/tools/src/main/scala/orca/agents/AgentCall.scala
+++ b/tools/src/main/scala/orca/agents/AgentCall.scala
@@ -207,7 +207,6 @@ class DefaultAgentCall[B <: BackendTag, O](
   )(using ai: AgentInput[I]): O =
     val serialized = ai.serialize(input)
     val effective = effectiveConfig(config)
-    announceEnforcementShortfall(effective, session)
     val initialPrompt = prompts.autonomous(
       serialized,
       outputSchema,
@@ -252,6 +251,10 @@ class DefaultAgentCall[B <: BackendTag, O](
       * can drive a corrective re-prompt loop around repeated calls to this.
       */
     def attemptOnce(): O =
+      // Per attempt, not once per call: the first attempt commits the session,
+      // so a corrective re-prompt runs as `Resumed` — which is a different
+      // guarantee on codex.
+      announceEnforcementShortfall(effective, session)
       val promptText = lastFailure match
         case Some(f) =>
           val corrective = prompts.retry(f.response, f.parserError)

--- a/tools/src/main/scala/orca/agents/AgentCall.scala
+++ b/tools/src/main/scala/orca/agents/AgentCall.scala
@@ -162,7 +162,7 @@ class DefaultAgentCall[B <: BackendTag, O](
     EnforcementNotice.announceShortfall(
       backend,
       effective,
-      backend.sessions.dispatchFor(session).turn,
+      backend.sessions.dispatchFor(session).asTurnDispatch,
       events
     )
 

--- a/tools/src/main/scala/orca/agents/AgentConfig.scala
+++ b/tools/src/main/scala/orca/agents/AgentConfig.scala
@@ -54,50 +54,6 @@ enum AutoApprove:
   case All
   case Only(tools: Set[String])
 
-/** How strongly a backend enforces the restriction a `(ToolSet, AutoApprove)`
-  * combination requests. For the read-only tiers the restriction is "no
-  * edits/shell"; for `Full` it is the approval policy itself.
-  *
-  *   - Hard — mechanically blocked (permission mode, sandbox, tool allowlist).
-  *     The gated boundary may sit at a documented SUPERSET of the request; the
-  *     cell's `rationale` says so where it does.
-  *   - SandboxApprox — approximated by a coarser sandbox; semantics widened.
-  *   - PromptOnly — only the prompt forbids it; the tools can physically do it.
-  *     [[orca.backend.SystemPromptComposer.ReadOnlyTurn]] is what puts that
-  *     prose on every read-only turn.
-  *   - Ignored — not encoded at all; behaviour depends on backend/server
-  *     configuration outside orca's control.
-  *
-  * This is the canonical statement of what the levels mean; the per-backend
-  * mapping is machine-checked in `runner/.../EnforcementTableTest.scala`, and
-  * per-cell rationale lives in each backend's `*Args.enforcementCell`.
-  */
-enum Enforcement:
-  case Hard, SandboxApprox, PromptOnly, Ignored
-
-/** Whether a turn starts a backend session or continues one — the second axis
-  * of the enforcement matrix, alongside `(ToolSet, AutoApprove)`. It matters
-  * because a backend may put its restriction flags on the spawn only: codex
-  * `exec resume` rejects `--sandbox`/`--full-auto`, so a resumed turn runs in
-  * the sandbox its session was created with, whatever tier the caller asked
-  * for.
-  *
-  * Derived from [[orca.backend.Dispatch]], which carries the wire ids this
-  * classification has no use for.
-  */
-enum TurnDispatch:
-  case Fresh, Resumed
-
-/** A backend's answer for one cell of the enforcement matrix: the level, and
-  * why it is that level. One value rather than two, so a backend whose flags
-  * change cannot have its level updated while a stale reason stays beside it.
-  *
-  * `rationale` is a single unwrapped sentence or two naming the mechanism (the
-  * flag, sandbox, or absence of one) that produces `level`. It is the only home
-  * for that text: AGENTS.md's table is rendered from the levels alone.
-  */
-case class EnforcementCell(level: Enforcement, rationale: String)
-
 /** The set of tools available to the agent — the capability tier on
   * [[AgentConfig.tools]]:
   *
@@ -117,8 +73,8 @@ enum ToolSet:
   case NetworkOnly
   case Full
 
-  /** Whether the tier hands the agent a write primitive, and so whether asking
-    * for it is asking for a no-edit gate at all.
+  /** Whether the tier hands the agent a write primitive at all. `false` is a
+    * caller asking for a no-edit gate; `true` asks for none.
     */
   def writeCapable: Boolean = this match
     case Full                   => true

--- a/tools/src/main/scala/orca/agents/AgentConfig.scala
+++ b/tools/src/main/scala/orca/agents/AgentConfig.scala
@@ -59,17 +59,33 @@ enum AutoApprove:
   * edits/shell"; for `Full` it is the approval policy itself.
   *
   *   - Hard — mechanically blocked (permission mode, sandbox, tool allowlist).
+  *     On `Full` the gated boundary may sit at a documented SUPERSET of the
+  *     request: claude's `--allowedTools` adds to its default permission mode's
+  *     approvals rather than confining the agent to the names listed, so the
+  *     approved set is those defaults ∪ the `Only` list.
   *   - SandboxApprox — approximated by a coarser sandbox; semantics widened.
   *   - PromptOnly — only the prompt forbids it; the tools can physically do it.
+  *     [[orca.backend.SystemPromptComposer.ReadOnlyTurn]] is what puts that
+  *     prose on every read-only turn.
   *   - Ignored — not encoded at all; behaviour depends on backend/server
   *     configuration outside orca's control.
   *
-  * The per-backend mapping is machine-checked in
-  * `runner/.../EnforcementTableTest.scala`; see each backend's
-  * `*Args.enforcement` for the per-cell rationale.
+  * This is the canonical statement of what the levels mean; the per-backend
+  * mapping is machine-checked in `runner/.../EnforcementTableTest.scala`, and
+  * per-cell rationale lives in each backend's `*Args.enforcementCell`.
   */
 enum Enforcement:
   case Hard, SandboxApprox, PromptOnly, Ignored
+
+/** A backend's answer for one cell of the enforcement matrix: the level, and
+  * why it is that level. One value rather than two, so a backend whose flags
+  * change cannot have its level updated while a stale reason stays beside it.
+  *
+  * `rationale` is a single unwrapped sentence or two naming the mechanism (the
+  * flag, sandbox, or absence of one) that produces `level`. It is the only home
+  * for that text: AGENTS.md's table is rendered from the levels alone.
+  */
+case class EnforcementCell(level: Enforcement, rationale: String)
 
 /** The set of tools available to the agent — the capability tier on
   * [[AgentConfig.tools]]:

--- a/tools/src/main/scala/orca/agents/AgentConfig.scala
+++ b/tools/src/main/scala/orca/agents/AgentConfig.scala
@@ -77,6 +77,19 @@ enum AutoApprove:
 enum Enforcement:
   case Hard, SandboxApprox, PromptOnly, Ignored
 
+/** Whether a turn starts a backend session or continues one — the second axis
+  * of the enforcement matrix, alongside `(ToolSet, AutoApprove)`. It matters
+  * because a backend may put its restriction flags on the spawn only: codex
+  * `exec resume` rejects `--sandbox`/`--full-auto`, so a resumed turn runs in
+  * the sandbox its session was created with, whatever tier the caller asked
+  * for.
+  *
+  * Derived from [[orca.backend.Dispatch]], which carries the wire ids this
+  * classification has no use for.
+  */
+enum TurnDispatch:
+  case Fresh, Resumed
+
 /** A backend's answer for one cell of the enforcement matrix: the level, and
   * why it is that level. One value rather than two, so a backend whose flags
   * change cannot have its level updated while a stale reason stays beside it.

--- a/tools/src/main/scala/orca/agents/AgentConfig.scala
+++ b/tools/src/main/scala/orca/agents/AgentConfig.scala
@@ -118,3 +118,18 @@ enum ToolSet:
   case ReadOnly
   case NetworkOnly
   case Full
+
+  /** Whether the tier hands the agent a write primitive, and so whether asking
+    * for it is asking for a no-edit gate at all.
+    */
+  def writeCapable: Boolean = this match
+    case Full                   => true
+    case ReadOnly | NetworkOnly => false
+
+  /** Whether the tier grants the SCOPED, read-only network access a planner
+    * needs — not "has network at all", which `Full` also does through its
+    * shell.
+    */
+  def hasScopedNetwork: Boolean = this match
+    case NetworkOnly     => true
+    case ReadOnly | Full => false

--- a/tools/src/main/scala/orca/agents/AgentConfig.scala
+++ b/tools/src/main/scala/orca/agents/AgentConfig.scala
@@ -59,10 +59,8 @@ enum AutoApprove:
   * edits/shell"; for `Full` it is the approval policy itself.
   *
   *   - Hard — mechanically blocked (permission mode, sandbox, tool allowlist).
-  *     On `Full` the gated boundary may sit at a documented SUPERSET of the
-  *     request: claude's `--allowedTools` adds to its default permission mode's
-  *     approvals rather than confining the agent to the names listed, so the
-  *     approved set is those defaults ∪ the `Only` list.
+  *     The gated boundary may sit at a documented SUPERSET of the request; the
+  *     cell's `rationale` says so where it does.
   *   - SandboxApprox — approximated by a coarser sandbox; semantics widened.
   *   - PromptOnly — only the prompt forbids it; the tools can physically do it.
   *     [[orca.backend.SystemPromptComposer.ReadOnlyTurn]] is what puts that

--- a/tools/src/main/scala/orca/agents/BaseAgent.scala
+++ b/tools/src/main/scala/orca/agents/BaseAgent.scala
@@ -108,6 +108,7 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
       )(using orca.InStage): String =
         checkNotClosed()
         val effective = effectiveConfig(callConfig)
+        announceEnforcementShortfall(effective, session)
         if emitPrompt then events.onEvent(OrcaEvent.UserPrompt(prompt))
         val result =
           runAccountingForFailure(effective, session):
@@ -131,6 +132,7 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
         case _: OrcaEvent.AssistantMessage | _: OrcaEvent.ToolUse => ()
         case other => events.onEvent(other)
     val session = SessionId.fresh[B]
+    announceEnforcementShortfall(effective, session)
     val result =
       runAccountingForFailure(effective, session):
         backend.runAutonomous(
@@ -152,6 +154,20 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
       interaction,
       agentName = name,
       agentRole = role
+    )
+
+  /** The dispatch is resolved the same way the backend will resolve it moments
+    * later, since on codex it decides the answer.
+    */
+  private def announceEnforcementShortfall(
+      effective: AgentConfig,
+      session: SessionId[B]
+  ): Unit =
+    EnforcementNotice.announceShortfall(
+      backend,
+      effective,
+      backend.sessions.dispatchFor(session).turn,
+      events
     )
 
   /** Run a backend turn, emitting the spend of a turn that fails after the

--- a/tools/src/main/scala/orca/agents/BaseAgent.scala
+++ b/tools/src/main/scala/orca/agents/BaseAgent.scala
@@ -166,7 +166,7 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
     EnforcementNotice.announceShortfall(
       backend,
       effective,
-      backend.sessions.dispatchFor(session).turn,
+      backend.sessions.dispatchFor(session).asTurnDispatch,
       events
     )
 

--- a/tools/src/main/scala/orca/agents/BaseAgent.scala
+++ b/tools/src/main/scala/orca/agents/BaseAgent.scala
@@ -108,7 +108,7 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
       )(using orca.InStage): String =
         checkNotClosed()
         val effective = effectiveConfig(callConfig)
-        announceEnforcementShortfall(effective, session)
+        backend.announceEnforcementShortfall(effective, session, events)
         if emitPrompt then events.onEvent(OrcaEvent.UserPrompt(prompt))
         val result =
           runAccountingForFailure(effective, session):
@@ -132,7 +132,7 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
         case _: OrcaEvent.AssistantMessage | _: OrcaEvent.ToolUse => ()
         case other => events.onEvent(other)
     val session = SessionId.fresh[B]
-    announceEnforcementShortfall(effective, session)
+    backend.announceEnforcementShortfall(effective, session, events)
     val result =
       runAccountingForFailure(effective, session):
         backend.runAutonomous(
@@ -154,20 +154,6 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
       interaction,
       agentName = name,
       agentRole = role
-    )
-
-  /** The dispatch is resolved the same way the backend will resolve it moments
-    * later, since on codex it decides the answer.
-    */
-  private def announceEnforcementShortfall(
-      effective: AgentConfig,
-      session: SessionId[B]
-  ): Unit =
-    EnforcementNotice.announceShortfall(
-      backend,
-      effective,
-      backend.sessions.dispatchFor(session).asTurnDispatch,
-      events
     )
 
   /** Run a backend turn, emitting the spend of a turn that fails after the

--- a/tools/src/main/scala/orca/agents/Enforcement.scala
+++ b/tools/src/main/scala/orca/agents/Enforcement.scala
@@ -1,0 +1,51 @@
+package orca.agents
+
+/** How strongly a backend enforces the restriction a `(ToolSet, AutoApprove)`
+  * combination requests. For the read-only tiers the restriction is "no
+  * edits/shell"; for `Full` it is the approval policy itself.
+  *
+  *   - Hard — mechanically blocked (permission mode, sandbox, tool allowlist).
+  *     The gated boundary may sit at a documented SUPERSET of the request; the
+  *     cell's `rationale` says so where it does.
+  *   - SandboxApprox — approximated by a coarser sandbox; semantics widened.
+  *     The line from a `Hard` cell with a documented superset is whether orca
+  *     can name the boundary the agent is held to: claude's additive allowlist
+  *     can (defaults ∪ the list), codex's swap to a whole-workspace sandbox
+  *     cannot.
+  *   - PromptOnly — only the prompt forbids it; the tools can physically do it.
+  *     [[orca.backend.SystemPromptComposer.ReadOnlyTurn]] is what puts that
+  *     prose on every read-only turn.
+  *   - Ignored — not encoded at all; behaviour depends on backend/server
+  *     configuration outside orca's control.
+  *
+  * This is the canonical statement of what the levels mean; the per-backend
+  * mapping is machine-checked in `runner/.../EnforcementTableTest.scala`, and
+  * per-cell rationale lives in each backend's `*Args.enforcementCell`.
+  */
+enum Enforcement:
+  case Hard, SandboxApprox, PromptOnly, Ignored
+
+/** A backend's answer for one cell of the enforcement matrix: the level, and
+  * why it is that level. One value rather than two, so a backend whose flags
+  * change cannot have its level updated while a stale reason stays beside it.
+  *
+  * `rationale` is a single unwrapped sentence or two naming the mechanism (the
+  * flag, sandbox, or absence of one) that produces `level`. It is the only home
+  * for that text: AGENTS.md's table is rendered from the levels alone, and
+  * [[EnforcementNotice]] puts the rationale in the log rather than in the
+  * user-facing line.
+  */
+case class EnforcementCell(level: Enforcement, rationale: String)
+
+/** Whether a turn starts a backend session or continues one — the second axis
+  * of the enforcement matrix, alongside `(ToolSet, AutoApprove)`. It matters
+  * because a backend may put its restriction flags on the spawn only: codex
+  * `exec resume` rejects `--sandbox`/`--full-auto`, so a resumed turn runs in
+  * the sandbox its session was created with, whatever tier the caller asked
+  * for.
+  *
+  * Derived from [[orca.backend.Dispatch]] by dropping the wire ids this
+  * classification has no use for.
+  */
+enum TurnDispatch:
+  case Fresh, Resumed

--- a/tools/src/main/scala/orca/agents/Enforcement.scala
+++ b/tools/src/main/scala/orca/agents/Enforcement.scala
@@ -25,6 +25,13 @@ package orca.agents
 enum Enforcement:
   case Hard, SandboxApprox, PromptOnly, Ignored
 
+  /** Whether `this` promises less than `other`. The cases are declared
+    * strongest first — a mechanical block, a mechanical block with widened
+    * semantics, prose, nothing — so the declaration order IS the ranking, and a
+    * new case has to be declared at its strength rather than appended.
+    */
+  def weakerThan(other: Enforcement): Boolean = ordinal > other.ordinal
+
 /** A backend's answer for one cell of the enforcement matrix: the level, and
   * why it is that level. One value rather than two, so a backend whose flags
   * change cannot have its level updated while a stale reason stays beside it.

--- a/tools/src/main/scala/orca/agents/Enforcement.scala
+++ b/tools/src/main/scala/orca/agents/Enforcement.scala
@@ -5,8 +5,10 @@ package orca.agents
   * edits/shell"; for `Full` it is the approval policy itself.
   *
   *   - Hard — mechanically blocked (permission mode, sandbox, tool allowlist).
-  *     The gated boundary may sit at a documented SUPERSET of the request; the
-  *     cell's `rationale` says so where it does.
+  *     The gated boundary may sit at a documented SUPERSET of the request — on
+  *     `Full`, claude's `--allowedTools` adds to the default permission mode
+  *     rather than replacing it — and the cell's `rationale` says so where it
+  *     does.
   *   - SandboxApprox — approximated by a coarser sandbox; semantics widened.
   *     The line from a `Hard` cell with a documented superset is whether orca
   *     can name the boundary the agent is held to: claude's additive allowlist
@@ -46,10 +48,10 @@ case class EnforcementCell(level: Enforcement, rationale: String)
 
 /** Whether a turn starts a backend session or continues one — the second axis
   * of the enforcement matrix, alongside `(ToolSet, AutoApprove)`. It matters
-  * because a backend may put its restriction flags on the spawn only: codex
-  * `exec resume` rejects `--sandbox`/`--full-auto`, so a resumed turn runs in
-  * the sandbox its session was created with, whatever tier the caller asked
-  * for.
+  * because a resumed session keeps whatever sandbox it was created with unless
+  * the backend re-applies one, and not every restriction has a knob to re-apply
+  * on the narrower resume argv: codex's `Full` + `AutoApprove.Only` has none,
+  * so that cell alone answers differently on a resumed turn.
   *
   * Derived from [[orca.backend.Dispatch]] by dropping the wire ids this
   * classification has no use for.

--- a/tools/src/main/scala/orca/agents/EnforcementNotice.scala
+++ b/tools/src/main/scala/orca/agents/EnforcementNotice.scala
@@ -31,8 +31,10 @@ private[orca] object EnforcementNotice:
     backend
       .enforcementShortfall(config.tools, config.autoApprove, dispatch)
       .foreach: cell =>
+        // The dispatch is left to the rationale: it only ever explains WHY the
+        // level is what it is (codex's resumed turns), which is the WARN's job.
         val summary =
-          s"${backend.tag.wireName} does not mechanically enforce ${config.tools} " +
-            s"on a ${dispatch.toString.toLowerCase} turn: ${cell.level}"
+          s"${backend.tag.wireName} does not mechanically enforce " +
+            s"${config.tools}: ${cell.level}"
         events.onEvent(OrcaEvent.Step(summary))
         log.warn("{} — {}", summary, cell.rationale)

--- a/tools/src/main/scala/orca/agents/EnforcementNotice.scala
+++ b/tools/src/main/scala/orca/agents/EnforcementNotice.scala
@@ -74,7 +74,10 @@ private[orca] object EnforcementNotice:
       dispatch: TurnDispatch
   ): Option[String] =
     for
-      request <- unmetRequest(config, turnWording(backend, config, dispatch))
+      request <- unmetRequest(
+        config,
+        turnWording(backend, config, cell, dispatch)
+      )
       consequence <- consequenceOf(cell.level)
     yield s"${backend.tag.wireName} cannot $request — $consequence"
 
@@ -108,22 +111,26 @@ private[orca] object EnforcementNotice:
       case Enforcement.Ignored =>
         Some("nothing orca puts on the wire says so")
 
-  /** Names the resumed turn ONLY where the fresh one would have been gated —
-    * without that, codex's resume-time notice reads as if the tier had never
-    * been enforced. Naming it unconditionally would instead split one fact into
-    * two sentences on every backend the dispatch doesn't change.
+  /** Names the resumed turn ONLY where resuming is what weakened the answer —
+    * without that, a notice that fires at resume time alone reads as if the
+    * restriction had never held (codex, whose read-only sandbox and `Only`
+    * approximation both survive only the spawn). Naming it unconditionally
+    * would instead split one fact into two sentences on every backend the
+    * dispatch doesn't change.
     */
   private def turnWording[B <: BackendTag](
       backend: AgentBackend[B],
       config: AgentConfig,
+      cell: EnforcementCell,
       dispatch: TurnDispatch
   ): String =
-    val freshWasGated =
+    val weakenedByResuming = cell.level.weakerThan(
       backend
         .enforcementCell(config.tools, config.autoApprove, TurnDispatch.Fresh)
-        .level == Enforcement.Hard
+        .level
+    )
     dispatch match
-      case TurnDispatch.Resumed if freshWasGated =>
+      case TurnDispatch.Resumed if weakenedByResuming =>
         s"a resumed ${config.tools} turn"
       case TurnDispatch.Fresh | TurnDispatch.Resumed =>
         s"a ${config.tools} turn"

--- a/tools/src/main/scala/orca/agents/EnforcementNotice.scala
+++ b/tools/src/main/scala/orca/agents/EnforcementNotice.scala
@@ -113,10 +113,10 @@ private[orca] object EnforcementNotice:
 
   /** Names the resumed turn ONLY where resuming is what weakened the answer —
     * without that, a notice that fires at resume time alone reads as if the
-    * restriction had never held (codex, whose read-only sandbox and `Only`
-    * approximation both survive only the spawn). Naming it unconditionally
-    * would instead split one fact into two sentences on every backend the
-    * dispatch doesn't change.
+    * restriction had never held (codex's `Only` approximation, which has no
+    * sandbox of its own to re-apply). Naming it unconditionally would instead
+    * split one fact into two sentences on every backend the dispatch doesn't
+    * change.
     */
   private def turnWording[B <: BackendTag](
       backend: AgentBackend[B],

--- a/tools/src/main/scala/orca/agents/EnforcementNotice.scala
+++ b/tools/src/main/scala/orca/agents/EnforcementNotice.scala
@@ -5,36 +5,125 @@ import orca.events.{OrcaEvent, OrcaListener}
 
 import org.slf4j.LoggerFactory
 
-/** Reports a turn whose requested no-edit tier the backend does not
-  * mechanically enforce — the one runtime consumer of [[Enforcement]].
+/** Says, when a turn asks a backend for a restriction it cannot mechanically
+  * apply, that the restriction is not mechanical — the runtime's only consumer
+  * of [[Enforcement]].
   *
   * Without it, a caller that asked for `withReadOnly` and got prose has no
   * signal anywhere: a run in which a reviewer drifted from reporting into
   * editing looks exactly like one in which editing was impossible, and telling
   * them apart means already knowing the matrix.
   *
-  * Two channels, because they have different readers: a short `Step` in the
-  * run's own stream, and a WARN carrying the cell's rationale in the log.
-  * [[AgentBackend.enforcementShortfall]] does the deduplication, so a
-  * twenty-reviewer fan-out says this once.
+  * Two channels, because they have different readers: the `Step` a run shows
+  * says in plain words what the agent may still do, and the WARN behind it
+  * carries the cell's rationale and level names for whoever is diagnosing.
+  *
+  * One instance per backend, held by [[AgentBackend]] and shared with any
+  * sibling backend derived from it, so a twenty-reviewer fan-out says each
+  * thing once.
   */
-private[orca] object EnforcementNotice:
+private[orca] final class EnforcementNotice:
 
-  private val log = LoggerFactory.getLogger(getClass)
+  /** Rendered `Step` lines already said. Keying on the sentence itself is what
+    * makes "already said" mean what a reader would mean by it: a different
+    * tier, dispatch or approval list repeats the notice exactly when it changes
+    * the sentence, and stays silent when it only changes the reasoning behind
+    * an identical one.
+    */
+  private val said =
+    java.util.concurrent.ConcurrentHashMap.newKeySet[String]()
 
+  /** Report `config`'s unmet restriction for the turn about to run against
+    * `session`, unless the same sentence has already been said.
+    *
+    * Resolves the dispatch itself, from the same `dispatchFor` the backend will
+    * consult moments later — the one derivation, so a caller cannot pair a
+    * fresh-turn classification with a resumed turn.
+    *
+    * Reporting, not refusing: a weaker gate is a documented property of the
+    * backend, and a restricted turn's prompt still carries
+    * [[orca.backend.SystemPromptComposer.ReadOnlyTurn]].
+    */
   def announceShortfall[B <: BackendTag](
       backend: AgentBackend[B],
       config: AgentConfig,
-      dispatch: TurnDispatch,
+      session: SessionId[B],
       events: OrcaListener
   ): Unit =
-    backend
-      .enforcementShortfall(config.tools, config.autoApprove, dispatch)
-      .foreach: cell =>
-        // The dispatch is left to the rationale: it only ever explains WHY the
-        // level is what it is (codex's resumed turns), which is the WARN's job.
-        val summary =
-          s"${backend.tag.wireName} does not mechanically enforce " +
-            s"${config.tools}: ${cell.level}"
-        events.onEvent(OrcaEvent.Step(summary))
-        log.warn("{} — {}", summary, cell.rationale)
+    val dispatch = backend.sessions.dispatchFor(session).asTurnDispatch
+    val cell =
+      backend.enforcementCell(config.tools, config.autoApprove, dispatch)
+    EnforcementNotice
+      .summary(backend, config, cell, dispatch)
+      .foreach: summary =>
+        if said.add(summary) then
+          events.onEvent(OrcaEvent.Step(summary))
+          EnforcementNotice.log.warn("{} — {}", summary, cell.rationale)
+
+private[orca] object EnforcementNotice:
+
+  private val log = LoggerFactory.getLogger(classOf[EnforcementNotice])
+
+  /** The sentence to say, or `None` when the turn asked for nothing this
+    * backend had to encode, or got what it asked for.
+    */
+  private def summary[B <: BackendTag](
+      backend: AgentBackend[B],
+      config: AgentConfig,
+      cell: EnforcementCell,
+      dispatch: TurnDispatch
+  ): Option[String] =
+    for
+      request <- unmetRequest(config, turnWording(backend, config, dispatch))
+      consequence <- consequenceOf(cell.level)
+    yield s"${backend.tag.wireName} cannot $request — $consequence"
+
+  /** What the caller asked this backend to withhold. The two arms are the two
+    * axes a caller can restrict on: the tier withholds the write tools,
+    * [[AutoApprove.Only]] withholds unprompted use of everything else. `Full` +
+    * `All` asked for neither, so there is nothing it can fail to get.
+    */
+  private def unmetRequest(config: AgentConfig, turn: String): Option[String] =
+    config.tools match
+      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+        Some(
+          s"stop $turn from editing files or running commands that change state"
+        )
+      case ToolSet.Full =>
+        config.autoApprove match
+          case AutoApprove.All => None
+          case AutoApprove.Only(_) =>
+            Some(s"hold $turn to the tools it was asked to auto-approve")
+
+  /** What the reader can act on, in place of the level's name — which stays in
+    * the WARN, where the vocabulary is already in play.
+    */
+  private def consequenceOf(level: Enforcement): Option[String] =
+    level match
+      case Enforcement.Hard => None
+      case Enforcement.PromptOnly =>
+        Some("only the turn's own prompt asks it not to")
+      case Enforcement.SandboxApprox =>
+        Some("the sandbox it runs in is wider than that")
+      case Enforcement.Ignored =>
+        Some("nothing orca puts on the wire says so")
+
+  /** Names the resumed turn ONLY where the fresh one would have been gated —
+    * without that, codex's resume-time notice reads as if the tier had never
+    * been enforced. Naming it unconditionally would instead split one fact into
+    * two sentences on every backend the dispatch doesn't change.
+    */
+  private def turnWording[B <: BackendTag](
+      backend: AgentBackend[B],
+      config: AgentConfig,
+      dispatch: TurnDispatch
+  ): String =
+    val freshWasGated =
+      backend
+        .enforcementCell(config.tools, config.autoApprove, TurnDispatch.Fresh)
+        .level == Enforcement.Hard
+    dispatch match
+      case TurnDispatch.Resumed if freshWasGated =>
+        s"a resumed ${config.tools} turn"
+      case TurnDispatch.Fresh | TurnDispatch.Resumed =>
+        s"a ${config.tools} turn"

--- a/tools/src/main/scala/orca/agents/EnforcementNotice.scala
+++ b/tools/src/main/scala/orca/agents/EnforcementNotice.scala
@@ -1,0 +1,38 @@
+package orca.agents
+
+import orca.backend.AgentBackend
+import orca.events.{OrcaEvent, OrcaListener}
+
+import org.slf4j.LoggerFactory
+
+/** Reports a turn whose requested no-edit tier the backend does not
+  * mechanically enforce — the one runtime consumer of [[Enforcement]].
+  *
+  * Without it, a caller that asked for `withReadOnly` and got prose has no
+  * signal anywhere: a run in which a reviewer drifted from reporting into
+  * editing looks exactly like one in which editing was impossible, and telling
+  * them apart means already knowing the matrix.
+  *
+  * Two channels, because they have different readers: a short `Step` in the
+  * run's own stream, and a WARN carrying the cell's rationale in the log.
+  * [[AgentBackend.enforcementShortfall]] does the deduplication, so a
+  * twenty-reviewer fan-out says this once.
+  */
+private[orca] object EnforcementNotice:
+
+  private val log = LoggerFactory.getLogger(getClass)
+
+  def announceShortfall[B <: BackendTag](
+      backend: AgentBackend[B],
+      config: AgentConfig,
+      dispatch: TurnDispatch,
+      events: OrcaListener
+  ): Unit =
+    backend
+      .enforcementShortfall(config.tools, config.autoApprove, dispatch)
+      .foreach: cell =>
+        val summary =
+          s"${backend.tag.wireName} does not mechanically enforce ${config.tools} " +
+            s"on a ${dispatch.toString.toLowerCase} turn: ${cell.level}"
+        events.onEvent(OrcaEvent.Step(summary))
+        log.warn("{} — {}", summary, cell.rationale)

--- a/tools/src/main/scala/orca/backend/AgentBackend.scala
+++ b/tools/src/main/scala/orca/backend/AgentBackend.scala
@@ -141,7 +141,7 @@ trait AgentBackend[B <: BackendTag](
       dispatch: TurnDispatch
   ): Option[EnforcementCell] =
     val cell = enforcementCell(tools, autoApprove, dispatch)
-    val shortfall = tools != ToolSet.Full && cell.level != Enforcement.Hard
+    val shortfall = !tools.writeCapable && cell.level != Enforcement.Hard
     Option.when(shortfall && reportedShortfalls.add((tools, dispatch)))(cell)
 
   private val reportedShortfalls =

--- a/tools/src/main/scala/orca/backend/AgentBackend.scala
+++ b/tools/src/main/scala/orca/backend/AgentBackend.scala
@@ -7,7 +7,7 @@ import orca.agents.{
   AutoApprove,
   BackendTag,
   AgentConfig,
-  Enforcement,
+  EnforcementCell,
   SessionId,
   StructuredOutputMode,
   ToolSet
@@ -100,21 +100,24 @@ trait AgentBackend[B <: BackendTag](
   def tag: B
 
   /** How strongly THIS backend enforces the restriction a `(tools,
-    * autoApprove)` combination requests — a pure classification of the flags
-    * this backend's `*Args` would build. The mapping differs materially across
-    * backends (a `Full` + `AutoApprove.Only` is a mechanical allowlist on
-    * claude but a whole-sandbox approximation on codex and unencoded on the
-    * rest), so it is surfaced as data. The complete matrix is machine-checked
-    * in `runner/src/test/scala/orca/runner/EnforcementTableTest.scala`; each
-    * backend delegates to its `*Args.enforcement`, where the per-cell rationale
-    * lives.
+    * autoApprove)` combination requests, and why — a pure classification of the
+    * flags this backend's `*Args` would build, surfaced as data because the
+    * answer differs materially across backends.
     *
     * Abstract, not defaulted to `Enforcement.Ignored`, so a new backend cannot
-    * ship without answering this. Real backends implement it and add their rows
-    * to `EnforcementTableTest`; test doubles that never call `enforcement` add
-    * a one-line `Enforcement.Ignored` override.
+    * ship without answering this. Real backends delegate to their
+    * `*Args.enforcementCell`; test doubles that never consult it add a one-line
+    * `Ignored` cell.
+    *
+    * @see
+    *   [[orca.agents.Enforcement]] for what the levels mean, and
+    *   `runner/src/test/scala/orca/runner/EnforcementTableTest.scala`, which
+    *   checks the full product and renders AGENTS.md's table from it.
     */
-  def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement
+  def enforcementCell(
+      tools: ToolSet,
+      autoApprove: AutoApprove
+  ): EnforcementCell
 
   /** How THIS backend's wire delivers a structured (`resultAs[O]`) payload
     * ([[orca.agents.StructuredOutputMode]]). Prompt assembly

--- a/tools/src/main/scala/orca/backend/AgentBackend.scala
+++ b/tools/src/main/scala/orca/backend/AgentBackend.scala
@@ -7,10 +7,12 @@ import orca.agents.{
   AutoApprove,
   BackendTag,
   AgentConfig,
+  Enforcement,
   EnforcementCell,
   SessionId,
   StructuredOutputMode,
-  ToolSet
+  ToolSet,
+  TurnDispatch
 }
 
 import ox.Ox
@@ -100,14 +102,16 @@ trait AgentBackend[B <: BackendTag](
   def tag: B
 
   /** How strongly THIS backend enforces the restriction a `(tools,
-    * autoApprove)` combination requests, and why — a pure classification of the
-    * flags this backend's `*Args` would build, surfaced as data because the
-    * answer differs materially across backends.
+    * autoApprove)` combination requests on a `dispatch` turn, and why — a pure
+    * classification of the flags this backend's `*Args` would build, surfaced
+    * as data because the answer differs materially across backends.
     *
     * Abstract, not defaulted to `Enforcement.Ignored`, so a new backend cannot
-    * ship without answering this. Real backends delegate to their
-    * `*Args.enforcementCell`; test doubles that never consult it add a one-line
-    * `Ignored` cell.
+    * ship without answering this; the `*Args` implementations match `dispatch`
+    * exhaustively, so it cannot answer for fresh turns only. Real backends
+    * delegate to their `*Args.enforcementCell`; test doubles that aren't
+    * exercising [[enforcementShortfall]] add a one-line `Hard` cell, the answer
+    * that reports nothing.
     *
     * @see
     *   [[orca.agents.Enforcement]] for what the levels mean, and
@@ -116,8 +120,33 @@ trait AgentBackend[B <: BackendTag](
     */
   def enforcementCell(
       tools: ToolSet,
-      autoApprove: AutoApprove
+      autoApprove: AutoApprove,
+      dispatch: TurnDispatch
   ): EnforcementCell
+
+  /** The cell of a turn that asked for a no-edit tier and did NOT get a
+    * mechanical gate — the FIRST time this backend is asked for that `(tools,
+    * dispatch)`. `None` afterwards, on [[ToolSet.Full]] (which asks for no such
+    * gate), and whenever the answer is `Enforcement.Hard`.
+    *
+    * Deduplicated here because every agent handle a flow derives shares this
+    * backend instance, so the caller reports the shortfall once rather than on
+    * every one of a fan-out's turns. Reporting, not refusing: a weaker gate is
+    * a documented property of the backend, and the turn's prompt still carries
+    * [[SystemPromptComposer.ReadOnlyTurn]].
+    */
+  final def enforcementShortfall(
+      tools: ToolSet,
+      autoApprove: AutoApprove,
+      dispatch: TurnDispatch
+  ): Option[EnforcementCell] =
+    val cell = enforcementCell(tools, autoApprove, dispatch)
+    val shortfall = tools != ToolSet.Full && cell.level != Enforcement.Hard
+    Option.when(shortfall && reportedShortfalls.add((tools, dispatch)))(cell)
+
+  private val reportedShortfalls =
+    java.util.concurrent.ConcurrentHashMap
+      .newKeySet[(ToolSet, TurnDispatch)]()
 
   /** How THIS backend's wire delivers a structured (`resultAs[O]`) payload
     * ([[orca.agents.StructuredOutputMode]]). Prompt assembly
@@ -125,7 +154,7 @@ trait AgentBackend[B <: BackendTag](
     * misdeclares gets an instruction that contradicts its wire and steers weak
     * models into malformed replies.
     *
-    * Abstract, not defaulted, for the same reason as [[enforcement]]. Real
+    * Abstract, not defaulted, for the same reason as [[enforcementCell]]. Real
     * backends declare what their CLI actually does; test doubles that never
     * assemble prompts add a one-line `RawText` override.
     */

--- a/tools/src/main/scala/orca/backend/AgentBackend.scala
+++ b/tools/src/main/scala/orca/backend/AgentBackend.scala
@@ -103,8 +103,11 @@ trait AgentBackend[B <: BackendTag](
 
   /** How strongly THIS backend enforces the restriction a `(tools,
     * autoApprove)` combination requests on a `dispatch` turn, and why — a pure
-    * classification of the flags this backend's `*Args` would build, surfaced
-    * as data because the answer differs materially across backends.
+    * classification of the tier and approval flags this backend's `*Args` would
+    * build, surfaced as data because the answer differs materially across
+    * backends. It does not see what a turn additionally GRANTS on top of the
+    * tier (claude's MCP tool names, pi's ask-user extension), which widens the
+    * tools on offer without changing how the tier itself is enforced.
     *
     * Abstract, not defaulted to `Enforcement.Ignored`, so a new backend cannot
     * ship without answering this; the `*Args` implementations match `dispatch`

--- a/tools/src/main/scala/orca/backend/AgentBackend.scala
+++ b/tools/src/main/scala/orca/backend/AgentBackend.scala
@@ -7,8 +7,8 @@ import orca.agents.{
   AutoApprove,
   BackendTag,
   AgentConfig,
-  Enforcement,
   EnforcementCell,
+  EnforcementNotice,
   SessionId,
   StructuredOutputMode,
   ToolSet,
@@ -41,7 +41,13 @@ trait AgentBackend[B <: BackendTag](
       * visible through both — otherwise a handle derived via that builder and
       * leaked past flow-end bypasses the use-after-close guard entirely.
       */
-    private[orca] val closedFlag: AtomicBoolean = new AtomicBoolean(false)
+    private[orca] val closedFlag: AtomicBoolean = new AtomicBoolean(false),
+    /** Which enforcement notices this backend has already given. A SIBLING
+      * backend must be passed the parent's, for the same reason as
+      * [[closedFlag]] above: a fresh log would say everything a second time.
+      */
+    private[orca] val enforcementNotice: EnforcementNotice =
+      new EnforcementNotice
 ):
   /** Run one autonomous turn against `session` and return its result.
     *
@@ -113,8 +119,8 @@ trait AgentBackend[B <: BackendTag](
     * ship without answering this; the `*Args` implementations match `dispatch`
     * exhaustively, so it cannot answer for fresh turns only. Real backends
     * delegate to their `*Args.enforcementCell`; test doubles that aren't
-    * exercising [[enforcementShortfall]] add a one-line `Hard` cell, the answer
-    * that reports nothing.
+    * exercising [[announceEnforcementShortfall]] add a one-line `Hard` cell,
+    * the answer that reports nothing.
     *
     * @see
     *   [[orca.agents.Enforcement]] for what the levels mean, and
@@ -127,37 +133,16 @@ trait AgentBackend[B <: BackendTag](
       dispatch: TurnDispatch
   ): EnforcementCell
 
-  /** The cell of a turn that asked for a no-edit tier and did NOT get a
-    * mechanical gate. `None` on [[ToolSet.Full]] (which asks for no such gate),
-    * whenever the answer is `Enforcement.Hard`, and whenever this backend has
-    * already answered the same way for the same tier.
-    *
-    * Deduplicated on `(tools, cell)` — on what the caller would SAY, so the
-    * other two inputs need no place in the key: a different `autoApprove` or
-    * `dispatch` repeats the notice only when it changes the answer, which is
-    * exactly when it is worth repeating (a codex session resumed read-only
-    * loses its sandbox and says so, having said nothing when it was created).
-    * Deduplicated on this instance because every agent handle a flow derives
-    * from one backend shares it, so a fan-out's twenty turns report once —
-    * though a flow that wires a second backend of the same kind gets its own
-    * notice.
-    *
-    * Reporting, not refusing: a weaker gate is a documented property of the
-    * backend, and the turn's prompt still carries
-    * [[SystemPromptComposer.ReadOnlyTurn]].
+  /** Report, at most once per distinct sentence for this backend, that the turn
+    * about to run against `session` asked for a restriction this backend cannot
+    * apply mechanically. Delegates to [[enforcementNotice]], which owns both
+    * the wording and the "already said" bookkeeping.
     */
-  final def enforcementShortfall(
-      tools: ToolSet,
-      autoApprove: AutoApprove,
-      dispatch: TurnDispatch
-  ): Option[EnforcementCell] =
-    val cell = enforcementCell(tools, autoApprove, dispatch)
-    val shortfall = !tools.writeCapable && cell.level != Enforcement.Hard
-    Option.when(shortfall && reportedShortfalls.add((tools, cell)))(cell)
-
-  private val reportedShortfalls =
-    java.util.concurrent.ConcurrentHashMap
-      .newKeySet[(ToolSet, EnforcementCell)]()
+  private[orca] final def announceEnforcementShortfall(
+      config: AgentConfig,
+      session: SessionId[B],
+      events: OrcaListener
+  ): Unit = enforcementNotice.announceShortfall(this, config, session, events)
 
   /** How THIS backend's wire delivers a structured (`resultAs[O]`) payload
     * ([[orca.agents.StructuredOutputMode]]). Prompt assembly

--- a/tools/src/main/scala/orca/backend/AgentBackend.scala
+++ b/tools/src/main/scala/orca/backend/AgentBackend.scala
@@ -125,14 +125,22 @@ trait AgentBackend[B <: BackendTag](
   ): EnforcementCell
 
   /** The cell of a turn that asked for a no-edit tier and did NOT get a
-    * mechanical gate — the FIRST time this backend is asked for that `(tools,
-    * dispatch)`. `None` afterwards, on [[ToolSet.Full]] (which asks for no such
-    * gate), and whenever the answer is `Enforcement.Hard`.
+    * mechanical gate. `None` on [[ToolSet.Full]] (which asks for no such gate),
+    * whenever the answer is `Enforcement.Hard`, and whenever this backend has
+    * already answered the same way for the same tier.
     *
-    * Deduplicated here because every agent handle a flow derives shares this
-    * backend instance, so the caller reports the shortfall once rather than on
-    * every one of a fan-out's turns. Reporting, not refusing: a weaker gate is
-    * a documented property of the backend, and the turn's prompt still carries
+    * Deduplicated on `(tools, cell)` — on what the caller would SAY, so the
+    * other two inputs need no place in the key: a different `autoApprove` or
+    * `dispatch` repeats the notice only when it changes the answer, which is
+    * exactly when it is worth repeating (a codex session resumed read-only
+    * loses its sandbox and says so, having said nothing when it was created).
+    * Deduplicated on this instance because every agent handle a flow derives
+    * from one backend shares it, so a fan-out's twenty turns report once —
+    * though a flow that wires a second backend of the same kind gets its own
+    * notice.
+    *
+    * Reporting, not refusing: a weaker gate is a documented property of the
+    * backend, and the turn's prompt still carries
     * [[SystemPromptComposer.ReadOnlyTurn]].
     */
   final def enforcementShortfall(
@@ -142,11 +150,11 @@ trait AgentBackend[B <: BackendTag](
   ): Option[EnforcementCell] =
     val cell = enforcementCell(tools, autoApprove, dispatch)
     val shortfall = !tools.writeCapable && cell.level != Enforcement.Hard
-    Option.when(shortfall && reportedShortfalls.add((tools, dispatch)))(cell)
+    Option.when(shortfall && reportedShortfalls.add((tools, cell)))(cell)
 
   private val reportedShortfalls =
     java.util.concurrent.ConcurrentHashMap
-      .newKeySet[(ToolSet, TurnDispatch)]()
+      .newKeySet[(ToolSet, EnforcementCell)]()
 
   /** How THIS backend's wire delivers a structured (`resultAs[O]`) payload
     * ([[orca.agents.StructuredOutputMode]]). Prompt assembly

--- a/tools/src/main/scala/orca/backend/SessionSupport.scala
+++ b/tools/src/main/scala/orca/backend/SessionSupport.scala
@@ -21,10 +21,11 @@ enum Dispatch[B <: BackendTag]:
   case Fresh(claim: Option[WireSessionId[B]])
   case Resume(wireId: WireSessionId[B])
 
-  /** This dispatch without its wire ids, for [[AgentBackend.enforcementCell]],
-    * which classifies the turn and has no use for them.
+  /** This dispatch with the wire ids dropped, as
+    * [[AgentBackend.enforcementCell]] takes it — that classification needs to
+    * know only which of the two this is.
     */
-  def turn: TurnDispatch = this match
+  def asTurnDispatch: TurnDispatch = this match
     case Dispatch.Fresh(_)  => TurnDispatch.Fresh
     case Dispatch.Resume(_) => TurnDispatch.Resumed
 

--- a/tools/src/main/scala/orca/backend/SessionSupport.scala
+++ b/tools/src/main/scala/orca/backend/SessionSupport.scala
@@ -1,7 +1,7 @@
 package orca.backend
 
 import orca.OrcaFlowException
-import orca.agents.{BackendTag, SessionId, WireSessionId, onWire}
+import orca.agents.{BackendTag, SessionId, TurnDispatch, WireSessionId, onWire}
 import org.slf4j.LoggerFactory
 
 import scala.util.control.NonFatal
@@ -20,6 +20,13 @@ import scala.util.control.NonFatal
 enum Dispatch[B <: BackendTag]:
   case Fresh(claim: Option[WireSessionId[B]])
   case Resume(wireId: WireSessionId[B])
+
+  /** This dispatch without its wire ids, for [[AgentBackend.enforcementCell]],
+    * which classifies the turn and has no use for them.
+    */
+  def turn: TurnDispatch = this match
+    case Dispatch.Fresh(_)  => TurnDispatch.Fresh
+    case Dispatch.Resume(_) => TurnDispatch.Resumed
 
 /** How a backend's wire-level session ids come to be — decides what a `Fresh`
   * dispatch may put on the wire and which id a commit records.

--- a/tools/src/main/scala/orca/backend/SystemPromptComposer.scala
+++ b/tools/src/main/scala/orca/backend/SystemPromptComposer.scala
@@ -6,8 +6,8 @@ import orca.util.PromptResource
 /** Assembles a backend-agnostic system-prompt body from the configured
   * [[AgentConfig.systemPrompt]], an optional `extraHint` (typically the
   * `ask_user` MCP hint on interactive calls), and the standing
-  * [[RuntimeOwnsGit]] and [[BackgroundWorkAbandonedAtTurnEnd]] rules, joining
-  * non-empty pieces with a blank line.
+  * [[RuntimeOwnsGit]] / [[ReadOnlyTurn]] / [[BackgroundWorkAbandonedAtTurnEnd]]
+  * rules, joining non-empty pieces with a blank line.
   *
   * Each backend delivers the result its own way — claude writes it to a temp
   * file for `--append-system-prompt-file`; codex and gemini have no such flag
@@ -58,27 +58,37 @@ private[orca] object SystemPromptComposer:
       "/orca/backend/prompts/background-work-abandoned-at-turn-end.md"
     )
 
-  /** Always `Some`: a standing rule applies to every turn, so there is nothing
-    * to compose that could come out empty. The `Option` is kept because every
-    * backend's delivery path is written around it — narrowing it would flip
-    * each of their system-prompt flags to unconditional.
+  /** Standing rule appended to every read-only turn (`ReadOnly` and
+    * `NetworkOnly`), which is what makes a `PromptOnly` cell of the
+    * [[orca.agents.Enforcement]] matrix true by construction: on a backend that
+    * encodes no mechanical gate, this text is the restriction. Appended on the
+    * hard-gated backends too — redundant there, but it needs no enforcement
+    * plumbing and stays correct if a cell is later reclassified.
+    *
+    * It forbids state changes without mentioning the network, so a
+    * `NetworkOnly` turn keeps the read-only network access it was given.
     */
+  val ReadOnlyTurn: String =
+    PromptResource.load("/orca/backend/prompts/readonly-turn.md")
+
   def combine(
       config: AgentConfig,
       extraHint: Option[String] = None
-  ): Option[String] = Some(composeAll(config, extraHint))
+  ): String = composeAll(config, extraHint)
 
   private def composeAll(
       config: AgentConfig,
       extraHint: Option[String]
   ): String =
-    // Only the git rule is tool-gated. It is additionally suppressed by
-    // `selfManagedGit`, which says who drives git — a question about the repo,
-    // not about what survives the turn boundary.
-    val gitRule = Option.when(
-      config.tools == ToolSet.Full && !config.selfManagedGit
-    )(RuntimeOwnsGit)
-    List(config.systemPrompt, extraHint, gitRule).flatten
+    // The two tool-gated rules are complementary: `Full` gets the git rule
+    // (unless `selfManagedGit` says the agent drives git itself — a question
+    // about the repo, not about what survives the turn boundary), the read-only
+    // tiers get the read-only rule.
+    val toolRule = config.tools match
+      case ToolSet.Full =>
+        Option.when(!config.selfManagedGit)(RuntimeOwnsGit)
+      case ToolSet.ReadOnly | ToolSet.NetworkOnly => Some(ReadOnlyTurn)
+    List(config.systemPrompt, extraHint, toolRule).flatten
       .appended(BackgroundWorkAbandonedAtTurnEnd)
       .mkString("\n\n")
 
@@ -88,10 +98,11 @@ private[orca] object SystemPromptComposer:
     *
     * Called for every turn of a thread, including resumed ones, so a long
     * codex/gemini chat carries one copy per turn. That is deliberate: the
-    * guidance is about the turn being executed — [[RuntimeOwnsGit]] and
-    * [[BackgroundWorkAbandonedAtTurnEnd]] both describe what happens at THIS
-    * turn's end — and restating it keeps it recent rather than buried at the
-    * top of the thread.
+    * guidance is about the turn being executed — [[RuntimeOwnsGit]],
+    * [[ReadOnlyTurn]] and [[BackgroundWorkAbandonedAtTurnEnd]] all describe
+    * THIS turn — and restating it keeps it recent rather than buried at the top
+    * of the thread. It also means a resumed codex turn, which inherits its
+    * sandbox from the original spawn, still carries the restriction text.
     */
   def foldIntoPrompt(
       config: AgentConfig,

--- a/tools/src/main/scala/orca/backend/SystemPromptComposer.scala
+++ b/tools/src/main/scala/orca/backend/SystemPromptComposer.scala
@@ -96,8 +96,8 @@ private[orca] object SystemPromptComposer:
     * guidance is about the turn being executed — [[RuntimeOwnsGit]],
     * [[ReadOnlyTurn]] and [[BackgroundWorkAbandonedAtTurnEnd]] all describe
     * THIS turn — and restating it keeps it recent rather than buried at the top
-    * of the thread. It also means a resumed codex turn, which inherits its
-    * sandbox from the original spawn, still carries the restriction text.
+    * of the thread. It also means a resumed turn carries the restriction text
+    * whatever its flags do — the belt to codex's re-applied sandbox braces.
     */
   def foldIntoPrompt(
       config: AgentConfig,

--- a/tools/src/main/scala/orca/backend/SystemPromptComposer.scala
+++ b/tools/src/main/scala/orca/backend/SystemPromptComposer.scala
@@ -74,11 +74,6 @@ private[orca] object SystemPromptComposer:
   def combine(
       config: AgentConfig,
       extraHint: Option[String] = None
-  ): String = composeAll(config, extraHint)
-
-  private def composeAll(
-      config: AgentConfig,
-      extraHint: Option[String]
   ): String =
     // The two tool-gated rules are complementary: `Full` gets the git rule
     // (unless `selfManagedGit` says the agent drives git itself — a question
@@ -111,5 +106,5 @@ private[orca] object SystemPromptComposer:
   ): String =
     // No `stripMargin`: `userPrompt` carries the diffs, lint output and review
     // issues that start lines with `|`, which it would eat.
-    s"System guidance:\n${composeAll(config, extraHint)}\n\n" +
+    s"System guidance:\n${combine(config, extraHint)}\n\n" +
       s"User request:\n$userPrompt"

--- a/tools/src/test/scala/orca/agents/AgentCallSessionCommittedTest.scala
+++ b/tools/src/test/scala/orca/agents/AgentCallSessionCommittedTest.scala
@@ -126,8 +126,11 @@ class AgentCallSessionCommittedTest extends munit.FunSuite:
     val sessions: SessionSupport[BackendTag.ClaudeCode.type] =
       SessionSupport.durable(IdScheme.ServerMinted, _ => false)
     val tag: BackendTag.ClaudeCode.type = BackendTag.ClaudeCode
-    def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
-      Enforcement.Ignored
+    def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove
+    ): EnforcementCell =
+      EnforcementCell(Enforcement.Ignored, "test double")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
     def runAutonomous(

--- a/tools/src/test/scala/orca/agents/AgentCallSessionCommittedTest.scala
+++ b/tools/src/test/scala/orca/agents/AgentCallSessionCommittedTest.scala
@@ -128,9 +128,10 @@ class AgentCallSessionCommittedTest extends munit.FunSuite:
     val tag: BackendTag.ClaudeCode.type = BackendTag.ClaudeCode
     def enforcementCell(
         tools: ToolSet,
-        autoApprove: AutoApprove
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Ignored, "test double")
+      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
     def runAutonomous(

--- a/tools/src/test/scala/orca/agents/AgentCallSessionCommittedTest.scala
+++ b/tools/src/test/scala/orca/agents/AgentCallSessionCommittedTest.scala
@@ -1,5 +1,6 @@
 package orca.agents
 
+import orca.testkit.StubEnforcement
 import orca.backend.{
   Conversation,
   Interaction,
@@ -131,7 +132,7 @@ class AgentCallSessionCommittedTest extends munit.FunSuite:
         autoApprove: AutoApprove,
         dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
+      StubEnforcement.cell
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
     def runAutonomous(

--- a/tools/src/test/scala/orca/agents/BaseAgentTest.scala
+++ b/tools/src/test/scala/orca/agents/BaseAgentTest.scala
@@ -174,6 +174,42 @@ class BaseAgentTest extends munit.FunSuite:
     )
     assertEquals(reply, "Show branch in menu")
 
+  // A caller that asks for a no-edit tier and gets prose has no other signal
+  // that the gate isn't mechanical — and a fan-out would repeat the notice per
+  // turn, which is why it is deduplicated rather than emitted per run call.
+  test("a read-only tier the backend doesn't gate is reported once per run"):
+    val seen =
+      new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
+    val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
+    val tool = new StubTool(
+      new UngatedBackend("first", "second"),
+      toolConfig = AgentConfig(tools = ToolSet.ReadOnly),
+      listener = listener,
+      prompts = DefaultPrompts
+    )
+    val _ = tool.run("one")
+    val _ = tool.run("two")
+    assertEquals(
+      seen.get().collect { case OrcaEvent.Step(m) => m },
+      List(
+        "Pi does not mechanically enforce ReadOnly on a fresh turn: PromptOnly"
+      )
+    )
+
+  // The notice answers "I asked for a gate and didn't get one". A `Full` turn
+  // asked for no gate, so the same weak declaration must stay silent.
+  test("a Full turn reports no enforcement shortfall"):
+    val seen =
+      new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
+    val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
+    val tool = new StubTool(
+      new UngatedBackend("only"),
+      listener = listener,
+      prompts = DefaultPrompts
+    )
+    val _ = tool.run("one")
+    assertEquals(seen.get().collect { case OrcaEvent.Step(m) => m }, Nil)
+
   // A turn that failed after the model ran still spent tokens; the success path
   // is the only other TokensUsed emitter, so without this the failed turn is
   // invisible in the run's cost summary.
@@ -533,9 +569,10 @@ class BaseAgentTest extends munit.FunSuite:
     val tag: BackendTag.Pi.type = BackendTag.Pi
     def enforcementCell(
         tools: ToolSet,
-        autoApprove: AutoApprove
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Ignored, "test double")
+      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 
@@ -565,9 +602,10 @@ class BaseAgentTest extends munit.FunSuite:
     val tag: BackendTag.Pi.type = BackendTag.Pi
     def enforcementCell(
         tools: ToolSet,
-        autoApprove: AutoApprove
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Ignored, "test double")
+      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 
@@ -603,9 +641,10 @@ class BaseAgentTest extends munit.FunSuite:
     val tag: BackendTag.Pi.type = BackendTag.Pi
     def enforcementCell(
         tools: ToolSet,
-        autoApprove: AutoApprove
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Ignored, "test double")
+      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 
@@ -621,6 +660,18 @@ class BaseAgentTest extends munit.FunSuite:
     * `replies` are answered one per call, so a retried call can be scripted
     * with an output that won't parse followed by one that will.
     */
+  /** Declares that it gates nothing mechanically — the condition
+    * `EnforcementNotice` exists to report.
+    */
+  private class UngatedBackend(replies: String*)
+      extends ScriptedDrainBackend(replies*):
+    override def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
+    ): EnforcementCell =
+      EnforcementCell(Enforcement.PromptOnly, "the prompt is the whole gate")
+
   private class ScriptedDrainBackend(replies: String*)
       extends AgentBackend[BackendTag.Pi.type]:
     private val remaining = replies.iterator
@@ -630,9 +681,10 @@ class BaseAgentTest extends munit.FunSuite:
     val tag: BackendTag.Pi.type = BackendTag.Pi
     def enforcementCell(
         tools: ToolSet,
-        autoApprove: AutoApprove
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Ignored, "test double")
+      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
     def runAutonomous(
@@ -713,9 +765,10 @@ class BaseAgentTest extends munit.FunSuite:
     val tag: BackendTag.Pi.type = BackendTag.Pi
     def enforcementCell(
         tools: ToolSet,
-        autoApprove: AutoApprove
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Ignored, "test double")
+      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
     def runAutonomous(
@@ -797,9 +850,10 @@ class BaseAgentTest extends munit.FunSuite:
     val tag: BackendTag.Pi.type = BackendTag.Pi
     def enforcementCell(
         tools: ToolSet,
-        autoApprove: AutoApprove
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Ignored, "test double")
+      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 
@@ -830,9 +884,10 @@ class BaseAgentTest extends munit.FunSuite:
     val tag: BackendTag.Pi.type = BackendTag.Pi
     def enforcementCell(
         tools: ToolSet,
-        autoApprove: AutoApprove
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Ignored, "test double")
+      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 
@@ -859,9 +914,10 @@ class BaseAgentTest extends munit.FunSuite:
     val tag: BackendTag.Pi.type = BackendTag.Pi
     def enforcementCell(
         tools: ToolSet,
-        autoApprove: AutoApprove
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Ignored, "test double")
+      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 

--- a/tools/src/test/scala/orca/agents/BaseAgentTest.scala
+++ b/tools/src/test/scala/orca/agents/BaseAgentTest.scala
@@ -531,8 +531,11 @@ class BaseAgentTest extends munit.FunSuite:
     val sessions: SessionSupport[BackendTag.Pi.type] =
       SessionSupport.ephemeral(IdScheme.ClientClaimed)
     val tag: BackendTag.Pi.type = BackendTag.Pi
-    def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
-      Enforcement.Ignored
+    def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove
+    ): EnforcementCell =
+      EnforcementCell(Enforcement.Ignored, "test double")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 
@@ -560,8 +563,11 @@ class BaseAgentTest extends munit.FunSuite:
     val sessions: SessionSupport[BackendTag.Pi.type] =
       SessionSupport.ephemeral(IdScheme.ClientClaimed)
     val tag: BackendTag.Pi.type = BackendTag.Pi
-    def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
-      Enforcement.Ignored
+    def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove
+    ): EnforcementCell =
+      EnforcementCell(Enforcement.Ignored, "test double")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 
@@ -595,8 +601,11 @@ class BaseAgentTest extends munit.FunSuite:
     val sessions: SessionSupport[BackendTag.Pi.type] =
       SessionSupport.ephemeral(IdScheme.ClientClaimed)
     val tag: BackendTag.Pi.type = BackendTag.Pi
-    def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
-      Enforcement.Ignored
+    def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove
+    ): EnforcementCell =
+      EnforcementCell(Enforcement.Ignored, "test double")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 
@@ -619,8 +628,11 @@ class BaseAgentTest extends munit.FunSuite:
     val sessions: SessionSupport[BackendTag.Pi.type] =
       SessionSupport.ephemeral(IdScheme.ClientClaimed)
     val tag: BackendTag.Pi.type = BackendTag.Pi
-    def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
-      Enforcement.Ignored
+    def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove
+    ): EnforcementCell =
+      EnforcementCell(Enforcement.Ignored, "test double")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
     def runAutonomous(
@@ -699,8 +711,11 @@ class BaseAgentTest extends munit.FunSuite:
     val sessions: SessionSupport[BackendTag.Pi.type] =
       SessionSupport.ephemeral(IdScheme.ClientClaimed)
     val tag: BackendTag.Pi.type = BackendTag.Pi
-    def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
-      Enforcement.Ignored
+    def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove
+    ): EnforcementCell =
+      EnforcementCell(Enforcement.Ignored, "test double")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
     def runAutonomous(
@@ -780,8 +795,11 @@ class BaseAgentTest extends munit.FunSuite:
     )(using ox.Ox): Conversation[BackendTag.Pi.type] =
       throw new UnsupportedOperationException
     val tag: BackendTag.Pi.type = BackendTag.Pi
-    def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
-      Enforcement.Ignored
+    def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove
+    ): EnforcementCell =
+      EnforcementCell(Enforcement.Ignored, "test double")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 
@@ -810,8 +828,11 @@ class BaseAgentTest extends munit.FunSuite:
     val sessions: SessionSupport[BackendTag.Pi.type] =
       SessionSupport.ephemeral(IdScheme.ClientClaimed)
     val tag: BackendTag.Pi.type = BackendTag.Pi
-    def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
-      Enforcement.Ignored
+    def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove
+    ): EnforcementCell =
+      EnforcementCell(Enforcement.Ignored, "test double")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 
@@ -836,8 +857,11 @@ class BaseAgentTest extends munit.FunSuite:
     val sessions: SessionSupport[BackendTag.Pi.type] =
       SessionSupport.ephemeral(IdScheme.ClientClaimed)
     val tag: BackendTag.Pi.type = BackendTag.Pi
-    def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
-      Enforcement.Ignored
+    def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove
+    ): EnforcementCell =
+      EnforcementCell(Enforcement.Ignored, "test double")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 

--- a/tools/src/test/scala/orca/agents/BaseAgentTest.scala
+++ b/tools/src/test/scala/orca/agents/BaseAgentTest.scala
@@ -1,5 +1,6 @@
 package orca.agents
 
+import orca.testkit.StubEnforcement
 import orca.backend.{
   Conversation,
   ConversationEvent,
@@ -650,7 +651,7 @@ class BaseAgentTest extends munit.FunSuite:
         autoApprove: AutoApprove,
         dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
+      StubEnforcement.cell
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 
@@ -683,7 +684,7 @@ class BaseAgentTest extends munit.FunSuite:
         autoApprove: AutoApprove,
         dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
+      StubEnforcement.cell
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 
@@ -722,7 +723,7 @@ class BaseAgentTest extends munit.FunSuite:
         autoApprove: AutoApprove,
         dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
+      StubEnforcement.cell
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 
@@ -750,7 +751,7 @@ class BaseAgentTest extends munit.FunSuite:
         autoApprove: AutoApprove,
         dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
+      StubEnforcement.cell
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
     def runAutonomous(
@@ -874,7 +875,7 @@ class BaseAgentTest extends munit.FunSuite:
         autoApprove: AutoApprove,
         dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
+      StubEnforcement.cell
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
     def runAutonomous(
@@ -959,7 +960,7 @@ class BaseAgentTest extends munit.FunSuite:
         autoApprove: AutoApprove,
         dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
+      StubEnforcement.cell
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 
@@ -993,7 +994,7 @@ class BaseAgentTest extends munit.FunSuite:
         autoApprove: AutoApprove,
         dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
+      StubEnforcement.cell
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 
@@ -1023,7 +1024,7 @@ class BaseAgentTest extends munit.FunSuite:
         autoApprove: AutoApprove,
         dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
+      StubEnforcement.cell
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 

--- a/tools/src/test/scala/orca/agents/BaseAgentTest.scala
+++ b/tools/src/test/scala/orca/agents/BaseAgentTest.scala
@@ -220,7 +220,7 @@ class BaseAgentTest extends munit.FunSuite:
   test("a corrective retry reports the resumed turn's weaker guarantee"):
     val steps = new StepRecorder
     val tool = new StubTool(
-      new GatedOnlyWhenFreshBackend(
+      new WeakerOnResumeBackend(
         "not json at all",
         """{"fixed":[],"ignored":[]}"""
       ),
@@ -235,6 +235,35 @@ class BaseAgentTest extends munit.FunSuite:
     assertEquals(
       steps.seen,
       List(BaseAgentTest.noEditNotice("resumed ReadOnly"))
+    )
+
+  // The turn is named "resumed" whenever resuming is what weakened the answer,
+  // not only where the fresh turn was a hard gate: this backend approximates the
+  // `Only` list on the spawn and encodes nothing at all on the resume, and the
+  // second sentence has to say which turn it is about.
+  test("a retry whose approximation is dropped names the resumed turn"):
+    val steps = new StepRecorder
+    val tool = new StubTool(
+      new WeakerOnResumeBackend(
+        "not json at all",
+        """{"fixed":[],"ignored":[]}"""
+      ),
+      toolConfig = AgentConfig(
+        autoApprove = AutoApprove.Only(Set("read")),
+        retrySchedule = Schedule.exponentialBackoff(1.milli).maxRetries(1)
+      ),
+      listener = steps.listener,
+      prompts = DefaultPrompts
+    )
+    val _ = tool.resultAs[FixOutcome].autonomous.run("fix compile errors")
+    assertEquals(
+      steps.seen,
+      List(
+        "Pi cannot hold a Full turn to the tools it was asked to auto-approve" +
+          " — the sandbox it runs in is wider than that",
+        "Pi cannot hold a resumed Full turn to the tools it was asked to" +
+          " auto-approve — nothing orca puts on the wire says so"
+      )
     )
 
   // The other axis: `Only` asks the backend to auto-approve just those tools,
@@ -821,10 +850,12 @@ class BaseAgentTest extends munit.FunSuite:
     ): EnforcementCell =
       EnforcementCell(Enforcement.PromptOnly, "the prompt is the whole gate")
 
-  /** codex's shape: a mechanical gate on the spawn, none on the resume. Only a
+  /** codex's shape: the sandbox flags ride on the spawn only, so every tier's
+    * answer weakens once the session is resumed — from a gate to prose on the
+    * read-only tiers, and from an approximation to nothing on `Full`. Only a
     * call that classifies per attempt sees the second answer.
     */
-  private class GatedOnlyWhenFreshBackend(replies: String*)
+  private class WeakerOnResumeBackend(replies: String*)
       extends ScriptedDrainBackend(replies*):
     override def enforcementCell(
         tools: ToolSet,
@@ -832,9 +863,26 @@ class BaseAgentTest extends munit.FunSuite:
         dispatch: TurnDispatch
     ): EnforcementCell = dispatch match
       case TurnDispatch.Fresh =>
-        EnforcementCell(Enforcement.Hard, "the spawn carries the sandbox flag")
+        tools match
+          case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+            EnforcementCell(
+              Enforcement.Hard,
+              "the spawn carries the sandbox flag"
+            )
+          case ToolSet.Full =>
+            EnforcementCell(
+              Enforcement.SandboxApprox,
+              "the spawn's sandbox is coarser than the list"
+            )
       case TurnDispatch.Resumed =>
-        EnforcementCell(Enforcement.PromptOnly, "the resume carries no flag")
+        tools match
+          case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+            EnforcementCell(
+              Enforcement.PromptOnly,
+              "the resume carries no flag"
+            )
+          case ToolSet.Full =>
+            EnforcementCell(Enforcement.Ignored, "the resume carries no flag")
 
   /** Throws `error` on its first turn and scripts the rest — an attempt that
     * dies before reaching the model, which consumes none of `replies`.

--- a/tools/src/test/scala/orca/agents/BaseAgentTest.scala
+++ b/tools/src/test/scala/orca/agents/BaseAgentTest.scala
@@ -27,6 +27,14 @@ case class MapCarrier(m: Map[String, Int]) derives JsonData
 private case class FixOutcome(fixed: List[String], ignored: List[String])
     derives JsonData
 
+private object BaseAgentTest:
+  /** The `EnforcementNotice` line for an ungated read-only `turn`, spelled out
+    * once so the tests below assert the sentence a user sees, not a fragment.
+    */
+  def noEditNotice(turn: String): String =
+    s"Pi cannot stop a $turn turn from editing files or running commands " +
+      "that change state — only the turn's own prompt asks it not to"
+
 class BaseAgentTest extends munit.FunSuite:
 
   // LLM `run` is gated on `InStage`; mint the token for the suite.
@@ -178,50 +186,38 @@ class BaseAgentTest extends munit.FunSuite:
   // that the gate isn't mechanical — and a fan-out would repeat the notice per
   // turn, which is why it is deduplicated rather than emitted per run call.
   test("a read-only tier the backend doesn't gate is reported once"):
-    val seen =
-      new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
-    val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
+    val steps = new StepRecorder
     val tool = new StubTool(
       new UngatedBackend("first", "second"),
       toolConfig = AgentConfig(tools = ToolSet.ReadOnly),
-      listener = listener,
+      listener = steps.listener,
       prompts = DefaultPrompts
     )
     val _ = tool.run("one")
     val _ = tool.run("two")
-    assertEquals(
-      seen.get().collect { case OrcaEvent.Step(m) => m },
-      List("Pi does not mechanically enforce ReadOnly: PromptOnly")
-    )
+    assertEquals(steps.seen, List(BaseAgentTest.noEditNotice("ReadOnly")))
 
   // Reviewers — the turns this notice exists for — reach the backend through
   // `resultAs`, which dispatches on its own path rather than through the text
   // one, so it has to raise the notice itself.
   test("a read-only structured turn reports the shortfall too"):
-    val seen =
-      new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
-    val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
+    val steps = new StepRecorder
     val tool = new StubTool(
       new UngatedBackend("""{"fixed":[],"ignored":[]}"""),
-      toolConfig = AgentConfig(tools = ToolSet.ReadOnly),
-      listener = listener,
+      toolConfig = AgentConfig(tools = ToolSet.NetworkOnly),
+      listener = steps.listener,
       prompts = DefaultPrompts
     )
     val _ = tool.resultAs[FixOutcome].autonomous.run("fix compile errors")
-    assertEquals(
-      seen.get().collect { case OrcaEvent.Step(m) => m },
-      List("Pi does not mechanically enforce ReadOnly: PromptOnly")
-    )
+    assertEquals(steps.seen, List(BaseAgentTest.noEditNotice("NetworkOnly")))
 
   // The first attempt commits the session, so the corrective re-prompt runs as
   // a resumed turn — which on this backend (codex's shape) is where the gate
   // disappears. Classified once per call instead of once per attempt, the
   // retry's weaker guarantee would go unreported: the first attempt is `Hard`,
-  // so the single Step below is entirely the second attempt's.
+  // so the single Step below is entirely the second attempt's, and says so.
   test("a corrective retry reports the resumed turn's weaker guarantee"):
-    val seen =
-      new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
-    val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
+    val steps = new StepRecorder
     val tool = new StubTool(
       new GatedOnlyWhenFreshBackend(
         "not json at all",
@@ -231,28 +227,66 @@ class BaseAgentTest extends munit.FunSuite:
         tools = ToolSet.ReadOnly,
         retrySchedule = Schedule.exponentialBackoff(1.milli).maxRetries(1)
       ),
-      listener = listener,
+      listener = steps.listener,
       prompts = DefaultPrompts
     )
     val _ = tool.resultAs[FixOutcome].autonomous.run("fix compile errors")
     assertEquals(
-      seen.get().collect { case OrcaEvent.Step(m) => m },
-      List("Pi does not mechanically enforce ReadOnly: PromptOnly")
+      steps.seen,
+      List(BaseAgentTest.noEditNotice("resumed ReadOnly"))
     )
 
-  // The notice answers "I asked for a gate and didn't get one". A `Full` turn
-  // asked for no gate, so the same weak declaration must stay silent.
-  test("a Full turn reports no enforcement shortfall"):
-    val seen =
-      new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
-    val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
+  // The other axis: `Only` asks the backend to auto-approve just those tools,
+  // and a backend that encodes no such list runs the agent wider than asked
+  // with nothing else saying so.
+  test("a Full turn whose Only list isn't encoded is reported"):
+    val steps = new StepRecorder
     val tool = new StubTool(
       new UngatedBackend("only"),
-      listener = listener,
+      toolConfig = AgentConfig(autoApprove = AutoApprove.Only(Set("read"))),
+      listener = steps.listener,
       prompts = DefaultPrompts
     )
     val _ = tool.run("one")
-    assertEquals(seen.get().collect { case OrcaEvent.Step(m) => m }, Nil)
+    assertEquals(
+      steps.seen,
+      List(
+        "Pi cannot hold a Full turn to the tools it was asked to auto-approve" +
+          " — only the turn's own prompt asks it not to"
+      )
+    )
+
+  // The notice answers "I asked for a restriction and didn't get one". A `Full`
+  // turn approving everything asked for none, so the same weak declaration must
+  // stay silent.
+  test("a Full turn approving everything reports no shortfall"):
+    val steps = new StepRecorder
+    val tool = new StubTool(
+      new UngatedBackend("only"),
+      listener = steps.listener,
+      prompts = DefaultPrompts
+    )
+    val _ = tool.run("one")
+    assertEquals(steps.seen, Nil)
+
+  // The log lives on the backend, so two backends of the same kind — a flow
+  // that wires its own second one — each say their piece. Documented on
+  // `AgentBackend`; pinned here because it is a consequence of where the state
+  // sits rather than of anything the notice does.
+  test("a second backend of the same kind gives its own notice"):
+    val steps = new StepRecorder
+    def readOnlyTool = new StubTool(
+      new UngatedBackend("reply"),
+      toolConfig = AgentConfig(tools = ToolSet.ReadOnly),
+      listener = steps.listener,
+      prompts = DefaultPrompts
+    )
+    val _ = readOnlyTool.run("one")
+    val _ = readOnlyTool.run("two")
+    assertEquals(
+      steps.seen,
+      List.fill(2)(BaseAgentTest.noEditNotice("ReadOnly"))
+    )
 
   // A turn that failed after the model ran still spent tokens; the success path
   // is the only other TokensUsed emitter, so without this the failed turn is
@@ -760,6 +794,19 @@ class BaseAgentTest extends munit.FunSuite:
         outputSchema: Option[String]
     )(using ox.Ox): Conversation[BackendTag.Pi.type] =
       throw new UnsupportedOperationException
+
+  /** Collects the `Step` lines a run showed, in order — the notice's
+    * user-facing channel.
+    */
+  private class StepRecorder:
+    private val steps =
+      new java.util.concurrent.atomic.AtomicReference[List[String]](Nil)
+    val listener: OrcaListener = event =>
+      event match
+        case OrcaEvent.Step(message) =>
+          val _ = steps.updateAndGet(message :: _)
+        case _ => ()
+    def seen: List[String] = steps.get().reverse
 
   /** Gates nothing mechanically, whichever way the turn dispatches — the
     * condition `EnforcementNotice` exists to report.

--- a/tools/src/test/scala/orca/agents/BaseAgentTest.scala
+++ b/tools/src/test/scala/orca/agents/BaseAgentTest.scala
@@ -177,7 +177,7 @@ class BaseAgentTest extends munit.FunSuite:
   // A caller that asks for a no-edit tier and gets prose has no other signal
   // that the gate isn't mechanical — and a fan-out would repeat the notice per
   // turn, which is why it is deduplicated rather than emitted per run call.
-  test("a read-only tier the backend doesn't gate is reported once per run"):
+  test("a read-only tier the backend doesn't gate is reported once"):
     val seen =
       new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
     val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
@@ -191,9 +191,53 @@ class BaseAgentTest extends munit.FunSuite:
     val _ = tool.run("two")
     assertEquals(
       seen.get().collect { case OrcaEvent.Step(m) => m },
-      List(
-        "Pi does not mechanically enforce ReadOnly on a fresh turn: PromptOnly"
-      )
+      List("Pi does not mechanically enforce ReadOnly: PromptOnly")
+    )
+
+  // Reviewers — the turns this notice exists for — reach the backend through
+  // `resultAs`, which dispatches on its own path rather than through the text
+  // one, so it has to raise the notice itself.
+  test("a read-only structured turn reports the shortfall too"):
+    val seen =
+      new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
+    val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
+    val tool = new StubTool(
+      new UngatedBackend("""{"fixed":[],"ignored":[]}"""),
+      toolConfig = AgentConfig(tools = ToolSet.ReadOnly),
+      listener = listener,
+      prompts = DefaultPrompts
+    )
+    val _ = tool.resultAs[FixOutcome].autonomous.run("fix compile errors")
+    assertEquals(
+      seen.get().collect { case OrcaEvent.Step(m) => m },
+      List("Pi does not mechanically enforce ReadOnly: PromptOnly")
+    )
+
+  // The first attempt commits the session, so the corrective re-prompt runs as
+  // a resumed turn — which on this backend (codex's shape) is where the gate
+  // disappears. Classified once per call instead of once per attempt, the
+  // retry's weaker guarantee would go unreported: the first attempt is `Hard`,
+  // so the single Step below is entirely the second attempt's.
+  test("a corrective retry reports the resumed turn's weaker guarantee"):
+    val seen =
+      new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
+    val listener: OrcaListener = e => { val _ = seen.updateAndGet(e :: _) }
+    val tool = new StubTool(
+      new GatedOnlyWhenFreshBackend(
+        "not json at all",
+        """{"fixed":[],"ignored":[]}"""
+      ),
+      toolConfig = AgentConfig(
+        tools = ToolSet.ReadOnly,
+        retrySchedule = Schedule.exponentialBackoff(1.milli).maxRetries(1)
+      ),
+      listener = listener,
+      prompts = DefaultPrompts
+    )
+    val _ = tool.resultAs[FixOutcome].autonomous.run("fix compile errors")
+    assertEquals(
+      seen.get().collect { case OrcaEvent.Step(m) => m },
+      List("Pi does not mechanically enforce ReadOnly: PromptOnly")
     )
 
   // The notice answers "I asked for a gate and didn't get one". A `Full` turn
@@ -660,18 +704,6 @@ class BaseAgentTest extends munit.FunSuite:
     * `replies` are answered one per call, so a retried call can be scripted
     * with an output that won't parse followed by one that will.
     */
-  /** Declares that it gates nothing mechanically — the condition
-    * `EnforcementNotice` exists to report.
-    */
-  private class UngatedBackend(replies: String*)
-      extends ScriptedDrainBackend(replies*):
-    override def enforcementCell(
-        tools: ToolSet,
-        autoApprove: AutoApprove,
-        dispatch: TurnDispatch
-    ): EnforcementCell =
-      EnforcementCell(Enforcement.PromptOnly, "the prompt is the whole gate")
-
   private class ScriptedDrainBackend(replies: String*)
       extends AgentBackend[BackendTag.Pi.type]:
     private val remaining = replies.iterator
@@ -728,6 +760,33 @@ class BaseAgentTest extends munit.FunSuite:
         outputSchema: Option[String]
     )(using ox.Ox): Conversation[BackendTag.Pi.type] =
       throw new UnsupportedOperationException
+
+  /** Gates nothing mechanically, whichever way the turn dispatches — the
+    * condition `EnforcementNotice` exists to report.
+    */
+  private class UngatedBackend(replies: String*)
+      extends ScriptedDrainBackend(replies*):
+    override def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
+    ): EnforcementCell =
+      EnforcementCell(Enforcement.PromptOnly, "the prompt is the whole gate")
+
+  /** codex's shape: a mechanical gate on the spawn, none on the resume. Only a
+    * call that classifies per attempt sees the second answer.
+    */
+  private class GatedOnlyWhenFreshBackend(replies: String*)
+      extends ScriptedDrainBackend(replies*):
+    override def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
+    ): EnforcementCell = dispatch match
+      case TurnDispatch.Fresh =>
+        EnforcementCell(Enforcement.Hard, "the spawn carries the sandbox flag")
+      case TurnDispatch.Resumed =>
+        EnforcementCell(Enforcement.PromptOnly, "the resume carries no flag")
 
   /** Throws `error` on its first turn and scripts the rest — an attempt that
     * dies before reaching the model, which consumes none of `replies`.

--- a/tools/src/test/scala/orca/agents/ChatTest.scala
+++ b/tools/src/test/scala/orca/agents/ChatTest.scala
@@ -69,8 +69,11 @@ class ChatTest extends munit.FunSuite:
     val sessions: SessionSupport[BackendTag.Pi.type] =
       SessionSupport.ephemeral(IdScheme.ClientClaimed)
     val tag: BackendTag.Pi.type = BackendTag.Pi
-    def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
-      Enforcement.Ignored
+    def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove
+    ): EnforcementCell =
+      EnforcementCell(Enforcement.Ignored, "test double")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 

--- a/tools/src/test/scala/orca/agents/ChatTest.scala
+++ b/tools/src/test/scala/orca/agents/ChatTest.scala
@@ -1,5 +1,6 @@
 package orca.agents
 
+import orca.testkit.StubEnforcement
 import orca.backend.{
   Conversation,
   Interaction,
@@ -74,7 +75,7 @@ class ChatTest extends munit.FunSuite:
         autoApprove: AutoApprove,
         dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
+      StubEnforcement.cell
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 

--- a/tools/src/test/scala/orca/agents/ChatTest.scala
+++ b/tools/src/test/scala/orca/agents/ChatTest.scala
@@ -71,9 +71,10 @@ class ChatTest extends munit.FunSuite:
     val tag: BackendTag.Pi.type = BackendTag.Pi
     def enforcementCell(
         tools: ToolSet,
-        autoApprove: AutoApprove
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Ignored, "test double")
+      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 

--- a/tools/src/test/scala/orca/agents/WithCheapModelTest.scala
+++ b/tools/src/test/scala/orca/agents/WithCheapModelTest.scala
@@ -1,5 +1,6 @@
 package orca.agents
 
+import orca.testkit.StubEnforcement
 import orca.backend.{
   Conversation,
   Interaction,
@@ -80,7 +81,7 @@ class WithCheapModelTest extends munit.FunSuite:
         autoApprove: AutoApprove,
         dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
+      StubEnforcement.cell
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 

--- a/tools/src/test/scala/orca/agents/WithCheapModelTest.scala
+++ b/tools/src/test/scala/orca/agents/WithCheapModelTest.scala
@@ -75,8 +75,11 @@ class WithCheapModelTest extends munit.FunSuite:
     val sessions: SessionSupport[BackendTag.Pi.type] =
       SessionSupport.ephemeral(IdScheme.ClientClaimed)
     val tag: BackendTag.Pi.type = BackendTag.Pi
-    def enforcement(tools: ToolSet, autoApprove: AutoApprove): Enforcement =
-      Enforcement.Ignored
+    def enforcementCell(
+        tools: ToolSet,
+        autoApprove: AutoApprove
+    ): EnforcementCell =
+      EnforcementCell(Enforcement.Ignored, "test double")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 

--- a/tools/src/test/scala/orca/agents/WithCheapModelTest.scala
+++ b/tools/src/test/scala/orca/agents/WithCheapModelTest.scala
@@ -77,9 +77,10 @@ class WithCheapModelTest extends munit.FunSuite:
     val tag: BackendTag.Pi.type = BackendTag.Pi
     def enforcementCell(
         tools: ToolSet,
-        autoApprove: AutoApprove
+        autoApprove: AutoApprove,
+        dispatch: TurnDispatch
     ): EnforcementCell =
-      EnforcementCell(Enforcement.Ignored, "test double")
+      EnforcementCell(Enforcement.Hard, "test double: nothing to report")
     def structuredOutputMode: StructuredOutputMode =
       StructuredOutputMode.RawText
 

--- a/tools/src/test/scala/orca/backend/SystemPromptComposerTest.scala
+++ b/tools/src/test/scala/orca/backend/SystemPromptComposerTest.scala
@@ -5,30 +5,34 @@ import orca.agents.{AgentConfig, ToolSet}
 class SystemPromptComposerTest extends munit.FunSuite:
 
   private val gitRule = SystemPromptComposer.RuntimeOwnsGit
+  private val readOnlyRule = SystemPromptComposer.ReadOnlyTurn
   private val backgroundRule =
     SystemPromptComposer.BackgroundWorkAbandonedAtTurnEnd
 
-  test("write-capable turn with nothing else gets both standing rules"):
+  test("write-capable turn with nothing else gets the git rule"):
     val out = SystemPromptComposer.combine(AgentConfig(), None)
-    assertEquals(out, Some(s"$gitRule\n\n$backgroundRule"))
+    assertEquals(out, s"$gitRule\n\n$backgroundRule")
 
-  test("read-only turn with nothing else gets the background rule alone"):
-    // Read-only turns can't commit, so the git rule is omitted; the turn
-    // boundary applies to them exactly as it does to a write-capable turn.
+  test("read-only turn gets the read-only rule instead of the git rule"):
     val out = SystemPromptComposer.combine(
       AgentConfig().copy(tools = ToolSet.ReadOnly),
       None
     )
-    assertEquals(out, Some(backgroundRule))
+    assertEquals(out, s"$readOnlyRule\n\n$backgroundRule")
 
-  test("network-only turn also gets the background rule alone"):
+  test("network-only turn gets the read-only rule too"):
     val out = SystemPromptComposer.combine(
       AgentConfig().copy(tools = ToolSet.NetworkOnly),
       None
     )
-    assertEquals(out, Some(backgroundRule))
+    assertEquals(out, s"$readOnlyRule\n\n$backgroundRule")
 
-  test("read-only config keeps its systemPrompt and drops only the git rule"):
+  test("the read-only rule says nothing about the network"):
+    // A NetworkOnly turn is given read-only network access on purpose; the
+    // shared rule must not take it back.
+    assert(!readOnlyRule.toLowerCase.contains("network"), readOnlyRule)
+
+  test("read-only config keeps its systemPrompt ahead of the standing rules"):
     val out = SystemPromptComposer.combine(
       AgentConfig().copy(
         systemPrompt = Some("be terse"),
@@ -36,7 +40,7 @@ class SystemPromptComposerTest extends munit.FunSuite:
       ),
       extraHint = None
     )
-    assertEquals(out, Some(s"be terse\n\n$backgroundRule"))
+    assertEquals(out, s"be terse\n\n$readOnlyRule\n\n$backgroundRule")
 
   test("selfManagedGit omits the git rule but keeps the background rule"):
     // With this flag the runtime stays out of the agent's git, so the agent may
@@ -46,7 +50,7 @@ class SystemPromptComposerTest extends munit.FunSuite:
       AgentConfig().copy(selfManagedGit = true),
       extraHint = None
     )
-    assertEquals(out, Some(backgroundRule))
+    assertEquals(out, backgroundRule)
 
   test("foldIntoPrompt keeps a user-prompt line that starts with `|`"):
     val out = SystemPromptComposer.foldIntoPrompt(
@@ -61,7 +65,4 @@ class SystemPromptComposerTest extends munit.FunSuite:
       AgentConfig().copy(systemPrompt = Some("be terse")),
       extraHint = Some("the hint")
     )
-    assertEquals(
-      out,
-      Some(s"be terse\n\nthe hint\n\n$gitRule\n\n$backgroundRule")
-    )
+    assertEquals(out, s"be terse\n\nthe hint\n\n$gitRule\n\n$backgroundRule")

--- a/tools/src/test/scala/orca/testkit/StubEnforcement.scala
+++ b/tools/src/test/scala/orca/testkit/StubEnforcement.scala
@@ -1,0 +1,15 @@
+package orca.testkit
+
+import orca.agents.{Enforcement, EnforcementCell}
+
+/** The `enforcementCell` answer for an `AgentBackend` double that isn't the
+  * subject of the test.
+  *
+  * `Hard` rather than `Ignored`: the level decides whether `EnforcementNotice`
+  * speaks, so an unrelated double declaring a weak level would put a Step into
+  * every read-only turn of every suite. Sharing one constant also makes the few
+  * doubles that DO declare something else read as deliberate.
+  */
+object StubEnforcement:
+  val cell: EnforcementCell =
+    EnforcementCell(Enforcement.Hard, "test double: nothing to report")


### PR DESCRIPTION
- The composer now adds a read-only rule to every ReadOnly/NetworkOnly turn, so a `PromptOnly` cell actually has a prompt behind it. Reviewer and cheap turns had none before.
- `SystemPromptComposer.combine` returns `String` instead of an always-`Some` `Option`; the three delivery sites no longer carry a dead `None` branch.
- Each backend declares one `EnforcementCell(level, rationale)` per matrix cell. `EnforcementTableTest` walks the full backend × ToolSet × AutoApprove × dispatch product and renders AGENTS.md's table, so the table can't drift.
- codex answers per dispatch: `exec resume` sends no sandbox flag, so a resumed read-only turn reports `PromptOnly`, not `Hard`.
- When a turn asks for a no-edit tier the backend doesn't mechanically gate, the run says so once — a `Step` plus a WARN — instead of the value being computed and read by nobody.
- `ToolSet.writeCapable` / `hasScopedNetwork` replace two `==` checks, so a new tier fails to compile next to the enum.

Skipped: AutoApprove axis fold (deliberate two-axis design); live CLI probes (codex resume, claude allowedTools).