### PR TITLE
Keep tool headlines on one line and show issue keys

### DIFF
--- a/adr/0008-terminal-output-design.md
+++ b/adr/0008-terminal-output-design.md
@@ -66,9 +66,9 @@ amendment for the tri-state).
 
 **Tool-call paths under `workDir` show as relative.** Absolute paths
 outside `workDir` stay absolute, so out-of-project file access is
-visually obvious. Free-form `command` / `pattern` / `query`
-fields pass through verbatim — only `file_path`/`path` headline
-fields get the rewrite.
+visually obvious. `command` and `url` pass through verbatim;
+`pattern`/`query` head the call and take a relativised ` in <dir>`
+suffix when the search was narrowed below `workDir`.
 
 **Subprocess stderr must be captured.** os-lib 0.11.x defaults
 `os.proc(...).call(...)`'s `stderr` to `Inherit`. A tool calling

--- a/flow/src/main/resources/orca/review/prompts/fix.md
+++ b/flow/src/main/resources/orca/review/prompts/fix.md
@@ -3,8 +3,8 @@ list it under `fixed`. Otherwise — when the issue is environmental, out of
 scope, or a false positive — list it and a brief reason under `ignored`. Every
 input issue should appear in exactly one of the two lists.
 
-Identify each issue by the key that starts its line (`I1`, `I2`, …), followed by
-its title: `I2 [Warning] The widget leaks a file handle`. The key is how the
-issue is matched back, so copy it exactly.
+Identify each issue by the key that starts its line (`I1.1`, `I1.2`, …),
+followed by its title: `I2.1 [Warning] The widget leaks a file handle`. The key
+is how the issue is matched back, so copy it exactly.
 
 Prefer minimal, scoped fixes.

--- a/flow/src/main/scala/orca/review/FixOutcome.scala
+++ b/flow/src/main/scala/orca/review/FixOutcome.scala
@@ -57,17 +57,17 @@ object FixOutcome:
     * paraphrase cannot record one real finding twice.
     */
   private[review] def reconcile(
-      handed: List[ReviewIssue],
+      handed: List[KeyedIssue],
       outcome: FixOutcome
   ): ReconciledFixOutcome =
-    val keyed = handed.zipWithIndex.map((i, n) => (FixRequest.key(n), i))
+    val issues = handed.map(_.issue)
 
     def resolve(echo: String): Option[ReviewIssue] =
       val text = echo.trim
-      keyed
-        .collectFirst { case (k, i) if startsWithKey(text, k) => i }
-        .orElse(handed.find(_.title.value == text))
-        .orElse(handed.find(i => normalised(i.title.value) == normalised(text)))
+      handed
+        .collectFirst { case k if startsWithKey(text, k.key) => k.issue }
+        .orElse(issues.find(_.title.value == text))
+        .orElse(issues.find(i => normalised(i.title.value) == normalised(text)))
 
     // Buckets are keyed by title throughout, so two reviewers reporting the
     // same title cannot land one copy in `ignored` and the other in
@@ -84,13 +84,12 @@ object FixOutcome:
     ReconciledFixOutcome(
       fixed = fixedTitles.distinct,
       ignored = ignoredEntries.map(IgnoredIssue(_, _)),
-      unaccounted = handed.map(_.title).distinct.filterNot(accounted.contains),
+      unaccounted = issues.map(_.title).distinct.filterNot(accounted.contains),
       unresolvedEchoes = echoes.filter(resolve(_).isEmpty)
     )
 
-  // A key only matches when the echo doesn't continue it with another letter or
-  // digit, so `I1` claims neither the reply naming `I10` nor one opening with
-  // an unrelated word like `I2C bus timing`.
+  // A key only matches when the echo doesn't continue it with another digit —
+  // otherwise `I1.1` would claim a reply naming `I1.10` — or with a letter.
   private def startsWithKey(echo: String, key: String): Boolean =
     echo.startsWith(key) &&
       (echo.length == key.length || !echo.charAt(key.length).isLetterOrDigit)

--- a/flow/src/main/scala/orca/review/FixRequest.scala
+++ b/flow/src/main/scala/orca/review/FixRequest.scala
@@ -11,22 +11,36 @@ import orca.agents.{AgentInput, JsonData, given}
   */
 private[review] case class FixRequest(
     instructions: String,
-    issues: List[ReviewIssue]
+    issues: List[KeyedIssue]
 ) derives JsonData
 
-private[review] object FixRequest:
-  /** The key the fixer is asked to echo for the issue at `index`. Positional
-    * and minted per turn, so it copies exactly where a paraphrased title does
-    * not; [[FixOutcome.reconcile]] resolves echoes against it.
-    */
-  def key(index: Int): String = s"I${index + 1}"
+/** A finding paired with the key the fixer is asked to echo for it. Minted when
+  * the gate splits an agent's findings, then used by both the display and the
+  * fix prompt, so what the fixer names in its prose ("Fix I2.1") is what the
+  * reader saw on screen.
+  */
+private[review] case class KeyedIssue(key: String, issue: ReviewIssue)
+    derives JsonData
 
+private[review] object KeyedIssue:
+  /** Mint the keys for one agent's findings in a round.
+    *
+    * Keys are positional and minted per turn, so the fixer copies them exactly
+    * where it would paraphrase a title; [[FixOutcome.reconcile]] resolves
+    * echoes against them. Numbering runs per agent rather than across the round
+    * so a key is fixed before the round's agents run: they report in any order,
+    * and each one's findings are shown as soon as it finishes.
+    */
+  def forAgent(agentIndex: Int, issues: List[ReviewIssue]): List[KeyedIssue] =
+    issues.zipWithIndex.map((issue, n) =>
+      KeyedIssue(s"I${agentIndex + 1}.${n + 1}", issue)
+    )
+
+private[review] object FixRequest:
   given AgentInput[FixRequest] with
     def serialize(r: FixRequest): String =
       val formatted =
-        r.issues.zipWithIndex
-          .map((i, n) => renderIssue(key(n), i))
-          .mkString("\n\n")
+        r.issues.map(k => renderIssue(k.key, k.issue)).mkString("\n\n")
       // No `stripMargin`: a reviewer's description or suggestion can carry
       // markdown tables and `|`-margin blocks, which it would eat.
       s"${r.instructions}\n\nIssues to fix:\n$formatted"

--- a/flow/src/main/scala/orca/review/ReviewFormatting.scala
+++ b/flow/src/main/scala/orca/review/ReviewFormatting.scala
@@ -10,17 +10,20 @@ private val WrapWidth: Int = 74
 
 /** Format a single review comment as the body lines of a `Step`.
   *
-  * Shape: `- [Severity] title ...wrapped...`, optionally followed by ` at
+  * Shape: `- I1.1 [Severity] title ...wrapped...`, optionally followed by ` at
   * file:line` and a ` suggestion: …` line. The leading `- ` makes the issue a
   * bullet within a multi-issue body; outer indentation is added by the caller
   * (typically [[formatReviewerOutcome]]).
   *
+  * `key` is the [[FixRequest]] key the fixer is asked to echo for this issue,
+  * shown so its "Fix I1.1/I1.2" narration names findings the reader can see.
+  *
   * `description` is deliberately not rendered: the screen shows the short form,
   * and the fixer gets the long one from [[FixRequest]]'s own rendering.
   */
-private[review] def formatIssue(issue: ReviewIssue): String =
+private[review] def formatIssue(key: String, issue: ReviewIssue): String =
   val header = TextWrap.wrap(
-    s"- [${issue.severity}] ${issue.title}",
+    s"- $key [${issue.severity}] ${issue.title}",
     maxWidth = WrapWidth,
     continuation = "  "
   )
@@ -45,29 +48,34 @@ private[review] def locationLine(location: Option[Location]): Option[String] =
   * reviewer + issue count, then bulleted issue details indented under it. Clean
   * reviews collapse to a single "<name>: 0 issues" line.
   *
-  * `result` holds only what cleared the confidence gate; `droppedCount` is how
-  * many of that reviewer's findings it held back, noted in the heading so a
-  * quiet reviewer isn't confused with a gated-out one. Those findings are
+  * `kept` holds only what cleared the confidence gate, already carrying the
+  * keys the fix turn will use ([[KeyedIssue.forAgent]]); `droppedCount` is how
+  * many of that reviewer's findings the gate held back, noted in the heading so
+  * a quiet reviewer isn't confused with a gated-out one. Those findings are
   * recorded by name in the loop's `IgnoredIssues`, not here.
   */
 private[review] def formatReviewerOutcome(
     reviewerName: String,
-    result: ReviewResult,
+    kept: List[KeyedIssue],
     droppedCount: Int
 ): String =
   val gated =
     if droppedCount == 0 then ""
     else s" ($droppedCount below the confidence gate)"
-  if result.issues.isEmpty then s"$reviewerName: 0 issues$gated"
+  if kept.isEmpty then s"$reviewerName: 0 issues$gated"
   else
     val header =
-      s"$reviewerName: ${TextUtil.pluralize(result.issues.size, "issue")}$gated"
-    val bullets = result.issues.map(formatIssue).mkString("\n")
+      s"$reviewerName: ${TextUtil.pluralize(kept.size, "issue")}$gated"
+    val bullets = kept.map(k => formatIssue(k.key, k.issue)).mkString("\n")
     s"$header\n$bullets"
 
 /** The block a review loop prints when it stops with findings still open: one
   * `- [Severity] title` line per finding, with the reason it is still open
   * below it. `None` when nothing is open.
+  *
+  * No [[FixRequest]] keys here: a key numbers one round's fix list, and this
+  * block spans rounds — an entry from round one carries no key the last round
+  * minted.
   *
   * A title missing from `severities` renders unprefixed rather than guessing a
   * severity.

--- a/flow/src/main/scala/orca/review/ReviewLoop.scala
+++ b/flow/src/main/scala/orca/review/ReviewLoop.scala
@@ -223,7 +223,9 @@ def fixLoop(
         announceExit(capExitMessage(maxIterations), open, seenSeverities)
         open
       case LoopStep.NeedsFix =>
-        val outcome = FixOutcome.reconcile(issues, fix(issues))
+        // One evaluator, so it is the round's only agent — index 0.
+        val outcome =
+          FixOutcome.reconcile(KeyedIssue.forAgent(0, issues), fix(issues))
         announceFixTurn(outcome)
         if outcome.fixed.isEmpty then
           val open = recordIgnored(accumulated, fixerHaltAdditions(outcome))
@@ -265,8 +267,9 @@ private case class ReviewLoopState(
     val withLint = lint.foldLeft(gateLedger): (ledger, c) =>
       ledger.record(GateLedger.Owner.Lint, c.gated.dropped)
     ReviewLoopState(
-      history = ReviewBatch(reviewers.map(c => (c.entry, c.gated.kept)))
-        :: history,
+      history = ReviewBatch(
+        reviewers.map(c => (c.entry, ReviewResult(c.gated.kept.map(_.issue))))
+      ) :: history,
       sessions =
         sessions ++ reviewers.flatMap(c => c.newSession.map(c.entry.id -> _)),
       lintChat = lint.flatMap(_.resumableSummariser),
@@ -302,9 +305,13 @@ private case class LintContribution(
 )
 
 /** One agent's findings split on the [[ConfidenceGate]]: `kept` goes to the
-  * fixer and the display, `dropped` is recorded rather than fixed.
+  * fixer and the display, carrying the keys both name it by; `dropped` is
+  * recorded rather than fixed.
   */
-private case class GatedIssues(kept: ReviewResult, dropped: List[ReviewIssue])
+private case class GatedIssues(
+    kept: List[KeyedIssue],
+    dropped: List[ReviewIssue]
+)
 
 /** The lint gate this round, paired with the conversation its summary runs on,
   * so neither can go missing without the other.
@@ -312,10 +319,11 @@ private case class GatedIssues(kept: ReviewResult, dropped: List[ReviewIssue])
 private case class LintRound(gate: Lint, summariser: Lint.Summariser)
 
 /** One evaluation round's outcome: the issues that cleared the gate this round,
-  * and the state to carry into the next round (which carries the gate rejects).
+  * keyed as the fixer will see them, and the state to carry into the next round
+  * (which carries the gate rejects).
   */
 private case class RoundOutcome(
-    issues: List[ReviewIssue],
+    issues: List[KeyedIssue],
     state: ReviewLoopState
 )
 
@@ -490,14 +498,15 @@ private[review] class ReviewFixLoop[B <: BackendTag](
   // are tagged with.
   private val lintName: String = "lint"
 
-  /** Split one agent's findings on the confidence gate. Rejects are kept, not
-    * discarded: [[ReviewLoopState]]'s [[GateLedger]] holds them until either
-    * the loop sees the finding fixed or an exit reports them in its
-    * [[IgnoredIssues]].
+  /** Split one agent's findings on the confidence gate, keying what it keeps by
+    * the agent's index in the round ([[KeyedIssue.forAgent]]). Rejects are
+    * kept, not discarded: [[ReviewLoopState]]'s [[GateLedger]] holds them until
+    * either the loop sees the finding fixed or an exit reports them in its
+    * [[IgnoredIssues]]. They carry no key — nothing hands them to the fixer.
     */
-  private def applyGate(result: ReviewResult): GatedIssues =
+  private def applyGate(agentIndex: Int, result: ReviewResult): GatedIssues =
     val (kept, dropped) = result.issues.partition(confidenceGate.admits)
-    GatedIssues(ReviewResult(kept), dropped)
+    GatedIssues(KeyedIssue.forAgent(agentIndex, kept), dropped)
 
   /** Run one reviewer against an immutable sessions snapshot. Returns the
     * review result plus the [[SessionEntry]] the caller folds into the next
@@ -611,14 +620,16 @@ private[review] class ReviewFixLoop[B <: BackendTag](
     val current =
       if active.isEmpty then DiffSample("", Nil) else diffSource.sample()
 
-    val reviewerTasks: List[() => AgentOutcome] = active.map: e =>
-      val stored = currentState.sessions.get(e.id)
-      () =>
-        val (result, newSession) =
-          reviewWithSession(e, stored, current, declined)
-        AgentOutcome.Reviewer(
-          RoundContribution(e, applyGate(result), newSession)
-        )
+    // Each agent's key index is its position here — fixed before the fan-out.
+    val reviewerTasks: List[() => AgentOutcome] =
+      active.zipWithIndex.map: (e, agentIndex) =>
+        val stored = currentState.sessions.get(e.id)
+        () =>
+          val (result, newSession) =
+            reviewWithSession(e, stored, current, declined)
+          AgentOutcome.Reviewer(
+            RoundContribution(e, applyGate(agentIndex, result), newSession)
+          )
 
     // Resolved outside the fork below so the next state carries the
     // conversation even on a round that short-circuits before any turn; minting
@@ -639,7 +650,9 @@ private[review] class ReviewFixLoop[B <: BackendTag](
             lint(r.gate.commands, r.summariser, ReviewLoopPrompts.SummariseLint)
           AgentOutcome.Lint(
             LintContribution(
-              applyGate(report.result),
+              // Lint findings come last in the fix list, so it takes the index
+              // after the last reviewer.
+              applyGate(active.size, report.result),
               report.resumableSummariser
             )
           )
@@ -695,8 +708,8 @@ private[review] class ReviewFixLoop[B <: BackendTag](
     val contributions = active.flatMap(e => byId.get(e.id))
     val lint = outcomes.collectFirst { case AgentOutcome.Lint(c) => c }
     RoundOutcome(
-      issues = contributions.flatMap(_.gated.kept.issues) ++
-        lint.toList.flatMap(_.gated.kept.issues),
+      issues = contributions.flatMap(_.gated.kept) ++
+        lint.toList.flatMap(_.gated.kept),
       state = currentState.afterRound(contributions, lint)
     )
 
@@ -768,7 +781,7 @@ private[review] class ReviewFixLoop[B <: BackendTag](
   // Routed through the durable [[FlowSession]] door: a coder whose backend
   // conversation is fresh or lost gets the seed + progress preamble re-applied
   // and its learned wire id persisted.
-  private def fix(issues: List[ReviewIssue])(using
+  private def fix(issues: List[KeyedIssue])(using
       fc: FlowControl,
       ws: WorkspaceWrite
   ): FixOutcome =
@@ -873,10 +886,10 @@ private[review] class ReviewFixLoop[B <: BackendTag](
     ): IgnoredIssues =
       orca.display(s"Iteration ${iteration + 1}")
       val round = evaluate(state, selectRound, declined)
-      val issues = round.issues
-      val seenSeverities = indexSeverities(severities, issues)
+      val findings = round.issues.map(_.issue)
+      val seenSeverities = indexSeverities(severities, findings)
       stopPolicy(
-        issues,
+        findings,
         iteration = iteration,
         maxIterations = maxIterations
       ) match
@@ -890,7 +903,7 @@ private[review] class ReviewFixLoop[B <: BackendTag](
             seenSeverities
           )
         case LoopStep.NeedsFix =>
-          val outcome = FixOutcome.reconcile(issues, fix(issues))
+          val outcome = FixOutcome.reconcile(round.issues, fix(round.issues))
           // `ctx` explicit for the same given-priority reason as `selectRound`.
           announceFixTurn(outcome)(using ctx)
           if outcome.fixed.isEmpty then

--- a/flow/src/test/scala/orca/review/FixLoopTest.scala
+++ b/flow/src/test/scala/orca/review/FixLoopTest.scala
@@ -174,7 +174,7 @@ class FixLoopTest extends munit.FunSuite:
         if evaluates == 1 then ReviewResult(List(issue("x")))
         else ReviewResult.empty
       ,
-      fix = _ => FixOutcome(List(Title("I1 sorted out the x problem")), Nil)
+      fix = _ => FixOutcome(List(Title("I1.1 sorted out the x problem")), Nil)
     )
     assertEquals(evaluates, 2, "a resolved fix must let the loop re-evaluate")
     assertEquals(result, IgnoredIssues(Nil))
@@ -236,8 +236,8 @@ class FixLoopTest extends munit.FunSuite:
       location = Some(Location("src/main/Foo.scala", Some(42))),
       suggestion = Some("stream batches instead of buffering")
     )
-    val rendered = formatIssue(real)
-    assert(rendered.contains("[Warning]"), s"missing severity: $rendered")
+    val rendered = formatIssue("I1.1", real)
+    assert(rendered.startsWith("- I1.1 [Warning]"), s"missing key: $rendered")
     assert(rendered.contains("Unbounded growth"), s"missing title: $rendered")
     assert(
       rendered.contains("at src/main/Foo.scala:42"),
@@ -251,18 +251,29 @@ class FixLoopTest extends munit.FunSuite:
   test("formatReviewerOutcome notes gate rejects on a clean review"):
     // A reviewer whose findings were all gated out must not read as quiet.
     assertEquals(
-      formatReviewerOutcome("loud", ReviewResult.empty, 3),
+      formatReviewerOutcome("loud", Nil, 3),
       "loud: 0 issues (3 below the confidence gate)"
     )
 
   test("formatReviewerOutcome notes gate rejects in the heading above bullets"):
     val rendered =
-      formatReviewerOutcome("loud", ReviewResult(List(issue("x"))), 1)
+      formatReviewerOutcome("loud", KeyedIssue.forAgent(0, List(issue("x"))), 1)
     assertEquals(
       rendered.linesIterator.next(),
       "loud: 1 issue (1 below the confidence gate)"
     )
-    assert(rendered.contains("- [Warning] x"), rendered)
+    assert(rendered.contains("- I1.1 [Warning] x"), rendered)
+
+  test("formatReviewerOutcome bullets carry the agent's own key index"):
+    // Keys name the agent that reported the finding, so the second agent's
+    // findings are I2.n — that is what the fixer echoes back.
+    val rendered = formatReviewerOutcome(
+      "second",
+      KeyedIssue.forAgent(1, List(issue("x"), issue("y"))),
+      0
+    )
+    assert(rendered.contains("- I2.1 [Warning] x"), rendered)
+    assert(rendered.contains("- I2.2 [Warning] y"), rendered)
 
   test("formatIssue renders a file-only location with no trailing line"):
     // A line without a file is unrepresentable (Location pairs them); this
@@ -275,7 +286,7 @@ class FixLoopTest extends munit.FunSuite:
       location = Some(Location("src/main/Foo.scala", None)),
       suggestion = None
     )
-    val rendered = formatIssue(fileOnly)
+    val rendered = formatIssue("I1.1", fileOnly)
     assert(
       rendered.contains("at src/main/Foo.scala") &&
         !rendered.contains("src/main/Foo.scala:"),

--- a/flow/src/test/scala/orca/review/FixOutcomeReconcileTest.scala
+++ b/flow/src/test/scala/orca/review/FixOutcomeReconcileTest.scala
@@ -8,27 +8,27 @@ import orca.plan.Title
   */
 class FixOutcomeReconcileTest extends munit.FunSuite:
 
-  private def handed(titles: String*): List[ReviewIssue] =
-    titles.toList.map(t => issue(t))
+  private def handed(titles: String*): List[KeyedIssue] =
+    KeyedIssue.forAgent(0, titles.toList.map(t => issue(t)))
 
   test("a key claims only its own issue, never one whose key it prefixes"):
-    // `I1` prefixes `I10`; the echo names the tenth issue, so the first must
-    // stay unaccounted.
+    // `I1.1` prefixes `I1.10`; the echo names the tenth issue, so the first
+    // must stay unaccounted.
     val issues = handed((1 to 10).map(n => s"finding $n")*)
     val reconciled = FixOutcome.reconcile(
       issues,
-      FixOutcome(List(Title("I10 finding 10")), Nil)
+      FixOutcome(List(Title("I1.10 finding 10")), Nil)
     )
     assertEquals(reconciled.fixed, List(Title("finding 10")))
 
   test("a key followed by a letter does not claim that issue"):
-    // "I2C bus timing" opens with `I2` but names something else entirely.
+    // The boundary check covers a following letter, not just a digit.
     val reconciled = FixOutcome.reconcile(
       handed("first", "second"),
-      FixOutcome(Nil, List(IgnoredIssue(Title("I2C bus timing"), "no")))
+      FixOutcome(Nil, List(IgnoredIssue(Title("I1.2C bus timing"), "no")))
     )
     assertEquals(reconciled.ignored, Nil)
-    assertEquals(reconciled.unresolvedEchoes, List("I2C bus timing"))
+    assertEquals(reconciled.unresolvedEchoes, List("I1.2C bus timing"))
 
   test("a title differing only in case and spacing still resolves"):
     val reconciled = FixOutcome.reconcile(
@@ -46,7 +46,7 @@ class FixOutcomeReconcileTest extends munit.FunSuite:
   test("an issue the fixer claimed twice is one fixed entry"):
     val reconciled = FixOutcome.reconcile(
       handed("real bug"),
-      FixOutcome(List(Title("I1 real bug"), Title("real bug")), Nil)
+      FixOutcome(List(Title("I1.1 real bug"), Title("real bug")), Nil)
     )
     assertEquals(reconciled.fixed, List(Title("real bug")))
 

--- a/flow/src/test/scala/orca/review/ReviewAndFixTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewAndFixTest.scala
@@ -191,6 +191,36 @@ class ReviewAndFixTest extends munit.FunSuite:
     )
     assertEquals(result.issues.map(_.title), List(Title("flaky")))
 
+  test("a finding is shown under the key the fixer is handed for it"):
+    // The fixer narrates its work by key ("Fix I2.1"), so a key on screen that
+    // named a different finding in the prompt would misattribute every fix.
+    val steps = new ReviewLoopFixture.StepCapture
+    given FlowControl = ReviewLoopFixture.control(steps.dispatcher)
+    val first = new FakeAgent(
+      name = "first",
+      outputs = List(ReviewResult(List(issue("a"), issue("b"))))
+    )
+    val second = new FakeAgent(
+      name = "second",
+      outputs = List(ReviewResult(List(issue("c"))))
+    )
+    val coder = new FakeAgent("coder", outputs = List(FixOutcome(Nil, Nil)))
+    val _ = reviewAndFixLoop(
+      coderSession = ReviewLoopFixture.coderSession(coder),
+      reviewers = List(first, second),
+      task = titled("build the widget"),
+      reviewerSelection = ReviewerSelector.allEveryRound,
+      diff = ReviewDiff.Pinned("")
+    )
+    assert(
+      steps.messages.exists(_.contains("- I2.1 [Warning] c")),
+      steps.messages.mkString("\n")
+    )
+    assert(
+      coder.seenPrompts.head.contains("I2.1 [Warning] c"),
+      coder.seenPrompts.mkString("\n")
+    )
+
   test("the clean exit names what the gate held back, and why"):
     // Termination honesty: a round whose only findings were gated out must not
     // report a bare "No review comments", and must say which finding it means.

--- a/flow/src/test/scala/orca/review/ReviewTypesTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewTypesTest.scala
@@ -56,14 +56,17 @@ class ReviewTypesTest extends munit.FunSuite:
     // so a quoted margin block reaches the prompt as a `|` line.
     val request = FixRequest(
       "fix these",
-      List(
-        ReviewIssue(
-          severity = Severity.Warning,
-          confidence = Confidence.orThrow(0.9),
-          title = Title("Mangled quote"),
-          description = "the quote is mangled",
-          location = None,
-          suggestion = Some("use:\n  |a| b|")
+      KeyedIssue.forAgent(
+        0,
+        List(
+          ReviewIssue(
+            severity = Severity.Warning,
+            confidence = Confidence.orThrow(0.9),
+            title = Title("Mangled quote"),
+            description = "the quote is mangled",
+            location = None,
+            suggestion = Some("use:\n  |a| b|")
+          )
         )
       )
     )

--- a/runner/src/main/scala/orca/runner/terminal/CommandHeadline.scala
+++ b/runner/src/main/scala/orca/runner/terminal/CommandHeadline.scala
@@ -20,10 +20,13 @@ private[terminal] object CommandHeadline:
   private val MinBoundaryDivisor: Int = 2
 
   def render(command: String, maxLength: Int): String =
-    val matcher = ShellWrapper.matcher(command)
+    // Collapsed first: a `git commit -m "subject\n\nbody"` arrives carrying real
+    // newlines, and both the wrapper match and the width budget assume one line.
+    val single = Text.collapseWhitespace(command)
+    val matcher = ShellWrapper.matcher(single)
     val unwrapped =
-      if matcher.lookingAt() then unquote(command.substring(matcher.end()))
-      else command
+      if matcher.lookingAt() then unquote(single.substring(matcher.end()))
+      else single
     truncateAtBoundary(unwrapped, maxLength)
 
   /** Drop the quotes the wrapper needed to pass the command as one argument.

--- a/runner/src/main/scala/orca/runner/terminal/TerminalEventListener.scala
+++ b/runner/src/main/scala/orca/runner/terminal/TerminalEventListener.scala
@@ -106,7 +106,9 @@ private[runner] class TerminalEventListener(
     * single emitter, nothing is prefixed — a stage running one agent looks
     * exactly as it did. From the moment a second agent emits, every line is
     * named, the first agent's included: with the review fan-out interleaving
-    * them, an unnamed line can no longer be attributed by position.
+    * them, an unnamed line can no longer be attributed by position. The first
+    * agent's earlier lines stay bare — the log is append-only, so nothing
+    * already printed can be prefixed after the fact.
     *
     * An event carrying no agent name never counts as an emitter.
     */

--- a/runner/src/main/scala/orca/runner/terminal/Text.scala
+++ b/runner/src/main/scala/orca/runner/terminal/Text.scala
@@ -5,6 +5,12 @@ package orca.runner.terminal
   */
 private[terminal] object Text:
 
+  /** Pre-compiled — `String.replaceAll` recompiles on every call, and this
+    * fires once per rendered event (many per turn on a busy session).
+    */
+  private val WhitespaceRun: java.util.regex.Pattern =
+    java.util.regex.Pattern.compile("\\s+")
+
   /** Cut `s` to at most `max` characters; if it overflowed, replace the last
     * visible character with an ellipsis. The returned string is therefore at
     * most `max` characters long.
@@ -13,14 +19,16 @@ private[terminal] object Text:
     if s.length <= max then s
     else s"${s.take(max - 1)}…"
 
-  /** Collapse all runs of whitespace to a single space and trim, then truncate.
-    * Use for places where the source string may include embedded newlines or
-    * tabs (tool-result content, status labels) that would otherwise break the
-    * single-line discipline.
+  /** Collapse all runs of whitespace to a single space and trim. Use before
+    * spending a width budget: an embedded newline or tab costs a character the
+    * reader never sees, and breaks the single-line discipline.
     */
+  def collapseWhitespace(s: String): String =
+    WhitespaceRun.matcher(s).replaceAll(" ").trim
+
+  /** [[collapseWhitespace]], then truncate to `max`. */
   def oneLine(s: String, max: Int): String =
-    val collapsed = s.replaceAll("\\s+", " ").trim
-    truncate(collapsed, max)
+    truncate(collapseWhitespace(s), max)
 
   /** Prefix `text` with `indent`, re-indenting every embedded newline so a
     * multi-line block stays aligned under the leading glyph/indent.

--- a/runner/src/main/scala/orca/runner/terminal/ToolInputSummary.scala
+++ b/runner/src/main/scala/orca/runner/terminal/ToolInputSummary.scala
@@ -16,24 +16,30 @@ private[terminal] object ToolInputSummary:
 
   /** How a matched field's value renders: `Path` is a single path, relativised
     * against `workDir`; `Command` is a shell command line, rendered through
-    * [[CommandHeadline]]; `Plain` is free-form text that may interleave paths
-    * with other text, so it is only truncated.
+    * [[CommandHeadline]]; `Search` is a pattern or query, suffixed with the
+    * subtree it was scoped to; `Plain` is free-form text that may interleave
+    * paths with other text, so it is only truncated.
     */
   private enum HeadlineKind:
-    case Path, Command, Plain
+    case Path, Command, Search, Plain
 
   /** Field names tried against the input's top-level JSON object, in order —
     * the first match wins — each with how its value renders. More specific
-    * names come first (`file_path` beats `path`, both beat `pattern`/`query`);
-    * the tail holds the generic ones, `name` ahead of `description`.
+    * names come first (`file_path` beats `pattern`/`query`, all three beat
+    * `path`); the tail holds the generic ones, `name` ahead of `description`.
+    *
+    * A search tool carries `pattern` (or `query`) alongside `path`, and the
+    * pattern is what identifies the call: `path` is usually the working
+    * directory itself, which relativises to `.`. The path still shows, as the
+    * `Search` suffix, when it narrows the search.
     */
   private val HeadlineFields: List[(String, HeadlineKind)] =
     List(
       "file_path" -> HeadlineKind.Path,
+      "pattern" -> HeadlineKind.Search,
+      "query" -> HeadlineKind.Search,
       "path" -> HeadlineKind.Path,
       "command" -> HeadlineKind.Command,
-      "pattern" -> HeadlineKind.Plain,
-      "query" -> HeadlineKind.Plain,
       "url" -> HeadlineKind.Plain,
       "rev" -> HeadlineKind.Plain,
       "skill" -> HeadlineKind.Plain,
@@ -49,28 +55,65 @@ private[terminal] object ToolInputSummary:
       maxLength: Int,
       workDir: Option[os.Path] = None
   ): String =
-    val collapsed = collapseWhitespace(rawJson)
+    val collapsed = Text.collapseWhitespace(rawJson)
     if collapsed.isEmpty || collapsed == "{}" then ""
     else
       HeadlineFields.iterator
         .flatMap((field, kind) =>
-          extractStringField(collapsed, field).map(kind -> _)
+          extractStringField(collapsed, field)
+            // A value that collapses to nothing would head the line with an
+            // empty string, or with a bare ` in <dir>` suffix.
+            .filter(v => Text.collapseWhitespace(v).nonEmpty)
+            .map(kind -> _)
         )
         .nextOption() match
         case Some((kind, value)) =>
-          s"(${headline(kind, value, maxLength, workDir)})"
+          val text = headline(
+            kind,
+            value = value,
+            json = collapsed,
+            maxLength = maxLength,
+            workDir = workDir
+          )
+          s"($text)"
         case None => fallback(collapsed, maxLength)
 
+  /** `json` is the whole (collapsed) input, which a [[HeadlineKind.Search]]
+    * needs for its second field.
+    *
+    * Each branch collapses whitespace again — `Command` inside
+    * [[CommandHeadline]] — because the raw JSON's was collapsed before
+    * extraction, but [[unescape]] then turned each `\n` in the value into a
+    * real newline: a `git commit -m` body would otherwise spread the headline
+    * over three lines and spend the width budget on characters nobody sees.
+    */
   private def headline(
       kind: HeadlineKind,
       value: String,
+      json: String,
       maxLength: Int,
       workDir: Option[os.Path]
   ): String = kind match
     case HeadlineKind.Path =>
-      Text.truncate(relativise(value, workDir), maxLength)
+      Text.oneLine(relativise(value, workDir), maxLength)
     case HeadlineKind.Command => CommandHeadline.render(value, maxLength)
-    case HeadlineKind.Plain   => Text.truncate(value, maxLength)
+    case HeadlineKind.Search =>
+      Text.oneLine(scopedPattern(value, json, workDir), maxLength)
+    case HeadlineKind.Plain => Text.oneLine(value, maxLength)
+
+  /** `pattern in dir` when the call narrowed the search, the bare pattern
+    * otherwise: a search scoped to the working directory relativises to `.`,
+    * which says nothing about the call.
+    */
+  private def scopedPattern(
+      pattern: String,
+      json: String,
+      workDir: Option[os.Path]
+  ): String =
+    extractStringField(json, "path")
+      .map(relativise(_, workDir))
+      .filter(p => p.nonEmpty && p != ".")
+      .fold(pattern)(p => s"$pattern in $p")
 
   /** No headline field matched. Show WHICH fields the call carried rather than
     * their values: the values are the reason no field matched (long edit
@@ -95,15 +138,6 @@ private[terminal] object ToolInputSummary:
         else if value.startsWith(s"$abs/") then Some(value.drop(abs.length + 1))
         else None
       .getOrElse(value)
-
-  /** Pre-compiled — `String.replaceAll` recompiles on every call, and this
-    * fires once per tool-use event (many per turn on a busy session).
-    */
-  private val WhitespaceRun: java.util.regex.Pattern =
-    java.util.regex.Pattern.compile("\\s+")
-
-  private def collapseWhitespace(raw: String): String =
-    WhitespaceRun.matcher(raw).replaceAll(" ").trim
 
   /** Matches a `"field": "value"` entry — JSON allows whitespace around the
     * colon, and an agent that pretty-prints its tool input would otherwise fall

--- a/runner/src/test/scala/orca/runner/terminal/ToolInputSummaryTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/ToolInputSummaryTest.scala
@@ -38,6 +38,42 @@ class ToolInputSummaryTest extends munit.FunSuite:
     val raw = """{"query":"file_path","file_path":"real.py"}"""
     assertEquals(ToolInputSummary.summarise(raw, maxLen), "(real.py)")
 
+  test("summarise keeps a command with an embedded newline on one line"):
+    // `\n` survives the raw JSON's whitespace collapse as two characters and
+    // only becomes a newline when the value is unescaped.
+    val raw =
+      """{"command":"git commit -m \"feat: add variance\n\nImplements it.\""}"""
+    val out = ToolInputSummary.summarise(raw, maxLen)
+    assertEquals(out, """(git commit -m "feat: add variance Implements it.")""")
+
+  test("summarise spends the width budget on visible characters only"):
+    // Newlines in the body would cost budget without showing the reader
+    // anything.
+    val body = List.fill(60)("line").mkString("\n")
+    val raw = s"""{"description":"${body.replace("\n", "\\n")}"}"""
+    val out = ToolInputSummary.summarise(raw, maxLen)
+    // 24 words ("line " × 24, less the trailing space) fill the 120-char
+    // budget, and the cut character becomes the ellipsis.
+    assertEquals(out, s"(${List.fill(24)("line").mkString(" ")}…)")
+
+  test("summarise heads a search with its pattern, scoped to a subtree"):
+    val workDir = os.Path("/tmp/orca-AbC")
+    val raw =
+      s"""{"pattern":"variance","path":"${workDir.toString}/stats"}"""
+    val out = ToolInputSummary.summarise(raw, maxLen, Some(workDir))
+    assertEquals(out, "(variance in stats)")
+
+  test("summarise drops a search path that is the working directory"):
+    // `relativise` turns it into `.`, which says nothing about the call.
+    val workDir = os.Path("/tmp/orca-AbC")
+    val raw = s"""{"pattern":"variance","path":"${workDir.toString}"}"""
+    val out = ToolInputSummary.summarise(raw, maxLen, Some(workDir))
+    assertEquals(out, "(variance)")
+
+  test("summarise still heads a path-only tool with its path"):
+    val raw = """{"path":"src/Main.scala"}"""
+    assertEquals(ToolInputSummary.summarise(raw, maxLen), "(src/Main.scala)")
+
   test("summarise picks the rev/skill/name headlines"):
     assertEquals(
       ToolInputSummary.summarise("""{"rev":"HEAD","stat":true}""", maxLen),
@@ -58,6 +94,10 @@ class ToolInputSummaryTest extends munit.FunSuite:
       ToolInputSummary.summarise(raw, maxLen),
       "{old_string, new_string}"
     )
+
+  test("summarise falls through a headline value that is only whitespace"):
+    val raw = """{"pattern":"\t"}"""
+    assertEquals(ToolInputSummary.summarise(raw, maxLen), "{pattern}")
 
   test("summarise lists only top-level field names, not nested ones"):
     val raw = """{"edits":[{"inner":"x"}],"dry_run":true}"""


### PR DESCRIPTION
Three output problems found in the final live run, plus one scaladoc fix.

## 1. Tool headlines could span three lines

A `git commit -m` with a message body printed like this:

```
⏺ Bash (git add stats.py test_stats.py && git commit -m "feat: add variance function to stats module

  Implements population…)
```

The summariser collapsed the whitespace of the raw JSON *before* unescaping it,
so every `\n` inside a value turned into a real newline afterwards. The 120-char
budget was also spent on those invisible characters.

Now:

```
⏺ Bash (git add stats.py test_stats.py && git commit -m "feat: add variance function to stats…)
```

The collapse moved after unescaping (`Text.collapseWhitespace`, shared with
`Text.oneLine` and `CommandHeadline`), so all headline paths are one line and
the budget only pays for characters the reader sees.

## 2. The fixer named issue keys nothing else printed

The fix prompt gives every issue a key, and the fixer narrates with it:

```
⏺ main: Now I'll fix all the issues: **Fix I1/I2** - Add test for empty list edge case:
```

But the findings list printed no keys, so `I1` meant nothing:

```
▶ test: 3 issues
  - [Warning] Missing edge case: empty list
```

Now the key is on screen, and it is the same key the fixer is handed:

```
▶ test: 3 issues
  - I2.1 [Warning] Missing edge case: empty list
```

Keys are `I<agent>.<n>`: the second agent's first finding is `I2.1`. They are
numbered per agent rather than across the round because each agent's findings
are printed the moment that agent finishes, and the other agents may still be
running — a round-wide number does not exist yet at that point.

Keys appear only in this per-round list. The closing "Unresolved findings" block
and the declined list sent to reviewers span rounds, and a key only names a
finding inside the round that minted it.

## 3. `Grep (.)` said nothing

A search scoped to the working directory relativised to `.`, and the path won
over the pattern:

```
⏺ test: Grep (.)
```

Now the pattern heads the line, and the path is added only when it narrows the
search:

```
⏺ test: Grep (variance)
⏺ test: Grep (variance in stats)
```

Path-headed tools (`Read`, `Edit`, …) are unchanged.

## 4. Attribution scaladoc

`TerminalEventListener.attribution` claimed that once a second agent emits,
"every line is named, the first agent's included". Output is append-only, so
lines already printed keep their bare form. The doc now says that.
