### PR TITLE
Name the cost summary's role-less bucket (no role)

### DIFF
--- a/flow/src/main/scala/orca/events/CostTracker.scala
+++ b/flow/src/main/scala/orca/events/CostTracker.scala
@@ -109,7 +109,7 @@ class CostTracker(pricingAsOf: LocalDate) extends OrcaListener:
   def perModelCost: Map[Option[Model], Cost] = costsOf(state.get().byModel)
 
   /** Per-role usage breakdown ([[Agent.role]], e.g. `Some("reviewer")`). `None`
-    * collects calls from an agent with no role tag — the common case.
+    * collects calls from every agent with no role tag — the common case.
     */
   def perRole: Map[Option[String], Usage] =
     state.get().byRole.view.mapValues(_.usage).toMap
@@ -120,7 +120,7 @@ class CostTracker(pricingAsOf: LocalDate) extends OrcaListener:
   /** Two or three sections — by-agent, by-model and by-role — each sorted
     * alphabetically by its rendered label. The by-role section appears only
     * when some call carried a [[orca.agents.Agent.role]] tag, and then includes
-    * the `(untagged)` bucket too, so it still sums to the run's total. Each
+    * the `(no role)` bucket too, so it still sums to the run's total. Each
     * by-agent line is prefixed with that agent's role when it has one (e.g.
     * `reviewer: performance`). Cache reads, cache writes and reasoning tokens
     * are shown parenthetically when non-zero. Token counts are rendered
@@ -203,11 +203,11 @@ class CostTracker(pricingAsOf: LocalDate) extends OrcaListener:
   private def modelLabel(model: Option[Model]): String =
     model.map(_.name).getOrElse("(unknown)")
 
-  /** Render a role bucket key for the summary. `None` covers calls from an
-    * agent with no role tag — too varied to name for any one role.
+  /** Render a role bucket key for the summary. `None` covers calls from every
+    * agent with no role tag.
     */
   private def roleLabel(role: Option[String]): String =
-    role.getOrElse("(untagged)")
+    role.getOrElse("(no role)")
 
   /** Render a by-agent line's label: the bare agent name, prefixed with its
     * role (looked up in `agentRoles`) when it has one. The `"reviewer: "`

--- a/flow/src/test/scala/orca/CostTrackerTest.scala
+++ b/flow/src/test/scala/orca/CostTrackerTest.scala
@@ -565,7 +565,7 @@ class CostTrackerTest extends munit.FunSuite:
     assertEquals(tracker.totalCost.map(_.estimated), Some(false))
     assert(tracker.summary.contains("Total: $0.1000"), tracker.summary)
 
-  test("perRole subtotals usage by role, with None as the untagged bucket"):
+  test("perRole subtotals usage by role, with None as the role-less bucket"):
     val tracker = new CostTracker(pricingAsOf)
     tracker.onEvent(
       tokens(
@@ -623,7 +623,7 @@ class CostTrackerTest extends munit.FunSuite:
     assert(!tracker.summary.contains("By role:"), tracker.summary)
 
   test(
-    "summary's By role section shows untagged spend, so it sums to the total"
+    "summary's By role section shows role-less spend, so it sums to the total"
   ):
     val tracker = new CostTracker(pricingAsOf)
     tracker.onEvent(
@@ -638,12 +638,31 @@ class CostTrackerTest extends munit.FunSuite:
       tokens("claude", Some("opus"), usage(100L, 50L, Some(BigDecimal("0.40"))))
     )
     val out = tracker.summary
-    assert(out.contains("  (untagged): 100 in, 50 out ($0.4000)"), out)
+    assert(out.contains("  (no role): 100 in, 50 out ($0.4000)"), out)
     assert(out.contains("  reviewer: 10 in, 5 out ($0.6000)"), out)
     assert(out.contains("Total: $1.0000"), out)
 
   test(
-    "summary's By role section has no untagged line when every call carried a role"
+    "summary's (no role) bucket sums every role-less agent, not just the lead"
+  ):
+    val tracker = new CostTracker(pricingAsOf)
+    tracker.onEvent(tokens("main", Some("opus"), usage(100L, 50L, None)))
+    tracker.onEvent(tokens("helper", Some("opus"), usage(20L, 10L, None)))
+    tracker.onEvent(
+      tokens(
+        "performance",
+        Some("opus"),
+        usage(10L, 5L, None),
+        role = Some("reviewer")
+      )
+    )
+    assert(
+      tracker.summary.contains("  (no role): 120 in, 60 out"),
+      tracker.summary
+    )
+
+  test(
+    "summary's By role section has no role-less line when every call carried a role"
   ):
     val tracker = new CostTracker(pricingAsOf)
     tracker.onEvent(
@@ -654,7 +673,7 @@ class CostTrackerTest extends munit.FunSuite:
         role = Some("reviewer")
       )
     )
-    assert(!tracker.summary.contains("(untagged)"), tracker.summary)
+    assert(!tracker.summary.contains("(no role)"), tracker.summary)
 
   test("summary is empty when nothing has been recorded"):
     assertEquals(new CostTracker(pricingAsOf).summary, "")


### PR DESCRIPTION
Two findings from the final live-run audit. One is fixed here; the other turned
out to have no safe fix, and this explains why.

## Fixed: `(untagged)` in the cost summary is now `(no role)`

In the `By role:` section, the bucket holding calls from agents with no role tag
was labelled `(untagged)`. "Tag" is internal vocabulary, and the section is
already about roles, so `(no role)` says the same thing in words the reader
already has.

The original suggestion was `main (no role)`, since in both audit runs that
bucket was exactly the `main` agent's spend. That would not be true in general:

- pi's lead agent is named `pi`, not `main` (`DefaultPiAgent`), so a pi-led run
  has no `main` line at all.
- `withName` without `withRole` is public API, and `buildReviewers` does exactly
  that pair, so several differently-named agents can land in this bucket
  together.

So the label names the missing role instead of guessing an agent. A new test
pins that the bucket sums every role-less agent. Sort order is unchanged — both
labels start with `(`, which sorts ahead of any real role name.

## Not fixed: scala-cli's gray `Compiling project …` lines keep their colour

Orca's own output already goes plain when it isn't writing to a terminal, but
scala-cli's two compile lines keep their escape codes, and in a redirected log
they are the only colour left. There is no good way to fix this today.

**scala-cli cannot be told.** Probed against scala-cli 1.15.0: there is no
colour option on `run` or globally, no config key, and `NO_COLOR=1` and
`TERM=dumb` are both ignored — the binary contains no `NO_COLOR` string at all.
The lines go to stderr, and `--quiet` alone would hide them but also hides
build errors, which is why the launcher passes `--quiet --verbose`.

**Filtering the bytes would hang the shell.** The obvious fallback is to pipe
the flow child's stderr and strip it when colour is off. That puts a pipe
between the shell and the whole flow process tree, and a pipe reports EOF only
once every write end is closed. Agent CLIs inherit that stderr
(`OsProcCliRunner`), and orca knowingly cannot reach a process an agent
detached from its tree — that is why `EnvCookieSweep` only reports survivors.
One such survivor keeps the shell's drain waiting for EOF after the flow has
finished, and because the spawn runs inside `ChildTerminal.withChild`, SIGINT is
ignored, so Ctrl-C will not get the user out. I reproduced the stall (4.2s with
a `setsid` grandchild that writes late; indefinite if it never writes), and
`OsProcCliRunner.destroyForciblyTree` already documents the same mechanism.

Trading an uninterruptible hang for two gray lines in a log is a bad deal, so
this ships unfixed. The only fix I found that avoids the pipe is compiling the
flow ourselves first so `run` has nothing to print — verified to work, but it
costs an extra scala-cli invocation per run and either delays or duplicates
compile errors. Worth a separate discussion, not this PR.
