### PR TITLE
Ask git which paths a commit changed, instead of reading it off the render

### DIFF
--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -50,8 +50,8 @@ object GitReadFailed:
 
   /** The read has no usable answer. `detail` is git's own message when git
     * refused (an unknown revision, a path missing from the commit), and orca's
-    * when git succeeded but the result is unusable — [[GitTool.show]] rendering
-    * nothing for the requested paths, [[GitTool.fileAt]] past its size limit.
+    * when git succeeded but the result is unusable — [[GitTool.show]] finding
+    * no change for the requested paths, [[GitTool.fileAt]] past its size limit.
     */
   final class Refused(detail: String) extends GitReadFailed(detail)
 
@@ -400,8 +400,8 @@ trait GitTool:
 
   /** `git show [--stat] <rev> [-- <paths>]` — a commit's message plus its diff,
     * or, under [[ShowDetail.StatOnly]], just its changed-file summary. `paths`
-    * narrows the diff; empty means the whole commit. When the commit renders no
-    * diff for `paths`, the result is a `Refused` rather than an empty success.
+    * narrows the diff; empty means the whole commit. When the commit changes
+    * none of `paths`, the result is a `Refused`.
     *
     * Built for agent-supplied arguments, so `rev` and `paths` are validated
     * before they reach git ([[GitRead.rev]], [[GitRead.path]]) and cannot be
@@ -870,20 +870,10 @@ private[orca] class OsGitTool(
   ): Either[GitReadFailed, String] = either:
     val checkedRev = GitRead.rev(rev).ok()
     val checkedPaths = paths.map(GitRead.path(_).ok())
-    val statFlag = detail match
-      case ShowDetail.StatOnly => Seq("--stat")
-      case ShowDetail.Full     => Nil
     val pathspec =
       if checkedPaths.isEmpty then Nil else "--" +: checkedPaths
-    // `--end-of-options` after the flags, so git cannot read `checkedRev` as
-    // one however it is spelled.
-    val output = gitRead(
-      Seq("show") ++ statFlag ++ Seq("--end-of-options", checkedRev) ++ pathspec
-    ).ok()
-    // git exits 0 printing nothing at all — not even the commit message — when
-    // it renders no diff for the pathspec. That blank cannot be told apart
-    // from a mistyped path, so there is no answer to hand back.
-    if checkedPaths.nonEmpty && output.out.isBlank then
+    // A diff-less render cannot be told apart from a mistyped path.
+    if checkedPaths.nonEmpty && !changesAnyPath(checkedRev, pathspec).ok() then
       Left(
         new GitReadFailed.Refused(
           s"$rev shows no diff for: ${paths.mkString(", ")} — they may be " +
@@ -893,7 +883,36 @@ private[orca] class OsGitTool(
             "commit, or read a file's contents at that revision."
         )
       ).ok()
-    else marked(output)
+    else
+      val statFlag = detail match
+        case ShowDetail.StatOnly => Seq("--stat")
+        case ShowDetail.Full     => Nil
+      // `--end-of-options` after the flags, so git cannot read `checkedRev` as
+      // one however it is spelled.
+      marked(
+        gitRead(
+          Seq("show") ++ statFlag ++
+            Seq("--end-of-options", checkedRev) ++ pathspec
+        ).ok()
+      )
+
+  /** Whether `checkedRev` changes any of `pathspec`. Asked of git rather than
+    * read off the render: since git 2.55 a `git show <rev> -- <paths>` that
+    * renders no diff still prints the commit header and message, so its output
+    * is not an emptiness signal.
+    *
+    * Same `show` invocation as the render, so pathspec, root-commit and merge
+    * semantics match it exactly; `--format=` leaves the changed-path list as
+    * the only output, and git writes not one byte of it when nothing changed.
+    */
+  private def changesAnyPath(
+      checkedRev: String,
+      pathspec: Seq[String]
+  ): Either[GitReadFailed, Boolean] =
+    gitRead(
+      Seq("show", "--name-only", "--format=", "--end-of-options", checkedRev)
+        ++ pathspec
+    ).map(_.out.nonEmpty)
 
   def fileAt(rev: String, path: String): Either[GitReadFailed, String] = either:
     val checkedRev = GitRead.rev(rev).ok()

--- a/tools/src/test/scala/orca/tools/OsGitToolTest.scala
+++ b/tools/src/test/scala/orca/tools/OsGitToolTest.scala
@@ -777,6 +777,20 @@ class OsGitToolTest extends munit.FunSuite:
       val failure = git.show("HEAD", paths = List("a.txt")).left.toOption.get
       assert(failure.isInstanceOf[GitReadFailed.Refused], failure)
 
+  test("show refuses on a merge, which renders no per-path diff by default"):
+    withRepo: (git, dir) =>
+      os.write(dir / "a.txt", "one")
+      git.commit("add a").orThrow
+      git.createBranch("side").orThrow
+      os.write(dir / "b.txt", "two")
+      git.commit("add b").orThrow
+      git.checkout("main").orThrow
+      val _ = os
+        .proc("git", "merge", "--no-ff", "-m", "merge side", "side")
+        .call(cwd = dir)
+      val failure = git.show("HEAD", paths = List("b.txt")).left.toOption.get
+      assert(failure.isInstanceOf[GitReadFailed.Refused], failure)
+
   test("fileAt returns a file's contents as of a commit"):
     withRepo: (git, dir) =>
       os.write(dir / "a.txt", "before")


### PR DESCRIPTION
CI's runner moved to git 2.55, and two `OsGitToolTest` cases started failing there.

## What git changed

`git show <rev> -- <paths>` where the commit changes none of those paths:

git 2.53 printed nothing at all, exit 0:

```
$ git show --end-of-options HEAD -- nosuch
$
```

git 2.55 prints the commit header and message, exit 0 — only the diff is missing:

```
$ git show --end-of-options HEAD -- nosuch
commit cec9270a9659cd76019aa5b108becee89a81d4a7
Author: t <t@t>
Date:   Mon Aug 24 10:27:10 2026 +0000

    add b
```

Same for a path that is present at the rev but untouched by the commit, and for a merge commit (git renders no per-path diff for a merge by default). No notice line, no new exit code — just output where there was none.

The cause is in git's `revision.c`: `get_revision_1` was rewritten around an explicit walk-mode switch, and in the `--no-walk` mode that `git show` uses, `process_parents` (and with it `try_to_simplify_commit`) no longer runs. The commit is no longer marked TREESAME against the pathspec, so it gets shown.

## What this means for orca

`OsGitTool.show` refuses when a commit renders no diff for the requested paths — that blank cannot be told apart from a mistyped path, so there is no answer to hand back. It detected the case with `output.out.isBlank`, which was only ever true because of what git 2.53 printed. On 2.55 the check never fires and `show` returns a header with no diff.

## The fix

Ask git the question directly, before rendering:

```
git show --name-only --format= --end-of-options <rev> -- <paths>
```

`--format=` drops the commit header, leaving the changed-path list as the only output — and git writes zero bytes of it when nothing changed. Verified byte-for-byte identical on 2.53 and 2.55 for every case: the three refusal cases print nothing, while binary changes, empty-file adds, mode-only changes, renames, root commits and directory pathspecs all print their paths.

It is the same `show` command as the render, so the pathspec, root-commit and merge semantics are the same by construction rather than by a second implementation that could drift.

The refusal message and the wire shape are unchanged.

## Testing

Built git 2.55.0 locally and ran `tools/test` against both binaries.

- git 2.53 + old code: green (the bug is invisible here)
- git 2.55 + old code: the two CI failures reproduce, `NoSuchElementException: None.get`
- git 2.55 + new code: 408/408 green
- git 2.53 + new code: 408/408 green, full `sbt test` green

Added a test for the merge case, which the refusal message names but nothing covered.
