### PR TITLE
Remove a failed stage's new files in failure teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ backend's model accessors and backend-specific extras:
 | `opencode` | `anthropicOpus`/`anthropicSonnet`/`anthropicHaiku`, `openaiSol`/`openaiTerra`/`openaiLuna`, `cheap` (provider-matched: openai→luna, else anthropicHaiku), `withModel(providerModel)` / `withModel(provider, modelId)` | [OpenCode](https://opencode.ai) coding/reviewing agent, driven over HTTP+SSE against a headless `opencode serve` (started lazily, shared for the run; sessions survive it — see [Sessions](#sessions)). Spans providers, so models are provider-qualified: use an accessor (`opencode.openaiLuna`) or `opencode.withModel("openai/gpt-5-mini")` / `opencode.withModel("ollama", "llama3.1")`. Inherits the user's configured `opencode` providers/auth. |
 | `pi` | `withModel(Model)` | [Pi](https://pi.dev/) coding agent backend, driven through `pi --mode rpc`. Pi handles provider/model selection through its own CLI configuration; pin a model with `pi.withModel(Model("provider/model"))`. Interactive calls can ask clarifying questions via Orca's `ask_user` bridge. |
 | `gemini` | `flash`, `cheap` (→ flash), `withModel(Model)` | Google Gemini CLI coding/reviewing agent, driven via `gemini --output-format stream-json`. Bare `gemini` pins **Gemini 2.5 Pro**; use `gemini.flash` for cheaper one-shot calls. Structured output is prompt-enforced (Gemini has no schema flag); `withReadOnly` maps to `--approval-mode plan`. See [ADR 0015](adr/0015-gemini-stream-json-driver.md). |
-| `git` | `createBranch`, `checkout`, `ensureClean`, `commit`, `forceAdd`, `push`, `currentBranch`, `headCommit`, `uncommittedDiff`, `changedFiles`, `reviewChanges`, `pendingChanges`, `diffVsBase`, `defaultBase`, `resetHard`, `deleteBranch`, `branchHasChangesExcludingOrca` | Git operations against the working tree. Recoverable failures (`BranchAlreadyExists`, `BranchNotFound`, `NothingToCommit`, `PushFailure` — `NonFastForward`/`RemoteDeclined`) surface as `Either`; `.orThrow` converts a `Left` back to an exception when the case is unexpected. `forceAdd`, `resetHard`, `deleteBranch` are used by the flow runtime for bookkeeping and teardown. `uncommittedDiff` covers the whole repository minus `.orca/` bookkeeping, tracked files only, and is empty once the work is committed — `diffVsBase` is the branch-wide view. `reviewChanges` is what `reviewAndFixLoop` hands reviewers: that diff plus the contents of files new to the repo, together with the list of every path in the change set and how much of each changed. It takes an optional commit to compare against (`headCommit` reads one) so work already committed still shows up. `changedFiles` is the path list on its own, for a consumer gating on file names — the diff text alone names neither a binary change nor a rename, and leaves a trailing tab on a path containing a space. `pendingChanges` describes what the next commit will include: a `--stat` summary, the new files, and the diff. |
+| `git` | `createBranch`, `checkout`, `ensureClean`, `commit`, `forceAdd`, `push`, `currentBranch`, `headCommit`, `uncommittedDiff`, `changedFiles`, `reviewChanges`, `pendingChanges`, `diffVsBase`, `defaultBase`, `discardUncommitted`, `deleteBranch`, `branchHasChangesExcludingOrca` | Git operations against the working tree. Recoverable failures (`BranchAlreadyExists`, `BranchNotFound`, `NothingToCommit`, `PushFailure` — `NonFastForward`/`RemoteDeclined`) surface as `Either`; `.orThrow` converts a `Left` back to an exception when the case is unexpected. `forceAdd`, `discardUncommitted`, `deleteBranch` are used by the flow runtime for bookkeeping and teardown. `uncommittedDiff` covers the whole repository minus `.orca/` bookkeeping, tracked files only, and is empty once the work is committed — `diffVsBase` is the branch-wide view. `reviewChanges` is what `reviewAndFixLoop` hands reviewers: that diff plus the contents of files new to the repo, together with the list of every path in the change set and how much of each changed. It takes an optional commit to compare against (`headCommit` reads one) so work already committed still shows up. `changedFiles` is the path list on its own, for a consumer gating on file names — the diff text alone names neither a binary change nor a rename, and leaves a trailing tab on a path containing a space. `pendingChanges` describes what the next commit will include: a `--stat` summary, the new files, and the diff. |
 | `gh` | `createPr`, `updatePr`, `readIssue`, `readIssueComments`, `readPrComments`, `writeComment(pr, body)` / `writeComment(issue, body)`, `upsertComment(pr, marker, body)` / `upsertComment(issue, marker, body)`, `buildStatus`, `waitForBuild` | GitHub PR + CI integration via the `gh` CLI. `createPr` is idempotent by branch (returns the existing PR if one is open); `upsertComment` finds a prior comment carrying `marker` and edits it in place (see [Authoring rules](#authoring-rules) for the re-run pattern). `updatePr` replaces a PR's title + body. `waitForBuild` returns `Either[BuildWaitFailed, …]`. |
 | `fs` | `read`, `write`, `list` | Working-tree file I/O. `read` returns `Option[String]` so a missing file is a branch point, not an exception. |
 
@@ -296,7 +296,7 @@ slot is typed `AgentWiring => Ox ?=> OpencodeAgent`.
 
 ### Side effects happen inside stages
 
-Every side-effecting call — git mutations (`commit`/`push`/`resetHard`/…),
+Every side-effecting call — git mutations (`commit`/`push`/`discardUncommitted`/…),
 `fs.write`, `gh` writes, every `agent.*.run` — must happen inside a `stage`
 body, and **the compiler enforces it**: a mutation outside a stage doesn't
 compile. Pure reads (`git.uncommittedDiff`, `git.changedFiles`, `gh.readIssue`, `fs.read`),
@@ -329,9 +329,14 @@ Each `flow(...)` run is bound to exactly one feature branch and one progress log
   is kept and HEAD **stays on it by default** (so you end on the work); pass
   `returnToStartBranch = true` — for flows that open a PR — to return HEAD to
   the starting branch instead.
-- **Failure teardown:** discard the failed stage's uncommitted partial edits
-  with `git reset --hard`; stay on the feature branch so a re-run resumes in
-  place.
+- **Failure teardown:** discard the failed stage's uncommitted partial edits —
+  `git reset --hard` for tracked files, plus `git clean -fd` for the files it
+  newly created; stay on the feature branch so a re-run resumes in place.
+  Gitignored paths and `.orca/` are never removed. Whether the clean runs at
+  all is decided once, at setup, for the whole run: a FRESH `--skip-branch` run
+  that started with a dirty tree left those files in place rather than stashing
+  them, so orca cannot tell them apart from the run's own — no untracked file
+  is deleted, in any stage, including ones the failed stage created.
 
 ### Settings
 

--- a/adr/0018-stage-bound-flow-runtime.md
+++ b/adr/0018-stage-bound-flow-runtime.md
@@ -427,17 +427,19 @@ the wrong branch.
   when the branch's upstream still contains the progress log — proof the flow
   itself published it — so teardown never pushes work the run wasn't asked to
   publish. On a **failure** exit the feature branch and
-  its committed log are kept intact so the next run can resume; only the failed
-  stage's uncommitted *tracked* partial edits are discarded (it re-runs on
-  resume) — teardown is `git reset --hard`, which does not remove *untracked*
-  files, so a failed stage's newly created files (the common shape of agent
-  output) survive teardown and stay in the working tree. They aren't lost:
-  R4's stash on the *next* run's start sweeps them up (`stash push -u` does
-  cover untracked paths) alongside any genuine user WIP, rather than
-  discarding them outright. Whether teardown should instead delete
-  run-touched untracked leftovers (a scoped clean, not blanket `git clean
-  -fd`, which would also claim pre-existing untracked user files) is an open
-  decision, not made here.
+  its committed log are kept intact so the next run can resume; the failed
+  stage's uncommitted partial edits are discarded (they re-run on resume).
+  Teardown is `git reset --hard`, which covers tracked files only, plus
+  `git clean -fd` for the files the stage newly created — the common shape of
+  agent output. The clean is scoped so it can only claim the run's own output:
+  no `-x`, so gitignored paths (build caches, `.orca/cache/`) stay; `.orca/`
+  itself is excluded, since it holds this run's progress log while no stage has
+  committed it yet, and other runs' progress logs; and it is skipped entirely
+  when setup did not establish a clean tree — a FRESH skip-branch run tolerates
+  a dirty tree instead of
+  stashing it (R4 amendment), so those untracked files pre-date the run and are
+  the flow's hand-off context, not its output. In that one case the untracked
+  leftovers stay, and the next run's stash (R4) sweeps them up.
 - **R6** — Push and PR creation are flow-controlled and usable at any point; the
   runtime imposes no single terminal push.
 - **R30** — On startup the runtime cross-checks the header's recorded branch against
@@ -549,9 +551,9 @@ Teardown on **success**:
 Teardown on **failure**:
 
 8. Discard the failed stage's uncommitted partial edits with `git reset --hard`
-   (which restores the last committed log) — **not** `git clean -x .orca/`, or a log
-   force-added but not yet committed in the crash window would be wiped. They re-run
-   on resume. **Stay on the feature branch** (R3); do not return to the starting
+   (which restores the last committed log), plus a scoped `git clean -fd` — see
+   R5 for what the clean spares and when it is skipped. They re-run on resume.
+   **Stay on the feature branch** (R3); do not return to the starting
    branch — HEAD is then already where the next run resumes and the committed log is
    in the working tree, so resume needs no branch lookup. The user switches back to
    the starting branch themselves once they've dealt with the failure.

--- a/adr/0019-project-stack-settings.md
+++ b/adr/0019-project-stack-settings.md
@@ -38,10 +38,11 @@ Two further findings shaped the design:
   object, the lint summariser agent, dissolves by convention (the flow
   supplies its own cheap tier; settings carry only the command).
 - **A force-staged file is *less* durable than an untracked one.** `git reset
-  --hard` (the failure-teardown step) deletes a staged-but-uncommitted file
-  but leaves an untracked file alone. Anything orca writes for the user must
-  therefore be written untracked, never pre-staged; it is written untracked
-  and committed separately (or by the user).
+  --hard` (the failure-teardown step) deletes a staged-but-uncommitted file,
+  while an untracked one under `.orca/` survives — teardown's `git clean`
+  excludes that directory. The settings file lives there, so it must be
+  written untracked, never pre-staged; it is written untracked and committed
+  separately (or by the user).
 
 Named presets (`preset = rust-cargo`) were considered and rejected: real
 projects differ in subtle ways (extra cargo features, a nonstandard sbt

--- a/runner/src/main/scala/orca/flow.scala
+++ b/runner/src/main/scala/orca/flow.scala
@@ -233,8 +233,8 @@ def flow(
   * then runs the body as a top-level stage with disjoint success/failure
   * teardown. Unlike [[flow]], a failure in any phase is **propagated** (after
   * body-failure teardown), not turned into a `System.exit`, so the
-  * crash→`resetHard`→resume wiring is directly testable. A phase that reports
-  * to the event surface first escapes wrapped in
+  * crash→`discardUncommitted`→resume wiring is directly testable. A phase that
+  * reports to the event surface first escapes wrapped in
   * [[orca.runner.SurfacedFlowFailure]]`(cause)`; a failure from BEFORE the
   * dispatcher and agents exist (e.g. an agent-override factory) has no event
   * surface and escapes unwrapped.

--- a/runner/src/main/scala/orca/runner/FlowLifecycle.scala
+++ b/runner/src/main/scala/orca/runner/FlowLifecycle.scala
@@ -28,7 +28,7 @@ import orca.progress.{
   UnsafeBranchRefRefused
 }
 import orca.settings.{AgentSettings, SettingsFile, SettingsScope}
-import orca.tools.GitTool
+import orca.tools.{GitTool, UntrackedFiles}
 import org.slf4j.LoggerFactory
 import ox.either.orThrow
 
@@ -85,23 +85,25 @@ object FlowLifecycle:
     // The whole flow body runs as a top-level stage: an otherwise unhandled
     // exception surfaces as a single Error event. `teardownFailure` runs only
     // here in the body phase, so a success-teardown error can never trigger
-    // `resetHard` or strand the user on the feature branch.
+    // `discardUncommitted` or strand the user on the feature branch.
     try surfaced(body(using ctx))
     catch
       case f @ SurfacedFlowFailure(e) =>
         // `e` was already reported by `surfaced`. If the reset itself fails, attach
         // it as suppressed (rather than replacing `e`), and log/print it too.
         //
-        // This Step names WHY the reset is about to discard changes — `resetHard`
-        // itself also emits its own "Discarded uncommitted changes" Step, which
-        // alone would read as unexplained data loss.
+        // This Step names WHY the reset is about to discard changes —
+        // `discardUncommitted` itself also emits its own "Discarded
+        // uncommitted changes" Step, which alone would read as unexplained
+        // data loss.
         ctx.emit(
           OrcaEvent.Step(
             "recovering from the failure — discarding uncommitted changes " +
-              "so a re-run resumes from the last completed stage"
+              "and the files the failed stage created, so a re-run resumes " +
+              "from the last completed stage"
           )
         )
-        try teardownFailure(ctx.git)
+        try teardownFailure(ctx.git, flowSetup.untrackedOnFailure)
         catch
           case NonFatal(t) =>
             e.addSuppressed(t)
@@ -209,13 +211,19 @@ object FlowLifecycle:
     * `branchMode` (mirrors [[ProgressHeader.branchMode]]) gates
     * [[finishBranch]]'s throwaway auto-delete: `Reused` blocks it, since orca
     * bound to a pre-existing branch rather than minting one.
+    *
+    * `untrackedOnFailure` is the cleanliness policy's verdict on what failure
+    * teardown may delete. `Keep` only when setup deliberately left pre-existing
+    * files in place (fresh skip-branch mode), where orca cannot tell the user's
+    * untracked files from the run's.
     */
   private[orca] case class FlowSetup(
       store: ProgressStore,
       featureBranch: FeatureBranch,
       startBranch: String,
       stackSettings: StackSettings,
-      branchMode: BranchMode
+      branchMode: BranchMode,
+      untrackedOnFailure: UntrackedFiles
   )
 
   /** The branch half of [[FlowSetup]] (FP2), resolved by whichever of
@@ -322,7 +330,7 @@ object FlowLifecycle:
         flowName,
         emit
       )
-    session.applyCleanlinessPolicy()
+    val untrackedOnFailure = session.applyCleanlinessPolicy()
     restoreLogIfMissing(store.path, snapshot)
     // Discovery (ADR 0019) is sequenced after the cleanliness decision (whose
     // stash, when it runs, would sweep a just-written untracked file straight
@@ -346,7 +354,8 @@ object FlowLifecycle:
       binding.featureBranch,
       binding.startBranch,
       stackSettings,
-      binding.branchMode
+      binding.branchMode,
+      untrackedOnFailure
     )
 
   /** On an unborn HEAD (`git init`, no commits) every later git call that names
@@ -474,21 +483,30 @@ object FlowLifecycle:
       * — the leftover files are likely the flow's own hand-off context. Every
       * other case (resume, or normal mode either way) auto-stashes, since an
       * interrupted stage's uncommitted work must not leak into the re-run.
+      *
+      * Returns what failure teardown may then do with untracked files (see
+      * [[FlowSetup.untrackedOnFailure]]).
       */
-    def applyCleanlinessPolicy()(using WorkspaceWrite): Unit =
+    def applyCleanlinessPolicy()(using WorkspaceWrite): UntrackedFiles =
       if args.skipBranch.value then
         val isResume =
           store.loadDetailed().isInstanceOf[ProgressStore.LoadResult.Loaded]
-        if isResume then git.ensureClean("orca: starting flow")
+        if isResume then
+          git.ensureClean("orca: starting flow")
+          UntrackedFiles.Remove
         else
           val dirty = git.dirtyPaths()
-          if dirty.nonEmpty then
+          if dirty.isEmpty then UntrackedFiles.Remove
+          else
             emit(
               OrcaEvent.Step(
                 s"leaving ${dirty.size} uncommitted/untracked file(s) in place for the flow"
               )
             )
-      else git.ensureClean("orca: starting flow")
+            UntrackedFiles.Keep
+      else
+        git.ensureClean("orca: starting flow")
+        UntrackedFiles.Remove
 
     /** Bind the run to a branch + progress log — resume onto the header's
       * branch for a valid log, warn and start fresh from a corrupt one, or
@@ -1061,8 +1079,12 @@ object FlowLifecycle:
 
   /** Failure teardown (ADR 0018 §2.5): discard the failed stage's uncommitted
     * partial edits with `git reset --hard` (which restores the last committed
-    * log), staying on the feature branch so the next run resumes in place.
+    * log) plus, when `untracked` allows it, the files the stage newly created,
+    * staying on the feature branch so the next run resumes in place.
     */
-  private[orca] def teardownFailure(git: GitTool): Unit =
+  private[orca] def teardownFailure(
+      git: GitTool,
+      untracked: UntrackedFiles
+  ): Unit =
     given WorkspaceWrite = RuntimeInStage.workspaceToken()
-    git.resetHard()
+    git.discardUncommitted(untracked)

--- a/runner/src/test/scala/orca/runner/FlowLifecycleTest.scala
+++ b/runner/src/test/scala/orca/runner/FlowLifecycleTest.scala
@@ -41,7 +41,7 @@ import orca.progress.{
   StageEntry
 }
 import orca.runner.terminal.TerminalInteraction
-import orca.tools.{FsTool, GitHubTool, GitTool, OsGitTool}
+import orca.tools.{FsTool, GitHubTool, GitTool, OsGitTool, UntrackedFiles}
 import mainargs.Flag
 import ox.supervised
 import ox.either.orThrow
@@ -94,8 +94,9 @@ class FlowLifecycleTest extends munit.FunSuite:
     "failure teardown: stays on feature branch with clean working tree and earlier commit present"
   ):
     // Build the pre-failure state manually: feature branch with a committed
-    // progress header + one completed stage entry, then staged (uncommitted)
-    // partial work from a second stage. Then apply failure teardown (resetHard).
+    // progress header + one completed stage entry, then a modified tracked file
+    // and a newly created untracked one from a second stage. Then apply failure
+    // teardown.
     val workDir = GitRepo.seeded()
     val git = new OsGitTool(workDir)
     val prompt = "lifecycle-failure"
@@ -124,15 +125,15 @@ class FlowLifecycleTest extends munit.FunSuite:
     git.forceAdd(store.path)
     val _ = git.commit("stage: stage-one")
 
-    // Simulate stage-two leaving staged but uncommitted work.
-    // Writing + staging makes this a modified-in-index file that `reset --hard`
-    // will remove (unlike untracked files which reset --hard leaves alone).
+    // Simulate stage-two leaving uncommitted work in both shapes a stage
+    // produces: an edit to a file committed by stage one, and a brand-new file
+    // — which `reset --hard` alone would leave behind.
+    os.write.over(workDir / "one.txt", "partial edit")
     os.write(workDir / "two.txt", "partial")
-    val _ = os.proc("git", "add", "two.txt").call(cwd = workDir)
     val featureBranch = git.currentBranch()
 
-    // Apply failure teardown (git reset --hard, stay on feature branch).
-    git.resetHard()
+    // Apply failure teardown (stay on feature branch).
+    git.discardUncommitted(UntrackedFiles.Remove)
 
     assertEquals(git.currentBranch(), featureBranch)
     val status =
@@ -150,8 +151,9 @@ class FlowLifecycleTest extends munit.FunSuite:
     assert(ids.contains("stage-one#0"), "stage one must remain recorded")
     assert(
       !os.exists(workDir / "two.txt"),
-      "staged partial file must be wiped by reset --hard"
+      "the new file the failed stage created must be gone"
     )
+    assertEquals(os.read(workDir / "one.txt"), "content")
 
   test(
     "setup resume: second flow call resumes feature branch; a stage body runs only once"
@@ -1992,6 +1994,60 @@ class FlowLifecycleTest extends munit.FunSuite:
       s"the header commit must still land, on the reused branch: $log"
     )
 
+  test(
+    "skip-branch mode on a dirty tree: failure teardown keeps the untracked files it started with"
+  ):
+    // A fresh skip-branch run tolerates a dirty tree instead of stashing it, so
+    // those untracked files pre-date the run — its hand-off context, not its
+    // output. Teardown's untracked removal must therefore be off here.
+    val workDir = GitRepo.seeded()
+    val prompt = "skip-branch-dirty-teardown"
+    val store = ProgressStore.default(workDir, prompt)
+    val git = new OsGitTool(workDir)
+    given WorkspaceWrite = WorkspaceWrite.unsafe
+    val _ = git.createBranch("my-work")
+    os.write(workDir / "handoff.md", "the plan")
+    val _ = intercept[SurfacedFlowFailure]:
+      supervised:
+        val interaction = TerminalInteraction.start(
+          out = new PrintStream(new ByteArrayOutputStream()),
+          useColor = false,
+          animated = false
+        )
+        runFlow(
+          args = OrcaArgs(prompt, skipBranch = Flag(true)),
+          stackSettings = Some(StackSettings.empty),
+          wiring = FlowWiring(claude = Some(_ => StubAgent.claude)),
+          workDir = workDir,
+          interaction = Some(interaction),
+          extraListeners = Nil,
+          branchNaming = None,
+          returnToStartBranch = false,
+          progressStore = Some(store)
+        ):
+          val _ = stage[String]("crash"):
+            throw new RuntimeException("boom body")
+    assert(
+      os.exists(workDir / "handoff.md"),
+      "a file that pre-dated the run must survive failure teardown"
+    )
+
+  test(
+    "failure teardown removes the untracked file a failed stage created"
+  ):
+    val workDir = GitRepo.seeded()
+    val prompt = "teardown-removes-untracked"
+    val store = ProgressStore.default(workDir, prompt)
+    val _ = intercept[SurfacedFlowFailure]:
+      runFlowForTest(workDir, prompt, store):
+        val _ = stage[String]("crash"):
+          os.write(workDir / "half-written.txt", "partial")
+          throw new RuntimeException("boom body")
+    assert(
+      !os.exists(workDir / "half-written.txt"),
+      "the failed stage's new file must not survive teardown"
+    )
+
   test("skip-branch mode refuses to bind to a protected branch"):
     val workDir = GitRepo.seeded() // starts on "main"
     val prompt = "skip-branch-protected"
@@ -2386,7 +2442,8 @@ class FlowLifecycleTest extends munit.FunSuite:
       featureBranch = featureBranch,
       startBranch = "main",
       stackSettings = StackSettings.empty,
-      branchMode = BranchMode.Reused
+      branchMode = BranchMode.Reused,
+      untrackedOnFailure = UntrackedFiles.Remove
     )
     FlowLifecycle.teardownSuccess(git, setup, returnToStartBranch = false)
     assert(
@@ -2436,7 +2493,8 @@ class FlowLifecycleTest extends munit.FunSuite:
         .get,
       startBranch = "main",
       stackSettings = StackSettings.empty,
-      branchMode = BranchMode.Reused
+      branchMode = BranchMode.Reused,
+      untrackedOnFailure = UntrackedFiles.Remove
     )
     TeardownPushRepo(git, remote, setup, store.path.subRelativeTo(workDir))
 
@@ -2749,10 +2807,10 @@ class FlowLifecycleTest extends munit.FunSuite:
     "surfaced: a body failure whose teardownFailure ALSO throws surfaces once; the reset failure rides along suppressed"
   ):
     // The body reports its Error at the stage boundary (one Error, no
-    // double-report). failure teardown (`resetHard`) still runs — and if the
-    // reset itself throws, that must NOT mask the original body failure: it is
-    // attached as suppressed so the user sees the body message and debug sees
-    // both.
+    // double-report). failure teardown (`discardUncommitted`) still runs — and
+    // if the reset itself throws, that must NOT mask the original body failure:
+    // it is attached as suppressed so the user sees the body message and debug
+    // sees both.
     val workDir = GitRepo.seeded()
     val prompt = "surfaced-suppressed"
     val store = ProgressStore.default(workDir, prompt)
@@ -2799,7 +2857,7 @@ class FlowLifecycleTest extends munit.FunSuite:
   test(
     "a body failure emits an explanatory Step before the reset --hard teardown runs"
   ):
-    // DC1: the reset's own Step ("Discarded uncommitted changes") reads as
+    // The reset's own Step ("Discarded uncommitted changes") reads as
     // unexplained data loss on its own — FlowLifecycle.run must emit a
     // preceding Step naming WHY the reset is about to happen (recovery, not
     // loss) whenever a body failure triggers failure teardown.
@@ -3083,13 +3141,15 @@ class FlowLifecycleTest extends munit.FunSuite:
         : AgentCall[BackendTag.ClaudeCode.type, O] =
       throw new UnsupportedOperationException
 
-  /** An `OsGitTool` whose `resetHard` always throws — to exercise the
+  /** An `OsGitTool` whose `discardUncommitted` always throws — to exercise the
     * body-phase failure teardown throwing while it handles a body failure, so
     * the reset error is attached as suppressed rather than masking the
     * original.
     */
   private class ResetThrowingGit(workDir: os.Path) extends OsGitTool(workDir):
-    override def resetHard()(using WorkspaceWrite): Unit =
+    override def discardUncommitted(untracked: UntrackedFiles)(using
+        WorkspaceWrite
+    ): Unit =
       throw new RuntimeException("reset boom")
 
   /** Codex counterpart of [[RecordingClaude]], used to assert that a

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -17,6 +17,17 @@ enum ShowDetail:
   /** Message plus `--stat`: which files changed and by how much, no hunks. */
   case StatOnly
 
+/** What [[GitTool.discardUncommitted]] does with untracked files, which `git
+  * reset --hard` alone never touches.
+  */
+enum UntrackedFiles:
+  /** Delete them. Only correct when everything untracked was created after the
+    * tree was last known clean — otherwise this destroys the user's own files.
+    */
+  case Remove
+
+  case Keep
+
 /** Why a [[GitTool.show]] / [[GitTool.fileAt]] read did not happen. Returned in
   * a `Left` rather than thrown: these reads take agent-supplied arguments, and
   * a bad one is an answer to relay, not a flow failure. Subclasses
@@ -273,14 +284,23 @@ trait GitTool:
     * committed progress log) intact, so a re-run resumes cleanly (ADR 0018
     * §2.5).
     *
-    * '''`reset --hard` does NOT remove untracked files''' — a failed stage's
-    * newly created files survive in the working tree. They're swept later, into
-    * the next run's `ensureClean` stash (`git stash push -u`), alongside any
-    * genuine user WIP. A scoped clean here would risk deleting pre-existing
-    * untracked files too (blanket `git clean -fd`), so that cleanup is
-    * deliberately left to `ensureClean`, not done here.
+    * `reset --hard` covers tracked files only, so `untracked` decides what
+    * happens to files the run newly created — the common shape of agent output.
+    * [[UntrackedFiles.Remove]] adds `git clean -fd`, which the caller may only
+    * ask for when it knows the tree started clean.
+    *
+    * The clean never passes `-x`, so gitignored paths (build caches,
+    * `.orca/cache/`) are kept, and it always excludes `.orca/` itself: that
+    * directory holds other runs' progress logs, and this run's log while no
+    * stage has committed it yet — neither is the failed stage's output.
+    *
+    * One case the exclusion cannot reason about: an empty untracked directory
+    * is invisible to `git status` (even `-uall`), so `-d` removes a non-ignored
+    * one whether or not the run created it. Empty ignored directories survive.
     */
-  def resetHard()(using WorkspaceWrite): Unit
+  def discardUncommitted(untracked: UntrackedFiles)(using
+      WorkspaceWrite
+  ): Unit
 
   /** All changes since the last commit (staged and unstaged) anywhere in the
     * repository, excluding `.orca/` bookkeeping. Tracked files only — an
@@ -416,8 +436,10 @@ trait GitTool:
     * untracked), one per entry. READ-ONLY. Used by skip-branch mode's
     * informational notice on a fresh run with a dirty tree (ADR 0018 amendment)
     * — the count, not the parsed content, is what's shown. Emptiness is also
-    * what [[commit]] and [[ensureClean]] decide on, so narrowing what this
-    * reports changes when they commit and when they stash.
+    * what [[commit]] and [[ensureClean]] decide on, and what the failure
+    * teardown's choice of [[UntrackedFiles]] follows from, so narrowing what
+    * this reports changes when they commit, when they stash, and whether
+    * untracked files are deleted.
     */
   def dirtyPaths(): List[String]
 
@@ -478,9 +500,12 @@ private[orca] class OsGitTool(
     git("branch", "--list", "--", name).trim.nonEmpty
 
   def dirtyPaths(): List[String] =
+    // The untracked mode is explicit because `status.showUntrackedFiles=no` in
+    // a user's git config would otherwise hide untracked paths from every
+    // consumer of this.
     // One porcelain line per path, except a rename ("R  old -> new"), which
     // is one line covering two paths — fine for an informational count.
-    git("status", "--porcelain").linesIterator
+    git("status", "--porcelain", "--untracked-files=normal").linesIterator
       .map(_.trim)
       .filter(_.nonEmpty)
       .toList
@@ -615,9 +640,21 @@ private[orca] class OsGitTool(
       probeSucceeds("cat-file", "-e", s"@{upstream}:./$relPath")
     catch case NonFatal(_) => false
 
-  def resetHard()(using WorkspaceWrite): Unit =
+  def discardUncommitted(untracked: UntrackedFiles)(using
+      WorkspaceWrite
+  ): Unit =
     val _ = git("reset", "--hard")
-    step("Discarded uncommitted changes (reset --hard)")
+    untracked match
+      case UntrackedFiles.Keep =>
+        step("Discarded uncommitted changes (reset --hard)")
+      case UntrackedFiles.Remove =>
+        // `.orca` is an unanchored pattern, so it is spared at any depth —
+        // including under the `:(top)` rescoping to the repository root.
+        val _ = git("clean", "-fdq", "-e", orca.OrcaDir.Name, "--", ":(top)")
+        step(
+          "Discarded uncommitted changes and new files (reset --hard, clean " +
+            "-fd excluding .orca)"
+        )
 
   def uncommittedDiff(): String = trackedDiff("HEAD")
 

--- a/tools/src/test/scala/orca/tools/OsGitToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitToolTest.scala
@@ -221,6 +221,50 @@ class OsGitToolTest extends munit.FunSuite:
         s"expected a stash Step; got: $steps"
       )
 
+  test(
+    "dirtyPaths sees untracked files even when status.showUntrackedFiles=no"
+  ):
+    withSeededRepo: (git, dir) =>
+      val _ =
+        os.proc("git", "config", "status.showUntrackedFiles", "no")
+          .call(cwd = dir)
+      os.write(dir / "user-file.txt", "precious")
+      assertEquals(git.dirtyPaths(), List("?? user-file.txt"))
+
+  test("discardUncommitted(Remove) deletes an untracked file"):
+    withSeededRepo: (git, dir) =>
+      os.write(dir / "new.txt", "created")
+      git.discardUncommitted(UntrackedFiles.Remove)
+      assert(!os.exists(dir / "new.txt"))
+
+  test("discardUncommitted(Keep) leaves an untracked file in place"):
+    withSeededRepo: (git, dir) =>
+      os.write(dir / "new.txt", "created")
+      git.discardUncommitted(UntrackedFiles.Keep)
+      assert(os.exists(dir / "new.txt"))
+
+  test("discardUncommitted(Remove) keeps `.orca/` bookkeeping"):
+    withSeededRepo: (git, dir) =>
+      // Neither file belongs to the failed stage: one is another run's
+      // progress log, the other cached session state.
+      os.write(
+        dir / ".orca" / "progress-other.json",
+        "{}",
+        createFolders = true
+      )
+      os.write(dir / ".orca" / "cache" / "s.jsonl", "{}", createFolders = true)
+      git.discardUncommitted(UntrackedFiles.Remove)
+      assert(os.exists(dir / ".orca" / "progress-other.json"))
+      assert(os.exists(dir / ".orca" / "cache" / "s.jsonl"))
+
+  test("discardUncommitted(Remove) keeps gitignored files"):
+    withSeededRepo: (git, dir) =>
+      os.write(dir / ".gitignore", "build/\n")
+      git.commit("ignore build output").orThrow
+      os.write(dir / "build" / "out.jar", "bytes", createFolders = true)
+      git.discardUncommitted(UntrackedFiles.Remove)
+      assert(os.exists(dir / "build" / "out.jar"))
+
   test("createBranch / commit / checkout each emit a Step event"):
     withRepoCapturingEvents: (git, dir, seen) =>
       os.write(dir / "seed.txt", "x")


### PR DESCRIPTION
## The problem

When a flow stage fails, teardown ran `git reset --hard`. That only touches
tracked files, so any file the failed stage newly created stayed in the working
tree. Seen in a live test: an interrupted stage's `second.txt` was still there
after the "Discarded uncommitted changes" step, and only disappeared later when
the next run's auto-stash swept it up.

The README said the failed stage's uncommitted partial edits are discarded.
That was only true for tracked files.

## The fix

Teardown now runs `git clean -fd` as well as the reset. `GitTool.resetHard()`
becomes `discardUncommitted(untracked: UntrackedFiles)`, so the caller has to
say whether untracked files go.

## Why the clean is safe

A blanket `git clean -fd` would delete files the user keeps untracked, so the
scope is narrowed three ways.

**No `-x`.** Gitignored paths are left alone — build caches, `.orca/cache/`,
`target/`, and so on. This matches the other side: flow start uses
`git stash push -u`, which also does not take gitignored files. Whatever the
stash leaves, the clean leaves.

**`.orca/` is excluded.** It holds this run's progress log while no stage has
committed it yet, plus other runs' progress logs. None of that is the failed
stage's output. The exclusion pattern is unanchored, so it holds at any depth,
and the clean is rescoped with `:(top)` so it covers the whole repository like
the reset and the stash do, rather than only the directory git happens to run
in.

**It is skipped when the run did not start from a clean tree.** Normally setup
stashes a dirty tree, so anything untracked at teardown must have been created
by the run. The exception is a fresh `--skip-branch` run, which deliberately
leaves a dirty tree in place — those files are the flow's hand-off context, and
deleting them would be worse than the bug being fixed. That decision is made
once at setup and recorded on `FlowSetup`.

Review also turned up a way the third rule could be defeated: the check that
decides whether to stash used `git status --porcelain`, which prints nothing
for untracked files if the user has `status.showUntrackedFiles=no` in their git
config. Setup would then skip the stash, teardown would wrongly conclude the
tree started clean, and the clean would delete the user's files. `dirtyPaths`
now passes `--untracked-files=normal` explicitly.

One case the scoping cannot reason about: an empty untracked directory is
invisible to `git status`, even with `-uall`, so `-d` removes a non-ignored one
whether or not the run created it. Empty ignored directories survive. This is
noted on the method.

## Tests

- Failure teardown with both a modified tracked file and a new untracked file —
  both gone, the earlier stage's commit intact.
- A failed stage's new file is removed end to end through the runner.
- A fresh `--skip-branch` run on a dirty tree keeps its pre-existing untracked
  files after a failure.
- `.orca/` bookkeeping survives the clean.
- Gitignored files survive the clean.
- `discardUncommitted(Keep)` leaves untracked files alone.
- `dirtyPaths` still sees untracked files under `status.showUntrackedFiles=no`.

README and ADR 0018 updated; ADR 0018 recorded this as an open decision, which
it no longer is. ADR 0019's note about untracked files surviving teardown is
narrowed to `.orca/`, which is the only place that still holds.