### PR TITLE
Name the agent behind fan-out lines; tidy tool headlines

### DIFF
--- a/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
@@ -292,7 +292,11 @@ class DefaultAgentCallTest extends munit.FunSuite:
     // events fire only when the backend gets the same listener the
     // DefaultAgentCall was constructed with.
     val backend = new SequencedBackend(List("""{"value":1}"""))
-    val myListener: orca.events.OrcaListener = (_: orca.events.OrcaEvent) => ()
+    val received =
+      new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
+    val myListener: OrcaListener = e => {
+      val _ = received.updateAndGet(e :: _)
+    }
     supervised:
       val _ = new DefaultAgentCall[BackendTag.ClaudeCode.type, Answer](
         backend = backend,
@@ -303,7 +307,12 @@ class DefaultAgentCallTest extends munit.FunSuite:
         interaction = stubInteraction,
         agentName = "claude"
       ).autonomous.run("anything")
-      assertEquals(backend.events, List(myListener))
+      // The backend is handed an agent-attributing wrapper, so identity would
+      // say nothing; what has to hold is that its events still arrive.
+      assertEquals(backend.events.size, 1)
+      received.set(Nil)
+      backend.events.foreach(_.onEvent(OrcaEvent.Step("probe")))
+      assertEquals(received.get(), List(OrcaEvent.Step("probe")))
 
   test(
     "autonomous emits StructuredResult with summary=None under default Announce"

--- a/runner/src/main/scala/orca/runner/LoggingListener.scala
+++ b/runner/src/main/scala/orca/runner/LoggingListener.scala
@@ -18,13 +18,14 @@ private[orca] class LoggingListener extends OrcaListener:
   private val log = LoggerFactory.getLogger("orca.flow")
 
   def onEvent(event: OrcaEvent): Unit = event match
-    case OrcaEvent.StageStarted(name)     => log.info("stage start: {}", name)
-    case OrcaEvent.StageCompleted(name)   => log.info("stage done:  {}", name)
-    case OrcaEvent.Step(message)          => log.info("step: {}", message)
-    case OrcaEvent.UserPrompt(text)       => log.debug("prompt sent:\n{}", text)
-    case OrcaEvent.AssistantMessage(text) => log.debug("assistant: {}", text)
-    case OrcaEvent.ToolUse(tool, args) =>
-      log.debug("tool use: {} {}", tool, args)
+    case OrcaEvent.StageStarted(name)   => log.info("stage start: {}", name)
+    case OrcaEvent.StageCompleted(name) => log.info("stage done:  {}", name)
+    case OrcaEvent.Step(message)        => log.info("step: {}", message)
+    case OrcaEvent.UserPrompt(text)     => log.debug("prompt sent:\n{}", text)
+    case OrcaEvent.AssistantMessage(text, agent) =>
+      log.debug("assistant ({}): {}", agent.getOrElse("?"), text)
+    case OrcaEvent.ToolUse(tool, args, agent) =>
+      log.debug("tool use ({}): {} {}", agent.getOrElse("?"), tool, args)
     case OrcaEvent.StructuredResult(raw, summary) =>
       // On a deliberately silent summary (`Some("")`) or a missing one
       // (`None`), log the raw JSON — display silence must not hide the result

--- a/runner/src/main/scala/orca/runner/terminal/AgentAttribution.scala
+++ b/runner/src/main/scala/orca/runner/terminal/AgentAttribution.scala
@@ -1,0 +1,18 @@
+package orca.runner.terminal
+
+/** The `name: ` prefix that tells apart lines from agents running in parallel
+  * (the review fan-out). [[TerminalEventListener]] decides which lines get one.
+  */
+private[terminal] object AgentAttribution:
+
+  /** Dark-gray, matching the tool-args tone: the name locates the line, the
+    * tool name / prose stays the thing being read.
+    */
+  val Style: fansi.Attrs = fansi.Color.DarkGray
+
+  /** The rendered prefix, or "" when the line needs no attribution. */
+  def prefix(
+      agent: Option[String],
+      paint: (fansi.Attrs, String) => String
+  ): String =
+    agent.fold("")(name => paint(Style, s"$name: "))

--- a/runner/src/main/scala/orca/runner/terminal/CommandHeadline.scala
+++ b/runner/src/main/scala/orca/runner/terminal/CommandHeadline.scala
@@ -1,0 +1,49 @@
+package orca.runner.terminal
+
+/** One-line headline for a shell command: drops the `sh -c "…"` wrapper some
+  * agent harnesses add around a command, then cuts on a token boundary so
+  * what's left reads as shell rather than stopping inside a quoted argument.
+  */
+private[terminal] object CommandHeadline:
+
+  /** `/bin/bash -lc `, `bash -c `, `sh -c ` and friends — identical on every
+    * call, so it says nothing.
+    */
+  private val ShellWrapper: java.util.regex.Pattern =
+    java.util.regex.Pattern
+      .compile("^(?:\\S*/)?(?:ba|z|da|k)?sh\\s+-[a-z]*c\\s+")
+
+  /** Divides `maxLength` to fix how early a token boundary may cut: at 2 at
+    * least half the width survives, and a single token longer than that is
+    * truncated mid-token instead.
+    */
+  private val MinBoundaryDivisor: Int = 2
+
+  def render(command: String, maxLength: Int): String =
+    val matcher = ShellWrapper.matcher(command)
+    val unwrapped =
+      if matcher.lookingAt() then unquote(command.substring(matcher.end()))
+      else command
+    truncateAtBoundary(unwrapped, maxLength)
+
+  /** Drop the quotes the wrapper needed to pass the command as one argument.
+    * Deciding whether the outer pair really matches would take a shell lexer:
+    * the commands this fires on toggle quoting mid-word (`-g '"'!*.pyc'"'`), so
+    * an interior quote is normal and proves nothing. Matching first against
+    * last is what reads correctly on those; a command the wrapper passed as two
+    * quoted words instead loses the boundary between them, which is a wrong
+    * headline for a shape orca's own backends never produce.
+    */
+  private def unquote(s: String): String =
+    val quoted = s.length >= 2 && (s.head == '"' || s.head == '\'') &&
+      s.last == s.head
+    if quoted then s.substring(1, s.length - 1) else s
+
+  private def truncateAtBoundary(s: String, maxLength: Int): String =
+    if s.length <= maxLength then s
+    else
+      val window = s.take(maxLength - 1)
+      val boundary = window.lastIndexWhere(_.isWhitespace)
+      if boundary < maxLength / MinBoundaryDivisor then
+        Text.truncate(s, maxLength)
+      else s"${window.take(boundary)}…"

--- a/runner/src/main/scala/orca/runner/terminal/ConversationRenderer.scala
+++ b/runner/src/main/scala/orca/runner/terminal/ConversationRenderer.scala
@@ -99,7 +99,7 @@ private[terminal] class ConversationRenderer(
 
   private def renderToolCall(name: String, input: String): Unit =
     enterSection(Section.Tool)
-    appendBlock(ToolCallLine.format(name, input, paint, workDir))
+    appendBlock(ToolCallLine.format(name, input, paint, workDir, agent = None))
 
   private def renderToolResult(ok: Boolean, content: String): Unit =
     enterSection(Section.Tool)

--- a/runner/src/main/scala/orca/runner/terminal/TerminalEventListener.scala
+++ b/runner/src/main/scala/orca/runner/terminal/TerminalEventListener.scala
@@ -2,6 +2,8 @@ package orca.runner.terminal
 
 import orca.events.{OrcaEvent, OrcaListener}
 
+import java.util.concurrent.atomic.AtomicReference
+
 /** Renders `OrcaEvent`s — stage transitions, steps, tool uses, errors — via a
   * [[TerminalOutput]] and tracks the active stage stack + indent depth.
   *
@@ -22,6 +24,7 @@ private[runner] class TerminalEventListener(
     ErrorGlyph,
     MaxAssistantMessageLength,
     MaxStructuredResultRawLength,
+    StageEmitters,
     StageStartGlyph,
     StepGlyphStyle,
     UserPromptGlyph,
@@ -32,21 +35,30 @@ private[runner] class TerminalEventListener(
   // single-writer/@volatile synchronization story.
   @volatile private var stack: List[String] = Nil
 
+  // Unlike `stack` this is written from the parallel agent forks too, hence the
+  // atomic rather than the @volatile single-writer story above.
+  private val stageEmitters =
+    new AtomicReference[StageEmitters](StageEmitters.Silent)
+
   def onEvent(event: OrcaEvent): Unit = event match
     case OrcaEvent.StageStarted(name) =>
       // Format at the current depth (so the marker aligns with the enclosing
       // stage's content), then push.
       val line = formatStepLine(name)
       stack = name :: stack
+      stageEmitters.set(StageEmitters.Silent)
       output.log(line)
       output.setStatus(stack.headOption)
     case OrcaEvent.StageCompleted(_) =>
       // Completions don't print: starting the next event implies the previous
       // one finished.
       stack = stack.drop(1)
+      stageEmitters.set(StageEmitters.Silent)
       output.setStatus(stack.headOption)
-    case OrcaEvent.ToolUse(tool, args) =>
-      val line = formatIndented(ToolCallLine.format(tool, args, paint, workDir))
+    case OrcaEvent.ToolUse(tool, args, agent) =>
+      val line = formatIndented(
+        ToolCallLine.format(tool, args, paint, workDir, attribution(agent))
+      )
       output.log(line)
     case _: OrcaEvent.TokensUsed =>
       () // Token accounting is owned by CostTracker.
@@ -73,12 +85,13 @@ private[runner] class TerminalEventListener(
       if collapsed.nonEmpty then
         val glyph = paint(UserPromptStyle, s"$UserPromptGlyph ")
         output.log(formatIndented(glyph + collapsed))
-    case OrcaEvent.AssistantMessage(text) =>
+    case OrcaEvent.AssistantMessage(text, agent) =>
       // One line per prose turn; empty payloads (turn-without-prose) dropped.
       val collapsed = Text.oneLine(text, MaxAssistantMessageLength)
       if collapsed.nonEmpty then
         val glyph = paint(AssistantGlyphStyle, s"$AssistantGlyph ")
-        output.log(formatIndented(glyph + collapsed))
+        val who = AgentAttribution.prefix(attribution(agent), paint)
+        output.log(formatIndented(glyph + who + collapsed))
     case OrcaEvent.Error(message) =>
       output.log(
         formatIndented(paint(fansi.Color.Red, s"$ErrorGlyph $message"))
@@ -88,6 +101,20 @@ private[runner] class TerminalEventListener(
 
   /** The current indent string. Lock-free read of the `@volatile` [[stack]]. */
   def currentIndent: String = "  " * stack.length
+
+  /** Which agent name, if any, to print on this line. While a stage has a
+    * single emitter, nothing is prefixed — a stage running one agent looks
+    * exactly as it did. From the moment a second agent emits, every line is
+    * named, the first agent's included: with the review fan-out interleaving
+    * them, an unnamed line can no longer be attributed by position.
+    *
+    * An event carrying no agent name never counts as an emitter.
+    */
+  private def attribution(agent: Option[String]): Option[String] =
+    agent.flatMap: name =>
+      stageEmitters.updateAndGet(_.plus(name)) match
+        case StageEmitters.One(_) => None
+        case _                    => Some(name)
 
   /** A `▶` step line: magenta-bold glyph, neutral body — matching the
     * assistant-prose styling so the "primary content" accent stays consistent.
@@ -106,6 +133,19 @@ private[runner] class TerminalEventListener(
     Ansi.paint(useColor, attr, text)
 
 private[runner] object TerminalEventListener:
+
+  /** The agents that have emitted a display event in the current stage, to the
+    * precision `attribution` needs: none, exactly one (named), or several.
+    */
+  private enum StageEmitters:
+    case Silent
+    case One(name: String)
+    case Many
+
+    def plus(emitter: String): StageEmitters = this match
+      case Silent                 => One(emitter)
+      case One(n) if n == emitter => this
+      case _                      => Many
 
   val StageStartGlyph: String = "▶"
   val StageDoneGlyph: String = "✔"

--- a/runner/src/main/scala/orca/runner/terminal/TerminalOutput.scala
+++ b/runner/src/main/scala/orca/runner/terminal/TerminalOutput.scala
@@ -123,6 +123,11 @@ private[terminal] class TerminalOutputState(
   // unwinding after scope-close) may append log lines but must not re-pin a
   // status row nothing will clear again.
   private var closed: Boolean = false
+  // A run of identical lines (an agent re-reading one file, say) is written
+  // once and counted; the count lands on its own line when the run ends, since
+  // a line already handed to `out` can no longer be amended.
+  private var openRunLine: Option[String] = None
+  private var suppressedRepeats: Int = 0
 
   def log(text: String): Unit =
     if suspended then
@@ -180,6 +185,10 @@ private[terminal] class TerminalOutputState(
     */
   def suspend(): Unit =
     if !suspended then
+      // Report the open run before the human takes the terminal, so the count
+      // lands above the prompt and can't span the interaction.
+      flushRepeats()
+      openRunLine = None
       suspended = true
       // Keep `currentLabel` so resume can redraw the same status.
       if animated && currentLabel.isDefined then
@@ -206,6 +215,10 @@ private[terminal] class TerminalOutputState(
       suspendedBuffer = Queue.empty
       suspended = false
       toDrain.foreach(writeLog)
+    flushRepeats()
+    // A late log line (a fork still unwinding) has no open run to join: nothing
+    // would flush its count afterwards, so it must print on its own.
+    openRunLine = None
     val wasShown = currentLabel.isDefined
     currentLabel = None
     closed = true
@@ -213,7 +226,25 @@ private[terminal] class TerminalOutputState(
       out.print(ClearLine)
       out.flush()
 
+  /** Blank lines are separators, never repeats. */
   private def writeLog(text: String): Unit =
+    if !text.isBlank && openRunLine.contains(text) then suppressedRepeats += 1
+    else
+      flushRepeats()
+      openRunLine = if text.isBlank then None else Some(text)
+      writeLine(text)
+
+  private def flushRepeats(): Unit =
+    if suppressedRepeats > 0 then
+      val total = suppressedRepeats + 1
+      suppressedRepeats = 0
+      // Aligned one level under the line it counts, like a tool result.
+      val indent = openRunLine.fold("")(_.takeWhile(_ == ' ')) + "  "
+      writeLine(
+        indent + paint(s"${TerminalOutputState.RepeatGlyph} ×$total", useColor)
+      )
+
+  private def writeLine(text: String): Unit =
     if !animated || currentLabel.isEmpty then
       out.print(text)
       if !text.endsWith("\n") then out.println()
@@ -245,6 +276,11 @@ private[terminal] object TerminalOutputState:
   private val ClearLine: String = "\r\u001b[2K"
 
   private val DefaultLabel: String = "Thinking..."
+
+  /** Same glyph the renderer uses for a tool result, so it reads as belonging
+    * to the line it sits under.
+    */
+  private[terminal] val RepeatGlyph: String = "⎿"
 
   val Frames: Vector[String] =
     Vector("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")

--- a/runner/src/main/scala/orca/runner/terminal/ToolCallLine.scala
+++ b/runner/src/main/scala/orca/runner/terminal/ToolCallLine.scala
@@ -13,13 +13,18 @@ private[terminal] object ToolCallLine:
     ToolNameStyle
   }
 
+  /** `agent` names the emitting agent when the line needs attributing (see
+    * [[AgentAttribution]]); `None` renders the bare `⏺ name (args)` form.
+    */
   def format(
       name: String,
       rawInput: String,
       paint: (fansi.Attrs, String) => String,
-      workDir: Option[os.Path]
+      workDir: Option[os.Path],
+      agent: Option[String]
   ): String =
     val args =
       ToolInputSummary.summarise(rawInput, MaxInlineInputLength, workDir)
-    val head = paint(ToolNameStyle, s"$ToolCallGlyph $name")
+    val head = paint(ToolNameStyle, s"$ToolCallGlyph ") +
+      AgentAttribution.prefix(agent, paint) + paint(ToolNameStyle, name)
     if args.isEmpty then head else head + " " + paint(ToolArgsStyle, args)

--- a/runner/src/main/scala/orca/runner/terminal/ToolInputSummary.scala
+++ b/runner/src/main/scala/orca/runner/terminal/ToolInputSummary.scala
@@ -5,8 +5,8 @@ import scala.annotation.tailrec
 /** Produces a short, human-readable summary of a tool call's raw JSON input —
   * the bit the renderer shows in parentheses after the tool name. A
   * deliberately small hand-written JSON string extractor rather than a full
-  * parser, since this is purely a display heuristic; unmatched input falls back
-  * to truncated JSON.
+  * parser, since this is purely a display heuristic; input with no field worth
+  * heading falls back to naming the fields it does carry.
   *
   * `workDir`, when supplied, relativises paths inside the flow's working
   * directory (`/tmp/orca-AbC/src/Main.scala` → `src/Main.scala`). Paths outside
@@ -14,26 +14,32 @@ import scala.annotation.tailrec
   */
 private[terminal] object ToolInputSummary:
 
-  /** Ordered field names tried against the input's top-level JSON object; the
-    * first match wins. Order matters — `file_path` beats `path`, which beats
-    * the more generic `pattern`/`query`.
+  /** How a matched field's value renders: `Path` is a single path, relativised
+    * against `workDir`; `Command` is a shell command line, rendered through
+    * [[CommandHeadline]]; `Plain` is free-form text that may interleave paths
+    * with other text, so it is only truncated.
     */
-  private val HeadlineFields: List[String] =
-    List(
-      "file_path",
-      "path",
-      "command",
-      "pattern",
-      "query",
-      "url",
-      "description"
-    )
+  private enum HeadlineKind:
+    case Path, Command, Plain
 
-  /** Headline fields whose values are single paths to relativise against
-    * `workDir`. The others are free-form strings that may interleave paths with
-    * other text, so they're left alone.
+  /** Field names tried against the input's top-level JSON object, in order —
+    * the first match wins — each with how its value renders. More specific
+    * names come first (`file_path` beats `path`, both beat `pattern`/`query`);
+    * the tail holds the generic ones, `name` ahead of `description`.
     */
-  private val PathFields: Set[String] = Set("file_path", "path")
+  private val HeadlineFields: List[(String, HeadlineKind)] =
+    List(
+      "file_path" -> HeadlineKind.Path,
+      "path" -> HeadlineKind.Path,
+      "command" -> HeadlineKind.Command,
+      "pattern" -> HeadlineKind.Plain,
+      "query" -> HeadlineKind.Plain,
+      "url" -> HeadlineKind.Plain,
+      "rev" -> HeadlineKind.Plain,
+      "skill" -> HeadlineKind.Plain,
+      "name" -> HeadlineKind.Plain,
+      "description" -> HeadlineKind.Plain
+    )
 
   /** Returns an already-truncated headline suitable for rendering after the
     * tool name. Empty string means "no args to show".
@@ -47,14 +53,35 @@ private[terminal] object ToolInputSummary:
     if collapsed.isEmpty || collapsed == "{}" then ""
     else
       HeadlineFields.iterator
-        .flatMap(field => extractStringField(collapsed, field).map(field -> _))
+        .flatMap((field, kind) =>
+          extractStringField(collapsed, field).map(kind -> _)
+        )
         .nextOption() match
-        case Some((field, value)) =>
-          val displayed =
-            if PathFields.contains(field) then relativise(value, workDir)
-            else value
-          s"(${Text.truncate(displayed, maxLength)})"
-        case None => Text.truncate(collapsed, maxLength)
+        case Some((kind, value)) =>
+          s"(${headline(kind, value, maxLength, workDir)})"
+        case None => fallback(collapsed, maxLength)
+
+  private def headline(
+      kind: HeadlineKind,
+      value: String,
+      maxLength: Int,
+      workDir: Option[os.Path]
+  ): String = kind match
+    case HeadlineKind.Path =>
+      Text.truncate(relativise(value, workDir), maxLength)
+    case HeadlineKind.Command => CommandHeadline.render(value, maxLength)
+    case HeadlineKind.Plain   => Text.truncate(value, maxLength)
+
+  /** No headline field matched. Show WHICH fields the call carried rather than
+    * their values: the values are the reason no field matched (long edit
+    * bodies, nested objects), and truncated raw JSON renders them as
+    * escaped-newline soup. Input that isn't a JSON object still falls back to
+    * the truncated text itself.
+    */
+  private def fallback(collapsed: String, maxLength: Int): String =
+    topLevelFieldNames(collapsed) match
+      case Nil   => Text.truncate(collapsed, maxLength)
+      case names => Text.truncate(names.mkString("{", ", ", "}"), maxLength)
 
   /** Convert an absolute path under `workDir` into a relative one; leave
     * anything else (relative paths, paths outside `workDir`, or when `workDir`
@@ -78,18 +105,67 @@ private[terminal] object ToolInputSummary:
   private def collapseWhitespace(raw: String): String =
     WhitespaceRun.matcher(raw).replaceAll(" ").trim
 
-  /** Matches a `"field":"value"` entry and walks the value honouring `\"` /
-    * `\\` escapes. Returns `None` if the field is absent or the string doesn't
-    * terminate. Escapes beyond the common shell/path ones round-trip verbatim.
+  /** Matches a `"field": "value"` entry — JSON allows whitespace around the
+    * colon, and an agent that pretty-prints its tool input would otherwise fall
+    * through to [[fallback]] on every call — and walks the value honouring `\"`
+    * / `\\` escapes. Returns `None` if the field is absent, its value isn't a
+    * string, or the string doesn't terminate. Escapes beyond the common
+    * shell/path ones round-trip verbatim.
     */
   private def extractStringField(json: String, field: String): Option[String] =
-    val needle = s""""$field":""""
-    val start = json.indexOf(needle)
-    if start < 0 then None
-    else
-      val valueStart = start + needle.length
-      findStringEnd(json, valueStart).map: end =>
-        unescape(json.substring(valueStart, end))
+    val key = s""""$field""""
+
+    // The unescaped string literal starting at `from`, if there is one there.
+    def stringAt(from: Int): Option[String] =
+      Option
+        .when(json.startsWith("\"", from))(from + 1)
+        .flatMap(start =>
+          findStringEnd(json, start)
+            .map(end => unescape(json.substring(start, end)))
+        )
+
+    // The name can also occur inside a value — an edit whose `old_string` is
+    // itself JSON, say — so keep looking until one occurrence is followed by a
+    // colon and a string.
+    @tailrec
+    def keyFrom(searchAt: Int): Option[String] =
+      json.indexOf(key, searchAt) match
+        case -1 => None
+        case at =>
+          val colon = skipSpaces(json, at + key.length)
+          if !json.startsWith(":", colon) then keyFrom(at + key.length)
+          else stringAt(skipSpaces(json, colon + 1))
+
+    keyFrom(0)
+
+  /** Top-level keys of a JSON object, in order; `Nil` when `json` isn't one.
+    * Strings are walked escape-aware, so a brace or quote inside a value can't
+    * shift the nesting depth.
+    */
+  private def topLevelFieldNames(json: String): List[String] =
+    @tailrec
+    def scan(i: Int, depth: Int, names: List[String]): List[String] =
+      if i >= json.length || depth <= 0 then names.reverse
+      else
+        json.charAt(i) match
+          case '"' =>
+            findStringEnd(json, i + 1) match
+              case None => names.reverse
+              case Some(end) =>
+                val isKey = depth == 1 &&
+                  json.startsWith(":", skipSpaces(json, end + 1))
+                val next =
+                  if isKey then json.substring(i + 1, end) :: names else names
+                scan(end + 1, depth, next)
+          case '{' | '[' => scan(i + 1, depth + 1, names)
+          case '}' | ']' => scan(i + 1, depth - 1, names)
+          case _         => scan(i + 1, depth, names)
+
+    if !json.startsWith("{") then Nil else scan(1, 1, Nil)
+
+  @tailrec
+  private def skipSpaces(s: String, i: Int): Int =
+    if i < s.length && s.charAt(i).isWhitespace then skipSpaces(s, i + 1) else i
 
   @tailrec
   private def findStringEnd(s: String, i: Int): Option[Int] =

--- a/runner/src/test/scala/orca/runner/terminal/ConversationRendererTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/ConversationRendererTest.scala
@@ -131,13 +131,13 @@ class ConversationRendererTest extends munit.FunSuite:
   test("AssistantToolCall renders the name and a summarised input"):
     val buf = new ByteArrayOutputStream()
     val conv = new ScriptedConversation(
-      List(ConversationEvent.AssistantToolCall("Bash", """{"cmd":"ls"}""")),
+      List(ConversationEvent.AssistantToolCall("Bash", """{"command":"ls"}""")),
       Right(sampleResult)
     )
     val _ = supervised(renderer(buf).render(conv))
     val out = buf.toString
     assert(out.contains("Bash"))
-    assert(out.contains("{\"cmd\":\"ls\"}"))
+    assert(out.contains("(ls)"))
 
   test("ToolResult rendering differs by ok flag"):
     val buf = new ByteArrayOutputStream()

--- a/runner/src/test/scala/orca/runner/terminal/TerminalEventListenerTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/TerminalEventListenerTest.scala
@@ -138,6 +138,59 @@ class TerminalEventListenerTest extends munit.FunSuite:
     val output = renderEvents(List(OrcaEvent.AssistantMessage("   \n\t  ")))
     assertEquals(output, "")
 
+  test("a stage's own agent is never named on its tool lines"):
+    val output = renderEvents(
+      List(
+        OrcaEvent.StageStarted("task"),
+        OrcaEvent.ToolUse("Read", """{"file_path":"stats.py"}""", Some("main")),
+        OrcaEvent.ToolUse("Read", """{"file_path":"other.py"}""", Some("main"))
+      )
+    )
+    assert(!output.contains("main:"), output)
+
+  test("a second agent's tool line is prefixed with its name"):
+    val output = renderEvents(
+      List(
+        OrcaEvent.StageStarted("task"),
+        OrcaEvent.ToolUse("Read", """{"file_path":"stats.py"}""", Some("main")),
+        OrcaEvent
+          .ToolUse("Read", """{"file_path":"stats.py"}""", Some("readability"))
+      )
+    )
+    assert(output.contains("⏺ readability: Read (stats.py)"), output)
+
+  test("a second agent's prose line is prefixed with its name"):
+    val output = renderEvents(
+      List(
+        OrcaEvent.StageStarted("task"),
+        OrcaEvent.AssistantMessage("planning", Some("main")),
+        OrcaEvent.AssistantMessage("reviewing", Some("test"))
+      )
+    )
+    assert(output.contains("● test: reviewing"), output)
+
+  test("the first agent is named too once a second one has emitted"):
+    val output = renderEvents(
+      List(
+        OrcaEvent.StageStarted("task"),
+        OrcaEvent.AssistantMessage("planning", Some("main")),
+        OrcaEvent.AssistantMessage("reviewing", Some("test")),
+        OrcaEvent.AssistantMessage("still planning", Some("main"))
+      )
+    )
+    assert(output.contains("● main: still planning"), output)
+
+  test("a new stage lets its own first agent go unnamed again"):
+    val output = renderEvents(
+      List(
+        OrcaEvent.StageStarted("outer"),
+        OrcaEvent.AssistantMessage("planning", Some("main")),
+        OrcaEvent.StageStarted("inner"),
+        OrcaEvent.AssistantMessage("reviewing", Some("test"))
+      )
+    )
+    assert(!output.contains("test:"), output)
+
   test("UserPrompt renders as a `▸` line with the one-line collapsed body"):
     val output =
       renderEvents(

--- a/runner/src/test/scala/orca/runner/terminal/TerminalOutputStateTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/TerminalOutputStateTest.scala
@@ -35,6 +35,42 @@ class TerminalOutputStateTest extends munit.FunSuite:
       bar.log("")
       assertEquals(buf.toString, "\n")
 
+  test("consecutive identical lines print once, then a repeat count"):
+    withBar(animated = false): (bar, buf) =>
+      for _ <- 1 to 3 do bar.log("  ⏺ Read (stats.py)")
+      bar.log("  ⏺ Write (stats.py)")
+      assertEquals(
+        buf.toString,
+        "  ⏺ Read (stats.py)\n    ⎿ ×3\n  ⏺ Write (stats.py)\n"
+      )
+
+  test("close reports a repeat run still open"):
+    withBar(animated = false): (bar, buf) =>
+      bar.log("line")
+      bar.log("line")
+      bar.close()
+      assertEquals(buf.toString, "line\n  ⎿ ×2\n")
+
+  test("a line repeating the last one still prints when logged after close"):
+    withBar(animated = false): (bar, buf) =>
+      bar.log("line")
+      bar.close()
+      bar.log("line")
+      assertEquals(buf.toString, "line\nline\n")
+
+  test("suspend reports a repeat run still open"):
+    withBar(animated = false): (bar, buf) =>
+      bar.log("line")
+      bar.log("line")
+      bar.suspend()
+      assertEquals(buf.toString, "line\n  ⎿ ×2\n")
+
+  test("blank separator lines are never collapsed as repeats"):
+    withBar(animated = false): (bar, buf) =>
+      bar.log("")
+      bar.log("")
+      assertEquals(buf.toString, "\n\n")
+
   test("non-animated mode emits no ANSI escapes"):
     withBar(animated = false): (bar, buf) =>
       bar.setStatus(Some("running"))

--- a/runner/src/test/scala/orca/runner/terminal/ToolInputSummaryTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/ToolInputSummaryTest.scala
@@ -30,6 +30,61 @@ class ToolInputSummaryTest extends munit.FunSuite:
     val out = ToolInputSummary.summarise(raw, maxLen, Some(workDir))
     assertEquals(out, "(.)")
 
+  test("summarise extracts a field written with a space after the colon"):
+    val raw = """{"file_path": "/tmp/foo.txt"}"""
+    assertEquals(ToolInputSummary.summarise(raw, maxLen), "(/tmp/foo.txt)")
+
+  test("summarise skips an occurrence of a headline name used as a value"):
+    val raw = """{"query":"file_path","file_path":"real.py"}"""
+    assertEquals(ToolInputSummary.summarise(raw, maxLen), "(real.py)")
+
+  test("summarise picks the rev/skill/name headlines"):
+    assertEquals(
+      ToolInputSummary.summarise("""{"rev":"HEAD","stat":true}""", maxLen),
+      "(HEAD)"
+    )
+    assertEquals(
+      ToolInputSummary.summarise("""{"skill":"tdd","args":"go"}""", maxLen),
+      "(tdd)"
+    )
+    assertEquals(
+      ToolInputSummary.summarise("""{"name":"reviewer"}""", maxLen),
+      "(reviewer)"
+    )
+
+  test("summarise names the fields of an input with no headline field"):
+    val raw = """{"old_string":"a\nb","new_string":"c\nd"}"""
+    assertEquals(
+      ToolInputSummary.summarise(raw, maxLen),
+      "{old_string, new_string}"
+    )
+
+  test("summarise lists only top-level field names, not nested ones"):
+    val raw = """{"edits":[{"inner":"x"}],"dry_run":true}"""
+    assertEquals(ToolInputSummary.summarise(raw, maxLen), "{edits, dry_run}")
+
+  test("summarise strips the shell wrapper from a command headline"):
+    val raw = """{"command":"/bin/bash -lc \"rtk git status --short\""}"""
+    assertEquals(
+      ToolInputSummary.summarise(raw, maxLen),
+      "(rtk git status --short)"
+    )
+
+  test("summarise unwraps a command that toggles quoting mid-word"):
+    val raw =
+      """{"command":"/bin/bash -lc \"rg --files -g '\"'!*.pyc'\"' | head\""}"""
+    assertEquals(
+      ToolInputSummary.summarise(raw, maxLen),
+      """(rg --files -g '"'!*.pyc'"' | head)"""
+    )
+
+  test("summarise cuts a long command at a token boundary"):
+    val command = List.fill(40)("token").mkString(" ")
+    val raw = s"""{"command":"$command"}"""
+    val out = ToolInputSummary.summarise(raw, maxLen)
+    assert(out.endsWith("token…)"), s"cut mid-token; got: $out")
+    assert(out.length <= maxLen + 2, s"headline exceeded the cap; got: $out")
+
   test("summarise leaves command/pattern/query unchanged when they look pathy"):
     val workDir = os.Path("/tmp/orca-AbC")
     val raw = s"""{"command":"ls ${workDir.toString}/src"}"""

--- a/tools/src/main/scala/orca/agents/AgentCall.scala
+++ b/tools/src/main/scala/orca/agents/AgentCall.scala
@@ -146,6 +146,12 @@ class DefaultAgentCall[B <: BackendTag, O](
     */
   private val outputSchema: String = JsonSchemaGen[O]
 
+  /** Autonomous turns only: an interactive turn has a human steering one agent,
+    * so its lines need no attribution.
+    */
+  private val attributedEvents: OrcaListener =
+    OrcaListener.attributedTo(events, agentName)
+
   val autonomous: AutonomousAgentCall[B, O] = new AutonomousAgentCall[B, O]:
     private[orca] def runWithSession[I: AgentInput](
         input: I,
@@ -242,7 +248,7 @@ class DefaultAgentCall[B <: BackendTag, O](
             promptText,
             session,
             effective,
-            events,
+            attributedEvents,
             outputSchema = Some(outputSchema)
           )
         catch

--- a/tools/src/main/scala/orca/agents/BaseAgent.scala
+++ b/tools/src/main/scala/orca/agents/BaseAgent.scala
@@ -102,7 +102,12 @@ abstract class BaseAgent[B <: BackendTag, Self <: Agent[B]](
         if emitPrompt then events.onEvent(OrcaEvent.UserPrompt(prompt))
         val accounting = turnAccounting(effective, session, sessionName)
         val result = accounting.recording:
-          backend.runAutonomous(prompt, session, effective, events)
+          backend.runAutonomous(
+            prompt,
+            session,
+            effective,
+            OrcaListener.attributedTo(events, name)
+          )
         accounting.succeeded(result, TurnAccounting.OnlyTurn)
         accounting.sessionCommitted()
         result.output

--- a/tools/src/main/scala/orca/events/OrcaEvent.scala
+++ b/tools/src/main/scala/orca/events/OrcaEvent.scala
@@ -20,7 +20,14 @@ import orca.agents.Model
 enum OrcaEvent:
   case StageStarted(name: String)
   case StageCompleted(name: String)
-  case ToolUse(tool: String, args: String)
+
+  /** One tool invocation by the agent named in `agent`. Backends emit `None` —
+    * a drain doesn't know which agent it runs for;
+    * [[OrcaListener.attributedTo]] wraps it and stamps the name on the way out.
+    * Renderers use the name to tell apart the interleaved lines of agents
+    * running in parallel.
+    */
+  case ToolUse(tool: String, args: String, agent: Option[String] = None)
 
   /** A single instantaneous note in the event log — neither a stage nor a
     * stream-of-text. Tools emit these for discrete progress: "switched to
@@ -94,9 +101,10 @@ enum OrcaEvent:
   /** A turn of free-form prose from the agent, one per
     * [[ConversationEvent.AssistantTurnEnd]] on the autonomous drain (the
     * interactive renderer surfaces these itself). The terminal listener renders
-    * it as a one-line `●`; full text reaches non-terminal listeners.
+    * it as a one-line `●`; full text reaches non-terminal listeners. `agent`
+    * carries the same attribution as [[ToolUse]].
     */
-  case AssistantMessage(text: String)
+  case AssistantMessage(text: String, agent: Option[String] = None)
 
   case Error(message: String)
 
@@ -156,3 +164,16 @@ object OrcaListener:
     * dispatcher (unit tests, lightweight scripts).
     */
   val noop: OrcaListener = (_: OrcaEvent) => ()
+
+  /** Stamps `agentName` onto the two display events a turn produces
+    * ([[OrcaEvent.ToolUse]], [[OrcaEvent.AssistantMessage]]) on their way to
+    * `downstream`; every other event passes through untouched. Wrapped around
+    * the listener handed to a backend drain, which emits those events without
+    * knowing which agent it is running for.
+    */
+  def attributedTo(downstream: OrcaListener, agentName: String): OrcaListener =
+    case e: OrcaEvent.ToolUse =>
+      downstream.onEvent(e.copy(agent = Some(agentName)))
+    case e: OrcaEvent.AssistantMessage =>
+      downstream.onEvent(e.copy(agent = Some(agentName)))
+    case other => downstream.onEvent(other)

--- a/tools/src/test/scala/orca/agents/BaseAgentTest.scala
+++ b/tools/src/test/scala/orca/agents/BaseAgentTest.scala
@@ -505,7 +505,10 @@ class BaseAgentTest extends munit.FunSuite:
       s"expected a StructuredResult event: $events"
     )
     assert(
-      !events.exists(_ == OrcaEvent.AssistantMessage(json)),
+      !events.exists:
+        case OrcaEvent.AssistantMessage(text, _) => text == json
+        case _                                   => false
+      ,
       s"the raw JSON payload must not also surface as an AssistantMessage: $events"
     )
 
@@ -529,8 +532,11 @@ class BaseAgentTest extends munit.FunSuite:
       seen
         .get()
         .reverse
-        .contains(OrcaEvent.AssistantMessage("plain prose reply")),
-      s"a plain text call must still surface its AssistantMessage: ${seen.get()}"
+        .contains(
+          OrcaEvent.AssistantMessage("plain prose reply", Some("stub"))
+        ),
+      s"a plain text call must still surface its AssistantMessage, attributed " +
+        s"to the agent that ran it: ${seen.get()}"
     )
 
   // The interactive structured door's closing turn IS the JSON payload too


### PR DESCRIPTION
Four fixes to what an autonomous run prints, all found by reading a live log.

## 1. Say which agent produced a line during the review fan-out

Up to 7 reviewers run at once. Their tool calls printed at the same indent with
nothing saying who did what — one live run had 32 lines in a row that couldn't be
attributed.

`OrcaEvent.ToolUse` and `AssistantMessage` gain an optional `agent` field.
Backends don't know which agent they run for, so `OrcaListener.attributedTo`
stamps the name on the way out of the two autonomous doors. Interactive turns
are left alone — a human is steering one agent there.

The terminal only prints the name when it helps: while a stage has one agent,
nothing is prefixed, so single-agent stages look exactly as before. From the
moment a second agent emits, every line is named, the first agent's included —
once lines interleave, an unnamed one can no longer be placed by position.

Before:

```
  ▶ Running 4 review agents
  ⏺ mcp__orca_repo__git_show {"rev":"45ca993"}
  ⏺ Read (stats.py)
  ● I'll review the changes for test coverage of the median function. Let me…
```

After:

```
  ▶ Running 4 review agents
  ⏺ readability: mcp__orca_repo__git_show (45ca993)
  ⏺ test: Read (stats.py)
  ● test: I'll review the changes for test coverage of the median function. Le…
```

## 2. Bash headlines no longer cut mid-quote

A `command` headline now drops the `sh -c "…"` wrapper some harnesses add, and
cuts at a whitespace boundary instead of mid-token.

Before:

```
  ⏺ bash (/bin/bash -lc "sed -n '1,240p' /home/adamw/.codex/RTK.md && pwd && rg --files -g '"'!*__pycache__*'"' -g '"'!*.pyc'"' |…)
```

After:

```
  ⏺ bash (sed -n '1,240p' /home/adamw/.codex/RTK.md && pwd && rg --files -g '"'!*__pycache__*'"' -g '"'!*.pyc'"' | head…)
```

## 3. Collapse a run of identical lines

The same line repeated up to 9 times in a row. It is now printed once and the
count follows when the run ends. A line already sent to the terminal can't be
changed, so the count goes on its own line rather than onto the original.

Before: `⏺ Read (stats.py)` nine times. After:

```
  ⏺ Read (stats.py)
    ⎿ ×9
```

## 4. Headline the fields that were missing, and never print values on a miss

`rev`, `skill` and `name` are now headline fields, and a field written with a
space after the colon is picked up. When no field matches, the summary names the
fields the call carried instead of dumping truncated JSON with escaped newlines
in it.

Before:

```
  ⏺ Skill {"skill":"superpowers:test-driven-development","args":"…
  ⏺ mcp__orca_repo__git_show {"rev":"45ca993"}
  ⏺ Edit {"old_string":"def test_median_two_elements():\n assert median([1, 2]) == 1.5\n\n\ndef test_median…
```

After:

```
  ⏺ Skill (superpowers:test-driven-development)
  ⏺ mcp__orca_repo__git_show (45ca993)
  ⏺ Edit {old_string, new_string}
```

## Notes

- The count in item 3 only appears once the run ends, so a long stall of
  identical calls shows one line and nothing more until it breaks. The spinner
  still ticks.
- Deciding whether a command's outer quotes really pair up would take a shell
  lexer, because these commands toggle quoting mid-word (`-g '"'!*.pyc'"'`).
  First-against-last is what reads correctly on real commands; one passed as two
  quoted words would lose the boundary between them, a shape orca's backends
  never produce.
