### PR TITLE
Emit Unobserved debit for usage-less claude error frames

### DIFF
--- a/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
@@ -272,14 +272,21 @@ private[claude] class ClaudeConversation(
       if deltasSinceLastFullTurn then "session failed (see message above)"
       else message
     eventQueue.enqueue(ConversationEvent.Error(displayed))
-    failWith(
-      new AgentTurnFailed(
-        s"claude session failed (subtype ${result.subtype}, " +
-          s"session ${result.sessionId}): $message",
+    // A frame that carried no `usage` object saw no tokens — reporting it as
+    // `Observed(Usage.empty)` would be an all-zero measurement. `total_cost_usd`
+    // rides inside `usage` and goes with it; no such frame has been seen.
+    val debit =
+      if result.usageReported then
         TurnDebit.Observed(
           withApiCalls(result.usage),
           turnModel(result).map(Model.apply)
         )
+      else TurnDebit.Unobserved
+    failWith(
+      new AgentTurnFailed(
+        s"claude session failed (subtype ${result.subtype}, " +
+          s"session ${result.sessionId}): $message",
+        debit
       )
     )
 

--- a/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
@@ -210,7 +210,7 @@ private[claude] class ClaudeConversation(
     settleSuccess(
       wireId = result.sessionId,
       output = resultBody(result).getOrElse(""),
-      usage = withApiCalls(result.usage),
+      usage = withApiCalls(result.usage.getOrElse(orca.events.Usage.empty)),
       modelId = turnModel(result)
     )
 
@@ -272,16 +272,13 @@ private[claude] class ClaudeConversation(
       if deltasSinceLastFullTurn then "session failed (see message above)"
       else message
     eventQueue.enqueue(ConversationEvent.Error(displayed))
-    // A frame that carried no `usage` object saw no tokens — reporting it as
-    // `Observed(Usage.empty)` would be an all-zero measurement. `total_cost_usd`
-    // rides inside `usage` and goes with it; no such frame has been seen.
-    val debit =
-      if result.usageReported then
-        TurnDebit.Observed(
-          withApiCalls(result.usage),
-          turnModel(result).map(Model.apply)
-        )
-      else TurnDebit.Unobserved
+    // A frame with no `usage` object saw no tokens — `Observed(Usage.empty)`
+    // would reach the cost summary as a measured zero. The wire's sibling
+    // `total_cost_usd` is folded into `Usage.cost`, so it is dropped with it.
+    val debit = result.usage match
+      case Some(u) =>
+        TurnDebit.Observed(withApiCalls(u), turnModel(result).map(Model.apply))
+      case None => TurnDebit.Unobserved
     failWith(
       new AgentTurnFailed(
         s"claude session failed (subtype ${result.subtype}, " +

--- a/claude/src/main/scala/orca/tools/claude/streamjson/InboundMessage.scala
+++ b/claude/src/main/scala/orca/tools/claude/streamjson/InboundMessage.scala
@@ -33,6 +33,12 @@ private[claude] enum InboundMessage:
     * validated value lands in `structuredOutput` as raw JSON; without the flag
     * (or in error cases) the agent's free-form reply lands in `output`. Callers
     * that need a single value should prefer `structuredOutput.orElse(output)`.
+    *
+    * `usage` zeroes an absent wire `usage` object, so it alone can't tell a
+    * frame that reported nothing from one that measured zero; `usageReported`
+    * is that distinction. Failure paths must consult it before claiming an
+    * observation — a usage-less frame (quota, rate limit, auth) has seen no
+    * tokens, not zero of them.
     */
   case Result(
       subtype: String,
@@ -40,6 +46,7 @@ private[claude] enum InboundMessage:
       output: Option[String],
       structuredOutput: Option[String],
       usage: Usage,
+      usageReported: Boolean,
       isError: Boolean,
       model: Option[String]
   )
@@ -102,6 +109,7 @@ private[claude] object InboundMessage:
         cost = wire.total_cost_usd,
         apiCalls = None
       ),
+      usageReported = wire.usage.isDefined,
       isError = wire.is_error.getOrElse(false),
       model = wire.model
     )

--- a/claude/src/main/scala/orca/tools/claude/streamjson/InboundMessage.scala
+++ b/claude/src/main/scala/orca/tools/claude/streamjson/InboundMessage.scala
@@ -33,20 +33,13 @@ private[claude] enum InboundMessage:
     * validated value lands in `structuredOutput` as raw JSON; without the flag
     * (or in error cases) the agent's free-form reply lands in `output`. Callers
     * that need a single value should prefer `structuredOutput.orElse(output)`.
-    *
-    * `usage` zeroes an absent wire `usage` object, so it alone can't tell a
-    * frame that reported nothing from one that measured zero; `usageReported`
-    * is that distinction. Failure paths must consult it before claiming an
-    * observation — a usage-less frame (quota, rate limit, auth) has seen no
-    * tokens, not zero of them.
     */
   case Result(
       subtype: String,
       sessionId: String,
       output: Option[String],
       structuredOutput: Option[String],
-      usage: Usage,
-      usageReported: Boolean,
+      usage: Option[Usage],
       isError: Boolean,
       model: Option[String]
   )
@@ -86,10 +79,6 @@ private[claude] object InboundMessage:
 
   private def parseResult(line: String): InboundMessage =
     val wire = readFromString[ResultWire](line)
-    val u = wire.usage.getOrElse(UsageWire())
-    // The wire's "cache creation" is orca's cache write.
-    val cacheWrite = u.cache_creation_input_tokens.getOrElse(0L)
-    val cacheRead = u.cache_read_input_tokens.getOrElse(0L)
     // The result message's own `num_turns` looks like a call count and is not
     // one: measured against claude 2.1.220 it is (tool calls + 1), so a
     // response issuing three tool calls at once reports three turns where one
@@ -100,16 +89,17 @@ private[claude] object InboundMessage:
       sessionId = wire.session_id,
       output = wire.result,
       structuredOutput = wire.structured_output.map(_.value),
-      usage = Usage(
-        freshInputTokens = u.input_tokens.getOrElse(0L),
-        cacheReadInputTokens = cacheRead,
-        cacheWriteInputTokens = cacheWrite,
-        outputTokens = u.output_tokens.getOrElse(0L),
-        reasoningOutputTokens = 0L,
-        cost = wire.total_cost_usd,
-        apiCalls = None
-      ),
-      usageReported = wire.usage.isDefined,
+      usage = wire.usage.map: u =>
+        Usage(
+          freshInputTokens = u.input_tokens.getOrElse(0L),
+          cacheReadInputTokens = u.cache_read_input_tokens.getOrElse(0L),
+          // The wire's "cache creation" is orca's cache write.
+          cacheWriteInputTokens = u.cache_creation_input_tokens.getOrElse(0L),
+          outputTokens = u.output_tokens.getOrElse(0L),
+          reasoningOutputTokens = 0L,
+          cost = wire.total_cost_usd,
+          apiCalls = None
+        ),
       isError = wire.is_error.getOrElse(false),
       model = wire.model
     )

--- a/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
@@ -207,9 +207,8 @@ class ClaudeConversationTest extends munit.FunSuite:
       )
     )
 
-  // Quota/rate-limit/auth failures come back with no `usage` object at all. An
-  // `Observed(Usage.empty)` debit here would reach the cost summary as a
-  // measured zero.
+  // `Observed(Usage.empty)` here would reach the cost summary as a measured
+  // zero.
   convTest("is_error without a usage object reports an unobserved debit"):
     val process = new FakePipedCliProcess()
     val conv = new ClaudeConversation(process, AgentConfig())

--- a/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/ClaudeConversationTest.scala
@@ -207,6 +207,22 @@ class ClaudeConversationTest extends munit.FunSuite:
       )
     )
 
+  // Quota/rate-limit/auth failures come back with no `usage` object at all. An
+  // `Observed(Usage.empty)` debit here would reach the cost summary as a
+  // measured zero.
+  convTest("is_error without a usage object reports an unobserved debit"):
+    val process = new FakePipedCliProcess()
+    val conv = new ClaudeConversation(process, AgentConfig())
+
+    process.enqueueStdout(
+      """{"type":"result","subtype":"error","session_id":"sid-nousage","result":"API Error: 400 quota exceeded","is_error":true}"""
+    )
+    process.closeStdout()
+
+    val _ = conv.events.toList
+    val failure = intercept[AgentTurnFailed](conv.awaitResult())
+    assertEquals(failure.debit, TurnDebit.Unobserved)
+
   convTest(
     "is_error after a tool-only turn (no assistant text) surfaces the full error body"
   ):

--- a/claude/src/test/scala/orca/tools/claude/streamjson/InboundMessageTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/streamjson/InboundMessageTest.scala
@@ -50,7 +50,7 @@ class InboundMessageTest extends munit.FunSuite:
     val r = msg.asInstanceOf[InboundMessage.Result]
     assertEquals(r.sessionId, "sid-1")
     assertEquals(r.structuredOutput, Some("""{"answer":42}"""))
-    assertEquals(r.usage, usage(10L, 20L, Some(BigDecimal("0.003"))))
+    assertEquals(r.usage, Some(usage(10L, 20L, Some(BigDecimal("0.003")))))
     assertEquals(r.isError, false)
 
   test("result keeps cache creation and cache reads on separate axes"):
@@ -59,16 +59,18 @@ class InboundMessageTest extends munit.FunSuite:
     )
     assertEquals(
       msg.asInstanceOf[InboundMessage.Result].usage,
-      Usage(
-        // The wire's `input_tokens` excludes both cache categories, so it is
-        // the fresh axis as it stands.
-        freshInputTokens = 10L,
-        cacheReadInputTokens = 4000L,
-        cacheWriteInputTokens = 300L,
-        outputTokens = 20L,
-        reasoningOutputTokens = 0L,
-        cost = Some(BigDecimal("0.5")),
-        apiCalls = None
+      Some(
+        Usage(
+          // The wire's `input_tokens` excludes both cache categories, so it is
+          // the fresh axis as it stands.
+          freshInputTokens = 10L,
+          cacheReadInputTokens = 4000L,
+          cacheWriteInputTokens = 300L,
+          outputTokens = 20L,
+          reasoningOutputTokens = 0L,
+          cost = Some(BigDecimal("0.5")),
+          apiCalls = None
+        )
       )
     )
 
@@ -78,7 +80,10 @@ class InboundMessageTest extends munit.FunSuite:
     val msg = InboundMessage.parse(
       """{"type":"result","subtype":"success","session_id":"sid-1","num_turns":4,"usage":{"input_tokens":10,"output_tokens":20}}"""
     )
-    assertEquals(msg.asInstanceOf[InboundMessage.Result].usage.apiCalls, None)
+    assertEquals(
+      msg.asInstanceOf[InboundMessage.Result].usage.flatMap(_.apiCalls),
+      None
+    )
 
   test("result surfaces the resolved model id when present"):
     val msg = InboundMessage.parse(
@@ -121,7 +126,7 @@ class InboundMessageTest extends munit.FunSuite:
     assertEquals(msg, InboundMessage.AssistantTurn(Nil, None))
 
   test(
-    "result with all optional fields absent defaults usage to zero and isError to false"
+    "result with all optional fields absent leaves usage absent and isError false"
   ):
     val msg = InboundMessage.parse(
       """{"type":"result","subtype":"success","session_id":"sid-x"}"""
@@ -129,8 +134,7 @@ class InboundMessageTest extends munit.FunSuite:
     val r = msg.asInstanceOf[InboundMessage.Result]
     assertEquals(r.output, None)
     assertEquals(r.structuredOutput, None)
-    assertEquals(r.usage, Usage.empty)
-    assertEquals(r.usageReported, false)
+    assertEquals(r.usage, None)
     assertEquals(r.isError, false)
 
   test("non-init system subtype is namespaced into Unknown"):

--- a/claude/src/test/scala/orca/tools/claude/streamjson/InboundMessageTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/streamjson/InboundMessageTest.scala
@@ -130,6 +130,7 @@ class InboundMessageTest extends munit.FunSuite:
     assertEquals(r.output, None)
     assertEquals(r.structuredOutput, None)
     assertEquals(r.usage, Usage.empty)
+    assertEquals(r.usageReported, false)
     assertEquals(r.isError, false)
 
   test("non-init system subtype is namespaced into Unknown"):


### PR DESCRIPTION
A claude `result` frame with `is_error: true` and no `usage` object was decoded as zero tokens, and `handleResultError` reported that as an observed debit. Quota, rate-limit and auth failures then showed up in the cost summary as a measured zero instead of nothing.

`InboundMessage.Result` now keeps a `usageReported` flag from the wire, and the error handler emits `TurnDebit.Unobserved` when no usage was reported. A frame's `total_cost_usd` rides inside `usage`, so it is dropped together with it.

Finding: docs/research/2026-08-review/cost-pipeline/01-claude-error-frame-fabricates-observed-debit.md
