### PR TITLE
Derive each backend's argv flags and enforcement cell from one match

### DIFF
--- a/adr/0016-toolset-capability-axis-and-planner-network.md
+++ b/adr/0016-toolset-capability-axis-and-planner-network.md
@@ -42,7 +42,7 @@ matrix in `AGENTS.md`, machine-checked by `EnforcementTableTest`.
 | --- | --- | --- | --- |
 | claude | `--tools <read-only tools + networkTools>` + `--allowedTools <mcpTools + networkTools>`, `github_issue` among the MCP tools | **hard** (`--tools` removes every unlisted built-in, shell and edits included) | web + host-side GitHub reads |
 | pi | `--tools …,bash` | **prompt-only** (bash permits writes) | shell (`gh`/`curl`) |
-| codex | `--full-auto` + `-c sandbox_workspace_write.network_access=true` | **prompt-only** (workspace-write permits writes) | shell + web |
+| codex | `--sandbox workspace-write` + `-c sandbox_workspace_write.network_access=true` | **prompt-only** (workspace-write permits writes) | shell + web |
 | gemini | `--approval-mode plan --allowed-tools web_fetch` | **prompt-only** (plan mode unmeasured against a write) | web |
 | opencode | write tools disabled (= `ReadOnly`) | hard | web only, server-dependent |
 

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -49,7 +49,12 @@ private[claude] object ClaudeArgs:
       modelArgs(config) ++
       systemPromptFileArgs(systemPromptFile) ++
       sessionArgs(dispatch) ++
-      permissionArgs(config, networkTools, mcpTools) ++
+      permissionWiring(
+        config.tools,
+        config.autoApprove,
+        networkTools,
+        mcpTools
+      ).args ++
       jsonSchemaArgs(jsonSchema) ++
       mcpConfigArgs(mcpConfig)
 
@@ -106,13 +111,28 @@ private[claude] object ClaudeArgs:
   private[claude] val ReadOnlyTools: Seq[String] =
     Seq("Read", "Grep", "Glob", "Skill")
 
-  /** Maps [[AgentConfig.tools]] to claude's tool and permission flags.
+  /** The permission flags a tier gets and the guarantee they achieve — one
+    * match builds both, so they cannot drift apart.
+    */
+  private case class PermissionWiring(args: Seq[String], cell: EnforcementCell)
+
+  /** The read-only tiers' cell. Shared because `--tools` confines both the same
+    * way; only the names on the list differ.
+    */
+  private val ReadOnlyTiersCell: EnforcementCell = EnforcementCell(
+    Enforcement.Hard,
+    "`--tools` confines the turn to the read-only names, so the write and shell tools are not on offer"
+  )
+
+  /** Maps [[AgentConfig.tools]] to claude's tool and permission flags, and
+    * classifies how strongly they hold.
     *
     * Both read-only tiers pass `--tools` (see [[ReadOnlyTools]]); `NetworkOnly`
     * appends `networkTools` to it. Both also [[approve]] what they must be able
     * to call: `mcpTools`, plus `networkTools` on `NetworkOnly`. These tiers
     * ignore [[AgentConfig.autoApprove]], so an MCP tool such a turn is meant to
-    * use has to arrive through `mcpTools`.
+    * use has to arrive through `mcpTools`. The grants widen what is on offer
+    * without changing the tier's guarantee, so the cell ignores them.
     *
     * `Full` follows [[AgentConfig.autoApprove]]: `All` → `bypassPermissions`;
     * `Only(_)` → default permission mode plus `--allowedTools`. Unlike
@@ -123,25 +143,53 @@ private[claude] object ClaudeArgs:
     * follow them in the argv — [[streamJson]] emits only flag-value pairs after
     * this, and the prompt goes over stdin.
     */
-  private def permissionArgs(
-      config: AgentConfig,
+  private def permissionWiring(
+      tools: ToolSet,
+      autoApprove: AutoApprove,
       networkTools: Seq[String],
       mcpTools: Seq[String]
-  ): Seq[String] =
-    config.tools match
+  ): PermissionWiring =
+    tools match
       case ToolSet.ReadOnly =>
-        Seq("--tools", ReadOnlyTools.mkString(",")) ++ approve(mcpTools)
+        PermissionWiring(
+          Seq("--tools", ReadOnlyTools.mkString(",")) ++ approve(mcpTools),
+          ReadOnlyTiersCell
+        )
       case ToolSet.NetworkOnly =>
-        Seq("--tools", (ReadOnlyTools ++ networkTools).mkString(",")) ++
-          approve(mcpTools ++ networkTools)
+        PermissionWiring(
+          Seq("--tools", (ReadOnlyTools ++ networkTools).mkString(",")) ++
+            approve(mcpTools ++ networkTools),
+          ReadOnlyTiersCell
+        )
       case ToolSet.Full =>
-        config.autoApprove match
+        autoApprove match
           case AutoApprove.All =>
-            Seq("--permission-mode", "bypassPermissions")
-          // Nothing pre-approved beyond claude's own defaults.
-          case AutoApprove.Only(tools) if tools.isEmpty => Seq.empty
-          case AutoApprove.Only(tools) =>
-            Seq("--allowedTools", tools.toSeq.sorted.mkString(","))
+            PermissionWiring(
+              Seq("--permission-mode", "bypassPermissions"),
+              EnforcementCell(
+                Enforcement.Hard,
+                "`--permission-mode bypassPermissions` approves everything, which is what `All` asks for"
+              )
+            )
+          // Nothing pre-approved beyond claude's own defaults, so no flag at
+          // all — and naming `--allowedTools` in the cell would describe a gate
+          // this arm never builds.
+          case AutoApprove.Only(names) if names.isEmpty =>
+            PermissionWiring(
+              Seq.empty,
+              EnforcementCell(
+                Enforcement.Hard,
+                "no flag: the turn runs in claude's default permission mode, which is the gate and approves nothing beyond its own defaults"
+              )
+            )
+          case AutoApprove.Only(names) =>
+            PermissionWiring(
+              Seq("--allowedTools", names.toSeq.sorted.mkString(",")),
+              EnforcementCell(
+                Enforcement.Hard,
+                "`--allowedTools` is a mechanical gate, but an ADDITIVE one: the auto-approved set is claude's default permission mode ∪ the `Only` list, and everything outside that union is denied. Probed 2026-08-07, claude 2.1.224: with only `Bash(echo *)` allowlisted a `Read` still ran unprompted, so the defaults survive the flag; the defaults seen to auto-approve are workspace reads and read-only `Bash`, while `Write` and mutating `Bash` were denied. The gate is hard; its boundary is a documented superset of the request"
+              )
+            )
 
   /** Whether a tier's `--tools` list withholds `Bash`, and so needs the host to
     * hand back the reads it would otherwise shell out for. Exactly the tiers
@@ -164,42 +212,16 @@ private[claude] object ClaudeArgs:
     else Seq("--allowedTools", tools.mkString(","))
 
   /** How strongly claude enforces each `(tools, autoApprove)` combination — see
-    * [[permissionArgs]] for the flags this classifies.
-    *
-    * Every axis is matched exhaustively rather than answered with a constant,
-    * so a future `ToolSet`/`AutoApprove`/`TurnDispatch` case fails compilation
-    * here.
+    * [[permissionWiring]], which derives this from the same match that builds
+    * the flags. The grant lists are empty here for the same reason the wiring's
+    * cell ignores them.
     */
   def enforcementCell(
       tools: ToolSet,
       autoApprove: AutoApprove,
       dispatch: TurnDispatch
   ): EnforcementCell = dispatch match
-    // Same either way: [[streamJson]] emits `permissionArgs` on `--resume` too.
+    // Same either way: [[streamJson]] emits the permission flags on `--resume`
+    // too. Matched rather than ignored so a new dispatch has to answer here.
     case TurnDispatch.Fresh | TurnDispatch.Resumed =>
-      tools match
-        case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
-          EnforcementCell(
-            Enforcement.Hard,
-            "`--tools` confines the turn to the read-only names, so the write and shell tools are not on offer"
-          )
-        case ToolSet.Full =>
-          autoApprove match
-            case AutoApprove.All =>
-              EnforcementCell(
-                Enforcement.Hard,
-                "`--permission-mode bypassPermissions` approves everything, which is what `All` asks for"
-              )
-            // Split as [[permissionArgs]] splits it: an empty `Only` emits no
-            // flag at all, so naming `--allowedTools` here would describe a
-            // gate that branch never builds.
-            case AutoApprove.Only(names) if names.isEmpty =>
-              EnforcementCell(
-                Enforcement.Hard,
-                "no flag: the turn runs in claude's default permission mode, which is the gate and approves nothing beyond its own defaults"
-              )
-            case AutoApprove.Only(_) =>
-              EnforcementCell(
-                Enforcement.Hard,
-                "`--allowedTools` is a mechanical gate, but an ADDITIVE one: the auto-approved set is claude's default permission mode ∪ the `Only` list, and everything outside that union is denied. Probed 2026-08-07, claude 2.1.224: with only `Bash(echo *)` allowlisted a `Read` still ran unprompted, so the defaults survive the flag; the defaults seen to auto-approve are workspace reads and read-only `Bash`, while `Write` and mutating `Bash` were denied. The gate is hard; its boundary is a documented superset of the request"
-              )
+      permissionWiring(tools, autoApprove, Seq.empty, Seq.empty).cell

--- a/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeArgs.scala
@@ -52,8 +52,8 @@ private[claude] object ClaudeArgs:
       permissionWiring(
         config.tools,
         config.autoApprove,
-        networkTools,
-        mcpTools
+        networkTools = networkTools,
+        mcpTools = mcpTools
       ).args ++
       jsonSchemaArgs(jsonSchema) ++
       mcpConfigArgs(mcpConfig)
@@ -111,9 +111,6 @@ private[claude] object ClaudeArgs:
   private[claude] val ReadOnlyTools: Seq[String] =
     Seq("Read", "Grep", "Glob", "Skill")
 
-  /** The permission flags a tier gets and the guarantee they achieve — one
-    * match builds both, so they cannot drift apart.
-    */
   private case class PermissionWiring(args: Seq[String], cell: EnforcementCell)
 
   /** The read-only tiers' cell. Shared because `--tools` confines both the same
@@ -224,4 +221,9 @@ private[claude] object ClaudeArgs:
     // Same either way: [[streamJson]] emits the permission flags on `--resume`
     // too. Matched rather than ignored so a new dispatch has to answer here.
     case TurnDispatch.Fresh | TurnDispatch.Resumed =>
-      permissionWiring(tools, autoApprove, Seq.empty, Seq.empty).cell
+      permissionWiring(
+        tools,
+        autoApprove,
+        networkTools = Seq.empty,
+        mcpTools = Seq.empty
+      ).cell

--- a/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
@@ -124,12 +124,7 @@ private[orca] class ClaudeBackend(
     */
   private val git: GitTool = new OsGitTool(workDir)
 
-  override def enforcementCell(
-      tools: ToolSet,
-      autoApprove: AutoApprove,
-      dispatch: TurnDispatch
-  ): EnforcementCell =
-    ClaudeArgs.enforcementCell(tools, autoApprove, dispatch)
+  export ClaudeArgs.enforcementCell
 
   /** `--json-schema` (passed whenever a structured call supplies a schema — see
     * [[runAutonomous]]) makes the CLI inject a StructuredOutput tool whose

--- a/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
@@ -111,8 +111,8 @@ private[codex] object CodexArgs:
   private def outputSchemaArgs(file: Option[os.Path]): Seq[String] =
     CliArgs.flag("--output-schema", file)(_.toString)
 
-  /** The sandbox flags a tier gets and the guarantee they achieve — one match
-    * builds both, so they cannot drift apart.
+  /** codex's flags for one tier, in the two argv slots they occupy, plus the
+    * guarantee they achieve.
     *
     * @param preSubcommand
     *   global `-c` overrides, which must precede `exec` for codex to read them
@@ -126,13 +126,27 @@ private[codex] object CodexArgs:
       cell: EnforcementCell
   )
 
+  /** The tier's sandbox mode as each dispatch carries it: `--sandbox <mode>`
+    * after the subcommand on a fresh turn; on a resumed one, which rejects that
+    * flag, the same mode as a global `-c` override — a TOML value, hence the
+    * embedded quotes.
+    */
+  private def sandboxModeArgs(
+      mode: String,
+      dispatch: TurnDispatch
+  ): (Seq[String], Seq[String]) = dispatch match
+    case TurnDispatch.Fresh   => (Nil, Seq("--sandbox", mode))
+    case TurnDispatch.Resumed => (Seq("-c", s"sandbox_mode=\"$mode\""), Nil)
+
   /** codex's isolation wiring for one `(tools, autoApprove, dispatch)`: which
     * flags [[exec]] / [[execResume]] emit, and how strongly they hold.
     *
-    * codex is the one backend whose answer depends on the dispatch, in one cell
-    * only: the read-only tiers get their sandbox re-applied per turn, so they
-    * answer the same either way, while a resumed `Full` + [[AutoApprove.Only]]
-    * turn keeps whatever sandbox its session was created with.
+    * codex is the one backend whose enforcement LEVEL depends on the dispatch,
+    * in one cell only: a resumed `Full` + [[AutoApprove.Only]] turn keeps
+    * whatever sandbox its session was created with. Every other cell holds
+    * either way — the read-only tiers re-apply their sandbox per turn and
+    * `Full` + [[AutoApprove.All]] re-asserts its bypass flag — and differs
+    * across dispatches only in what its rationale can cite.
     *
     * Two probes, both 2026-08-07 against codex-cli 0.145.0, decide the resume
     * arms. A resumed session INHERITS the sandbox it was created with: a
@@ -152,13 +166,9 @@ private[codex] object CodexArgs:
       autoApprove: AutoApprove,
       dispatch: TurnDispatch
   ): SandboxWiring =
-    // `-c` values are TOML, hence the embedded quotes.
     tools match
       case ToolSet.ReadOnly =>
-        val (pre, post) = dispatch match
-          case TurnDispatch.Fresh => (Nil, Seq("--sandbox", "read-only"))
-          case TurnDispatch.Resumed =>
-            (Seq("-c", "sandbox_mode=\"read-only\""), Nil)
+        val (pre, post) = sandboxModeArgs("read-only", dispatch)
         SandboxWiring(
           pre,
           post,
@@ -172,13 +182,9 @@ private[codex] object CodexArgs:
       // since workspace-write blocks it by default.
       case ToolSet.NetworkOnly =>
         val network = Seq("-c", "sandbox_workspace_write.network_access=true")
-        val (pre, post) = dispatch match
-          case TurnDispatch.Fresh =>
-            (network, Seq("--sandbox", "workspace-write"))
-          case TurnDispatch.Resumed =>
-            (Seq("-c", "sandbox_mode=\"workspace-write\"") ++ network, Nil)
+        val (pre, post) = sandboxModeArgs("workspace-write", dispatch)
         SandboxWiring(
-          pre,
+          pre ++ network,
           post,
           EnforcementCell(
             Enforcement.PromptOnly,

--- a/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexArgs.scala
@@ -33,11 +33,13 @@ private[codex] object CodexArgs:
       workDir: os.Path,
       mcpServerUrl: Option[String] = None
   ): Seq[String] =
+    val wiring =
+      sandboxWiring(config.tools, config.autoApprove, TurnDispatch.Fresh)
     Seq("codex") ++
       mcpServerArgs(mcpServerUrl) ++
-      networkConfigArgs(config) ++
+      wiring.preSubcommand ++
       Seq("exec", "--json") ++
-      sandboxArgs(config) ++
+      wiring.postSubcommand ++
       CliArgs.modelArgs(config) ++
       cwdArgs(workDir) ++
       // codex bails if it can't tell whether cwd is a git repo, a poor fit
@@ -55,16 +57,8 @@ private[codex] object CodexArgs:
     *     retry-with-corrective-prompt loop in `DefaultAgentCall` handles parse
     *     failures.
     *   - rejects `--sandbox <mode>` ("unexpected argument"), which is why the
-    *     tier's sandbox is re-applied through [[resumeSandboxModeArgs]]' `-c`
-    *     override instead. `--full-auto` is accepted but deprecated, and
-    *     omitted for that reason rather than because resume refuses it.
-    *
-    * A resumed session INHERITS the sandbox it was created with — probed
-    * 2026-08-07 against codex-cli 0.145.0: a flagless resume of a `--full-auto`
-    * session wrote a file, while a flagless fresh turn was blocked read-only.
-    * So the tier has to be re-asserted per turn; without that, a session
-    * created `NetworkOnly` and resumed `ReadOnly` (which `Plan.reviewed` does)
-    * would keep workspace write.
+    *     tier's sandbox is re-applied through [[sandboxWiring]]'s `-c` override
+    *     instead.
     *
     * codex also rejects resuming a session started with `--ephemeral`; the
     * backend never passes `--ephemeral`, so resume always finds a rollout.
@@ -75,47 +69,16 @@ private[codex] object CodexArgs:
       config: AgentConfig,
       mcpServerUrl: Option[String] = None
   ): Seq[String] =
+    val wiring =
+      sandboxWiring(config.tools, config.autoApprove, TurnDispatch.Resumed)
     Seq("codex") ++
       mcpServerArgs(mcpServerUrl) ++
-      resumeSandboxModeArgs(config) ++
-      networkConfigArgs(config) ++
+      wiring.preSubcommand ++
       Seq("exec", "resume", "--json", WireSessionId.value(sessionId)) ++
-      resumeSandboxArgs(config) ++
+      wiring.postSubcommand ++
       CliArgs.modelArgs(config) ++
       Seq("--skip-git-repo-check") ++
       Seq(prompt)
-
-  /** Re-applies the read-only tiers' sandbox on a resumed turn, through the
-    * global `-c` slot `exec resume` does accept — the `--sandbox` flag it
-    * doesn't. Verified to narrow an already-widened session: resuming a
-    * `--full-auto` session with `-c sandbox_mode="read-only"` blocked the write
-    * (probed 2026-08-07, codex-cli 0.145.0).
-    *
-    * `Full` is absent because its two shapes are already handled after the
-    * subcommand — [[AutoApprove.All]] by the bypass flag in
-    * [[resumeSandboxArgs]], and `Only` by neither, matching what a resumed
-    * `Only` turn can be held to.
-    */
-  private def resumeSandboxModeArgs(config: AgentConfig): Seq[String] =
-    // Values are TOML, hence the embedded quotes.
-    config.tools match
-      case ToolSet.ReadOnly    => Seq("-c", "sandbox_mode=\"read-only\"")
-      case ToolSet.NetworkOnly => Seq("-c", "sandbox_mode=\"workspace-write\"")
-      case ToolSet.Full        => Nil
-
-  /** Sandbox flags accepted by `exec resume` AFTER the subcommand (a subset of
-    * [[sandboxArgs]]): only `--dangerously-bypass-approvals-and-sandbox` (Full
-    * + [[AutoApprove.All]]), re-asserted each turn to keep approvals off. The
-    * read-only tiers go through [[resumeSandboxModeArgs]] instead.
-    */
-  private def resumeSandboxArgs(config: AgentConfig): Seq[String] =
-    config.tools match
-      case ToolSet.Full =>
-        config.autoApprove match
-          case AutoApprove.All =>
-            Seq("--dangerously-bypass-approvals-and-sandbox")
-          case AutoApprove.Only(_) => Seq.empty
-      case ToolSet.ReadOnly | ToolSet.NetworkOnly => Seq.empty
 
   /** Top-level `-c mcp_servers.<name>.{url,tool_timeout_sec}` overrides, placed
     * BEFORE the subcommand so they land in codex's global-config slot. The URL
@@ -148,97 +111,130 @@ private[codex] object CodexArgs:
   private def outputSchemaArgs(file: Option[os.Path]): Seq[String] =
     CliArgs.flag("--output-schema", file)(_.toString)
 
-  /** Maps [[AgentConfig.tools]] to codex's sandbox flags (placed after the
-    * `exec` subcommand). codex has no per-tool CLI allowlist, so
-    * [[AutoApprove.Only]] is approximated with the coarser `--full-auto`, and
-    * `NetworkOnly` has to take `workspace-write` too — codex has no
-    * read-only-with-network sandbox.
-    */
-  private def sandboxArgs(config: AgentConfig): Seq[String] =
-    config.tools match
-      case ToolSet.ReadOnly    => Seq("--sandbox", "read-only")
-      case ToolSet.NetworkOnly => Seq("--full-auto")
-      case ToolSet.Full =>
-        config.autoApprove match
-          case AutoApprove.All =>
-            Seq("--dangerously-bypass-approvals-and-sandbox")
-          case AutoApprove.Only(_) => Seq("--full-auto")
-
-  /** Global `-c` override (must precede `exec` so codex reads it into top-level
-    * config). On [[ToolSet.NetworkOnly]], enables network for the
-    * workspace-write sandbox; off by default, so without it the planner's
-    * `gh`/`curl` calls would be blocked. Empty for the other tiers.
-    */
-  private def networkConfigArgs(config: AgentConfig): Seq[String] =
-    config.tools match
-      case ToolSet.NetworkOnly =>
-        Seq("-c", "sandbox_workspace_write.network_access=true")
-      case ToolSet.ReadOnly | ToolSet.Full => Nil
-
-  /** How strongly codex enforces each `(tools, autoApprove)` combination — see
-    * [[sandboxArgs]] / [[networkConfigArgs]] for the flags a fresh turn gets,
-    * and [[resumeSandboxModeArgs]] / [[resumeSandboxArgs]] for a resumed one.
+  /** The sandbox flags a tier gets and the guarantee they achieve — one match
+    * builds both, so they cannot drift apart.
     *
-    * codex is the one backend whose answer still depends on the dispatch, and
-    * now in one cell only: the read-only tiers get their sandbox re-applied per
-    * turn, so they answer the same either way, while a resumed `Full` +
-    * [[AutoApprove.Only]] turn keeps whatever sandbox its session was created
-    * with — which this classification cannot know.
+    * @param preSubcommand
+    *   global `-c` overrides, which must precede `exec` for codex to read them
+    *   into top-level config.
+    * @param postSubcommand
+    *   sandbox flags, which go after the subcommand.
+    */
+  private case class SandboxWiring(
+      preSubcommand: Seq[String],
+      postSubcommand: Seq[String],
+      cell: EnforcementCell
+  )
+
+  /** codex's isolation wiring for one `(tools, autoApprove, dispatch)`: which
+    * flags [[exec]] / [[execResume]] emit, and how strongly they hold.
+    *
+    * codex is the one backend whose answer depends on the dispatch, in one cell
+    * only: the read-only tiers get their sandbox re-applied per turn, so they
+    * answer the same either way, while a resumed `Full` + [[AutoApprove.Only]]
+    * turn keeps whatever sandbox its session was created with.
+    *
+    * Two probes, both 2026-08-07 against codex-cli 0.145.0, decide the resume
+    * arms. A resumed session INHERITS the sandbox it was created with: a
+    * flagless resume of a `--full-auto` session wrote a file, while a flagless
+    * fresh turn was blocked read-only. Re-applying narrows it back: resuming
+    * that session with `-c sandbox_mode="read-only"` blocked the write. Without
+    * the re-application a session created `NetworkOnly` and resumed `ReadOnly`
+    * (which `Plan.reviewed` does) would keep workspace write.
+    *
+    * The fresh arms spell `workspace-write` out rather than using
+    * `--full-auto`, which the CLI now warns is deprecated in favour of exactly
+    * that flag. Both spellings were probed identical under `exec` (2026-08-07,
+    * codex-cli 0.145.0): `approval: never`, `sandbox: workspace-write`.
+    */
+  private def sandboxWiring(
+      tools: ToolSet,
+      autoApprove: AutoApprove,
+      dispatch: TurnDispatch
+  ): SandboxWiring =
+    // `-c` values are TOML, hence the embedded quotes.
+    tools match
+      case ToolSet.ReadOnly =>
+        val (pre, post) = dispatch match
+          case TurnDispatch.Fresh => (Nil, Seq("--sandbox", "read-only"))
+          case TurnDispatch.Resumed =>
+            (Seq("-c", "sandbox_mode=\"read-only\""), Nil)
+        SandboxWiring(
+          pre,
+          post,
+          EnforcementCell(
+            Enforcement.Hard,
+            "the `read-only` sandbox blocks writes, and a resumed turn re-applies it rather than inheriting the session's (probed 2026-08-07, codex-cli 0.145.0)"
+          )
+        )
+      // codex has no read-only-with-network sandbox, so network costs the tier
+      // its `workspace-write` sandbox; the `-c` override turns network on,
+      // since workspace-write blocks it by default.
+      case ToolSet.NetworkOnly =>
+        val network = Seq("-c", "sandbox_workspace_write.network_access=true")
+        val (pre, post) = dispatch match
+          case TurnDispatch.Fresh =>
+            (network, Seq("--sandbox", "workspace-write"))
+          case TurnDispatch.Resumed =>
+            (Seq("-c", "sandbox_mode=\"workspace-write\"") ++ network, Nil)
+        SandboxWiring(
+          pre,
+          post,
+          EnforcementCell(
+            Enforcement.PromptOnly,
+            "network needs the `workspace-write` sandbox, which also permits writes, so only the prompt withholds edits"
+          )
+        )
+      case ToolSet.Full =>
+        autoApprove match
+          // The one sandbox flag `exec resume` also accepts, so it rides on
+          // both dispatches.
+          case AutoApprove.All =>
+            SandboxWiring(
+              Nil,
+              Seq("--dangerously-bypass-approvals-and-sandbox"),
+              dispatch match
+                case TurnDispatch.Fresh =>
+                  EnforcementCell(
+                    Enforcement.Hard,
+                    "`--dangerously-bypass-approvals-and-sandbox` approves everything, which is what `All` asks for"
+                  )
+                case TurnDispatch.Resumed =>
+                  EnforcementCell(
+                    Enforcement.Hard,
+                    "`--dangerously-bypass-approvals-and-sandbox` is re-asserted on every resumed turn, and `exec resume --help` lists it (probed 2026-08-07, codex-cli 0.145.0)"
+                  )
+            )
+          // codex has no per-tool CLI allowlist, so the requested subset is
+          // approximated by a whole-workspace sandbox — one a resumed turn has
+          // no `-c` shape for, leaving it with the session's own.
+          case AutoApprove.Only(_) =>
+            dispatch match
+              case TurnDispatch.Fresh =>
+                SandboxWiring(
+                  Nil,
+                  Seq("--sandbox", "workspace-write"),
+                  EnforcementCell(
+                    Enforcement.SandboxApprox,
+                    "no per-tool allowlist, so the requested subset becomes `--sandbox workspace-write`, a whole-sandbox approximation wider than what was asked"
+                  )
+                )
+              case TurnDispatch.Resumed =>
+                SandboxWiring(
+                  Nil,
+                  Nil,
+                  EnforcementCell(
+                    Enforcement.Ignored,
+                    "the requested subset has no sandbox of its own to re-apply, so a resumed turn keeps whichever sandbox its session was created with (probed 2026-08-07, codex-cli 0.145.0)"
+                  )
+                )
+
+  /** How strongly codex enforces each `(tools, autoApprove)` combination on a
+    * `dispatch` turn — see [[sandboxWiring]], which derives this from the same
+    * match that builds the flags.
     */
   def enforcementCell(
       tools: ToolSet,
       autoApprove: AutoApprove,
       dispatch: TurnDispatch
-  ): EnforcementCell = dispatch match
-    case TurnDispatch.Fresh   => freshCell(tools, autoApprove)
-    case TurnDispatch.Resumed => resumedCell(tools, autoApprove)
-
-  private def freshCell(
-      tools: ToolSet,
-      autoApprove: AutoApprove
-  ): EnforcementCell =
-    tools match
-      case ToolSet.ReadOnly =>
-        EnforcementCell(
-          Enforcement.Hard,
-          "the `read-only` sandbox blocks writes, and a resumed turn re-applies it rather than inheriting the session's (probed 2026-08-07, codex-cli 0.145.0)"
-        )
-      case ToolSet.NetworkOnly =>
-        EnforcementCell(
-          Enforcement.PromptOnly,
-          "network needs the `workspace-write` sandbox, which also permits writes, so only the prompt withholds edits"
-        )
-      case ToolSet.Full =>
-        autoApprove match
-          case AutoApprove.All =>
-            EnforcementCell(
-              Enforcement.Hard,
-              "`--dangerously-bypass-approvals-and-sandbox` approves everything, which is what `All` asks for"
-            )
-          case AutoApprove.Only(_) =>
-            EnforcementCell(
-              Enforcement.SandboxApprox,
-              "no per-tool allowlist, so the requested subset becomes `--full-auto`, a whole-sandbox approximation wider than what was asked"
-            )
-
-  private def resumedCell(
-      tools: ToolSet,
-      autoApprove: AutoApprove
-  ): EnforcementCell =
-    tools match
-      // The read-only tiers answer exactly as a fresh turn does, because
-      // `resumeSandboxModeArgs` re-applies the same sandbox.
-      case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
-        freshCell(tools, autoApprove)
-      case ToolSet.Full =>
-        autoApprove match
-          case AutoApprove.All =>
-            EnforcementCell(
-              Enforcement.Hard,
-              "`--dangerously-bypass-approvals-and-sandbox` is re-asserted on every resumed turn, and `exec resume --help` lists it (probed 2026-08-07, codex-cli 0.145.0)"
-            )
-          case AutoApprove.Only(_) =>
-            EnforcementCell(
-              Enforcement.Ignored,
-              "the requested subset has no sandbox of its own to re-apply, so a resumed turn keeps whichever sandbox its session was created with — inheritance confirmed by probing a flagless resume of a `--full-auto` session (2026-08-07, codex-cli 0.145.0)"
-            )
+  ): EnforcementCell = sandboxWiring(tools, autoApprove, dispatch).cell

--- a/codex/src/main/scala/orca/tools/codex/CodexBackend.scala
+++ b/codex/src/main/scala/orca/tools/codex/CodexBackend.scala
@@ -72,12 +72,7 @@ private[orca] class CodexBackend(
     */
   val tag: BackendTag.Codex.type = BackendTag.Codex
 
-  override def enforcementCell(
-      tools: ToolSet,
-      autoApprove: AutoApprove,
-      dispatch: TurnDispatch
-  ): EnforcementCell =
-    CodexArgs.enforcementCell(tools, autoApprove, dispatch)
+  export CodexArgs.enforcementCell
 
   /** `--output-schema` constrains the FINAL MESSAGE text — the reply text is
     * still the JSON value orca parses; there is no structured-output tool.

--- a/codex/src/test/scala/orca/tools/codex/CodexArgsTest.scala
+++ b/codex/src/test/scala/orca/tools/codex/CodexArgsTest.scala
@@ -60,16 +60,19 @@ class CodexArgsTest extends munit.FunSuite:
       os.pwd
     )
     assert(args.contains("--dangerously-bypass-approvals-and-sandbox"))
-    assert(!args.contains("--full-auto"))
+    assert(!args.containsSlice(Seq("--sandbox", "workspace-write")))
 
-  test("AutoApprove.Only maps to --full-auto"):
+  test("AutoApprove.Only maps to --sandbox workspace-write"):
     val args = CodexArgs.exec(
       "x",
       AgentConfig().copy(autoApprove = AutoApprove.Only(Set("Bash"))),
       None,
       os.pwd
     )
-    assert(args.contains("--full-auto"))
+    assert(
+      args.containsSlice(Seq("--sandbox", "workspace-write")),
+      args.toString
+    )
     assert(!args.contains("--dangerously-bypass-approvals-and-sandbox"))
 
   test(
@@ -90,19 +93,24 @@ class CodexArgsTest extends munit.FunSuite:
     )
     assert(args.containsSlice(Seq("--sandbox", "read-only")), args.toString)
     assert(!args.contains("--dangerously-bypass-approvals-and-sandbox"))
-    assert(!args.contains("--full-auto"))
+    assert(!args.containsSlice(Seq("--sandbox", "workspace-write")))
 
-  test("ToolSet.NetworkOnly uses --full-auto + network override before exec"):
+  test(
+    "ToolSet.NetworkOnly uses --sandbox workspace-write + network override before exec"
+  ):
     // codex has no read-only-with-network sandbox: network needs
-    // workspace-write (via --full-auto), enabled by the global `-c` override
-    // which must precede the `exec` subcommand.
+    // workspace-write, enabled by the global `-c` override which must precede
+    // the `exec` subcommand.
     val args = CodexArgs.exec(
       "x",
       AgentConfig().copy(tools = ToolSet.NetworkOnly),
       None,
       os.pwd
     )
-    assert(args.contains("--full-auto"), args.toString)
+    assert(
+      args.containsSlice(Seq("--sandbox", "workspace-write")),
+      args.toString
+    )
     assert(!args.containsSlice(Seq("--sandbox", "read-only")), args.toString)
     val execIdx = args.indexOf("exec")
     val cIdx = args.indexOf("sandbox_workspace_write.network_access=true")
@@ -162,11 +170,9 @@ class CodexArgsTest extends munit.FunSuite:
     assert(!args.contains("-C"))
     assert(!args.contains("--output-schema"))
 
-  test("execResume omits --sandbox and --full-auto"):
-    // `--sandbox` is a hard regression: `codex exec resume` errors with
-    // "unexpected argument". `--full-auto` is accepted but deprecated as of
-    // codex-cli 0.145.0 (probed 2026-08-07), and omitted for that reason —
-    // the tier travels through `-c sandbox_mode` instead.
+  test("execResume omits --sandbox on every tier"):
+    // A hard regression: `codex exec resume` errors with "unexpected argument"
+    // on `--sandbox`, so the tier travels through `-c sandbox_mode` instead.
     val sid = WireSessionId[BackendTag.Codex.type]("sid")
     val readOnly =
       CodexArgs.execResume(
@@ -181,13 +187,13 @@ class CodexArgsTest extends munit.FunSuite:
         "x",
         AgentConfig().copy(tools = ToolSet.NetworkOnly)
       )
-    assert(!networkOnly.contains("--full-auto"), networkOnly)
+    assert(!networkOnly.contains("--sandbox"), networkOnly)
     val fullOnly = CodexArgs.execResume(
       sid,
       "x",
       AgentConfig().copy(autoApprove = AutoApprove.Only(Set("Bash")))
     )
-    assert(!fullOnly.contains("--full-auto"), fullOnly)
+    assert(!fullOnly.contains("--sandbox"), fullOnly)
 
   test(
     "execResume re-applies the read-only tiers' sandbox before the subcommand"

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
@@ -66,9 +66,6 @@ private[gemini] object GeminiArgs:
     */
   private val NetworkTools: Seq[String] = Seq("web_fetch")
 
-  /** The approval flags a tier gets and the guarantee they achieve — one match
-    * builds both, so they cannot drift apart.
-    */
   private case class ApprovalWiring(args: Seq[String], cell: EnforcementCell)
 
   /** The read-only tiers' cell. Shared because both ride on `--approval-mode

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiArgs.scala
@@ -33,7 +33,7 @@ private[gemini] object GeminiArgs:
     Seq("gemini") ++
       trustArgs ++
       CliArgs.modelArgs(config) ++
-      approvalArgs(config) ++
+      approvalWiring(config.tools, config.autoApprove).args ++
       Seq("--output-format", "stream-json", "-p", prompt)
 
   /** Multi-turn continuation: `gemini --resume <id> -p <prompt>`. The id is the
@@ -47,7 +47,7 @@ private[gemini] object GeminiArgs:
     Seq("gemini") ++
       trustArgs ++
       CliArgs.modelArgs(config) ++
-      approvalArgs(config) ++
+      approvalWiring(config.tools, config.autoApprove).args ++
       Seq("--resume", WireSessionId.value(sessionId)) ++
       Seq("--output-format", "stream-json", "-p", prompt)
 
@@ -66,53 +66,74 @@ private[gemini] object GeminiArgs:
     */
   private val NetworkTools: Seq[String] = Seq("web_fetch")
 
-  /** Maps [[AgentConfig.tools]] to gemini's approval mode. `Full` has no
-    * per-tool CLI allowlist, and in headless mode `auto_edit` blocks on shell
-    * approvals no one can answer, so both [[AutoApprove.All]] and
-    * [[AutoApprove.Only]] map to `yolo` (the `Only` widening: ADR 0015).
+  /** The approval flags a tier gets and the guarantee they achieve — one match
+    * builds both, so they cannot drift apart.
     */
-  private def approvalArgs(config: AgentConfig): Seq[String] =
-    config.tools match
-      case ToolSet.ReadOnly => Seq("--approval-mode", "plan")
+  private case class ApprovalWiring(args: Seq[String], cell: EnforcementCell)
+
+  /** The read-only tiers' cell. Shared because both ride on `--approval-mode
+    * plan`; `NetworkOnly` only pre-approves web reads on top. It records what
+    * orca can stand behind rather than what the flag was assumed to do, so the
+    * rationale carries the whole argument — this is its only home.
+    */
+  private val PlanModeCell: EnforcementCell = EnforcementCell(
+    Enforcement.PromptOnly,
+    "`--approval-mode plan` is UNMEASURED, not known weak: no headless `plan` turn has been run against a write attempt. The same class of mechanism on claude — `--permission-mode plan` — was measured and removes no tools (`docs/research/run-cost/09-diff-vs-coordinates.md` §2). Raise this cell when a probe establishes more."
+  )
+
+  /** Maps [[AgentConfig.tools]] to gemini's approval mode, and classifies how
+    * strongly it holds. `Full` has no per-tool CLI allowlist, and in headless
+    * mode `auto_edit` blocks on shell approvals no one can answer, so both
+    * [[AutoApprove.All]] and [[AutoApprove.Only]] map to `yolo` (the `Only`
+    * widening: ADR 0015) — the same flag, but not the same guarantee.
+    */
+  private def approvalWiring(
+      tools: ToolSet,
+      autoApprove: AutoApprove
+  ): ApprovalWiring =
+    tools match
+      case ToolSet.ReadOnly =>
+        ApprovalWiring(Seq("--approval-mode", "plan"), PlanModeCell)
       case ToolSet.NetworkOnly =>
-        Seq(
-          "--approval-mode",
-          "plan",
-          "--allowed-tools",
-          NetworkTools.mkString(",")
+        ApprovalWiring(
+          Seq(
+            "--approval-mode",
+            "plan",
+            "--allowed-tools",
+            NetworkTools.mkString(",")
+          ),
+          PlanModeCell
         )
       case ToolSet.Full =>
-        config.autoApprove match
-          case AutoApprove.All | AutoApprove.Only(_) =>
-            Seq("--approval-mode", "yolo")
+        val yolo = Seq("--approval-mode", "yolo")
+        autoApprove match
+          case AutoApprove.All =>
+            ApprovalWiring(
+              yolo,
+              EnforcementCell(
+                Enforcement.Hard,
+                "`yolo` honours \"approve everything\" verbatim"
+              )
+            )
+          case AutoApprove.Only(_) =>
+            ApprovalWiring(
+              yolo,
+              EnforcementCell(
+                Enforcement.Ignored,
+                "no per-tool allowlist, so any `Only` set is widened to `yolo` — the requested subset reaches the CLI nowhere"
+              )
+            )
 
   /** How strongly gemini enforces each `(tools, autoApprove)` combination — see
-    * [[approvalArgs]] for the flags this classifies. The read-only cells record
-    * what orca can stand behind rather than what a flag was assumed to do, so
-    * their rationale carries the whole argument — this is its only home.
+    * [[approvalWiring]], which derives this from the same match that builds the
+    * flags.
     */
   def enforcementCell(
       tools: ToolSet,
       autoApprove: AutoApprove,
       dispatch: TurnDispatch
   ): EnforcementCell = dispatch match
-    // Same either way: [[resume]] carries `approvalArgs` as [[headless]] does.
+    // Same either way: [[resume]] carries the approval flags as [[headless]]
+    // does. Matched rather than ignored so a new dispatch has to answer here.
     case TurnDispatch.Fresh | TurnDispatch.Resumed =>
-      tools match
-        case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
-          EnforcementCell(
-            Enforcement.PromptOnly,
-            "`--approval-mode plan` is UNMEASURED, not known weak: no headless `plan` turn has been run against a write attempt. The same class of mechanism on claude — `--permission-mode plan` — was measured and removes no tools (`docs/research/run-cost/09-diff-vs-coordinates.md` §2). Raise this cell when a probe establishes more."
-          )
-        case ToolSet.Full =>
-          autoApprove match
-            case AutoApprove.All =>
-              EnforcementCell(
-                Enforcement.Hard,
-                "`yolo` honours \"approve everything\" verbatim"
-              )
-            case AutoApprove.Only(_) =>
-              EnforcementCell(
-                Enforcement.Ignored,
-                "no per-tool allowlist, so any `Only` set is widened to `yolo` — the requested subset reaches the CLI nowhere"
-              )
+      approvalWiring(tools, autoApprove).cell

--- a/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
+++ b/gemini/src/main/scala/orca/tools/gemini/GeminiBackend.scala
@@ -67,12 +67,7 @@ private[orca] class GeminiBackend(
     */
   val tag: BackendTag.Gemini.type = BackendTag.Gemini
 
-  override def enforcementCell(
-      tools: ToolSet,
-      autoApprove: AutoApprove,
-      dispatch: TurnDispatch
-  ): EnforcementCell =
-    GeminiArgs.enforcementCell(tools, autoApprove, dispatch)
+  export GeminiArgs.enforcementCell
 
   /** The gemini CLI has no output-schema flag (see [[runAutonomous]]) —
     * enforcement is prompt-only and the reply text is the JSON value.

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
@@ -90,9 +90,8 @@ private[opencode] object OpencodeArgs:
     )
 
   /** The tool flags a tier's message body carries and the guarantee they
-    * achieve — one match builds both, so they cannot drift apart. The
-    * `question` gate is not here: it follows the conversation mode, not the
-    * tier.
+    * achieve. The `question` gate is not here: it follows the conversation
+    * mode, not the tier.
     */
   private case class TierWiring(
       flags: Map[String, Boolean],

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
@@ -74,33 +74,44 @@ private[opencode] object OpencodeArgs:
     val (provider, id) = OpencodeModel.split(model)
     ModelRef(provider, id)
 
+  /** The tools a non-writing turn withholds. `task` is one of them: it spawns a
+    * subagent that runs with the agent profile's default, write-capable tool
+    * set, and whether these per-message flags reach a subagent is unmeasured.
+    * `todowrite` is not: it writes the agent's own todo state, not the
+    * workspace.
+    */
+  private val writingToolsOff: Map[String, Boolean] =
+    Map(
+      "write" -> false,
+      "edit" -> false,
+      "bash" -> false,
+      "patch" -> false,
+      "task" -> false
+    )
+
   /** Per-turn tool gate: disable the write tools on a read-only turn, and the
     * `question` tool on an autonomous turn. Returns `None` when nothing is
     * gated so the body omits `tools` and the server's defaults apply.
     *
-    * `NetworkOnly` gets no dedicated handling and behaves like `ReadOnly`:
-    * scoped network would need `bash` enabled, dropping the hard no-edit
-    * guarantee, so opencode flows pre-fetch issue/PR context instead.
+    * `webfetch` reads the network without a shell, which is what separates the
+    * two restricted tiers: `ReadOnly` disables it too, `NetworkOnly` leaves it
+    * on. Neither tier has `bash`, so a `NetworkOnly` turn can read the web but
+    * not run `gh`.
     */
   private def toolFlags(
       config: AgentConfig,
       mode: ConversationMode
   ): Option[Map[String, Boolean]] =
-    val writeGate =
+    val tierGate =
       config.tools match
-        case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
-          Map(
-            "write" -> false,
-            "edit" -> false,
-            "bash" -> false,
-            "patch" -> false
-          )
-        case ToolSet.Full => Map.empty[String, Boolean]
+        case ToolSet.ReadOnly    => writingToolsOff + ("webfetch" -> false)
+        case ToolSet.NetworkOnly => writingToolsOff
+        case ToolSet.Full        => Map.empty[String, Boolean]
     val question =
       if mode.isInteractive then Map.empty[String, Boolean]
       else Map("question" -> false)
     // The two key sets are disjoint, so the merge order is irrelevant.
-    val flags = writeGate ++ question
+    val flags = tierGate ++ question
     Option.when(flags.nonEmpty)(flags)
 
   /** How strongly opencode enforces each `(tools, autoApprove)` combination —
@@ -114,10 +125,15 @@ private[opencode] object OpencodeArgs:
     // Same either way: the gate rides on [[message]], which every turn sends.
     case TurnDispatch.Fresh | TurnDispatch.Resumed =>
       tools match
-        case ToolSet.ReadOnly | ToolSet.NetworkOnly =>
+        case ToolSet.ReadOnly =>
           EnforcementCell(
             Enforcement.Hard,
-            "the message body disables `write`, `edit`, `bash` and `patch` by name, so the server offers none of those four — unlike an allowlist, this stays exact only while opencode ships no fifth writing tool"
+            "the message body disables `write`, `edit`, `bash`, `patch`, `task` and `webfetch` by name, so the server offers none of those six — unlike an allowlist, this stays exact only while opencode ships no further writing or network tool"
+          )
+        case ToolSet.NetworkOnly =>
+          EnforcementCell(
+            Enforcement.Hard,
+            "the message body disables `write`, `edit`, `bash`, `patch` and `task` by name; `webfetch` stays on, so the turn reads the web through it and has no shell to do anything else with"
           )
         case ToolSet.Full =>
           autoApprove match

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeArgs.scala
@@ -89,33 +89,75 @@ private[opencode] object OpencodeArgs:
       "task" -> false
     )
 
-  /** Per-turn tool gate: disable the write tools on a read-only turn, and the
-    * `question` tool on an autonomous turn. Returns `None` when nothing is
-    * gated so the body omits `tools` and the server's defaults apply.
+  /** The tool flags a tier's message body carries and the guarantee they
+    * achieve — one match builds both, so they cannot drift apart. The
+    * `question` gate is not here: it follows the conversation mode, not the
+    * tier.
+    */
+  private case class TierWiring(
+      flags: Map[String, Boolean],
+      cell: EnforcementCell
+  )
+
+  /** Maps [[AgentConfig.tools]] to the per-turn tool gate, and classifies how
+    * strongly it holds.
     *
     * `webfetch` reads the network without a shell, which is what separates the
     * two restricted tiers: `ReadOnly` disables it too, `NetworkOnly` leaves it
     * on. Neither tier has `bash`, so a `NetworkOnly` turn can read the web but
     * not run `gh`.
     */
+  private def tierWiring(
+      tools: ToolSet,
+      autoApprove: AutoApprove
+  ): TierWiring =
+    tools match
+      case ToolSet.ReadOnly =>
+        TierWiring(
+          writingToolsOff + ("webfetch" -> false),
+          EnforcementCell(
+            Enforcement.Hard,
+            "the message body disables `write`, `edit`, `bash`, `patch`, `task` and `webfetch` by name, so the server offers none of those six — unlike an allowlist, this stays exact only while opencode ships no further writing or network tool"
+          )
+        )
+      case ToolSet.NetworkOnly =>
+        TierWiring(
+          writingToolsOff,
+          EnforcementCell(
+            Enforcement.Hard,
+            "the message body disables `write`, `edit`, `bash`, `patch` and `task` by name; `webfetch` stays on, so the turn reads the web through it and has no shell to do anything else with"
+          )
+        )
+      case ToolSet.Full =>
+        autoApprove match
+          case AutoApprove.All | AutoApprove.Only(_) =>
+            TierWiring(
+              Map.empty,
+              EnforcementCell(
+                Enforcement.Ignored,
+                "the approval policy is whatever the user's `opencode` server config answers a `permission.asked` with, outside orca's control (ADR 0014 risk)"
+              )
+            )
+
+  /** Per-turn tool gate: the tier's gate from [[tierWiring]], plus the
+    * `question` tool disabled on an autonomous turn. Returns `None` when
+    * nothing is gated so the body omits `tools` and the server's defaults
+    * apply.
+    */
   private def toolFlags(
       config: AgentConfig,
       mode: ConversationMode
   ): Option[Map[String, Boolean]] =
-    val tierGate =
-      config.tools match
-        case ToolSet.ReadOnly    => writingToolsOff + ("webfetch" -> false)
-        case ToolSet.NetworkOnly => writingToolsOff
-        case ToolSet.Full        => Map.empty[String, Boolean]
     val question =
       if mode.isInteractive then Map.empty[String, Boolean]
       else Map("question" -> false)
     // The two key sets are disjoint, so the merge order is irrelevant.
-    val flags = tierGate ++ question
+    val flags = tierWiring(config.tools, config.autoApprove).flags ++ question
     Option.when(flags.nonEmpty)(flags)
 
   /** How strongly opencode enforces each `(tools, autoApprove)` combination —
-    * see [[toolFlags]] for the gate this classifies.
+    * see [[tierWiring]], which derives this from the same match that builds the
+    * gate.
     */
   def enforcementCell(
       tools: ToolSet,
@@ -123,22 +165,6 @@ private[opencode] object OpencodeArgs:
       dispatch: TurnDispatch
   ): EnforcementCell = dispatch match
     // Same either way: the gate rides on [[message]], which every turn sends.
+    // Matched rather than ignored so a new dispatch has to answer here.
     case TurnDispatch.Fresh | TurnDispatch.Resumed =>
-      tools match
-        case ToolSet.ReadOnly =>
-          EnforcementCell(
-            Enforcement.Hard,
-            "the message body disables `write`, `edit`, `bash`, `patch`, `task` and `webfetch` by name, so the server offers none of those six — unlike an allowlist, this stays exact only while opencode ships no further writing or network tool"
-          )
-        case ToolSet.NetworkOnly =>
-          EnforcementCell(
-            Enforcement.Hard,
-            "the message body disables `write`, `edit`, `bash`, `patch` and `task` by name; `webfetch` stays on, so the turn reads the web through it and has no shell to do anything else with"
-          )
-        case ToolSet.Full =>
-          autoApprove match
-            case AutoApprove.All | AutoApprove.Only(_) =>
-              EnforcementCell(
-                Enforcement.Ignored,
-                "the approval policy is whatever the user's `opencode` server config answers a `permission.asked` with, outside orca's control (ADR 0014 risk)"
-              )
+      tierWiring(tools, autoApprove).cell

--- a/opencode/src/main/scala/orca/tools/opencode/OpencodeBackend.scala
+++ b/opencode/src/main/scala/orca/tools/opencode/OpencodeBackend.scala
@@ -127,12 +127,7 @@ private[orca] class OpencodeBackend(
 
   val tag: BackendTag.Opencode.type = BackendTag.Opencode
 
-  override def enforcementCell(
-      tools: ToolSet,
-      autoApprove: AutoApprove,
-      dispatch: TurnDispatch
-  ): EnforcementCell =
-    OpencodeArgs.enforcementCell(tools, autoApprove, dispatch)
+  export OpencodeArgs.enforcementCell
 
   /** The `format: json_schema` message field is a response-format constraint —
     * the model still emits the JSON as its reply text (the server parses it

--- a/opencode/src/test/scala/orca/tools/opencode/OpencodeArgsTest.scala
+++ b/opencode/src/test/scala/orca/tools/opencode/OpencodeArgsTest.scala
@@ -103,7 +103,7 @@ class OpencodeArgsTest extends munit.FunSuite:
       OpencodeArgs.message(AgentConfig(), "hi", None, interactive)
     assertEquals(body.tools, None)
 
-  test("read-only turn disables the write tools (write/edit/bash/patch)"):
+  test("read-only turn disables the write tools, task and webfetch"):
     val cfg =
       AgentConfig().copy(
         tools = ToolSet.ReadOnly,
@@ -118,18 +118,20 @@ class OpencodeArgsTest extends munit.FunSuite:
     assertEquals(tools.get("edit"), Some(false))
     assertEquals(tools.get("bash"), Some(false))
     assertEquals(tools.get("patch"), Some(false))
+    assertEquals(tools.get("task"), Some(false))
+    assertEquals(tools.get("webfetch"), Some(false))
 
-  test("NetworkOnly keeps bash disabled (no writable-shell network)"):
-    // opencode has no scoped network: NetworkOnly gates the same write tools as
-    // ReadOnly, so the planner can't shell out to `gh`.
+  test("NetworkOnly keeps webfetch, with the write tools still disabled"):
     val cfg = AgentConfig().copy(tools = ToolSet.NetworkOnly)
     val tools =
       OpencodeArgs
         .message(cfg, "hi", None, interactive)
         .tools
         .getOrElse(Map.empty)
+    assertEquals(tools.get("webfetch"), None)
     assertEquals(tools.get("bash"), Some(false))
     assertEquals(tools.get("edit"), Some(false))
+    assertEquals(tools.get("task"), Some(false))
 
   test("read-only autonomous turn gates both write tools and question"):
     val cfg = AgentConfig().copy(tools = ToolSet.ReadOnly)

--- a/pi/src/main/scala/orca/tools/pi/PiArgs.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiArgs.scala
@@ -39,25 +39,58 @@ private[pi] object PiArgs:
       Option.when(resume)("--continue").toSeq ++
       CliArgs.modelArgs(config) ++
       systemPromptArgs(systemPromptFile) ++
-      toolsArgs(config, askUserExtension.isDefined) ++
+      toolsWiring(
+        config.tools,
+        config.autoApprove,
+        askUserExtension.isDefined
+      ).args ++
       extensionArgs(askUserExtension)
 
   private def systemPromptArgs(file: Option[os.Path]): Seq[String] =
     CliArgs.flag("--append-system-prompt", file)(_.toString)
 
-  /** Maps [[AgentConfig.tools]] to pi's `--tools` allowlist (`Full` omits the
-    * flag for all built-ins); the ask-user extension tool is appended when
-    * present.
+  /** The `--tools` allowlist a tier gets and the guarantee it achieves — one
+    * match builds both, so they cannot drift apart.
     */
-  private def toolsArgs(
-      config: AgentConfig,
+  private case class ToolsWiring(args: Seq[String], cell: EnforcementCell)
+
+  /** Maps [[AgentConfig.tools]] to pi's `--tools` allowlist (`Full` omits the
+    * flag for all built-ins), and classifies how strongly it holds. The
+    * ask-user extension tool is appended when present; it widens what is on
+    * offer without changing the tier's guarantee, so the cell ignores it.
+    */
+  private def toolsWiring(
+      tools: ToolSet,
+      autoApprove: AutoApprove,
       includeAskUser: Boolean
-  ): Seq[String] =
-    config.tools match
-      case ToolSet.Full     => Seq.empty
-      case ToolSet.ReadOnly => toolsFlag(ReadOnlyTools, includeAskUser)
+  ): ToolsWiring =
+    tools match
+      case ToolSet.ReadOnly =>
+        ToolsWiring(
+          toolsFlag(ReadOnlyTools, includeAskUser),
+          EnforcementCell(
+            Enforcement.Hard,
+            "the `--tools` allowlist excludes every writable tool"
+          )
+        )
       case ToolSet.NetworkOnly =>
-        toolsFlag(ReadOnlyTools :+ NetworkTool, includeAskUser)
+        ToolsWiring(
+          toolsFlag(ReadOnlyTools :+ NetworkTool, includeAskUser),
+          EnforcementCell(
+            Enforcement.PromptOnly,
+            "the allowlist has to include `bash` to reach the network, and `bash` also writes, so only the prompt withholds edits"
+          )
+        )
+      case ToolSet.Full =>
+        autoApprove match
+          case AutoApprove.All | AutoApprove.Only(_) =>
+            ToolsWiring(
+              Seq.empty,
+              EnforcementCell(
+                Enforcement.Ignored,
+                "pi RPC never prompts, and the argv encodes no approval policy"
+              )
+            )
 
   private def toolsFlag(
       tools: Seq[String],
@@ -71,30 +104,16 @@ private[pi] object PiArgs:
     CliArgs.flag("--extension", file)(_.toString)
 
   /** How strongly pi enforces each `(tools, autoApprove)` combination — see
-    * [[toolsArgs]] for the flags this classifies.
+    * [[toolsWiring]], which derives this from the same match that builds the
+    * flags. `includeAskUser` is `false` here for the same reason the wiring's
+    * cell ignores it.
     */
   def enforcementCell(
       tools: ToolSet,
       autoApprove: AutoApprove,
       dispatch: TurnDispatch
   ): EnforcementCell = dispatch match
-    // Same either way: [[rpc]] emits `toolsArgs` alongside `--continue`.
+    // Same either way: [[rpc]] emits the `--tools` flag alongside `--continue`.
+    // Matched rather than ignored so a new dispatch has to answer here.
     case TurnDispatch.Fresh | TurnDispatch.Resumed =>
-      tools match
-        case ToolSet.ReadOnly =>
-          EnforcementCell(
-            Enforcement.Hard,
-            "the `--tools` allowlist excludes every writable tool"
-          )
-        case ToolSet.NetworkOnly =>
-          EnforcementCell(
-            Enforcement.PromptOnly,
-            "the allowlist has to include `bash` to reach the network, and `bash` also writes, so only the prompt withholds edits"
-          )
-        case ToolSet.Full =>
-          autoApprove match
-            case AutoApprove.All | AutoApprove.Only(_) =>
-              EnforcementCell(
-                Enforcement.Ignored,
-                "pi RPC never prompts, and the argv encodes no approval policy"
-              )
+      toolsWiring(tools, autoApprove, includeAskUser = false).cell

--- a/pi/src/main/scala/orca/tools/pi/PiArgs.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiArgs.scala
@@ -49,9 +49,6 @@ private[pi] object PiArgs:
   private def systemPromptArgs(file: Option[os.Path]): Seq[String] =
     CliArgs.flag("--append-system-prompt", file)(_.toString)
 
-  /** The `--tools` allowlist a tier gets and the guarantee it achieves — one
-    * match builds both, so they cannot drift apart.
-    */
   private case class ToolsWiring(args: Seq[String], cell: EnforcementCell)
 
   /** Maps [[AgentConfig.tools]] to pi's `--tools` allowlist (`Full` omits the

--- a/pi/src/main/scala/orca/tools/pi/PiBackend.scala
+++ b/pi/src/main/scala/orca/tools/pi/PiBackend.scala
@@ -77,12 +77,7 @@ private[orca] class PiBackend private[pi] (
 
   val tag: BackendTag.Pi.type = BackendTag.Pi
 
-  override def enforcementCell(
-      tools: ToolSet,
-      autoApprove: AutoApprove,
-      dispatch: TurnDispatch
-  ): EnforcementCell =
-    PiArgs.enforcementCell(tools, autoApprove, dispatch)
+  export PiArgs.enforcementCell
 
   /** Pi has no native structured-output / JSON-schema flag (see
     * [[PiConversation]]) — the reply text is the JSON value.


### PR DESCRIPTION
Each backend answered "what flags does this tier emit" and "how strongly do they hold" (`enforcementCell`) in two separate matches over the same axes, with nothing checking they agree. codex had six such matches.

Every backend now has one wiring match per tier that returns the flags and the cell together, so they cannot drift. The five identical `*Backend` forwarders became one-line `export`s. codex's fresh path now emits `--sandbox workspace-write` instead of `--full-auto`: codex-cli 0.145.0 prints "`--full-auto` is deprecated; use `--sandbox workspace-write` instead", and probing both (2026-08-07, 0.145.0) gave the same `approval: never` / `sandbox: workspace-write`. No other emitted flag changed, and no enforcement level moved.

Stacks on the review/ai-1 PR.

Findings: `docs/research/2026-08-review/agent-isolation/01-derive-flags-and-cell-from-one-match.md`, `11-codex-fresh-path-deprecated-full-auto.md`, `08-enforcement-prose-one-fact-many-homes.md` (codex part only).