### PR TITLE
Say what the review loop is doing in its output lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,7 +845,7 @@ are indented.
 | `⏺` | Tool call (path / command / query in grey) |
 | `⎿` | Tool result, truncated to one line (interactive calls only) |
 | `✖` | Error |
-| `?` | Approval request |
+| `?` | Approval request, or a question for you (interactive calls only) |
 
 </details>
 

--- a/flow/src/main/scala/orca/review/ReviewLoop.scala
+++ b/flow/src/main/scala/orca/review/ReviewLoop.scala
@@ -178,8 +178,12 @@ private[review] def announceFixTurn(
       s"Fixer named ${outcome.unresolvedEchoes.mkString(", ")}, " +
         "which matched no issue it was handed"
     )
+  // Both loops continue exactly when something was fixed, so only then does the
+  // line promise another round; the halt branch prints FixerHaltMessage.
+  val next =
+    if outcome.fixed.nonEmpty then "; reviewing again after the fixes" else ""
   orca.display(
-    s"Fixed ${outcome.fixed.size}, ignored ${outcome.ignored.size}"
+    s"Fixed ${outcome.fixed.size}, ignored ${outcome.ignored.size}$next"
   )
 
 /** Evaluate, fix, re-evaluate until the reviewer reports no issues, the fixer
@@ -728,11 +732,15 @@ private[review] class ReviewFixLoop[B <: BackendTag](
     // round finds no issues, and the stop policy converges — the loop never
     // resurrects the roster behind the selector's back.
     val active = selectRound(state.history).distinctBy(_.id)
-    val totalAgents = active.size + (if lintGate.isDefined then 1 else 0)
-    if totalAgents > 0 then
+    // The same names the per-agent Steps use, in selection order with the lint
+    // gate last; those Steps arrive in completion order, not this one.
+    val agentNames =
+      active.map(_.name) ++ Option.when(lintGate.isDefined)(lintName)
+    if agentNames.nonEmpty then
       ctx.emit(
         OrcaEvent.Step(
-          s"Running ${TextUtil.pluralize(totalAgents, "review agent")}"
+          s"Running ${TextUtil.pluralize(agentNames.size, "review agent")}: " +
+            agentNames.mkString(", ")
         )
       )
     // Say so when a round runs nobody though reviewers are configured: the

--- a/flow/src/main/scala/orca/review/ReviewerSelector.scala
+++ b/flow/src/main/scala/orca/review/ReviewerSelector.scala
@@ -11,6 +11,7 @@ import orca.{FlowContext, InStage}
 import orca.events.OrcaEvent
 import orca.agents.Agent
 import orca.plan.Title
+import orca.util.TextUtil
 
 import scala.util.matching.Regex
 
@@ -259,9 +260,9 @@ object ReviewerSelector:
       if gated.nonEmpty then
         ctx.emit(
           OrcaEvent.Step(
-            s"reviewer selection: no changed files to match against; keeping " +
-              s"${gated.size} file-gated reviewer(s) eligible " +
-              s"(${gated.mkString(", ")})"
+            s"reviewer selection: no changed files were found; keeping " +
+              s"${TextUtil.pluralize(gated.size, "file-gated reviewer")} " +
+              s"eligible (${gated.mkString(", ")})"
           )
         )
       all

--- a/flow/src/main/scala/orca/review/SelectedReviewers.scala
+++ b/flow/src/main/scala/orca/review/SelectedReviewers.scala
@@ -47,8 +47,8 @@ object SelectedReviewers:
       plain.codec
     )
 
-  /** Deliberately silent: the review loop narrates the selection itself
-    * ("Running N review agents"), so a summary here would render the picker's
-    * raw JSON on top of that line.
+  /** Deliberately silent: the review loop names the agents it runs each round
+    * ("Running N review agents: …"), so a summary here would render the
+    * picker's raw JSON on top of that line.
     */
   given Announce[SelectedReviewers] = Announce.from(_ => "")

--- a/flow/src/test/scala/orca/review/FixLoopTest.scala
+++ b/flow/src/test/scala/orca/review/FixLoopTest.scala
@@ -127,6 +127,30 @@ class FixLoopTest extends munit.FunSuite:
       List(IgnoredIssue(Title("x"), "fixer reported no fixes"))
     )
 
+  test("the fix line says another review round follows the fixes"):
+    val rec = new Recorder
+    given FlowContext = new TestFlowContext(new EventDispatcher(List(rec)))
+    val _ = fixLoop(
+      evaluate =
+        scripted(List(ReviewResult(List(issue("a"))), ReviewResult.empty)),
+      fix = _ => FixOutcome(List(Title("a")), Nil)
+    )
+    assert(
+      rec.steps.contains(
+        "Fixed 1, ignored 0; reviewing again after the fixes"
+      ),
+      rec.steps.mkString("\n")
+    )
+
+  test("the fix line promises no further review when nothing was fixed"):
+    val rec = new Recorder
+    given FlowContext = new TestFlowContext(new EventDispatcher(List(rec)))
+    val _ = fixLoop(
+      evaluate = scripted(List(ReviewResult(List(issue("a"))))),
+      fix = _ => FixOutcome(Nil, List(IgnoredIssue(Title("a"), "won't fix")))
+    )
+    assert(rec.steps.contains("Fixed 0, ignored 1"), rec.steps.mkString("\n"))
+
   test("the halt exit says why the loop stopped"):
     val rec = new Recorder
     given FlowContext = new TestFlowContext(new EventDispatcher(List(rec)))

--- a/flow/src/test/scala/orca/review/ReviewAndFixTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewAndFixTest.scala
@@ -1419,6 +1419,31 @@ class ReviewAndFixTest extends munit.FunSuite:
       List(IgnoredIssue(Title("only-x"), "accepted"))
     )
 
+  test("the round's opening Step names every agent it runs"):
+    // The lint gate is one of the named agents, not a silent extra.
+    val steps = new ReviewLoopFixture.StepCapture
+    given FlowControl = ReviewLoopFixture.control(steps.dispatcher)
+    val summariser =
+      new FakeAgent(name = "summariser", outputs = List(ReviewResult.empty))
+    val _ = reviewAndFixLoop(
+      coderSession =
+        ReviewLoopFixture.coderSession(new FakeAgent(name = "coder")),
+      reviewers = List(
+        new FakeAgent(name = "a", outputs = List(ReviewResult.empty)),
+        new FakeAgent(name = "b", outputs = List(ReviewResult.empty))
+      ),
+      task = titled("named agents"),
+      reviewerSelection = ReviewerSelector.allEveryRound,
+      // `echo` emits output so `lint` doesn't short-circuit before calling the
+      // summariser.
+      lint = Configured.Use(Lint(List("echo lint-output"), summariser)),
+      diff = ReviewDiff.Pinned("")
+    )
+    assert(
+      steps.messages.contains("Running 3 review agents: a, b, lint"),
+      steps.messages.mkString("\n")
+    )
+
   test("each agent's Step lands on listeners as it finishes, not at end"):
     // Two reviewers gated on latches we control: gate2 releases first, so
     // the second reviewer must finish first; its Step must be visible to a

--- a/flow/src/test/scala/orca/review/ReviewerSelectorTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewerSelectorTest.scala
@@ -174,9 +174,9 @@ class ReviewerSelectorTest extends munit.FunSuite:
       summon[orca.InStage]
     )(Nil)
     assert(
-      capture.messages.exists(m =>
-        m.startsWith("reviewer selection: no changed files") &&
-          m.endsWith("(scala-fp)")
+      capture.messages.contains(
+        "reviewer selection: no changed files were found; keeping " +
+          "1 file-gated reviewer eligible (scala-fp)"
       ),
       capture.messages.mkString("\n")
     )

--- a/runner/src/main/scala/orca/OrcaArgs.scala
+++ b/runner/src/main/scala/orca/OrcaArgs.scala
@@ -6,7 +6,7 @@ import mainargs.{Flag, ParserForClass, arg}
 case class OrcaArgs(
     @arg(positional = true, doc = "task description")
     userPrompt: String = "",
-    @arg(doc = "verbose logging")
+    @arg(doc = "print a stack trace if the flow aborts")
     verbose: Flag = Flag(),
     @arg(doc = "run on the current branch instead of creating a new one")
     skipBranch: Flag = Flag()


### PR DESCRIPTION
Four output lines from a live-log audit said too little. Each one now states what the code actually does.

**1. The round's opening line names the agents it runs**

- before: `Running 5 review agents`
- after: `Running 5 review agents: performance, readability, simplicity, test, lint`

The names and their order are the selector's pick, with the lint gate last — the same names the per-agent result lines below use. `SelectedReviewers`' scaladoc said this line was a bare count; updated.

**2. The fix line says another review round follows**

- before: `Fixed 1, ignored 2`
- after: `Fixed 1, ignored 2; reviewing again after the fixes`

Both loops run another round exactly when something was fixed, so the clause is added only then. When nothing was fixed the loop stops, and the existing `Fixer reported no fixes; ending review` line follows instead.

**3. The reviewer-selection edge case**

- before: `reviewer selection: no changed files to match against; keeping 1 file-gated reviewer(s) eligible (scala-fp)`
- after: `reviewer selection: no changed files were found; keeping 1 file-gated reviewer eligible (scala-fp)`

Uses `TextUtil.pluralize`, so no more `(s)`.

**4. Two docs fixes**

- `--verbose`'s help text was "verbose logging"; the flag only prints a stack trace if the flow aborts, so it now says that.
- The README glyph legend's `?` row is interactive-only, like the `⎿` row fixed in #143. It also marks a question the agent asks you, which the row now says.

Tests pin the new strings: the selector test moved from a prefix/suffix check to the whole line, and there are new tests for the opening line (including the lint gate) and for both forms of the fix line.