### PR TITLE
Fix docs claims about --verbose and the tool-result glyph

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ agent:
 orca run implement.sc "add a rate limiter to /login"
 ```
 
-Useful flags: `--verbose`, `--skip-branch` (continue on the current branch
-instead of creating one).
+Useful flag: `--skip-branch` (continue on the current branch instead of
+creating one).
 
 In every mode, which agent (and model) handles the planning, coding, and review
 roles comes from `settings.properties` — written for you by the shell's
@@ -843,7 +843,7 @@ are indented.
 | `▸` | User's prompt at the start of an interactive session |
 | `●` | Assistant prose |
 | `⏺` | Tool call (path / command / query in grey) |
-| `⎿` | Tool result (truncated to one line) |
+| `⎿` | Tool result, truncated to one line (interactive calls only) |
 | `✖` | Error |
 | `?` | Approval request |
 
@@ -906,7 +906,7 @@ action non-interactively and exits.
 
 | Command | Key flags | Does |
 |---|---|---|
-| `orca run <flow> [task]` | `--verbose`, `--skip-branch`, `--honor-pin` (use the flow's own pinned orca version) | run a flow, propagating its exit code; task is read from stdin when omitted and piped |
+| `orca run <flow> [task]` | `--verbose` (stack trace on abort), `--skip-branch`, `--honor-pin` (use the flow's own pinned orca version) | run a flow, propagating its exit code; task is read from stdin when omitted and piped |
 | `orca view <flow>` | `--plain`, `--color` | print a flow's source (highlighted when stdout is a terminal) |
 | `orca edit <flow>` | `--to project\|global` | open a flow in `$VISUAL`/`$EDITOR`/vi (`--to` required to customize a built-in) |
 | `orca create "<goal>"` | `--name <file>`, `--global` | author a new flow: the built-in `simple.sc` flow writes it in an isolated sandbox with the configured role agents; `--name` is auto-derived when omitted |

--- a/skills/using-orca/SKILL.md
+++ b/skills/using-orca/SKILL.md
@@ -30,7 +30,7 @@ orca run implement.sc "<task description>"
 across the project/global/built-in tiers.
 
 Key flags:
-- `--verbose` — stream flow output.
+- `--verbose` — print a stack trace if the flow aborts.
 - `--skip-branch` — continue on the current branch instead of creating a
   new one. Use this when the current branch already has plan/context files
   the flow should pick up (e.g. it was planned with a harness first).


### PR DESCRIPTION
The `⎿` tool-result glyph is only rendered by the interactive renderer — autonomous runs drop tool results — so the glyph legend now says "interactive calls only".

`--verbose` only prints a stack trace when a flow aborts, so the README no longer lists it as a useful flag in the quickstart, and the CLI table plus the using-orca skill now say what it actually does.