### PR TITLE
Silence the launcher's dependency-download wall

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,8 @@ the released one. Isolate the config and cache dirs so your real
 `~/.config/orca` and wizard state stay untouched; `--workspace` keeps
 scala-cli's own `.scala-build`/`.bsp` for this no-input `--dep`+`--main-class`
 invocation out of the scratch project, the same fix the `orca` shim applies
-(`install.sh`).
+(`install.sh`). `--quiet --verbose` is one setting, not two — dropping either
+half costs you a wall of `Downloading` lines or a silent exit 1 (ADR 0021).
 
 ```bash
 version="$(sbt -batch -error "print shell/version" | tail -1)"
@@ -88,7 +89,7 @@ cd /tmp/orca-dev/project
 git init -q 2>/dev/null; git commit -q --allow-empty -m scratch 2>/dev/null; true
 
 XDG_CONFIG_HOME=/tmp/orca-dev/xdg/config XDG_CACHE_HOME=/tmp/orca-dev/xdg/cache \
-  scala-cli run --workspace /tmp/orca-dev/workspace --jvm 21 --quiet \
+  scala-cli run --workspace /tmp/orca-dev/workspace --jvm 21 --quiet --verbose \
     --dep "org.virtuslab::orca-shell:$version" \
     --repository ivy2local \
     --main-class orca.shell.Main
@@ -99,7 +100,7 @@ the headless CLI, append the subcommand after `--`:
 
 ```bash
 XDG_CONFIG_HOME=... XDG_CACHE_HOME=... \
-  scala-cli run --workspace /tmp/orca-dev/workspace --jvm 21 --quiet \
+  scala-cli run --workspace /tmp/orca-dev/workspace --jvm 21 --quiet --verbose \
     --dep "org.virtuslab::orca-shell:$version" \
     --repository ivy2local \
     --main-class orca.shell.Main -- run implement.sc "your task"

--- a/README.md
+++ b/README.md
@@ -967,7 +967,7 @@ scala-cli's own build metadata out of the current directory (it lands under the
 given directory instead):
 
 ```bash
-scala-cli run --workspace "${XDG_CACHE_HOME:-$HOME/.cache}/orca/shell/workspace" --jvm 21 --quiet --dep "org.virtuslab::orca-shell:0.1.3" --main-class orca.shell.Main
+scala-cli run --workspace "${XDG_CACHE_HOME:-$HOME/.cache}/orca/shell/workspace" --jvm 21 --quiet --verbose --dep "org.virtuslab::orca-shell:0.1.3" --main-class orca.shell.Main
 ```
 
 ## Documentation

--- a/adr/0021-orca-shell.md
+++ b/adr/0021-orca-shell.md
@@ -51,24 +51,31 @@ official installer if it's missing:
 
 ```bash
 #!/usr/bin/env bash
-exec scala-cli run --jvm 21 --quiet \
+exec scala-cli run --jvm 21 --quiet --verbose \
   --dep "org.virtuslab::orca-shell:latest.release" \
   --main-class orca.shell.Main -- "$@"
 ```
 
 Verified: scala-cli runs a main class straight from a Maven dependency with
-no sources, and `latest.release` resolves (research 04). `--quiet` suppresses
-coursier's fetch-progress chrome (which otherwise races the wizard's first
-prompt paint); verified it does NOT hide real compile/resolution errors —
-those still print. The shim therefore
-never needs version bumps; the shell prints its resolved version at startup
-(manifest `Implementation-Version`, the existing `OrcaBanner.version`
-pattern — no BuildInfo plugin). The README additionally documents the pinned
-one-liner (bumped by `updateDocs`) for CI and the install-averse. Rejected:
-coursier app descriptors and `scala-cli --power package` as the launch story
-(both bypass scala-cli at launch and add prerequisites/build surface;
-research 04 §2b–2c) — a URL-based `cs install` channel JSON may be added
-later as a convenience.
+no sources, and `latest.release` resolves (research 04). `--quiet`
+suppresses coursier's fetch-progress chrome (which otherwise races the
+wizard's first prompt paint) — on a cold cache that is a ~900-line wall of
+`Downloading`/`Downloaded`/`Failed to download`, the failed ones being
+expected repository fallback probes. `--quiet` alone would go too far:
+scala-cli derives both the coursier logger AND its verbosity from that one
+flag, and at verbosity -1 it prints no build exception, so a dependency that
+fails to resolve exits nonzero in complete silence. `--verbose` restores
+verbosity 0 while leaving the fetch log off — resolution errors print again
+(verified against scala-cli 1.15.0). Both flags together are one setting;
+`FlowLauncher` passes the same pair when it spawns a flow. The shim
+therefore never needs version bumps; the shell prints its resolved version
+at startup (manifest `Implementation-Version`, the existing
+`OrcaBanner.version` pattern — no BuildInfo plugin). The README additionally
+documents the pinned one-liner (bumped by `updateDocs`) for CI and the
+install-averse. Rejected: coursier app descriptors and
+`scala-cli --power package` as the launch story (both bypass scala-cli at
+launch and add prerequisites/build surface; research 04 §2b–2c) — a
+URL-based `cs install` channel JSON may be added later as a convenience.
 
 All modules release under one dynver version, so shell version = orca
 version with no extra plumbing.

--- a/install.sh
+++ b/install.sh
@@ -53,12 +53,14 @@ fi
 
 mkdir -p "$bin_dir"
 
+# --quiet also drops scala-cli's verbosity to -1, where it prints no build
+# exception at all; --verbose restores verbosity 0 with the fetch log still off.
 cat > "$bin_path" <<EOF
 #!/usr/bin/env bash
 $marker
 workspace="\${XDG_CACHE_HOME:-\$HOME/.cache}/orca/shell/workspace"
 mkdir -p "\$workspace"
-exec scala-cli run --workspace "\$workspace" --jvm 21 --quiet \\
+exec scala-cli run --workspace "\$workspace" --jvm 21 --quiet --verbose \\
   --dep "org.virtuslab::orca-shell:latest.release" \\
   --main-class orca.shell.Main -- "\$@"
 EOF

--- a/shell/src/main/scala/orca/shell/run/FlowLauncher.scala
+++ b/shell/src/main/scala/orca/shell/run/FlowLauncher.scala
@@ -38,6 +38,18 @@ private[shell] object FlowLauncher:
 
   private val orgAndArtifact = "org.virtuslab::orca"
 
+  /** scala-cli's own logging flags, on every spawn.
+    *
+    * `--quiet` silences coursier's per-artifact fetch log — on a cold cache a
+    * ~900-line wall of `Downloading`/`Downloaded`/`Failed to download` before
+    * the flow prints anything. But it also drops scala-cli's verbosity to -1,
+    * where scala-cli prints no build exception at all: a flow whose
+    * dependencies fail to resolve would exit nonzero in silence. `--verbose`
+    * puts verbosity back to 0, leaving the fetch log off. Verified against
+    * scala-cli 1.15.0; the `orca` shim passes the same pair (ADR 0021).
+    */
+  private val loggingArgs = Seq("--quiet", "--verbose")
+
   /** `--dep org.virtuslab::orca:<v>`, or nothing when `orcaVersion` is `None`
     * (dev build, or an already-declined fallback).
     */
@@ -46,16 +58,16 @@ private[shell] object FlowLauncher:
       .map(v => Seq("--dep", s"$orgAndArtifact:$v"))
       .getOrElse(Seq.empty)
 
-  /** `scala-cli run <flow> [--dep ...] --workspace <dir> -- <task> [--verbose]
-    * [--skip-branch]`. `--verbose`/`--skip-branch` are flow-script arguments
-    * (parsed by the flow's own `OrcaArgs`, whose flags are spelled
-    * `--verbose`/`--skip-branch`), so they land after `--` alongside the task
-    * text, not before it. `--workspace` relocates scala-cli's own
-    * `.scala-build`/`.bsp` build metadata to `workspaceDir`
-    * ([[resolveWorkspaceDir]]) instead of next to `flow` — load-bearing for a
-    * Project-tier flow, whose script lives inside the user's own repo
-    * (`<repo>/.orca/flows/<name>.sc`), same pollution class the `orca` shim's
-    * own `--workspace` fixes (ADR 0021 §1 amendment).
+  /** `scala-cli run <flow> --quiet --verbose [--dep ...] --workspace <dir> --
+    * <task> [--verbose] [--skip-branch]`. The `--verbose` before `--` is
+    * scala-cli's own ([[loggingArgs]]); the one after is the flow's, parsed by
+    * its own `OrcaArgs` — which spells its flags `--verbose`/`--skip-branch`,
+    * so they land after `--` alongside the task text, not before it.
+    * `--workspace` relocates scala-cli's own `.scala-build`/`.bsp` build
+    * metadata to `workspaceDir` ([[resolveWorkspaceDir]]) instead of next to
+    * `flow` — load-bearing for a Project-tier flow, whose script lives inside
+    * the user's own repo (`<repo>/.orca/flows/<name>.sc`), same pollution class
+    * the `orca` shim's own `--workspace` fixes (ADR 0021 §1 amendment).
     *
     * Requires `task` to be non-blank — `Main.promptTask` re-prompts on blank
     * input before this is ever called, so an empty task here means a caller
@@ -75,10 +87,11 @@ private[shell] object FlowLauncher:
     val verboseArgs = if flags.verbose then Seq("--verbose") else Seq.empty
     val skipBranchArgs =
       if flags.skipBranch then Seq("--skip-branch") else Seq.empty
-    Seq("scala-cli", "run", flow.toString) ++ depArgs(orcaVersion) ++ Seq(
-      "--workspace",
-      workspaceDir.toString
-    ) ++ Seq("--", task) ++ verboseArgs ++ skipBranchArgs
+    Seq("scala-cli", "run", flow.toString) ++
+      loggingArgs ++
+      depArgs(orcaVersion) ++
+      Seq("--workspace", workspaceDir.toString) ++
+      Seq("--", task) ++ verboseArgs ++ skipBranchArgs
 
   /** The compile probe's argv — same `--workspace` treatment as [[argv]], and
     * for the same reason: without it, the probe (run whenever the forced
@@ -212,12 +225,18 @@ private[shell] object FlowLauncher:
     * ([[runAnnounced]]), the `--honor-pin` run ([[runHonoringPin]]), and
     * [[run]]'s own pin-honouring fallback re-run. `spawn` produces the
     * [[LaunchResult]] whose [[outcomeSuffix]] closes the bracket.
+    *
+    * The child is silent while it resolves ([[loggingArgs]]) and the launcher
+    * can't see when that starts or ends, so the notice is unconditional: a warm
+    * cache gets one extra line, a cold one gets the only sign the run isn't
+    * hung.
     */
   private[run] def announced(startLabel: String, flowName: String)(
       spawn: => LaunchResult
   ): LaunchResult =
     println()
     ShellOutput.section(startLabel)
+    ShellOutput.info("resolving dependencies…")
     val result = spawn
     ShellOutput.section(s"flow $flowName ${outcomeSuffix(result)}")
     println()

--- a/shell/src/test/scala/orca/shell/run/FlowLauncherTest.scala
+++ b/shell/src/test/scala/orca/shell/run/FlowLauncherTest.scala
@@ -19,6 +19,8 @@ class FlowLauncherTest extends munit.FunSuite:
         "scala-cli",
         "run",
         flow.toString,
+        "--quiet",
+        "--verbose",
         "--dep",
         "org.virtuslab::orca:0.0.18",
         "--workspace",
@@ -42,6 +44,8 @@ class FlowLauncherTest extends munit.FunSuite:
         "scala-cli",
         "run",
         flow.toString,
+        "--quiet",
+        "--verbose",
         "--workspace",
         workspaceDir.toString,
         "--",
@@ -65,6 +69,8 @@ class FlowLauncherTest extends munit.FunSuite:
         "scala-cli",
         "run",
         flow.toString,
+        "--quiet",
+        "--verbose",
         "--dep",
         "org.virtuslab::orca:0.0.18",
         "--workspace",
@@ -74,9 +80,10 @@ class FlowLauncherTest extends munit.FunSuite:
         "--verbose"
       )
     )
-    assert(
-      result.indexOf("--verbose") > result.indexOf("--"),
-      "--verbose must come after --"
+    assertEquals(
+      result(result.indexOf("--") + 2),
+      "--verbose",
+      "the flow's own --verbose follows the task, after --"
     )
 
   test(
@@ -95,6 +102,8 @@ class FlowLauncherTest extends munit.FunSuite:
         "scala-cli",
         "run",
         flow.toString,
+        "--quiet",
+        "--verbose",
         "--dep",
         "org.virtuslab::orca:0.0.18",
         "--workspace",
@@ -123,6 +132,8 @@ class FlowLauncherTest extends munit.FunSuite:
         "scala-cli",
         "run",
         flow.toString,
+        "--quiet",
+        "--verbose",
         "--workspace",
         workspaceDir.toString,
         "--",
@@ -142,7 +153,7 @@ class FlowLauncherTest extends munit.FunSuite:
       workspaceDir
     )
     assertEquals(result(2), spacedFlow.toString)
-    assertEquals(result.length, 7)
+    assertEquals(result.length, 9)
 
   test(
     "argv rejects a blank task — Main.promptTask should have re-prompted before this is ever called"


### PR DESCRIPTION
Starting a flow on a cold coursier cache printed `◆ ── starting flow implement.sc ──`
and then ~900-2000 lines of coursier `Downloading` / `Downloaded` /
`Failed to download` before anything from orca appeared. The `Failed to download`
lines are the worst part: they are expected repository fallback probes that
succeed elsewhere, so a successful run showed hundreds of things that read like
errors.

The launcher was spawning `scala-cli run` with no logging flags at all.

## The fix

`FlowLauncher` now passes `--quiet --verbose` to scala-cli. Both flags are needed,
and this is the non-obvious part:

- scala-cli's `--quiet` sets two independent things. It silences coursier's
  fetch log (that's what we want), and it also drops scala-cli's verbosity to
  -1.
- At verbosity -1 scala-cli prints no build exception at all. A flow whose
  dependencies fail to resolve exits 1 with **zero output** — the run just dies
  in silence.
- `--verbose` puts verbosity back to 0 (scala-cli computes
  `verbosity = verbose - quiet`), which leaves the fetch log off but brings the
  errors back.

Measured on scala-cli 1.15.0, cold cache, orca resolved from a local snapshot
with a nightlies repo in the list (the exact case from the report):

| flags | stderr lines | of which `Failed to download` |
|---|---|---|
| none (before) | 907 | 230 |
| `--quiet --verbose` (after) | 0 | 0 |

## Real errors still show

A flow with a dependency that doesn't exist, run through the new argv shape:

```
exit=1
[error] ./flows/broken.sc:4:15
[error] Error downloading org.virtuslab:orca-does-not-exist_3:9.9.9
[error]   not found: /home/adamw/.ivy2/local/...
[error]   No fallback URL found
[error]   not found: https://repo1.maven.org/maven2/...
[error] //> using dep org.virtuslab::orca-does-not-exist:9.9.9
```

Compile errors and the flow's own runtime output were never affected — the
compiler's reporter isn't verbosity-gated. Only scala-cli's own build
exceptions were, which is why `--quiet` alone would have been a silent-failure
bug.

## Both launch paths

Every flow spawn goes through `FlowLauncher.argv`: the interactive shell
(`RunAction` → `runAnnounced`), the headless `orca run` (`RunCli`, both the
forced and the `--honor-pin` branch), the pin-honouring fallback re-run, and
`AuthorAction`'s launch. The compile probe (`compileArgv`) is left alone — it
runs through `QuietProc`, which pipes both streams, so its output never reaches
the terminal anyway.

The same flag pair goes into the `orca` shim (`install.sh`), the README's pinned
one-liner, and the CONTRIBUTING recipes. The shim already had `--quiet`, so it
had the silent-resolution-failure hole too.

## One line of courtesy

The launcher can't see when resolution starts or ends, so it prints
`◆ resolving dependencies…` once before the spawn. On a warm cache that's one
extra line; on a cold one it's the only sign the run isn't hung.

ADR 0021 claimed `--quiet` "does NOT hide real compile/resolution errors". That
was half right and is corrected there.
