### PR TITLE
Align opencode's read-only tier with the documented grants

### DIFF
--- a/adr/0016-toolset-capability-axis-and-planner-network.md
+++ b/adr/0016-toolset-capability-axis-and-planner-network.md
@@ -55,7 +55,8 @@ gets web reads (no shell `gh`). What that probe did *not* establish is gemini's
 no-edit guarantee — see the amendment below.
 `--allowed-tools` is deprecated (gemini 1.0 → Policy Engine); migrate then.
 opencode keeps `bash` off (no writable-shell network); its web tool isn't in the
-disabled set, so web may work (server-dependent, unverified).
+disabled set, so web may work (server-dependent, unverified). opencode's two
+tiers are no longer the same gate — see the amendment below.
 
 ### Claude allowlist placement
 
@@ -92,6 +93,17 @@ class of mechanism — turned out to remove no tools at all, and gemini also
 downgrades `plan` to `default` in untrusted folders, which is where orca runs
 agents. The cell records what orca can stand behind, not a known weakness;
 raise it when a probe establishes more.
+
+### opencode's two restricted tiers
+
+Amended 2026-08-08 (#111): opencode's `ReadOnly` and `NetworkOnly` are no longer
+the same gate. Both disable `write`, `edit`, `bash`, `patch` and `task` (`task`
+spawns a subagent with the profile's write-capable default set, and flag
+propagation into subagents is unmeasured). `ReadOnly` also disables `webfetch`
+by name; `NetworkOnly` leaves it unset, so opencode's `NetworkOnly` grants web
+reads with no shell, the same shape as claude's. Both tiers stay **hard**. This
+supersedes the opencode row in the table above and the "opencode planners stay
+network-free and rely on pre-fetching" consequence below.
 
 ## Consequences
 

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
@@ -74,33 +74,44 @@ private[opencode] object OpencodeArgs:
     val (provider, id) = OpencodeModel.split(model)
     ModelRef(provider, id)
 
+  /** The tools a non-writing turn withholds. `task` is one of them: it spawns a
+    * subagent that runs with the agent profile's default, write-capable tool
+    * set, and whether these per-message flags reach a subagent is unmeasured.
+    * `todowrite` is not: it writes the agent's own todo state, not the
+    * workspace.
+    */
+  private val writingToolsOff: Map[String, Boolean] =
+    Map(
+      "write" -> false,
+      "edit" -> false,
+      "bash" -> false,
+      "patch" -> false,
+      "task" -> false
+    )
+
   /** Per-turn tool gate: disable the write tools on a read-only turn, and the
     * `question` tool on an autonomous turn. Returns `None` when nothing is
     * gated so the body omits `tools` and the server's defaults apply.
     *
-    * `NetworkOnly` gets no dedicated handling and behaves like `ReadOnly`:
-    * scoped network would need `bash` enabled, dropping the hard no-edit
-    * guarantee, so opencode flows pre-fetch issue/PR context instead.
+    * `webfetch` reads the network without a shell, which is what separates the
+    * two restricted tiers: `ReadOnly` disables it too, `NetworkOnly` leaves it
+    * on. Neither tier has `bash`, so a `NetworkOnly` turn can read the web but
+    * not run `gh`.
     */
   private def toolFlags(
       config: AgentConfig,
       mode: ConversationMode
   ): Option[Map[String, Boolean]] =
-    val writeGate =
+    val tierGate =
       config.tools match
-        case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
-          Map(
-            "write" -> false,
-            "edit" -> false,
-            "bash" -> false,
-            "patch" -> false
-          )
-        case ToolSet.Full => Map.empty[String, Boolean]
+        case ToolSet.ReadOnly    => writingToolsOff + ("webfetch" -> false)
+        case ToolSet.NetworkOnly => writingToolsOff
+        case ToolSet.Full        => Map.empty[String, Boolean]
     val question =
       if mode.isInteractive then Map.empty[String, Boolean]
       else Map("question" -> false)
     // The two key sets are disjoint, so the merge order is irrelevant.
-    val flags = writeGate ++ question
+    val flags = tierGate ++ question
     Option.when(flags.nonEmpty)(flags)
 
   /** How strongly opencode enforces each `(tools, autoApprove)` combination —
@@ -114,10 +125,15 @@ private[opencode] object OpencodeArgs:
     // Same either way: the gate rides on [[message]], which every turn sends.
     case TurnDispatch.Fresh | TurnDispatch.Resumed =>
       tools match
-        case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+        case ToolSet.ReadOnly =>
           EnforcementCell(
             Enforcement.Hard,
-            "the message body disables `write`, `edit`, `bash` and `patch` by name, so the server offers none of those four — unlike an allowlist, this stays exact only while opencode ships no fifth writing tool"
+            "the message body disables `write`, `edit`, `bash`, `patch`, `task` and `webfetch` by name, so the server offers none of those six — unlike an allowlist, this stays exact only while opencode ships no further writing or network tool"
+          )
+        case ToolSet.NetworkOnly =>
+          EnforcementCell(
+            Enforcement.Hard,
+            "the message body disables `write`, `edit`, `bash`, `patch` and `task` by name; `webfetch` stays on, so the turn reads the web through it and has no shell to do anything else with"
           )
         case ToolSet.Full =>
           autoApprove match

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
@@ -74,13 +74,13 @@ private[opencode] object OpencodeArgs:
     val (provider, id) = OpencodeModel.split(model)
     ModelRef(provider, id)
 
-  /** The tools a non-writing turn withholds. `task` is one of them: it spawns a
-    * subagent that runs with the agent profile's default, write-capable tool
+  /** The tools both restricted tiers withhold. `task` is one of them: it spawns
+    * a subagent that runs with the agent profile's default, write-capable tool
     * set, and whether these per-message flags reach a subagent is unmeasured.
     * `todowrite` is not: it writes the agent's own todo state, not the
     * workspace.
     */
-  private val writingToolsOff: Map[String, Boolean] =
+  private val restrictedToolsOff: Map[String, Boolean] =
     Map(
       "write" -> false,
       "edit" -> false,
@@ -89,14 +89,15 @@ private[opencode] object OpencodeArgs:
       "task" -> false
     )
 
-  /** Per-turn tool gate: disable the write tools on a read-only turn, and the
-    * `question` tool on an autonomous turn. Returns `None` when nothing is
-    * gated so the body omits `tools` and the server's defaults apply.
+  /** Per-turn tool gate: withhold the restricted tiers' tools on a `ReadOnly`
+    * or `NetworkOnly` turn, and the `question` tool on an autonomous turn.
+    * Returns `None` when nothing is gated so the body omits `tools` and the
+    * server's defaults apply.
     *
     * `webfetch` reads the network without a shell, which is what separates the
-    * two restricted tiers: `ReadOnly` disables it too, `NetworkOnly` leaves it
-    * on. Neither tier has `bash`, so a `NetworkOnly` turn can read the web but
-    * not run `gh`.
+    * two restricted tiers: `ReadOnly` disables it by name, `NetworkOnly` leaves
+    * it unset so the server's own default decides. Neither tier has `bash`, so
+    * a `NetworkOnly` turn cannot run `gh`.
     */
   private def toolFlags(
       config: AgentConfig,
@@ -104,8 +105,8 @@ private[opencode] object OpencodeArgs:
   ): Option[Map[String, Boolean]] =
     val tierGate =
       config.tools match
-        case ToolSet.ReadOnly    => writingToolsOff + ("webfetch" -> false)
-        case ToolSet.NetworkOnly => writingToolsOff
+        case ToolSet.ReadOnly    => restrictedToolsOff + ("webfetch" -> false)
+        case ToolSet.NetworkOnly => restrictedToolsOff
         case ToolSet.Full        => Map.empty[String, Boolean]
     val question =
       if mode.isInteractive then Map.empty[String, Boolean]
@@ -128,12 +129,12 @@ private[opencode] object OpencodeArgs:
         case ToolSet.ReadOnly =>
           EnforcementCell(
             Enforcement.Hard,
-            "the message body disables `write`, `edit`, `bash`, `patch`, `task` and `webfetch` by name, so the server offers none of those six — unlike an allowlist, this stays exact only while opencode ships no further writing or network tool"
+            "the message body disables `write`, `edit`, `bash`, `patch`, `task` and `webfetch` by name, so the server offers none of them — a denylist, so it stays exact only while opencode ships no further writing or network tool"
           )
         case ToolSet.NetworkOnly =>
           EnforcementCell(
             Enforcement.Hard,
-            "the message body disables `write`, `edit`, `bash`, `patch` and `task` by name; `webfetch` stays on, so the turn reads the web through it and has no shell to do anything else with"
+            "the message body disables `write`, `edit`, `bash`, `patch` and `task` by name and leaves `webfetch` to the server default, so the turn reads the web where the server offers it but has no `bash` to run `gh` — a denylist, so it stays exact only while opencode ships no further writing tool"
           )
         case ToolSet.Full =>
           autoApprove match

--- a/opencode/src/test/scala/orca/tools/opencode/OpencodeArgsTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/OpencodeArgsTest.scala
@@ -103,7 +103,7 @@ class OpencodeArgsTest extends munit.FunSuite:
       OpencodeArgs.message(AgentConfig(), "hi", None, interactive)
     assertEquals(body.tools, None)
 
-  test("read-only turn disables the write tools (write/edit/bash/patch)"):
+  test("read-only turn disables the write tools, task and webfetch"):
     val cfg =
       AgentConfig().copy(
         tools = ToolSet.ReadOnly,
@@ -118,18 +118,20 @@ class OpencodeArgsTest extends munit.FunSuite:
     assertEquals(tools.get("edit"), Some(false))
     assertEquals(tools.get("bash"), Some(false))
     assertEquals(tools.get("patch"), Some(false))
+    assertEquals(tools.get("task"), Some(false))
+    assertEquals(tools.get("webfetch"), Some(false))
 
-  test("NetworkOnly keeps bash disabled (no writable-shell network)"):
-    // opencode has no scoped network: NetworkOnly gates the same write tools as
-    // ReadOnly, so the planner can't shell out to `gh`.
+  test("NetworkOnly keeps webfetch, with the write tools still disabled"):
     val cfg = AgentConfig().copy(tools = ToolSet.NetworkOnly)
     val tools =
       OpencodeArgs
         .message(cfg, "hi", None, interactive)
         .tools
         .getOrElse(Map.empty)
+    assertEquals(tools.get("webfetch"), None)
     assertEquals(tools.get("bash"), Some(false))
     assertEquals(tools.get("edit"), Some(false))
+    assertEquals(tools.get("task"), Some(false))
 
   test("read-only autonomous turn gates both write tools and question"):
     val cfg = AgentConfig().copy(tools = ToolSet.ReadOnly)


### PR DESCRIPTION
opencode's ReadOnly turns still had `task` (spawns a subagent whose tools are the profile's write-capable default) and `webfetch` enabled, so ReadOnly kept network access even though ADR 0016 says read-only blocks the network on every backend. ReadOnly and NetworkOnly also produced the exact same gate, so NetworkOnly was an alias.

The gate now disables `task` in both tiers and `webfetch` in ReadOnly only, so NetworkOnly is web reads without a shell.

Findings: docs/research/2026-08-review/agent-isolation/02-opencode-readonly-hard-cell-ignores-task-tool.md, docs/research/2026-08-review/agent-isolation/03-opencode-readonly-keeps-webfetch.md