### PR TITLE
Render a turn's prose before the tool calls it announces

### DIFF
--- a/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeBackend.scala
@@ -134,13 +134,8 @@ private[orca] class ClaudeBackend(
 
   export ClaudeArgs.enforcementCell
 
-  /** `--json-schema` (passed whenever a structured call supplies a schema — see
-    * [[runAutonomous]]) makes the CLI inject a StructuredOutput tool whose
-    * parameters are the schema's top-level properties; the payload arrives as
-    * that tool call, never as reply text.
-    */
   override def structuredOutputMode: StructuredOutputMode =
-    StructuredOutputMode.Tool
+    ClaudeBackend.StructuredOutputDelivery
 
   /** The sole session handle. [[IdScheme.ClientClaimed]]: ids are claimed via
     * `--session-id` so subsequent calls use `--resume` (the CLI refuses to
@@ -468,3 +463,10 @@ object ClaudeBackend:
     * rendering the tool call too would show the same JSON twice.
     */
   private[claude] val StructuredOutputToolName: String = "StructuredOutput"
+
+  /** Shared by [[ClaudeBackend.structuredOutputMode]] and
+    * [[ClaudeConversation]], so prompt assembly and the drain can't disagree
+    * about how the payload arrives.
+    */
+  private[claude] val StructuredOutputDelivery: StructuredOutputMode =
+    StructuredOutputMode.Tool

--- a/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
+++ b/claude/src/main/scala/orca/tools/claude/ClaudeConversation.scala
@@ -1,6 +1,12 @@
 package orca.tools.claude
 
-import orca.agents.{AutoApprove, BackendTag, AgentConfig, Model}
+import orca.agents.{
+  AutoApprove,
+  BackendTag,
+  AgentConfig,
+  Model,
+  StructuredOutputMode
+}
 import orca.AgentTurnFailed
 import orca.events.TurnDebit
 import orca.backend.{ApprovalDecision, ConversationEvent}
@@ -41,6 +47,9 @@ private[claude] class ClaudeConversation(
       backendName = "claude",
       initialPrompt = initialPrompt
     ):
+
+  override def structuredOutputMode: StructuredOutputMode =
+    ClaudeBackend.StructuredOutputDelivery
 
   // The reader thread is the sole writer for the fields below, and reads happen
   // on the same thread within `handle(...)` dispatch — no cross-thread

--- a/tools/src/main/scala/orca/agents/StructuredOutputMode.scala
+++ b/tools/src/main/scala/orca/agents/StructuredOutputMode.scala
@@ -1,9 +1,10 @@
 package orca.agents
 
 /** How a backend's wire delivers the payload of a structured (`resultAs[O]`)
-  * turn. Declared per backend via `AgentBackend.structuredOutputMode` and
-  * consumed by [[Prompts.autonomous]], so the delivery instruction matches what
-  * the wire actually expects.
+  * turn. Declared per backend via `AgentBackend.structuredOutputMode`; read by
+  * [[Prompts.autonomous]], so the delivery instruction matches the wire, and by
+  * the autonomous drain (`orca.backend.Conversations`), to know whether the
+  * closing assistant turn is the payload.
   */
 enum StructuredOutputMode:
   /** The result arrives as a CLI-injected `StructuredOutput` tool call whose

--- a/tools/src/main/scala/orca/backend/Conversation.scala
+++ b/tools/src/main/scala/orca/backend/Conversation.scala
@@ -1,6 +1,6 @@
 package orca.backend
 
-import orca.agents.{BackendTag}
+import orca.agents.{BackendTag, StructuredOutputMode}
 import orca.sweep.EnvCookie
 import orca.{OrcaInteractiveCancelled}
 
@@ -26,6 +26,16 @@ trait Conversation[B <: BackendTag]:
     * in favour of an `OrcaEvent.StructuredResult`) or genuine prose to flush.
     */
   def outputSchema: Option[String]
+
+  /** Conversation-side view of [[AgentBackend.structuredOutputMode]], read only
+    * when [[outputSchema]] is defined.
+    *
+    * Defaults to `RawText`, the withholding shape: a `Tool` backend that
+    * forgets to declare loses its closing turn's prose, whereas the reverse
+    * default would leak the JSON payload. A decorator must forward what it
+    * wraps, for the same reason as [[envCookie]].
+    */
+  def structuredOutputMode: StructuredOutputMode = StructuredOutputMode.RawText
 
   /** Events from the subprocess, in arrival order. Blocks on `next()` until a
     * line has been parsed or the session ends; `hasNext` returns false once the

--- a/tools/src/main/scala/orca/backend/Conversations.scala
+++ b/tools/src/main/scala/orca/backend/Conversations.scala
@@ -1,7 +1,7 @@
 package orca.backend
 
 import orca.events.{OrcaEvent, OrcaListener}
-import orca.agents.{AutoApprove, BackendTag, SessionId}
+import orca.agents.{AutoApprove, BackendTag, SessionId, StructuredOutputMode}
 import orca.sweep.{EnvCookie, EnvCookieSweep}
 
 import ox.{Ox, supervised}
@@ -9,17 +9,16 @@ import ox.{Ox, supervised}
 /** Drains a [[Conversation]] for the autonomous path, mapping conversation
   * events to [[OrcaEvent]]s and returning the awaited `AgentResult`.
   *
-  * Structured mode (`conv.outputSchema.isDefined`) withholds the last assistant
-  * turn so the closing JSON payload doesn't surface as an `AssistantMessage` —
-  * the caller emits it via `OrcaEvent.StructuredResult` instead. The
-  * withheld-turn state machine lives in [[TurnBuffer]].
+  * A structured call whose payload arrives as reply text withholds the closing
+  * assistant turn so the JSON doesn't surface as an `AssistantMessage` — the
+  * caller emits it via `OrcaEvent.StructuredResult` instead. The withheld-turn
+  * state machine lives in [[TurnBuffer]].
   *
-  * This covers the payload arriving as streamed PROSE only. A backend whose
-  * structured payload arrives as a tool call instead (claude's `--json-schema`
-  * exit call) never streams it as prose — there is nothing for `TurnBuffer` to
-  * withhold, so `StructuredResult.raw` is the sole carrier. Whether that raw
-  * payload gets echoed is `Announce[O]`'s contract (ADR 0008/0009), not this
-  * drain's.
+  * A backend whose structured payload arrives as a tool call instead (claude's
+  * `--json-schema` exit call, `StructuredOutputMode.Tool`) never streams it as
+  * prose, so nothing is withheld and `StructuredResult.raw` is the sole
+  * carrier. Whether that raw payload gets echoed is `Announce[O]`'s contract
+  * (ADR 0008/0009), not this drain's.
   *
   * Interactive-only events that reach this drain are handled explicitly to
   * avoid blocking the subprocess: `ApproveTool` is auto-denied and
@@ -27,38 +26,72 @@ import ox.{Ox, supervised}
   */
 private[orca] object Conversations:
 
-  /** Structured-mode turn buffer: streams every completed turn EXCEPT the most
-    * recent, which is withheld one turn (the final turn is the JSON payload,
-    * the caller re-surfaces it via OrcaEvent.StructuredResult). Turn N thus
-    * renders when turn N+1 completes — a one-turn display delay that keeps the
-    * payload out of the prose stream. In non-structured mode every turn flushes
-    * immediately.
+  /** Whether the drain renders a conversation's closing assistant prose turn,
+    * or keeps it out of the prose stream because it carries the structured
+    * payload.
+    */
+  private enum ClosingProse:
+    case Withhold, Render
+
+  /** Whether an autonomous call's closing prose turn is the structured payload:
+    * it is what the backend's wire delivers, the same fact `Prompts.autonomous`
+    * picks its delivery instruction from.
+    */
+  private def autonomousClosingProse(conv: Conversation[?]): ClosingProse =
+    if conv.outputSchema.isEmpty then ClosingProse.Render
+    else
+      conv.structuredOutputMode match
+        case StructuredOutputMode.RawText => ClosingProse.Withhold
+        case StructuredOutputMode.Tool    => ClosingProse.Render
+
+  /** Whether an interactive call's closing prose turn is the structured
+    * payload. `Prompts.interactive` asks every backend for a JSON-only final
+    * message — it doesn't branch on `StructuredOutputMode` — so here a schema
+    * alone decides.
+    */
+  private def interactiveClosingProse(conv: Conversation[?]): ClosingProse =
+    if conv.outputSchema.isDefined then ClosingProse.Withhold
+    else ClosingProse.Render
+
+  /** Renders each completed assistant turn's prose as one `emit`, holding back
+    * the CLOSING turn when it carries the structured payload.
+    *
+    * A turn can only be recognised as closing after the fact, so a completed
+    * turn is parked in `withheld` and released by [[onActivity]] — the first
+    * assistant event of the next turn — which keeps a turn's narration ahead of
+    * the tool calls it announces. What survives to end-of-stream is the closing
+    * turn, and only that is dropped.
     *
     * State is confined to the drain's single-threaded event loop — the mutable
     * `StringBuilder`/`var` here is a deliberate, reviewed deviation from the
     * codebase's Ox-concurrency default, not an actor oversight: this runs on
     * one thread only, so no channel/actor would buy anything.
     */
-  private final class TurnBuffer(structuredMode: Boolean, emit: String => Unit):
+  private final class TurnBuffer(closing: ClosingProse, emit: String => Unit):
     private val current = new StringBuilder
     private var withheld: Option[String] = None
+
+    /** Assistant activity opening a turn (`ConversationEvent.opensTurn`): the
+      * parked turn isn't the closing one after all, so release it. Call before
+      * rendering the triggering event, so a turn's narration lands ahead of the
+      * tool call it announces.
+      */
+    def onActivity(): Unit =
+      withheld.foreach(emit)
+      withheld = None
 
     def append(delta: String): Unit =
       val _ = current.append(delta)
 
-    /** Close the current turn. Structured: emit the previously-withheld turn
-      * and withhold this one (the one-turn delay); non-structured: emit now.
-      */
     def turnEnd(): Unit =
       if current.nonEmpty then
         val text = current.toString
         current.clear()
-        if structuredMode then
-          withheld.foreach(emit)
-          withheld = Some(text)
-        else emit(text)
+        closing match
+          case ClosingProse.Withhold => withheld = Some(text)
+          case ClosingProse.Render   => emit(text)
 
-    /** Normal end of stream: the withheld turn IS the payload — drop it (the
+    /** Normal end of stream: the parked turn IS the payload — drop it (the
       * caller emits StructuredResult); flush any unfinished current buffer.
       *
       * Since ForkedConversation auto-closes every completed turn, a normal
@@ -101,57 +134,59 @@ private[orca] object Conversations:
       events: OrcaListener = OrcaListener.noop
   )(using Ox): AgentResult[B] =
     val buffer = new TurnBuffer(
-      conv.outputSchema.isDefined,
+      autonomousClosingProse(conv),
       text => events.onEvent(OrcaEvent.AssistantMessage(text))
     )
     try
-      conv.events.foreach:
-        case ConversationEvent.AssistantToolCall(name, raw) =>
-          events.onEvent(OrcaEvent.ToolUse(name, raw))
-        case ConversationEvent.AssistantTextDelta(delta) =>
-          buffer.append(delta)
-        case ConversationEvent.AssistantThinkingDelta(_) => ()
-        case ConversationEvent.AssistantTurnEnd          => buffer.turnEnd()
-        case ConversationEvent.Error(msg) =>
-          events.onEvent(OrcaEvent.Error(msg))
-        case ConversationEvent.ApproveTool(toolName, _, respond) =>
-          // The subprocess blocks on stdin waiting for our decision and
-          // autonomous mode has no user to ask, so deny with a reason (so the
-          // agent can adapt) and surface as an error; dropping would deadlock.
-          val cause = denialCause(toolName, autoApprove)
-          respond(
-            ApprovalDecision.Deny(
-              Some(
-                s"$toolName denied: $cause, and autonomous mode cannot prompt"
+      conv.events.foreach: event =>
+        if event.opensTurn then buffer.onActivity()
+        event match
+          case ConversationEvent.AssistantToolCall(name, raw) =>
+            events.onEvent(OrcaEvent.ToolUse(name, raw))
+          case ConversationEvent.AssistantTextDelta(delta) =>
+            buffer.append(delta)
+          case ConversationEvent.AssistantThinkingDelta(_) => ()
+          case ConversationEvent.AssistantTurnEnd          => buffer.turnEnd()
+          case ConversationEvent.Error(msg) =>
+            events.onEvent(OrcaEvent.Error(msg))
+          case ConversationEvent.ApproveTool(toolName, _, respond) =>
+            // The subprocess blocks on stdin waiting for our decision and
+            // autonomous mode has no user to ask, so deny with a reason (so the
+            // agent can adapt) and surface as an error; dropping would deadlock.
+            val cause = denialCause(toolName, autoApprove)
+            respond(
+              ApprovalDecision.Deny(
+                Some(
+                  s"$toolName denied: $cause, and autonomous mode cannot prompt"
+                )
               )
             )
-          )
-          events.onEvent(
-            OrcaEvent.Error(
-              s"Denied $toolName: $cause; autonomous mode cannot prompt"
+            events.onEvent(
+              OrcaEvent.Error(
+                s"Denied $toolName: $cause; autonomous mode cannot prompt"
+              )
             )
-          )
-        case ConversationEvent.UserQuestion(_, respond) =>
-          // The ask_user MCP bridge isn't wired in autonomous mode (see
-          // `ConversationMode.Autonomous`), so this should be unreachable. If it
-          // ever fires, the bridge thread is blocked on `respond` — unblock it
-          // rather than leak the thread.
-          respond("[autonomous mode: no user available to answer]")
-          events.onEvent(
-            OrcaEvent.Error(
-              "ask_user fired during an autonomous call; auto-answered"
+          case ConversationEvent.UserQuestion(_, respond) =>
+            // The ask_user MCP bridge isn't wired in autonomous mode (see
+            // `ConversationMode.Autonomous`), so this should be unreachable. If it
+            // ever fires, the bridge thread is blocked on `respond` — unblock it
+            // rather than leak the thread.
+            respond("[autonomous mode: no user available to answer]")
+            events.onEvent(
+              OrcaEvent.Error(
+                "ask_user fired during an autonomous call; auto-answered"
+              )
             )
-          )
-        case ConversationEvent.UserMessage(_) =>
-          // Wire-level echo of input we already sent; surfaced upstream as
-          // `OrcaEvent.UserPrompt` from the Agent layer.
-          ()
-        case ConversationEvent.ToolResult(_, _, _) =>
-          // Tool output volume is unbounded (full cargo-test logs, etc.), so it
-          // isn't surfaced here; the matching `AssistantToolCall` already went
-          // out as `OrcaEvent.ToolUse`. Listeners needing raw output subscribe
-          // at the `ConversationEvent` layer instead.
-          ()
+          case ConversationEvent.UserMessage(_) =>
+            // Wire-level echo of input we already sent; surfaced upstream as
+            // `OrcaEvent.UserPrompt` from the Agent layer.
+            ()
+          case ConversationEvent.ToolResult(_, _, _) =>
+            // Tool output volume is unbounded (full cargo-test logs, etc.), so it
+            // isn't surfaced here; the matching `AssistantToolCall` already went
+            // out as `OrcaEvent.ToolUse`. Listeners needing raw output subscribe
+            // at the `ConversationEvent` layer instead.
+            ()
       buffer.finishNormally()
     catch
       case t: Throwable =>
@@ -210,9 +245,10 @@ private[orca] object Conversations:
     * live [[Conversation]] so its assistant PROSE (text deltas + the turn
     * boundary that closes them) is translated into `OrcaEvent.AssistantMessage`
     * on `events` — exactly like [[drainAutonomous]] — instead of being exposed
-    * on the conversation's own event stream. Structured mode
-    * (`conv.outputSchema.isDefined`) withholds the final turn the same
-    * one-turn-delayed way `TurnBuffer` does; the caller re-surfaces it via
+    * on the conversation's own event stream. A structured call has its closing
+    * turn withheld the same way `TurnBuffer` does (see
+    * [[interactiveClosingProse]] for why the backend's wire doesn't come into
+    * it here); the caller re-surfaces the payload via
     * `OrcaEvent.StructuredResult` instead (see `AgentCall.runInteractiveOnce`).
     *
     * Every OTHER event (tool calls/results, approvals, questions, errors, the
@@ -228,6 +264,8 @@ private[orca] object Conversations:
   ): Conversation[B] =
     new Conversation[B]:
       def outputSchema: Option[String] = conv.outputSchema
+      override def structuredOutputMode: StructuredOutputMode =
+        conv.structuredOutputMode
       def canAskUser: Boolean = conv.canAskUser
       def cancel(): Unit = conv.cancel()
       override def envCookie: Option[EnvCookie] = conv.envCookie
@@ -235,7 +273,7 @@ private[orca] object Conversations:
       def events(using Ox): Iterator[ConversationEvent] =
         ProseWithholdingIterator(
           conv.events,
-          conv.outputSchema.isDefined,
+          interactiveClosingProse(conv),
           text => listener.onEvent(OrcaEvent.AssistantMessage(text))
         )
 
@@ -258,10 +296,10 @@ private[orca] object Conversations:
     */
   private final class ProseWithholdingIterator(
       inner: Iterator[ConversationEvent],
-      structuredMode: Boolean,
+      closing: ClosingProse,
       emit: String => Unit
   ) extends Iterator[ConversationEvent]:
-    private val buffer = new TurnBuffer(structuredMode, emit)
+    private val buffer = new TurnBuffer(closing, emit)
     private val pending =
       scala.collection.mutable.Queue.empty[ConversationEvent]
     private var settled = false
@@ -269,7 +307,9 @@ private[orca] object Conversations:
     private def fill(): Unit =
       try
         while pending.isEmpty && inner.hasNext do
-          inner.next() match
+          val event = inner.next()
+          if event.opensTurn then buffer.onActivity()
+          event match
             case ConversationEvent.AssistantTextDelta(text) =>
               buffer.append(text)
             case ConversationEvent.AssistantThinkingDelta(_) => ()

--- a/tools/src/test/scala/orca/backend/ConversationsTest.scala
+++ b/tools/src/test/scala/orca/backend/ConversationsTest.scala
@@ -2,7 +2,13 @@ package orca.backend
 
 import orca.{AgentTurnFailed, OrcaFlowException, OrcaInteractiveCancelled}
 import orca.events.{OrcaEvent, OrcaListener, TurnDebit, Usage}
-import orca.agents.{AutoApprove, BackendTag, SessionId, WireSessionId}
+import orca.agents.{
+  AutoApprove,
+  BackendTag,
+  SessionId,
+  StructuredOutputMode,
+  WireSessionId
+}
 
 import ox.{Ox, supervised}
 
@@ -13,7 +19,9 @@ private class ScriptedConversation(
     outcome: Either[OrcaInteractiveCancelled, AgentResult[
       BackendTag.Codex.type
     ]],
-    val outputSchema: Option[String] = None
+    val outputSchema: Option[String] = None,
+    override val structuredOutputMode: StructuredOutputMode =
+      StructuredOutputMode.RawText
 ) extends Conversation[BackendTag.Codex.type]:
   val drained = new AtomicInteger(0)
   val cancelCount = new AtomicInteger(0)
@@ -492,10 +500,9 @@ class ConversationsTest extends munit.FunSuite:
     "structured mode: a tool call inside the sole turn doesn't defeat the " +
       "withhold"
   ):
-    // A single completed turn (activity opened by a tool call, closed once by
-    // the trailing AssistantTurnEnd) must stay withheld regardless of what
-    // kind of activity preceded the text delta — the one-turn delay only
-    // ever concerns TURN COUNT, not the shape of a turn's activity.
+    // Only activity AFTER a turn closed releases it: here the tool call and
+    // its result open the very turn whose text is the payload, so that turn
+    // stays withheld and the JSON never renders.
     val recorder = new RecordingListener
     val conv = new ScriptedConversation(
       List(
@@ -513,6 +520,101 @@ class ConversationsTest extends munit.FunSuite:
       recorder.events,
       List(OrcaEvent.ToolUse("bash", """{"command":"ls"}"""))
     )
+
+  test("a completed turn's prose renders before the next turn's tool call"):
+    // claude closes a narration turn, then opens a tool-only turn: the
+    // narration must render above the tool call it announces.
+    val recorder = new RecordingListener
+    val conv = new ScriptedConversation(
+      List(
+        ConversationEvent.AssistantTextDelta(
+          "Now let me read the existing stats.py file:"
+        ),
+        ConversationEvent.AssistantTurnEnd,
+        ConversationEvent.AssistantToolCall("Read", """{"file":"stats.py"}"""),
+        ConversationEvent.AssistantTurnEnd,
+        ConversationEvent.AssistantTextDelta("""{"answer":42}"""),
+        ConversationEvent.AssistantTurnEnd
+      ),
+      Right(sampleResult),
+      outputSchema = Some("""{"type":"object"}""")
+    )
+    val _ =
+      supervised(Conversations.drainAutonomous(conv, AutoApprove.All, recorder))
+    assertEquals(
+      recorder.events,
+      List(
+        OrcaEvent.AssistantMessage(
+          "Now let me read the existing stats.py file:"
+        ),
+        OrcaEvent.ToolUse("Read", """{"file":"stats.py"}""")
+      )
+    )
+
+  test("a Tool-mode structured call renders its closing prose turn"):
+    // In Tool mode the payload never streams as reply text, so withholding the
+    // closing turn would only lose genuine narration.
+    val recorder = new RecordingListener
+    val conv = new ScriptedConversation(
+      List(
+        ConversationEvent.AssistantTextDelta("Writing the plan now."),
+        ConversationEvent.AssistantTurnEnd
+      ),
+      Right(sampleResult),
+      outputSchema = Some("""{"type":"object"}"""),
+      structuredOutputMode = StructuredOutputMode.Tool
+    )
+    val _ =
+      supervised(Conversations.drainAutonomous(conv, AutoApprove.All, recorder))
+    assertEquals(
+      recorder.events,
+      List(OrcaEvent.AssistantMessage("Writing the plan now."))
+    )
+
+  test(
+    "the interactive filter emits a turn's prose before it yields the " +
+      "next turn's tool call"
+  ):
+    // Prose reaches the listener while the tool call reaches the consumer, so
+    // the order is only observable by checking the listener at the moment the
+    // tool call is handed over.
+    val recorder = new RecordingListener
+    val conv = new ScriptedConversation(
+      List(
+        ConversationEvent.AssistantTextDelta("Reading the file:"),
+        ConversationEvent.AssistantTurnEnd,
+        ConversationEvent.AssistantToolCall("Read", "{}")
+      ),
+      Right(sampleResult),
+      outputSchema = Some("""{"type":"object"}""")
+    )
+    supervised:
+      val forwarded =
+        Conversations.withholdInteractiveProse(conv, recorder).events.next()
+      assertEquals(
+        recorder.events,
+        List(OrcaEvent.AssistantMessage("Reading the file:"))
+      )
+      assertEquals(forwarded, ConversationEvent.AssistantToolCall("Read", "{}"))
+
+  test("the interactive filter withholds a closing turn even in Tool mode"):
+    // `Prompts.interactive` asks every backend for a JSON-only final message,
+    // so the wire's autonomous delivery doesn't decide anything here.
+    val recorder = new RecordingListener
+    val conv = new ScriptedConversation(
+      List(
+        ConversationEvent.AssistantTextDelta("""{"answer":42}"""),
+        ConversationEvent.AssistantTurnEnd
+      ),
+      Right(sampleResult),
+      outputSchema = Some("""{"type":"object"}"""),
+      structuredOutputMode = StructuredOutputMode.Tool
+    )
+    supervised:
+      val forwarded =
+        Conversations.withholdInteractiveProse(conv, recorder).events.toList
+      assertEquals(forwarded, Nil)
+      assertEquals(recorder.events, Nil)
 
   test("two back-to-back turns flush independently"):
     // Pins the textBuf.clear() inside the AssistantTurnEnd case so the


### PR DESCRIPTION
In a live run the agent's narration showed up *after* the tool call it
announced:

```
  ◊ Read (stats.py)
  ● Now let me read the existing stats.py file:
  ◊ Glob (*test*.py)
  ● Let me check if there are any test files:
```

And the last sentence of each structured stage was never shown at all.

## Why the buffer exists

For most backends a structured call (`resultAs[O]`) delivers its JSON as the
agent's last message. We must not print that JSON as prose, because the caller
already shows it as a structured result. Since you only know a turn was the
last one after the stream ends, `TurnBuffer` parks the most recent finished
turn and only prints it once the *next* turn finished.

Claude ends a turn after each assistant message, so the narration turn is
parked while the following tool-only turn renders — hence the flipped order,
and hence the last parked turn being dropped.

## The fix

Two changes:

- A parked turn is released as soon as the next turn starts (its first text
  delta, tool call or tool result), not when that turn ends. So the narration
  is printed just before the tool call it announces. What is still parked at
  the end of the stream is the closing turn, and only that is dropped.

- Claude never sends the JSON as text — it calls the CLI's `StructuredOutput`
  tool, which the driver hides. So there is nothing to park: claude's
  autonomous calls now print every turn, including the last one. This reuses
  the existing per-backend `StructuredOutputMode`, which already records this
  fact; `Conversation` now exposes it to the drain.

Interactive calls keep parking the closing turn for every backend, because
`Prompts.interactive` asks all of them for a JSON-only final message.

Tests cover the observed sequence, the closing turn still being suppressed,
and the interactive filter's ordering.
