### PR TITLE
Show untagged spend in the cost summary's By role section

### DIFF
--- a/flow/src/main/scala/orca/events/CostTracker.scala
+++ b/flow/src/main/scala/orca/events/CostTracker.scala
@@ -14,10 +14,10 @@ import java.util.concurrent.atomic.AtomicReference
   * report a figure that disagrees with the run's. `pricingAsOf` is the legend's
   * date only; pass the `lastUpdated` of the table the run prices with.
   *
-  * All axes share the same underlying calls, so summing any of the maps yields
-  * the grand total. The `model` axis keys on `Option[Model]` because the
-  * reported model isn't always present; the summary surfaces the missing case
-  * as `(unknown)`.
+  * All axes share the same underlying calls, so summing any of the maps — or
+  * any section the summary renders — yields the grand total. The `model` and
+  * `role` axes key on `Option` because neither the reported model nor a role
+  * tag is always present.
   */
 class CostTracker(pricingAsOf: LocalDate) extends OrcaListener:
 
@@ -117,15 +117,16 @@ class CostTracker(pricingAsOf: LocalDate) extends OrcaListener:
   private def costsOf[K](buckets: Map[K, Tally]): Map[K, Cost] =
     buckets.collect { case (key, Tally(_, Some(cost))) => key -> cost }
 
-  /** Two or three sections — by-agent, by-model, and (only when at least one
-    * call carried a [[orca.agents.Agent.role]] tag) by-role — each sorted
-    * alphabetically by its rendered label. Each by-agent line is prefixed with
-    * that agent's role when it has one (e.g. `reviewer: performance`). Cache
-    * reads, cache writes and reasoning tokens are shown parenthetically when
-    * non-zero. Token counts are rendered compactly (`1K`, `103.8K`, `3.2M`)
-    * from 1000 up; cost (when known) stays exact and is appended as `$X.XXXX`,
-    * with an asterisk marking an estimated figure and a trailing legend line
-    * when any estimate is present.
+  /** Two or three sections — by-agent, by-model and by-role — each sorted
+    * alphabetically by its rendered label. The by-role section appears only
+    * when some call carried a [[orca.agents.Agent.role]] tag, and then includes
+    * the `(untagged)` bucket too, so it still sums to the run's total. Each
+    * by-agent line is prefixed with that agent's role when it has one (e.g.
+    * `reviewer: performance`). Cache reads, cache writes and reasoning tokens
+    * are shown parenthetically when non-zero. Token counts are rendered
+    * compactly (`1K`, `103.8K`, `3.2M`) from 1000 up; cost (when known) stays
+    * exact and is appended as `$X.XXXX`, with an asterisk marking an estimated
+    * figure and a trailing legend line when any estimate is present.
     *
     * A turn that spent tokens but resolved to no cost contributes nothing to
     * the total, so the total's label carries `(some turns unpriced)` and gains
@@ -147,12 +148,12 @@ class CostTracker(pricingAsOf: LocalDate) extends OrcaListener:
         .map: (model, t) =>
           s"  ${modelLabel(model)}: ${formatLine(t)}"
       val roleLines = s.byRole.toList
-        .collect { case (Some(role), t) => (role, t) }
-        .sortBy(_._1)
+        .sortBy((role, _) => roleLabel(role))
         .map: (role, t) =>
-          s"  $role: ${formatLine(t)}"
+          s"  ${roleLabel(role)}: ${formatLine(t)}"
+      val anyRoleTagged = s.byRole.keys.exists(_.isDefined)
       val roleSection =
-        if roleLines.isEmpty then ""
+        if !anyRoleTagged then ""
         else s"""
                  |
                  |By role:
@@ -199,6 +200,12 @@ class CostTracker(pricingAsOf: LocalDate) extends OrcaListener:
     */
   private def modelLabel(model: Option[Model]): String =
     model.map(_.name).getOrElse("(unknown)")
+
+  /** Render a role bucket key for the summary. `None` covers calls from an
+    * agent with no role tag — too varied to name for any one role.
+    */
+  private def roleLabel(role: Option[String]): String =
+    role.getOrElse("(untagged)")
 
   /** Render a by-agent line's label: the bare agent name, prefixed with its
     * role (looked up in `agentRoles`) when it has one. The `"reviewer: "`

--- a/flow/src/test/scala/orca/CostTrackerTest.scala
+++ b/flow/src/test/scala/orca/CostTrackerTest.scala
@@ -539,6 +539,40 @@ class CostTrackerTest extends munit.FunSuite:
     tracker.onEvent(tokens("claude", Some("opus"), usage(10L, 5L, None)))
     assert(!tracker.summary.contains("By role:"), tracker.summary)
 
+  test(
+    "summary's By role section shows untagged spend, so it sums to the total"
+  ):
+    val tracker = new CostTracker(pricingAsOf)
+    tracker.onEvent(
+      tokens(
+        "performance",
+        Some("opus"),
+        usage(10L, 5L, Some(BigDecimal("0.60"))),
+        role = Some("reviewer")
+      )
+    )
+    tracker.onEvent(
+      tokens("claude", Some("opus"), usage(100L, 50L, Some(BigDecimal("0.40"))))
+    )
+    val out = tracker.summary
+    assert(out.contains("  (untagged): 100 in, 50 out ($0.4000)"), out)
+    assert(out.contains("  reviewer: 10 in, 5 out ($0.6000)"), out)
+    assert(out.contains("Total: $1.0000"), out)
+
+  test(
+    "summary's By role section has no untagged line when every call carried a role"
+  ):
+    val tracker = new CostTracker(pricingAsOf)
+    tracker.onEvent(
+      tokens(
+        "performance",
+        Some("opus"),
+        usage(10L, 5L, None),
+        role = Some("reviewer")
+      )
+    )
+    assert(!tracker.summary.contains("(untagged)"), tracker.summary)
+
   test("summary is empty when nothing has been recorded"):
     assertEquals(new CostTracker(pricingAsOf).summary, "")
 


### PR DESCRIPTION
The cost summary printed at the end of a run has three sections. Two of
them add up to the total; `By role:` did not, and nothing said so.

A real codex run:

```
By role:
  reviewer: 258.4K in, 6.1K out ($0.6467)

Total: $1.2622
```

Half the money is missing. The by-role map has a bucket for calls from
agents with no role tag, and the renderer skipped it — only
`Some(role)` buckets were printed. `withRole` is used in one place, the
review loop, so everything else in a flow (planning, coding, commit
messages, PR summaries) landed in that dropped bucket.

## What changed

The section now prints the untagged bucket too, as `(untagged)`:

```
By agent:
  claude: 100 in, 50 out ($0.4000)
  reviewer: performance: 10 in, 5 out ($0.6000)

By model:
  opus: 110 in, 55 out ($1.0000)

By role:
  (untagged): 100 in, 50 out ($0.4000)
  reviewer: 10 in, 5 out ($0.6000)

Total: $1.0000
```

## Why this name, and not a caveat label

The other option was to leave the bucket out and rename the header to
`By role (tagged agents only)`. Two reasons not to:

- The by-model section already has this exact problem and solves it the
  same way: a call whose model the backend didn't report prints as
  `(unknown)`. Doing something different one section lower would be odd.
- A caveat label tells the reader that a number is missing but not how
  big it is, which is the part they actually want. Showing it costs one
  line.

The bucket does not get a made-up role name like `main`, because the
calls in it share nothing except having no tag. `(untagged)` says what
it is.

The section still only appears when at least one call carried a role
tag — otherwise it would be a single `(untagged)` line repeating the
total.

The class scaladoc claimed \"summing any of the maps yields the grand
total\", which was true of the maps but not of what got printed. It now
covers both.