### PR TITLE
Make the reviewer picker unable to answer "none apply"

### DIFF
--- a/flow/src/main/resources/orca/review/prompts/select-reviewers.md
+++ b/flow/src/main/resources/orca/review/prompts/select-reviewers.md
@@ -11,10 +11,11 @@ list means the change set could not be described, not that nothing changed.
 
 When you are unsure whether a reviewer applies, include it — a needless review
 costs a little time, a missed one costs a defect that ships. Skip a reviewer
-only when the files plainly contain nothing in its scope, e.g. a
-pure-documentation change with no executable code. That bar is highest for the
-risk-bearing reviewers, security and code-functionality above all.
+only when the files plainly contain nothing in its scope, e.g. a change that
+touches no test file has nothing for the test reviewer. That bar is highest
+for the risk-bearing reviewers, security and code-functionality above all.
 
-Reply with a SelectedReviewers whose `names` are copied verbatim from the `name`
-field of `availableReviewers` (one entry per chosen reviewer). When some
-reviewers apply, don't return an empty list.
+Reply with `names` copied verbatim from the `name` field of
+`availableReviewers`, one entry per chosen reviewer. Name at least one: an
+empty list makes every reviewer run. If you think none apply, name the one or
+two whose scope is closest to the changed files.

--- a/flow/src/main/scala/orca/review/ReviewerSelector.scala
+++ b/flow/src/main/scala/orca/review/ReviewerSelector.scala
@@ -183,12 +183,13 @@ object ReviewerSelector:
       val selected = picked.entries
       // Safety floor: the picker narrows the set, it can't skip review. If it
       // picks nothing while reviewers are eligible, fall back to all eligible
-      // so a real change is never silently unreviewed.
+      // so a real change is never silently unreviewed. The schema's
+      // `minItems: 1` binds only the backends that enforce it on the wire.
       val active =
         if selected.isEmpty && eligible.nonEmpty then
           ctx.emit(
             OrcaEvent.Step(
-              s"reviewer selection: picker returned no usable names; " +
+              "reviewer selection: the pick resolved to no reviewer; " +
                 s"falling back to all ${eligible.size} eligible reviewer(s)"
             )
           )

--- a/flow/src/main/scala/orca/review/SelectedReviewers.scala
+++ b/flow/src/main/scala/orca/review/SelectedReviewers.scala
@@ -2,6 +2,8 @@ package orca.review
 
 import orca.agents.{Announce, JsonData}
 
+import sttp.tapir.Validator
+
 /** What [[SelectedReviewers.pick]] resolved: the roster entries the picker
   * named, in roster order, and the names that matched none of them. A caller
   * cannot consume a partially-failed pick without naming the residue — a
@@ -13,7 +15,7 @@ private[review] case class PickedReviewers(
     unresolved: List[String]
 )
 
-case class SelectedReviewers(names: List[String]) derives JsonData:
+case class SelectedReviewers(names: List[String]):
   /** Resolve the picker's reply to roster entries by matching the bare slug.
     * Matching against the handed [[RosterEntry]] list (not raw names) is the
     * hallucinated-picker floor: an invented name that no entry carries matches
@@ -33,6 +35,18 @@ case class SelectedReviewers(names: List[String]) derives JsonData:
     )
 
 object SelectedReviewers:
+  /** `names` carries `minItems: 1`, so backends that enforce the schema on the
+    * wire (claude `--json-schema`, codex `--output-schema`) can't reply "no
+    * reviewer applies" — a reply [[ReviewerSelector.agentDriven]] can only
+    * honour by running the whole roster.
+    */
+  given JsonData[SelectedReviewers] =
+    val plain = JsonData.derived[SelectedReviewers]
+    JsonData(
+      plain.schema.modify(_.names)(_.validate(Validator.nonEmpty)),
+      plain.codec
+    )
+
   /** Deliberately silent: the review loop narrates the selection itself
     * ("Running N review agents"), so a summary here would render the picker's
     * raw JSON on top of that line.

--- a/flow/src/test/scala/orca/review/JsonSchemaGenTest.scala
+++ b/flow/src/test/scala/orca/review/JsonSchemaGenTest.scala
@@ -6,7 +6,7 @@ import orca.util.JsonSchemaGen
 import com.networknt.schema.{InputFormat, JsonSchemaFactory, SpecVersion}
 
 class JsonSchemaGenTest extends munit.FunSuite:
-  private def compiledSchema =
+  private def compiledResultSchema =
     val schemaString = JsonSchemaGen[ReviewResult]
     val factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
     factory.getSchema(schemaString)
@@ -23,7 +23,7 @@ class JsonSchemaGenTest extends munit.FunSuite:
         |  "location":null,
         |  "suggestion":null
         |}]}""".stripMargin
-    val errors = compiledSchema.validate(sample, InputFormat.JSON)
+    val errors = compiledResultSchema.validate(sample, InputFormat.JSON)
     assert(errors.isEmpty, s"Validation errors: $errors")
 
   test("generated schema rejects an unknown severity value"):
@@ -36,7 +36,7 @@ class JsonSchemaGenTest extends munit.FunSuite:
         |  "location":null,
         |  "suggestion":null
         |}]}""".stripMargin
-    val errors = compiledSchema.validate(invalid, InputFormat.JSON)
+    val errors = compiledResultSchema.validate(invalid, InputFormat.JSON)
     assert(!errors.isEmpty, "Schema should reject unknown severity values")
 
   test("generated schema rejects a confidence outside [0,1]"):
@@ -51,7 +51,7 @@ class JsonSchemaGenTest extends munit.FunSuite:
         |  "location":null,
         |  "suggestion":null
         |}]}""".stripMargin
-    val errors = compiledSchema.validate(invalid, InputFormat.JSON)
+    val errors = compiledResultSchema.validate(invalid, InputFormat.JSON)
     assert(!errors.isEmpty, "Schema should reject a percent-style confidence")
 
   test("generated schema rejects a payload that omits a nullable field"):
@@ -65,7 +65,7 @@ class JsonSchemaGenTest extends munit.FunSuite:
         |  "description":"x",
         |  "location":null
         |}]}""".stripMargin
-    val errors = compiledSchema.validate(invalid, InputFormat.JSON)
+    val errors = compiledResultSchema.validate(invalid, InputFormat.JSON)
     assert(
       !errors.isEmpty,
       "Schema should reject payloads that omit a nullable property"
@@ -74,8 +74,25 @@ class JsonSchemaGenTest extends munit.FunSuite:
   test("generated schema rejects additional properties"):
     val invalid =
       """{"issues":[],"unexpected":"x"}"""
-    val errors = compiledSchema.validate(invalid, InputFormat.JSON)
+    val errors = compiledResultSchema.validate(invalid, InputFormat.JSON)
     assert(
       !errors.isEmpty,
       "Schema should reject unknown top-level keys (additionalProperties:false)"
     )
+
+  private def compiledSelectionSchema =
+    JsonSchemaFactory
+      .getInstance(SpecVersion.VersionFlag.V202012)
+      .getSchema(JsonSchemaGen[SelectedReviewers])
+
+  test("generated schema rejects a selection that names no reviewer"):
+    // What claude:haiku and codex reply on a small change when the schema
+    // permits it; the selector's fallback then runs the whole roster.
+    val errors =
+      compiledSelectionSchema.validate("""{"names":[]}""", InputFormat.JSON)
+    assert(!errors.isEmpty, "Schema should reject an empty selection")
+
+  test("generated schema accepts a selection that names one reviewer"):
+    val errors = compiledSelectionSchema
+      .validate("""{"names":["code-functionality"]}""", InputFormat.JSON)
+    assert(errors.isEmpty, s"Validation errors: $errors")

--- a/flow/src/test/scala/orca/review/ReviewTypesTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewTypesTest.scala
@@ -42,6 +42,15 @@ class ReviewTypesTest extends munit.FunSuite:
       readFromString[ReviewResult](json)
     )
 
+  test("an empty picker selection still decodes"):
+    // The schema forbids it, but only backends that enforce the schema on the
+    // wire are bound by that — the rest reach `ReviewerSelector`'s fallback
+    // through this decode.
+    assertEquals(
+      readFromString[SelectedReviewers]("""{"names":[]}"""),
+      SelectedReviewers(Nil)
+    )
+
   test("the fix prompt keeps a suggestion line that starts with `|`"):
     // `FixRequest`'s renderer keeps a suggestion's own line breaks and indents,
     // so a quoted margin block reaches the prompt as a `|` line.


### PR DESCRIPTION
## Problem

On every live `implement.sc` run of the last test round — four runs, on both
`claude:haiku` and `codex` — the reviewer picker ended the same way:

```
step: reviewer selection: picker returned no usable names; falling back to all 7 eligible reviewer(s)
step: Running 7 review agents
```

Each run paid for a picker call and then ran the whole roster anyway.

## Root cause

The picker was not broken and its reply was not malformed. It answered "no
reviewer applies", and the code had no way to tell that apart from a broken
answer.

The raw replies from the two live runs:

- codex (`--output-schema`): `{"type":"item.completed","item":{"type":"agent_message","text":"{\"names\":[]}"}}`
- claude (`--json-schema`): `"structured_output":{"names":[]}`

Both are valid against the schema orca sent. The prompt invited that answer: it
said "When some reviewers apply, don't return an empty list", which reads as
"when none apply, an empty list is fine", and it named "a pure-documentation
change with no executable code" as a reason to skip. The live tasks were exactly
that — two text files in one run, and a task with no code change at all in the
other.

`ReviewerSelector.agentDriven` then hit its safety floor (an empty pick may
never skip review) and ran every eligible reviewer. So the one answer the prompt
sanctioned was the one answer the selector could only honour by doing the
opposite of what the picker is for.

I reproduced this outside orca, against both real CLIs, with the exact prompt
and schema a live flow builds: both returned `{"names":[]}`.

## Fix

`SelectedReviewers` now generates its JSON Schema with `minItems: 1` on `names`:

```json
{"title":"SelectedReviewers","type":"object","properties":{"names":{"type":"array","minItems":1,"items":{"type":"string"}}},"additionalProperties":false,"required":["names"]}
```

claude (`--json-schema`) and codex (`--output-schema`) both enforce that on the
wire, so "no reviewer applies" stops being an answer they can give. Re-running
the same probes on the same trivial change, they returned
`{"names":["readability"]}` (codex) and `{"names":["code-functionality"]}`
(claude). This is a change to the contract, not to the wording, so it does not
depend on how one model reads a sentence.

The prompt is updated to match: name at least one reviewer, and an empty list
makes every reviewer run. Its skip example was also a whole-roster licence
("a pure-documentation change"), so it now scopes to a single reviewer.

Backends with no native schema enforcement (gemini, opencode, pi) see the
schema only in the prompt, so the selector keeps its fallback for them. The
fallback message no longer calls a deliberate answer "no usable names", and is
now worded to fit its other case too — a pick whose names matched no reviewer.

Tests pin the generated schema against the captured `{"names":[]}` reply and
against a valid one-name reply, plus a decode test for the empty list, which
the fallback path depends on.
