### PR TITLE
Share one unit per count group; name every role's model in the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,8 +407,11 @@ project or global file still aborts the run either way. `setup` announces the
 resolved roles and where each came from:
 
 ```text
-agents: planning=claude:claude-opus-5[1m] (default), coding=codex:gpt-5-mini (project), review=codex (global)
+agents: planning=claude:claude-opus-5[1m] (default), coding=codex:gpt-5-mini (project), review=opencode:<harness default> (global)
 ```
+
+`<harness default>` marks a role where nothing pins a model, so the harness
+picks one itself.
 
 **Auto-discovery.** Discovery runs when the project file is absent or has no
 stack line; discovered entries are appended below any existing content, so

--- a/flow/src/main/scala/orca/events/CostTracker.scala
+++ b/flow/src/main/scala/orca/events/CostTracker.scala
@@ -124,9 +124,11 @@ class CostTracker(pricingAsOf: LocalDate) extends OrcaListener:
     * by-agent line is prefixed with that agent's role when it has one (e.g.
     * `reviewer: performance`). Cache reads, cache writes and reasoning tokens
     * are shown parenthetically when non-zero. Token counts are rendered
-    * compactly (`1K`, `103.8K`, `3.2M`) from 1000 up; cost (when known) stays
-    * exact and is appended as `$X.XXXX`, with an asterisk marking an estimated
-    * figure and a trailing legend line when any estimate is present.
+    * compactly (`1K`, `103.8K`, `3.2M`) from 1000 up, a count and its
+    * parenthetical breakdown at one shared unit (`1.63M in (1.15M cache read,
+    * 0.48M cache write)`); cost (when known) stays exact and is appended as
+    * `$X.XXXX`, with an asterisk marking an estimated figure and a trailing
+    * legend line when any estimate is present.
     *
     * A turn that spent tokens but resolved to no cost contributes nothing to
     * the total, so the total's label carries `(some turns unpriced)` and gains
@@ -221,45 +223,42 @@ class CostTracker(pricingAsOf: LocalDate) extends OrcaListener:
     val tokens = formatUsage(tally.usage)
     tally.cost.fold(tokens)(c => s"$tokens (${formatCost(c)})")
 
-  /** Cache reads and cache writes share one parenthetical after the input
-    * count, each part dropped when zero.
+  /** Input and output are two independent groups: cache reads and writes are
+    * parts of the input count, reasoning a part of the output count.
     */
   private def formatUsage(usage: Usage): String =
-    val cacheParts = List(
-      Option.when(usage.cacheReadInputTokens > 0)(
-        s"${formatCount(usage.cacheReadInputTokens)} cache read"
-      ),
-      Option.when(usage.cacheWriteInputTokens > 0)(
-        s"${formatCount(usage.cacheWriteInputTokens)} cache write"
+    val in = formatGroup(
+      usage.inputTokens,
+      "in",
+      List(
+        usage.cacheReadInputTokens -> "cache read",
+        usage.cacheWriteInputTokens -> "cache write"
       )
-    ).flatten
-    val cache =
-      if cacheParts.isEmpty then "" else cacheParts.mkString(" (", ", ", ")")
-    val reasoning =
-      if usage.reasoningOutputTokens > 0 then
-        s" (${formatCount(usage.reasoningOutputTokens)} reasoning)"
-      else ""
-    val in = formatCount(usage.inputTokens)
-    val out = formatCount(usage.outputTokens)
-    s"$in in$cache, $out out$reasoning"
+    )
+    val out = formatGroup(
+      usage.outputTokens,
+      "out",
+      List(usage.reasoningOutputTokens -> "reasoning")
+    )
+    s"$in, $out"
 
-  /** Render a token count compactly: plain digits below 1000, from 1000 up one
-    * decimal place with a K/M/B suffix and no trailing `.0` — `1K`, `103.8K`,
-    * `3.2M`. Halves round up.
+  /** `<total> <totalLabel>`, followed by the non-zero `parts` in one
+    * parenthetical.
     */
-  private def formatCount(n: Long): String =
-    if n < 1000 then n.toString
+  private def formatGroup(
+      total: Long,
+      totalLabel: String,
+      parts: List[(Long, String)]
+  ): String =
+    val nonZeroParts = parts.filter((n, _) => n > 0)
+    val scale = CostTracker.CountScale.of(total, nonZeroParts.map((n, _) => n))
+    val head = s"${scale.format(total)} $totalLabel"
+    if nonZeroParts.isEmpty then head
     else
-      val units = List(1_000L -> "K", 1_000_000L -> "M", 1_000_000_000L -> "B")
-      def mantissa(unit: Long): BigDecimal =
-        (BigDecimal(n) / unit).setScale(1, BigDecimal.RoundingMode.HALF_UP)
-      // Ascending scan for the first unit whose *rounded* mantissa stays under
-      // 1000: rounding up carries 999,950 to "1000.0K", which belongs one unit
-      // higher as "1M". `getOrElse` covers counts past the largest unit.
-      val (unit, suffix) =
-        units.find((u, _) => mantissa(u) < 1000).getOrElse(units.last)
-      // Scale is fixed at 1, so a plain suffix strip turns "2.0" into "2".
-      s"${mantissa(unit).toString.stripSuffix(".0")}$suffix"
+      val breakdown = nonZeroParts
+        .map((n, partLabel) => s"${scale.format(n)} $partLabel")
+        .mkString(", ")
+      s"$head ($breakdown)"
 
   private def formatAmount(c: Cost): String =
     val rounded = c.amount.setScale(4, BigDecimal.RoundingMode.HALF_UP)
@@ -276,3 +275,60 @@ class CostTracker(pricingAsOf: LocalDate) extends OrcaListener:
   def printSummary(): Unit =
     val s = summary
     if s.nonEmpty then println(s"\n$s")
+
+private object CostTracker:
+
+  /** The unit and decimal count shared by one group of counts — a total and the
+    * counts that break it down. One unit across the group is what lets the
+    * parts be read against the total without a conversion in between, and no
+    * part is ever printed larger than the total it came from.
+    */
+  private case class CountScale(unit: Long, suffix: String, decimals: Int):
+
+    /** `n` at this scale: a mantissa with a K/M/B suffix, halves rounding up. A
+      * trailing `.0` is dropped, but a two-decimal group keeps its zeros, so
+      * every count in it is shown to the same precision.
+      *
+      * A count below a tenth of the unit keeps its OWN scale instead: at this
+      * one it would lose its leading significant digit (5 tokens as `0.01K`),
+      * and it is far too small to move the total it sits under.
+      */
+    def format(n: Long): String =
+      if this == CountScale.Plain then n.toString
+      else if n < unit / 10 then CountScale.of(n, Nil).format(n)
+      else
+        val mantissa = (BigDecimal(n) / unit)
+          .setScale(decimals, BigDecimal.RoundingMode.HALF_UP)
+        val digits =
+          if decimals == 1 then mantissa.toString.stripSuffix(".0")
+          else mantissa.toString
+        s"$digits$suffix"
+
+  private object CountScale:
+
+    /** Counts small enough to print in full. */
+    private val Plain = CountScale(1L, "", 0)
+
+    private val units =
+      List(1_000L -> "K", 1_000_000L -> "M", 1_000_000_000L -> "B")
+
+    /** The scale for a group with this `total` and these non-zero `parts`. The
+      * unit comes from the total, always the largest count in the group. A part
+      * that lands below one unit takes the whole group to two decimals so it
+      * shows a digit rather than `0.0M`; the total never needs that, its own
+      * mantissa being what picked the unit.
+      */
+    def of(total: Long, parts: List[Long]): CountScale =
+      if total < 1000 then Plain
+      else
+        def mantissa(unit: Long): BigDecimal =
+          (BigDecimal(total) / unit)
+            .setScale(1, BigDecimal.RoundingMode.HALF_UP)
+        // Ascending scan for the first unit whose *rounded* mantissa stays
+        // under 1000: rounding up carries 999,950 to "1000.0K", which belongs
+        // one unit higher as "1M". `getOrElse` covers counts past the largest
+        // unit.
+        val (unit, suffix) =
+          units.find((u, _) => mantissa(u) < 1000).getOrElse(units.last)
+        val subUnitPart = parts.exists(p => p >= unit / 10 && p < unit)
+        CountScale(unit, suffix, if subUnitPart then 2 else 1)

--- a/flow/src/test/scala/orca/CostTrackerTest.scala
+++ b/flow/src/test/scala/orca/CostTrackerTest.scala
@@ -393,6 +393,89 @@ class CostTrackerTest extends munit.FunSuite:
       tracker.summary
     )
 
+  test("a group with a sub-unit part renders every count at two decimals"):
+    // Counts from a live run: the parts have to sum to the total above them.
+    val tracker = new CostTracker(pricingAsOf)
+    tracker.onEvent(
+      tokens(
+        "claude",
+        Some("opus"),
+        usage(
+          input = 1_630_100L,
+          output = 30_200L,
+          cost = None,
+          cacheRead = 1_151_000L,
+          cacheWrite = 479_100L
+        )
+      )
+    )
+    assert(
+      tracker.summary.contains(
+        "claude: 1.63M in (1.15M cache read, 0.48M cache write), 30.2K out"
+      ),
+      tracker.summary
+    )
+
+  test("a part far below the group's unit keeps its own scale"):
+    // At the group's unit this would round to 0.00M, which reads as "no cache
+    // writes at all" — a different fact from "too few to show at this scale".
+    val tracker = new CostTracker(pricingAsOf)
+    tracker.onEvent(
+      tokens(
+        "claude",
+        Some("opus"),
+        usage(
+          input = 2_000_000L,
+          output = 0L,
+          cost = None,
+          cacheWrite = 900L
+        )
+      )
+    )
+    assert(
+      tracker.summary.contains("claude: 2M in (900 cache write), 0 out"),
+      tracker.summary
+    )
+
+  test(
+    "a two-decimal group shows the total to the same precision as its parts"
+  ):
+    // Stripping the total to "12.4M" would leave the reader adding 11.9 + 0.51
+    // against a headline shown to one fewer digit.
+    val tracker = new CostTracker(pricingAsOf)
+    tracker.onEvent(
+      tokens(
+        "claude",
+        Some("opus"),
+        usage(
+          input = 12_412_300L,
+          output = 100L,
+          cost = None,
+          cacheRead = 11_900_000L,
+          cacheWrite = 512_300L
+        )
+      )
+    )
+    assert(
+      tracker.summary.contains(
+        "claude: 12.41M in (11.90M cache read, 0.51M cache write), 100 out"
+      ),
+      tracker.summary
+    )
+
+  test("the output group keeps its own unit, unaffected by a large input"):
+    // Sharing ONE unit across the whole line would render this as "0.1K out";
+    // output is not a part of input, so nothing is summed across the two.
+    val tracker = new CostTracker(pricingAsOf)
+    tracker.onEvent(
+      tokens(
+        "claude",
+        Some("opus"),
+        usage(input = 3_000_000L, output = 100L, cost = None)
+      )
+    )
+    assert(tracker.summary.contains("claude: 3M in, 100 out"), tracker.summary)
+
   test("summary drops the cache-write part when a backend reports no writes"):
     val tracker = new CostTracker(pricingAsOf)
     tracker.onEvent(

--- a/runner/src/main/scala/orca/runner/RoleAgents.scala
+++ b/runner/src/main/scala/orca/runner/RoleAgents.scala
@@ -151,24 +151,25 @@ private[orca] object RoleAgents:
   /** The `harness`/`model` pair an announcement shows for one role. The harness
     * comes from the winning [[AgentSpec]] when there is one (project/global),
     * otherwise from the resolved agent's backend tag (an override shows its
-    * backend's harness; the built-in default resolves to claude). The model
-    * shown is whichever settings never override: a settings pin wins outright
-    * (that's what the user asked for); absent a pin, the resolved agent's OWN
-    * configured model (e.g. claude's wired Opus1M default) is shown instead of
-    * staying silent — pi/opencode, which pin no default, stay bare.
+    * backend's harness; the built-in default resolves to claude).
+    *
+    * The model comes from the spec's pin first, and only then from the agent's
+    * own configured model (claude/codex/gemini pin a default; pi and opencode
+    * don't). That order matters because an agent implementing `Agent` directly
+    * rather than via `BaseAgent` reports no configured model, which would
+    * otherwise drop the user's pin.
     */
   private def harnessAndModel(
       agent: Agent[?],
       spec: Option[AgentSpec]
   ): (String, Option[String]) =
-    spec match
-      case Some(s) => (AgentSpec.harnessNameFor(s.backend), s.model)
+    val harness = spec match
+      case Some(s) => AgentSpec.harnessNameFor(s.backend)
       case None =>
-        val harness =
-          agent.backendTag
-            .flatMap(AgentSpec.harnessNameFor.get)
-            .getOrElse("claude")
-        (harness, agent.configuredModel.map(_.name))
+        agent.backendTag
+          .flatMap(AgentSpec.harnessNameFor.get)
+          .getOrElse("claude")
+    (harness, spec.flatMap(_.model).orElse(agent.configuredModel.map(_.name)))
 
   private def resolveOne(
       label: String,
@@ -209,11 +210,18 @@ private[orca] object RoleAgents:
               foreign = false
             )
 
-  /** One role's announcement segment, `label=harness[:model] (source)` — pure
+  /** Stands in for a role where nothing orca can see pins a model — neither the
+    * settings nor the wired agent (pi and opencode pin no default). The harness
+    * picks one at spawn time, which the header can't know before the first
+    * turn.
+    */
+  private val UnpinnedModelLabel = "<harness default>"
+
+  /** One role's announcement segment, `label=harness:model (source)` — pure
     * formatting of [[RoleChoice]]'s precomputed fields.
     */
   private def announce(c: RoleChoice): String =
-    s"${c.label}=${c.harness}${c.model.map(":" + _).getOrElse("")} (${sourceLabel(c.source)})"
+    s"${c.label}=${c.harness}:${c.model.getOrElse(UnpinnedModelLabel)} (${sourceLabel(c.source)})"
 
   private def sourceLabel(source: RoleSource): String =
     source match

--- a/runner/src/test/scala/orca/runner/RoleAgentsTest.scala
+++ b/runner/src/test/scala/orca/runner/RoleAgentsTest.scala
@@ -114,8 +114,9 @@ class RoleAgentsTest extends munit.FunSuite:
     )
     assertEquals(
       resolution.announcement,
-      "agents: planning=claude (default), coding=codex (project), " +
-        "review=gemini (global)"
+      "agents: planning=claude:<harness default> (default), " +
+        "coding=codex:<harness default> (project), " +
+        "review=gemini:<harness default> (global)"
     )
     assertEquals(resolution.foreignWarnings, Nil)
 
@@ -138,7 +139,7 @@ class RoleAgentsTest extends munit.FunSuite:
     )
 
   test(
-    "resolveAll stays bare when neither settings nor the wired agent pin a model"
+    "resolveAll marks a role nobody pinned a model for as the harness's own default"
   ):
     val resolution = RoleAgents.resolveAll(
       project = AgentSettings(coding = Some(AgentSpec(BackendTag.Codex, None))),
@@ -148,8 +149,27 @@ class RoleAgentsTest extends munit.FunSuite:
       onRoleResolved = _ => ()
     )
     assert(
-      resolution.announcement.contains("coding=codex (project)"),
-      s"an agent with no default model pin must stay bare: ${resolution.announcement}"
+      resolution.announcement.contains(
+        "coding=codex:<harness default> (project)"
+      ),
+      s"a role nobody pinned a model for must say the harness picks: " +
+        resolution.announcement
+    )
+
+  test(
+    "a settings entry naming only a harness announces that agent's own model"
+  ):
+    // The header and the cost table must name the same model.
+    val resolution = RoleAgents.resolveAll(
+      project = AgentSettings(coding = Some(AgentSpec(BackendTag.Codex, None))),
+      global = AgentSettings.empty,
+      overrides = RoleOverrides(None, None, None),
+      agents = wiredAgents(codex = new DefaultModelCodex),
+      onRoleResolved = _ => ()
+    )
+    assert(
+      resolution.announcement.contains("coding=codex:gpt-5.6-sol (project)"),
+      s"expected the wired codex's own model: ${resolution.announcement}"
     )
 
   test("resolveAll renders a project model pin as harness:model"):
@@ -201,7 +221,9 @@ class RoleAgentsTest extends munit.FunSuite:
       onRoleResolved = _ => ()
     )
     assert(
-      resolution.announcement.contains("coding=codex (override)"),
+      resolution.announcement.contains(
+        "coding=codex:<harness default> (override)"
+      ),
       s"an override must beat the project file and label (override): " +
         resolution.announcement
     )
@@ -288,7 +310,7 @@ class RoleAgentsTest extends munit.FunSuite:
     override private[orca] def configuredModel: Option[Model] =
       Some(Model("claude-opus-5[1m]"))
 
-  private object NoopCodex extends CodexAgent:
+  private class NoopCodexAgent extends CodexAgent:
     val name = "noop-codex"
     // A real backend tag so the override-announcement test can read the
     // resolved backend's harness (`codex`) off the agent, as production does.
@@ -304,6 +326,14 @@ class RoleAgentsTest extends munit.FunSuite:
       throw new UnsupportedOperationException
     def resultAs[O: JsonData: Announce]: AgentCall[BackendTag.Codex.type, O] =
       throw new UnsupportedOperationException
+
+  private object NoopCodex extends NoopCodexAgent
+
+  /** [[NoopCodexAgent]] with a model of its own, for the settings path. */
+  private class DefaultModelCodex extends NoopCodexAgent:
+    override val name = "codex"
+    override private[orca] def configuredModel: Option[Model] =
+      Some(Model("gpt-5.6-sol"))
 
   private object NoopOpencode extends OpencodeAgent:
     val name = "noop-opencode"

--- a/runner/src/test/scala/orca/runner/RoleSettingsFlowTest.scala
+++ b/runner/src/test/scala/orca/runner/RoleSettingsFlowTest.scala
@@ -266,8 +266,9 @@ class RoleSettingsFlowTest extends munit.FunSuite:
     assertEquals(
       announcements,
       List(
-        "agents: planning=claude (default), coding=codex (project), " +
-          "review=gemini (global)"
+        "agents: planning=claude:<harness default> (default), " +
+          "coding=codex:<harness default> (project), " +
+          "review=gemini:<harness default> (global)"
       ),
       s"expected exactly one per-role announcement, saw: ${steps.get()}"
     )
@@ -286,32 +287,11 @@ class RoleSettingsFlowTest extends munit.FunSuite:
     assertEquals(
       announcements,
       List(
-        "agents: planning=claude (default), coding=codex:gpt-5-mini (project), " +
-          "review=claude (default)"
+        "agents: planning=claude:<harness default> (default), " +
+          "coding=codex:gpt-5-mini (project), " +
+          "review=claude:<harness default> (default)"
       ),
       s"expected the pinned model in the coding segment: ${steps.get()}"
-    )
-
-  test(
-    "an unpinned role keeps the bare harness form, unchanged"
-  ):
-    val workDir = GitRepo.seeded()
-    writeProject(workDir, "codingAgent = codex\n")
-    val steps = new AtomicReference[List[String]](Nil)
-    driveFlow(
-      workDir,
-      stackSettings = Some(StackSettings.empty),
-      listeners = List(recordSteps(steps)),
-      wiring = wiringWith(claude = StubAgent.claude, codex = new StubCodex)
-    )(())
-    val announcements = steps.get().filter(_.startsWith("agents:"))
-    assertEquals(
-      announcements,
-      List(
-        "agents: planning=claude (default), coding=codex (project), " +
-          "review=claude (default)"
-      ),
-      s"an unset model must not render a `:` suffix: ${steps.get()}"
     )
 
   test(
@@ -332,7 +312,8 @@ class RoleSettingsFlowTest extends munit.FunSuite:
       announcements,
       List(
         "agents: planning=claude:claude-opus-5[1m] (default), " +
-          "coding=codex (project), review=claude:claude-opus-5[1m] (default)"
+          "coding=codex:<harness default> (project), " +
+          "review=claude:claude-opus-5[1m] (default)"
       ),
       s"expected the wired default model for the unpinned roles: ${steps.get()}"
     )

--- a/shell/src/main/scala/orca/shell/actions/ConfigSummary.scala
+++ b/shell/src/main/scala/orca/shell/actions/ConfigSummary.scala
@@ -9,9 +9,9 @@ import orca.settings.AgentSpec
   * via the SAME precedence a flow run applies
   * ([[RoleAgents.projectOverGlobal]], also used by `RoleAgents.resolveOne`),
   * minus its live-agent default-model fallback — no agent is built just to
-  * print this line, so an unset role always shows bare `claude` here, even
-  * though a real run might additionally show that backend's own configured
-  * default model.
+  * print this line, so a role with no model in the settings shows the bare
+  * harness here, whereas a real run's header instead names the resolved agent's
+  * own default model, or `<harness default>` when the backend pins none.
   *
   * [[branchLine]] is NOT part of that summary: `Main.loop` prints it once per
   * redraw, so it stays true after a flow run switches branches.


### PR DESCRIPTION
Two fixes to what a run reports, both found by reading a real run's log.

## 1. The cost summary rounded each number on its own

A live line read:

```
claude: 1.6M in (1.2M cache read, 479.1K cache write), 30.2K out
```

The two numbers in brackets are parts of the number before them, but each was
rounded at its own scale. 1.2M + 479.1K is 1.68M, which is more than the 1.6M
above it — it reads like the sum is wrong.

Now a number and the numbers that break it down share one unit, so they can be
compared directly:

```
claude: 1.63M in (1.15M cache read, 0.48M cache write), 30.2K out
```

1.15 + 0.48 = 1.63. A part that would lose its leading digit at the shared unit
keeps its own instead, so 900 cache-write tokens under a 2M input still print as
`900`, not `0.00M`. Input and output stay separate groups — output is not a part
of input — so a small output next to a huge input still prints as `100 out`
rather than `0.0001M out`.

## 2. The run header hid which model a role would use

The header said:

```
agents: planning=codex (project), coding=codex (project), review=codex (project)
```

while the cost table for that same run listed `gpt-5.6-sol`. The header showed a
model only when the settings file pinned one, so `codingAgent = codex` printed
bare even though the run used codex's own default model.

Now the header names the model for every role — the settings pin if there is
one, otherwise the agent's own default:

```
agents: planning=codex:gpt-5.6-sol (project), coding=codex:gpt-5.6-sol (project), review=codex:gpt-5.6-sol (project)
```

pi and opencode pin no default, so orca has nothing to name for them; those
roles now say `<harness default>` instead of staying silent.

Tests pin the exact rendered strings on both sides. The README's example header
is updated.
