### PR TITLE
Give an empty diff sample its own LastSent case; drop RosterEntry's type parameter

### DIFF
--- a/flow/src/main/scala/orca/review/ReviewLoop.scala
+++ b/flow/src/main/scala/orca/review/ReviewLoop.scala
@@ -288,7 +288,7 @@ private object ReviewLoopState:
   * is nothing new to record).
   */
 private case class RoundContribution(
-    entry: RosterEntry[?],
+    entry: RosterEntry,
     gated: GatedIssues,
     newSession: Option[SessionEntry]
 )
@@ -484,7 +484,7 @@ private[review] class ReviewFixLoop[B <: BackendTag](
 ):
   import config.*
 
-  private val roster: List[RosterEntry[?]] = RosterEntry.roster(reviewers)
+  private val roster: List[RosterEntry] = RosterEntry.roster(reviewers)
 
   // Displayed for the lint gate's own findings, and the identity its LLM runs
   // are tagged with.
@@ -509,7 +509,7 @@ private[review] class ReviewFixLoop[B <: BackendTag](
     * `stored` is the reviewer's existing [[SessionEntry]], if any.
     */
   private def reviewWithSession(
-      e: RosterEntry[?],
+      e: RosterEntry,
       stored: Option[SessionEntry],
       current: DiffSample,
       declined: List[IgnoredIssue]
@@ -544,7 +544,7 @@ private[review] class ReviewFixLoop[B <: BackendTag](
     // files without adding or removing any must still register.
     val advanced = changes match
       case ReReviewChanges.Updated(_) =>
-        Some(se.copy(lastSent = LastSent.Inline(current.diff)))
+        Some(se.copy(lastSent = LastSent.inlined(current.diff)))
       case ReReviewChanges.TooLarge(_) =>
         Some(se.copy(lastSent = LastSent.PathsOnly(current.diff)))
       case ReReviewChanges.AlreadySeen(_) => None
@@ -556,7 +556,7 @@ private[review] class ReviewFixLoop[B <: BackendTag](
     * one.
     */
   private def firstReview(
-      e: RosterEntry[?],
+      e: RosterEntry,
       currentDiff: String,
       declined: List[IgnoredIssue]
   ): (ReviewResult, Option[SessionEntry]) =
@@ -577,7 +577,7 @@ private[review] class ReviewFixLoop[B <: BackendTag](
           ),
           emitPrompt = false
         )
-    (result, Some(SessionEntry(chat, LastSent.Inline(currentDiff))))
+    (result, Some(SessionEntry(chat, LastSent.inlined(currentDiff))))
 
   /** What one fork of the round's fan-out came back with — the same
     * contribution the loop state folds in, tagged with which kind of agent
@@ -598,7 +598,7 @@ private[review] class ReviewFixLoop[B <: BackendTag](
     * fixed, delivered to this round's reviewers.
     */
   private def runReviewersAndLint(
-      active: List[RosterEntry[?]],
+      active: List[RosterEntry],
       currentState: ReviewLoopState,
       declined: List[IgnoredIssue]
   ): RoundOutcome =
@@ -685,7 +685,7 @@ private[review] class ReviewFixLoop[B <: BackendTag](
     * happened to finish first.
     */
   private def collectRound(
-      active: List[RosterEntry[?]],
+      active: List[RosterEntry],
       currentState: ReviewLoopState,
       outcomes: List[AgentOutcome]
   ): RoundOutcome =
@@ -719,7 +719,7 @@ private[review] class ReviewFixLoop[B <: BackendTag](
 
   private def evaluate(
       state: ReviewLoopState,
-      selectRound: List[ReviewBatch] -> List[RosterEntry[?]],
+      selectRound: List[ReviewBatch] -> List[RosterEntry],
       declined: List[IgnoredIssue]
   )(using WorkspaceWrite): RoundOutcome =
     // Format before reviewing so the implementation's and each fix's edits are
@@ -850,7 +850,7 @@ private[review] class ReviewFixLoop[B <: BackendTag](
     // is the resulting pure per-iteration narrowing, passed to `evaluate` so it
     // stays a function of its inputs. `ctx`/`ev` passed explicitly for the same
     // given-priority reason as the constructor call in `reviewAndFixLoop`.
-    val selectRound: List[ReviewBatch] -> List[RosterEntry[?]] =
+    val selectRound: List[ReviewBatch] -> List[RosterEntry] =
       reviewerSelection.prepare(roster, task.title, diffSource.selectorFiles)(
         using
         ctx,

--- a/flow/src/main/scala/orca/review/ReviewLoopPrompts.scala
+++ b/flow/src/main/scala/orca/review/ReviewLoopPrompts.scala
@@ -179,24 +179,41 @@ object ReviewLoopPrompts:
         "No new change set this round — the file list already in this " +
           "conversation still describes the change set. Re-read those files " +
           "to see whether your earlier findings still stand."
+      case ReReviewChanges.AlreadySeen(LastSent.NoteOnly(_)) =>
+        "Still no change set could be sampled, so nothing was sent this " +
+          "round either. Do not conclude that nothing changed; check the code " +
+          "the task describes to see whether your earlier findings still stand."
 
   /** The diff as a fenced block, or a note when nothing could be sampled. An
     * empty sample means the loop couldn't describe the change, not that none
     * was made (ADR 0011), so the note has to say so.
     */
   private def diffBlock(diff: String): String =
-    if diff.trim.isEmpty then
+    if LastSent.nothingToShow(diff) then
       "(no change set could be sampled — do not conclude that nothing " +
         "changed; inspect the code the task describes)"
     else s"```diff\n$diff\n```"
 
-/** What the reviewer was last sent about the change set: the diff text it
-  * compares against, and whether that text or only its paths reached the
-  * conversation.
+/** What the reviewer was last sent about the change set: the sample it compares
+  * against, and how much of that sample reached the conversation — the diff
+  * text, only its paths, or only the placeholder note an empty sample renders
+  * as.
   */
 private[review] enum LastSent(val diff: String):
   case Inline(d: String) extends LastSent(d)
   case PathsOnly(d: String) extends LastSent(d)
+  case NoteOnly(d: String) extends LastSent(d)
+
+private[review] object LastSent:
+  /** Whether a sample has nothing to show, in which case a reviewer gets the
+    * placeholder note instead of a diff. The one home for that test: what the
+    * prompt renders and what the loop records must agree.
+    */
+  def nothingToShow(sample: String): Boolean = sample.trim.isEmpty
+
+  /** What an inlined sample leaves the reviewer holding. */
+  def inlined(sample: String): LastSent =
+    if nothingToShow(sample) then NoteOnly(sample) else Inline(sample)
 
 /** What a resumed reviewer is told about the change set this round.
   *
@@ -218,7 +235,9 @@ private[review] enum ReReviewChanges:
 
   /** Byte-identical to what this reviewer already holds, so nothing is sent.
     * Carries how that change set reached the conversation: after a [[TooLarge]]
-    * round only the paths are there to point back at.
+    * round only the paths are there to point back at, and after an empty sample
+    * only the placeholder note — which is no change set at all, so the reviewer
+    * must not be told it holds one.
     */
   case AlreadySeen(last: LastSent)
 

--- a/flow/src/main/scala/orca/review/ReviewLoopPrompts.scala
+++ b/flow/src/main/scala/orca/review/ReviewLoopPrompts.scala
@@ -180,9 +180,9 @@ object ReviewLoopPrompts:
           "conversation still describes the change set. Re-read those files " +
           "to see whether your earlier findings still stand."
       case ReReviewChanges.AlreadySeen(LastSent.NoteOnly(_)) =>
-        "Still no change set could be sampled, so nothing was sent this " +
-          "round either. Do not conclude that nothing changed; check the code " +
-          "the task describes to see whether your earlier findings still stand."
+        "No change set could be sampled this round either. Do not conclude " +
+          "that nothing changed — check the code the task describes to see " +
+          "whether your earlier findings still stand."
 
   /** The diff as a fenced block, or a note when nothing could be sampled. An
     * empty sample means the loop couldn't describe the change, not that none
@@ -195,9 +195,8 @@ object ReviewLoopPrompts:
     else s"```diff\n$diff\n```"
 
 /** What the reviewer was last sent about the change set: the sample it compares
-  * against, and how much of that sample reached the conversation — the diff
-  * text, only its paths, or only the placeholder note an empty sample renders
-  * as.
+  * against, and how much of it reached the conversation — an empty sample
+  * reaches it only as the placeholder note.
   */
 private[review] enum LastSent(val diff: String):
   case Inline(d: String) extends LastSent(d)
@@ -205,13 +204,14 @@ private[review] enum LastSent(val diff: String):
   case NoteOnly(d: String) extends LastSent(d)
 
 private[review] object LastSent:
-  /** Whether a sample has nothing to show, in which case a reviewer gets the
-    * placeholder note instead of a diff. The one home for that test: what the
-    * prompt renders and what the loop records must agree.
+  /** Whether a sample renders as the placeholder note instead of a diff. Shared
+    * so the prompt and the recorded [[LastSent]] can't disagree.
     */
   def nothingToShow(sample: String): Boolean = sample.trim.isEmpty
 
-  /** What an inlined sample leaves the reviewer holding. */
+  /** Records a sample sent inline — an empty one reaches the reviewer as the
+    * placeholder note, not as a diff.
+    */
   def inlined(sample: String): LastSent =
     if nothingToShow(sample) then NoteOnly(sample) else Inline(sample)
 

--- a/flow/src/main/scala/orca/review/ReviewerRoster.scala
+++ b/flow/src/main/scala/orca/review/ReviewerRoster.scala
@@ -1,6 +1,6 @@
 package orca.review
 
-import orca.agents.{Agent, BackendTag}
+import orca.agents.Agent
 
 // The vocabulary `reviewAndFixLoop` and every [[ReviewerSelector]] speak about
 // the configured reviewers. Kept out of `ReviewLoop.scala` so the loop file
@@ -23,8 +23,8 @@ private[review] object ReviewerId:
   * reviewer is unrepresentable, so the loop needs no runtime roster-membership
   * defences.
   */
-final class RosterEntry[B <: BackendTag] private[review] (
-    private[review] val agent: Agent[B],
+final class RosterEntry private[review] (
+    private[review] val agent: Agent[?],
     private[review] val id: ReviewerId
 ):
   /** The reviewer's bare slug — its identity, and what the picker LLM is shown
@@ -34,24 +34,16 @@ final class RosterEntry[B <: BackendTag] private[review] (
   def name: String = agent.name
 
 private[review] object RosterEntry:
-  /** Wrap a roster agent, opening the wildcard so the entry gets a concrete
-    * tag. Nothing downstream reads that tag — every use site spells
-    * `RosterEntry[?]` — it exists only because the class requires one.
-    */
-  def wrap(a: Agent[?], id: ReviewerId): RosterEntry[?] =
-    a match
-      case a: Agent[b] => new RosterEntry[b](a, id)
-
   /** The whole roster, each agent wrapped once. The only place a [[ReviewerId]]
     * is minted.
     */
-  def roster(agents: List[Agent[?]]): List[RosterEntry[?]] =
-    agents.zipWithIndex.map((a, i) => wrap(a, ReviewerId(i)))
+  def roster(agents: List[Agent[?]]): List[RosterEntry] =
+    agents.zipWithIndex.map((a, i) => new RosterEntry(a, ReviewerId(i)))
 
 /** One round of reviews, with each reviewer's individual outcome preserved and
   * kept in configured order, so the loop can decide which reviewers to re-run
   * next iteration based on which ones found issues.
   */
-case class ReviewBatch(outcomes: List[(RosterEntry[?], ReviewResult)]):
-  def reviewersWithIssues: List[RosterEntry[?]] =
+case class ReviewBatch(outcomes: List[(RosterEntry, ReviewResult)]):
+  def reviewersWithIssues: List[RosterEntry] =
     outcomes.collect { case (r, rr) if rr.issues.nonEmpty => r }

--- a/flow/src/main/scala/orca/review/ReviewerSelector.scala
+++ b/flow/src/main/scala/orca/review/ReviewerSelector.scala
@@ -42,10 +42,10 @@ import scala.util.matching.Regex
   */
 trait ReviewerSelector:
   def prepare(
-      all: List[RosterEntry[?]],
+      all: List[RosterEntry],
       taskTitle: Title,
       changedFiles: List[String]
-  )(using FlowContext, InStage): List[ReviewBatch] -> List[RosterEntry[?]]
+  )(using FlowContext, InStage): List[ReviewBatch] -> List[RosterEntry]
 
 object ReviewerSelector:
 
@@ -68,10 +68,10 @@ object ReviewerSelector:
     */
   val allEveryRound: ReviewerSelector = new ReviewerSelector:
     def prepare(
-        all: List[RosterEntry[?]],
+        all: List[RosterEntry],
         taskTitle: Title,
         changedFiles: List[String]
-    )(using FlowContext, InStage): List[ReviewBatch] -> List[RosterEntry[?]] =
+    )(using FlowContext, InStage): List[ReviewBatch] -> List[RosterEntry] =
       _ => all
 
   /** Asks a picker LLM which reviewers are worth running for a given task. The
@@ -109,13 +109,13 @@ object ReviewerSelector:
     */
   def agentDriven: ReviewerSelector = new ReviewerSelector:
     def prepare(
-        all: List[RosterEntry[?]],
+        all: List[RosterEntry],
         taskTitle: Title,
         changedFiles: List[String]
     )(using
         ctx: FlowContext,
         ev: InStage
-    ): List[ReviewBatch] -> List[RosterEntry[?]] =
+    ): List[ReviewBatch] -> List[RosterEntry] =
       agentDriven(ctx.reviewAgent.cheap).prepare(all, taskTitle, changedFiles)
 
   /** See the parameterless [[agentDriven]] above for the full description. Wrap
@@ -129,13 +129,13 @@ object ReviewerSelector:
       filePatterns: Map[String, Regex] = ReviewerPrompts.filePatternsBySlug
   ): ReviewerSelector = new ReviewerSelector:
     def prepare(
-        all: List[RosterEntry[?]],
+        all: List[RosterEntry],
         taskTitle: Title,
         changedFiles: List[String]
     )(using
         ctx: FlowContext,
         ev: InStage
-    ): List[ReviewBatch] -> List[RosterEntry[?]] =
+    ): List[ReviewBatch] -> List[RosterEntry] =
       val eligible = eligibleForPicker(all, filePatterns, changedFiles)
       val infos = eligible.map: r =>
         ReviewerInfo(
@@ -212,13 +212,13 @@ object ReviewerSelector:
   def narrowingAcrossRounds(base: ReviewerSelector): ReviewerSelector =
     new ReviewerSelector:
       def prepare(
-          all: List[RosterEntry[?]],
+          all: List[RosterEntry],
           taskTitle: Title,
           changedFiles: List[String]
       )(using
           ctx: FlowContext,
           ev: InStage
-      ): List[ReviewBatch] -> List[RosterEntry[?]] =
+      ): List[ReviewBatch] -> List[RosterEntry] =
         val basePick = base.prepare(all, taskTitle, changedFiles)
         history =>
           val active = basePick(history)
@@ -251,10 +251,10 @@ object ReviewerSelector:
     * nothing downstream can put it back.
     */
   private def eligibleForPicker(
-      all: List[RosterEntry[?]],
+      all: List[RosterEntry],
       filePatterns: Map[String, Regex],
       changedFiles: List[String]
-  )(using ctx: FlowContext): List[RosterEntry[?]] =
+  )(using ctx: FlowContext): List[RosterEntry] =
     if changedFiles.isEmpty then
       val gated = all.map(_.name).filter(filePatterns.contains)
       if gated.nonEmpty then

--- a/flow/src/main/scala/orca/review/SelectedReviewers.scala
+++ b/flow/src/main/scala/orca/review/SelectedReviewers.scala
@@ -11,7 +11,7 @@ import sttp.tapir.Validator
   * downstream can put it back.
   */
 private[review] case class PickedReviewers(
-    entries: List[RosterEntry[?]],
+    entries: List[RosterEntry],
     unresolved: List[String]
 )
 
@@ -25,7 +25,7 @@ case class SelectedReviewers(names: List[String]):
     * is what a cheap picker model actually gets wrong, and slugs never collide
     * case-insensitively.
     */
-  private[review] def pick(all: List[RosterEntry[?]]): PickedReviewers =
+  private[review] def pick(all: List[RosterEntry]): PickedReviewers =
     def key(name: String): String =
       name.trim.toLowerCase(java.util.Locale.ROOT)
     val wanted = names.map(key).toSet

--- a/flow/src/test/scala/orca/CcNegativeCompileTest.scala
+++ b/flow/src/test/scala/orca/CcNegativeCompileTest.scala
@@ -162,10 +162,10 @@ class CcNegativeCompileTest extends munit.FunSuite:
        |object SelectorFixture:
        |  val selector: ReviewerSelector = new ReviewerSelector:
        |    def prepare(
-       |        all: List[RosterEntry[?]],
+       |        all: List[RosterEntry],
        |        taskTitle: Title,
        |        changedFiles: List[String]
-       |    )(using ctx: FlowContext, ev: InStage): List[ReviewBatch] -> List[RosterEntry[?]] =
+       |    )(using ctx: FlowContext, ev: InStage): List[ReviewBatch] -> List[RosterEntry] =
        |      $body
        |""".stripMargin
 

--- a/flow/src/test/scala/orca/review/AllReviewersTest.scala
+++ b/flow/src/test/scala/orca/review/AllReviewersTest.scala
@@ -54,7 +54,7 @@ class AllReviewersTest extends munit.FunSuite:
     val base = new RecordingTool
     val all =
       allReviewers(base).zipWithIndex.map((a, i) =>
-        RosterEntry.wrap(a, ReviewerId(i))
+        new RosterEntry(a, ReviewerId(i))
       )
     val picked =
       SelectedReviewers(List("performance", "code-structure")).pick(all)

--- a/flow/src/test/scala/orca/review/ReviewChangeSetTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewChangeSetTest.scala
@@ -82,7 +82,9 @@ class ReviewChangeSetTest extends munit.FunSuite:
   test("a resumed reviewer sees an edit the fixer committed"):
     val (ctx, dir) = stagingControl()
     // The reviewer runs both rounds, so round two resumes its session — and its
-    // own `git diff HEAD` is empty once the fixer commits.
+    // own `git diff HEAD` is empty once the fixer commits. Nothing is committed
+    // before the loop, so round one also samples nothing: this is the empty
+    // sample followed by a real one.
     val reviewer = new FakeAgent(
       "r",
       outputs = List(ReviewResult(List(issue("real bug"))), ReviewResult.empty)
@@ -138,6 +140,44 @@ class ReviewChangeSetTest extends munit.FunSuite:
       .lift(1)
       .getOrElse(fail("the reviewer ran once; no resume happened"))
     assert(!resumePrompt.contains("pinned.scala"), resumePrompt)
+
+  test("after an empty sample an unchanged sample says there is still none"):
+    val (ctx, _) = stagingControl()
+    // Nothing could be sampled in round one, so all the reviewer holds is the
+    // placeholder note saying so. Round two samples the same nothing: pointing
+    // it back at the diff in its conversation would name a diff it was never
+    // sent.
+    val reviewer = new FakeAgent(
+      "r",
+      outputs = List(ReviewResult(List(issue("real bug"))), ReviewResult.empty)
+    )
+    val coder = new FakeAgent(
+      "coder",
+      outputs = List(FixOutcome(List(Title("real bug")), Nil))
+    )
+    given FlowControl = ctx
+    stage("implement the widget"):
+      val _ = reviewAndFixLoop(
+        coderSession = ReviewLoopFixture.coderSession(coder),
+        reviewers = List(reviewer),
+        task = titled("build the widget"),
+        reviewerSelection = ReviewerSelector.allEveryRound,
+        diff = ReviewDiff.Pinned("")
+      )
+    val resumePrompt = reviewer.seenPrompts
+      .lift(1)
+      .getOrElse(fail("the reviewer ran once; no resume happened"))
+    assert(
+      resumePrompt.contains(
+        "Still no change set could be sampled, so nothing was sent this " +
+          "round either."
+      ),
+      resumePrompt
+    )
+    assert(
+      !resumePrompt.contains("the diff already in this conversation"),
+      resumePrompt
+    )
 
   test("a change set too large to inline reaches a resumed reviewer as paths"):
     val (ctx, dir) = stagingControl()
@@ -261,7 +301,7 @@ class ReviewChangeSetTest extends munit.FunSuite:
       new java.util.concurrent.atomic.AtomicReference[List[String]](Nil)
     val recording = new ReviewerSelector:
       def prepare(
-          all: List[RosterEntry[?]],
+          all: List[RosterEntry],
           taskTitle: Title,
           changedFiles: List[String]
       )(using FlowContext, InStage) =

--- a/flow/src/test/scala/orca/review/ReviewChangeSetTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewChangeSetTest.scala
@@ -83,8 +83,7 @@ class ReviewChangeSetTest extends munit.FunSuite:
     val (ctx, dir) = stagingControl()
     // The reviewer runs both rounds, so round two resumes its session — and its
     // own `git diff HEAD` is empty once the fixer commits. Nothing is committed
-    // before the loop, so round one also samples nothing: this is the empty
-    // sample followed by a real one.
+    // before the loop, so round one's sample is empty and round two's is not.
     val reviewer = new FakeAgent(
       "r",
       outputs = List(ReviewResult(List(issue("real bug"))), ReviewResult.empty)
@@ -141,7 +140,7 @@ class ReviewChangeSetTest extends munit.FunSuite:
       .getOrElse(fail("the reviewer ran once; no resume happened"))
     assert(!resumePrompt.contains("pinned.scala"), resumePrompt)
 
-  test("after an empty sample an unchanged sample says there is still none"):
+  test("after an empty-sample round an unchanged sample says so again"):
     val (ctx, _) = stagingControl()
     // Nothing could be sampled in round one, so all the reviewer holds is the
     // placeholder note saying so. Round two samples the same nothing: pointing
@@ -169,8 +168,9 @@ class ReviewChangeSetTest extends munit.FunSuite:
       .getOrElse(fail("the reviewer ran once; no resume happened"))
     assert(
       resumePrompt.contains(
-        "Still no change set could be sampled, so nothing was sent this " +
-          "round either."
+        "No change set could be sampled this round either. Do not conclude " +
+          "that nothing changed — check the code the task describes to see " +
+          "whether your earlier findings still stand."
       ),
       resumePrompt
     )

--- a/flow/src/test/scala/orca/review/ReviewLoopFixture.scala
+++ b/flow/src/test/scala/orca/review/ReviewLoopFixture.scala
@@ -172,10 +172,10 @@ private[review] def issue(
   * round with `narrow(roster, history)`.
   */
 private[review] def selector(
-    narrow: (List[RosterEntry[?]], List[ReviewBatch]) => List[RosterEntry[?]]
+    narrow: (List[RosterEntry], List[ReviewBatch]) => List[RosterEntry]
 ): ReviewerSelector = new ReviewerSelector:
   def prepare(
-      all: List[RosterEntry[?]],
+      all: List[RosterEntry],
       taskTitle: Title,
       changedFiles: List[String]
   )(using FlowContext, InStage) =

--- a/flow/src/test/scala/orca/review/ReviewLoopPromptsTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewLoopPromptsTest.scala
@@ -103,7 +103,7 @@ class ReviewLoopPromptsTest extends munit.FunSuite:
   test("reReview carries the fixer's declines as a position, not a ruling"):
     val prompt = TextUtil.collapseWhitespace(
       ReviewLoopPrompts.reReview(
-        ReReviewChanges.AlreadySeen(LastSent.Inline("")),
+        ReReviewChanges.AlreadySeen(LastSent.NoteOnly("")),
         List(IgnoredIssue(Title("rename the field"), "the name is on our API"))
       )
     )
@@ -125,7 +125,7 @@ class ReviewLoopPromptsTest extends munit.FunSuite:
     // every round would cost tokens for nothing.
     val prompt = TextUtil.collapseWhitespace(
       ReviewLoopPrompts.reReview(
-        ReReviewChanges.AlreadySeen(LastSent.Inline("")),
+        ReReviewChanges.AlreadySeen(LastSent.NoteOnly("")),
         Nil
       )
     )
@@ -141,7 +141,7 @@ class ReviewLoopPromptsTest extends munit.FunSuite:
     // Same separator argument as the base-commit section above.
     val prompt = TextUtil.collapseWhitespace(
       ReviewLoopPrompts.reReview(
-        ReReviewChanges.AlreadySeen(LastSent.Inline("")),
+        ReReviewChanges.AlreadySeen(LastSent.NoteOnly("")),
         Nil
       )
     )

--- a/flow/src/test/scala/orca/review/ReviewerSelectorTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewerSelectorTest.scala
@@ -55,11 +55,11 @@ class ReviewerSelectorTest extends munit.FunSuite:
   // token for the suite.
   private given orca.InStage = orca.InStage.unsafe
 
-  private val scalaFp: RosterEntry[?] =
-    RosterEntry.wrap(new FakeAgent("scala-fp"), ReviewerId(0))
-  private val generic: RosterEntry[?] =
-    RosterEntry.wrap(new FakeAgent("generic"), ReviewerId(1))
-  private val all: List[RosterEntry[?]] = List(scalaFp, generic)
+  private val scalaFp: RosterEntry =
+    new RosterEntry(new FakeAgent("scala-fp"), ReviewerId(0))
+  private val generic: RosterEntry =
+    new RosterEntry(new FakeAgent("generic"), ReviewerId(1))
+  private val all: List[RosterEntry] = List(scalaFp, generic)
 
   private val filePatterns =
     Map("scala-fp" -> """\.scala$""".r)
@@ -68,7 +68,7 @@ class ReviewerSelectorTest extends munit.FunSuite:
   private class SelectorSteps extends ReviewLoopFixture.StepCapture:
     val ctx: FlowContext = new TestFlowContext(dispatcher)
 
-  private def reported(e: RosterEntry[?]): ReviewBatch =
+  private def reported(e: RosterEntry): ReviewBatch =
     ReviewBatch(List(e -> ReviewResult(List(issue("found something")))))
 
   test("file-pattern reviewers are dropped before the picker sees them"):

--- a/runner/src/test/scala/flowtests/FlowCompilesTest.scala
+++ b/runner/src/test/scala/flowtests/FlowCompilesTest.scala
@@ -144,7 +144,7 @@ object FlowCanary:
   def customReviewerSelectorSurface(): Unit =
     val _: ReviewerSelector = new ReviewerSelector:
       def prepare(
-          all: List[RosterEntry[?]],
+          all: List[RosterEntry],
           taskTitle: Title,
           changedFiles: List[String]
       )(using FlowContext, InStage) =


### PR DESCRIPTION
Two review-loop internals.

## An empty diff sample gets its own `LastSent` case

The loop records, per reviewer, what it last sent that reviewer. An empty
sample was recorded as `Inline("")` — as if a diff had been sent. What the
reviewer actually got was the placeholder note ("no change set could be
sampled..."). So when the next round sampled nothing again, the reviewer was
told:

> No new change set this round — the diff already in this conversation is the
> one under review.

There was no such diff. Now an empty sample records `LastSent.NoteOnly`, and
the repeat says:

> No change set could be sampled this round either. Do not conclude that
> nothing changed — check the code the task describes to see whether your
> earlier findings still stand.

The wording keeps the rule from ADR 0011: an empty sample means the loop could
not describe the change, not that nothing changed.

`ReReviewChanges.of` is unchanged — it still compares the sample bytes, and
`NoteOnly` carries the sample like the other two cases, so nothing about the
comparison shifts. `TooLarge` only fires over 16 KiB, so it can never carry an
empty sample.

New test: an empty sample twice in a row. The empty-then-real sequence was
already covered by "a resumed reviewer sees an edit the fixer committed" — its
first round samples nothing.

## `RosterEntry` loses its type parameter

Every use site spelled `RosterEntry[?]`, and nothing read the tag. The
`wrap` factory existed only to open the wildcard, so it goes too; `roster`
calls the constructor, which stays `private[review]` — a selector still cannot
build an entry of its own.

This touches `CcNegativeCompileTest`, which compiles a selector fixture with a
real compiler and checks the exact error. The fixture was updated. Its
positive case still compiles with no errors, and its negative case still fails
with "cannot flow into capture set", so both still test what they claim.
