### PR TITLE
Print the enforcement shortfall as a run caveat, not a step

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,6 +849,7 @@ are indented.
 | `⎿` | Tool result, truncated to one line (interactive calls only) |
 | `✖` | Error |
 | `?` | Approval request, or a question for you (interactive calls only) |
+| `!` | Caveat about what Orca can enforce for this run (never indented under a stage) |
 
 </details>
 

--- a/adr/0008-terminal-output-design.md
+++ b/adr/0008-terminal-output-design.md
@@ -93,6 +93,7 @@ Used in the event log:
 | `⎿` | grey | The result of the preceding tool call, truncated to one line. |
 | `✖` | red | An error — either an `OrcaEvent.Error` from a stage that threw, or a non-fatal mid-session error. |
 | `?` | yellow | Approval request — the agent wants a tool that isn't auto-approved. |
+| `!` | yellow, bold | An `OrcaEvent.Caveat` — something true of the whole run, today a restriction a backend cannot apply mechanically. |
 
 Used in the status line:
 
@@ -109,6 +110,9 @@ Glyph choices are pragmatic:
   introducing a third arrow shape.
 - `⏺` / `⎿` for tool call / result echo the Claude Code aesthetic;
   changing them is fine but they should stay paired.
+- `!` is ASCII punctuation like `?`, marking a line that isn't progress.
+  It is also the one event-log line printed at zero indent whatever stage
+  is open, since the caveat's scope is the run.
 - The braille spinner's column-stable width (each frame is one
   glyph) is what makes single-line redraws clean.
 

--- a/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
+++ b/claude/src/test/scala/orca/tools/claude/DefaultAgentCallTest.scala
@@ -706,8 +706,8 @@ class DefaultAgentCallTest extends munit.FunSuite:
         interaction = drivingInteraction,
         agentName = "claude"
       ).interactive.run("anything")
-      val steps = seen.get().collect { case s: OrcaEvent.Step => s.message }
-      assert(steps.contains(expected), steps)
+      val caveats = seen.get().collect { case c: OrcaEvent.Caveat => c.message }
+      assert(caveats.contains(expected), caveats)
 
   test("interactive.runWithSession registers the (clientSid, serverSid) map"):
     // The framework must call `backend.sessions.register(session, result.wireId)`

--- a/runner/src/main/scala/orca/runner/LoggingListener.scala
+++ b/runner/src/main/scala/orca/runner/LoggingListener.scala
@@ -21,6 +21,7 @@ private[orca] class LoggingListener extends OrcaListener:
     case OrcaEvent.StageStarted(name)   => log.info("stage start: {}", name)
     case OrcaEvent.StageCompleted(name) => log.info("stage done:  {}", name)
     case OrcaEvent.Step(message)        => log.info("step: {}", message)
+    case OrcaEvent.Caveat(message)      => log.info("caveat: {}", message)
     case OrcaEvent.UserPrompt(text)     => log.debug("prompt sent:\n{}", text)
     case OrcaEvent.AssistantMessage(text, agent) =>
       log.debug("assistant ({}): {}", agent.getOrElse("?"), text)

--- a/runner/src/main/scala/orca/runner/terminal/TerminalEventListener.scala
+++ b/runner/src/main/scala/orca/runner/terminal/TerminalEventListener.scala
@@ -21,6 +21,8 @@ private[runner] class TerminalEventListener(
   import TerminalEventListener.{
     AssistantGlyph,
     AssistantGlyphStyle,
+    CaveatGlyph,
+    CaveatStyle,
     ErrorGlyph,
     MaxAssistantMessageLength,
     MaxStructuredResultRawLength,
@@ -64,6 +66,9 @@ private[runner] class TerminalEventListener(
       () // Token accounting is owned by CostTracker.
     case OrcaEvent.Step(message) =>
       output.log(formatStepLine(message))
+    case OrcaEvent.Caveat(message) =>
+      // No `formatIndented`, unlike every sibling arm: it is run-scoped.
+      output.log(paint(CaveatStyle, s"$CaveatGlyph ") + message)
     case OrcaEvent.StructuredResult(raw, summary) =>
       // Surfaces the result the conversation renderer suppressed in structured
       // mode. `summary` is tri-state (see the event's scaladoc): `Some(s)`
@@ -154,6 +159,11 @@ private[runner] object TerminalEventListener:
   val ErrorGlyph: String = "✖"
   val AssistantGlyph: String = "●"
 
+  /** Marker for a run-level caveat ([[OrcaEvent.Caveat]]). ASCII punctuation,
+    * like the approval prompt's `?`, marks a line that isn't flow progress.
+    */
+  val CaveatGlyph: String = "!"
+
   /** Marker for the human input sent to the agent. Matches the
     * [[ConversationRenderer]]'s `▸` user glyph.
     */
@@ -173,6 +183,9 @@ private[runner] object TerminalEventListener:
 
   /** Cyan-bold to mirror the [[ConversationRenderer]]'s user-message header. */
   val UserPromptStyle: fansi.Attrs = fansi.Color.Cyan ++ fansi.Bold.On
+
+  /** Yellow-bold: a caution, short of the red an [[OrcaEvent.Error]] gets. */
+  val CaveatStyle: fansi.Attrs = fansi.Color.Yellow ++ fansi.Bold.On
 
   /** Per-turn cap collapsing long agent prose to one line. Matches the live
     * renderer's tool-result-content cap.

--- a/runner/src/test/scala/orca/runner/terminal/TerminalEventListenerTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/TerminalEventListenerTest.scala
@@ -87,6 +87,36 @@ class TerminalEventListenerTest extends munit.FunSuite:
       s"Step events must never produce a closing ✔ line; got: $output"
     )
 
+  test("a Caveat renders un-indented with `!`, whatever stage is open"):
+    val output = renderEvents(
+      List(
+        OrcaEvent.StageStarted("plan"),
+        OrcaEvent.Caveat("Codex cannot stop a NetworkOnly turn"),
+        OrcaEvent.StageCompleted("plan")
+      )
+    )
+    val line = output
+      .split('\n')
+      .find(_.contains("NetworkOnly"))
+      .getOrElse(fail(s"missing caveat line; got: $output"))
+    assertEquals(
+      line,
+      s"${TerminalEventListener.CaveatGlyph} Codex cannot stop a NetworkOnly turn"
+    )
+
+  test("a Caveat's glyph is painted in the caveat style, its body left plain"):
+    val output = renderWith(
+      animated = false,
+      events = List(OrcaEvent.Caveat("no gate here")),
+      listenerUseColor = true
+    )
+    val glyph = TerminalEventListener
+      .CaveatStyle(s"${TerminalEventListener.CaveatGlyph} ")
+      .render
+    val line = output.split('\n').head
+    assert(line.startsWith(glyph), line)
+    assertEquals(line.stripPrefix(glyph), "no gate here")
+
   test("errors are prefixed with an error marker"):
     val output = renderEvents(List(OrcaEvent.Error("boom")))
     assert(output.contains(TerminalEventListener.ErrorGlyph))

--- a/tools/src/main/scala/orca/agents/EnforcementNotice.scala
+++ b/tools/src/main/scala/orca/agents/EnforcementNotice.scala
@@ -11,19 +11,22 @@ import org.slf4j.LoggerFactory
   * reporting into editing looks exactly like one in which editing was
   * impossible.
   *
-  * Two channels, because they have different readers: the `Step` a run shows
+  * Two channels, because they have different readers: the `Caveat` a run shows
   * says in plain words what the agent may still do, and the WARN behind it
   * carries the cell's rationale and level names for whoever is diagnosing.
   *
   * One instance per backend, held by [[AgentBackend]] and shared with any
   * sibling backend derived from it, so a twenty-reviewer fan-out says each
   * thing once.
+  *
+  * Said at the first turn that asks, not at run start: a flow picks a turn's
+  * `ToolSet` when it makes the call, so the run header cannot know the tiers.
   */
 private[orca] final class EnforcementNotice:
 
-  /** Rendered `Step` lines already said. Keyed on the sentence rather than the
-    * cell, so a different tier, dispatch or approval list repeats the notice
-    * exactly when it changes the wording.
+  /** Sentences already said. Keyed on the sentence rather than the cell, so a
+    * different tier, dispatch or approval list repeats the notice exactly when
+    * it changes the wording.
     */
   private val said =
     java.util.concurrent.ConcurrentHashMap.newKeySet[String]()
@@ -52,7 +55,7 @@ private[orca] final class EnforcementNotice:
       .summary(backend, config, cell, dispatch)
       .foreach: summary =>
         if said.add(summary) then
-          events.onEvent(OrcaEvent.Step(summary))
+          events.onEvent(OrcaEvent.Caveat(summary))
           EnforcementNotice.log.warn("{} — {}", summary, cell.rationale)
 
 private[orca] object EnforcementNotice:

--- a/tools/src/main/scala/orca/events/OrcaEvent.scala
+++ b/tools/src/main/scala/orca/events/OrcaEvent.scala
@@ -35,6 +35,15 @@ enum OrcaEvent:
     */
   case Step(message: String)
 
+  /** Something true of the whole run rather than of the stage it surfaced in —
+    * today, a restriction a backend cannot apply mechanically
+    * ([[orca.agents.EnforcementNotice]]). Distinct from [[Step]] because a
+    * caveat about what orca can guarantee must not read as progress: the
+    * terminal listener prints it un-indented with a `!`, so the stage it
+    * happened to fire under doesn't look like its scope.
+    */
+  case Caveat(message: String)
+
   /** Token usage for a single LLM call, attributed along three independent axes
     * that `CostTracker` summarises separately:
     *

--- a/tools/src/test/scala/orca/agents/BaseAgentTest.scala
+++ b/tools/src/test/scala/orca/agents/BaseAgentTest.scala
@@ -188,51 +188,66 @@ class BaseAgentTest extends munit.FunSuite:
   // that the gate isn't mechanical — and a fan-out would repeat the notice per
   // turn, which is why it is deduplicated rather than emitted per run call.
   test("a read-only tier the backend doesn't gate is reported once"):
-    val steps = new StepRecorder
+    val notices = new NoticeRecorder
     val tool = new StubTool(
       new UngatedBackend("first", "second"),
       toolConfig = AgentConfig(tools = ToolSet.ReadOnly),
-      listener = steps.listener,
+      listener = notices.listener,
       prompts = DefaultPrompts
     )
     val _ = tool.run("one")
     val _ = tool.run("two")
-    assertEquals(steps.seen, List(BaseAgentTest.noEditNotice("ReadOnly")))
+    assertEquals(notices.caveats, List(BaseAgentTest.noEditNotice("ReadOnly")))
+
+  test("the shortfall is not announced as progress"):
+    val notices = new NoticeRecorder
+    val tool = new StubTool(
+      new UngatedBackend("first"),
+      toolConfig = AgentConfig(tools = ToolSet.ReadOnly),
+      listener = notices.listener,
+      prompts = DefaultPrompts
+    )
+    val _ = tool.run("one")
+    assert(notices.caveats.nonEmpty)
+    assertEquals(notices.steps, Nil)
 
   // Reviewers — the turns this notice exists for — reach the backend through
   // `resultAs`, which dispatches on its own path rather than through the text
   // one, so it has to raise the notice itself.
   test("a read-only structured turn reports the shortfall too"):
-    val steps = new StepRecorder
+    val notices = new NoticeRecorder
     val tool = new StubTool(
       new UngatedBackend("""{"fixed":[],"ignored":[]}"""),
       toolConfig = AgentConfig(tools = ToolSet.NetworkOnly),
-      listener = steps.listener,
+      listener = notices.listener,
       prompts = DefaultPrompts
     )
     val _ = tool.resultAs[FixOutcome].autonomous.run("fix compile errors")
-    assertEquals(steps.seen, List(BaseAgentTest.noEditNotice("NetworkOnly")))
+    assertEquals(
+      notices.caveats,
+      List(BaseAgentTest.noEditNotice("NetworkOnly"))
+    )
 
   // The gate lives on `AgentBackend.runAutonomous` itself, so a turn entry
   // point that never goes through `BaseAgent` or `DefaultAgentCall` still
   // announces — a new door cannot forget it.
   test("a direct runAutonomous call announces the shortfall"):
-    val steps = new StepRecorder
+    val notices = new NoticeRecorder
     val _ = new UngatedBackend("reply").runAutonomous(
       "one",
       SessionId.fresh[BackendTag.Pi.type],
       AgentConfig(tools = ToolSet.ReadOnly),
-      steps.listener
+      notices.listener
     )
-    assertEquals(steps.seen, List(BaseAgentTest.noEditNotice("ReadOnly")))
+    assertEquals(notices.caveats, List(BaseAgentTest.noEditNotice("ReadOnly")))
 
   // The first attempt commits the session, so the corrective re-prompt runs as
   // a resumed turn — which on this backend (codex's shape) is where the gate
   // disappears. Classified once per call instead of once per attempt, the
   // retry's weaker guarantee would go unreported: the first attempt is `Hard`,
-  // so the single Step below is entirely the second attempt's, and says so.
+  // so the single Caveat below is entirely the second attempt's, and says so.
   test("a corrective retry reports the resumed turn's weaker guarantee"):
-    val steps = new StepRecorder
+    val notices = new NoticeRecorder
     val tool = new StubTool(
       new WeakerOnResumeBackend(
         "not json at all",
@@ -242,12 +257,12 @@ class BaseAgentTest extends munit.FunSuite:
         tools = ToolSet.ReadOnly,
         retrySchedule = Schedule.exponentialBackoff(1.milli).maxRetries(1)
       ),
-      listener = steps.listener,
+      listener = notices.listener,
       prompts = DefaultPrompts
     )
     val _ = tool.resultAs[FixOutcome].autonomous.run("fix compile errors")
     assertEquals(
-      steps.seen,
+      notices.caveats,
       List(BaseAgentTest.noEditNotice("resumed ReadOnly"))
     )
 
@@ -256,7 +271,7 @@ class BaseAgentTest extends munit.FunSuite:
   // `Only` list on the spawn and encodes nothing at all on the resume, and the
   // second sentence has to say which turn it is about.
   test("a retry whose approximation is dropped names the resumed turn"):
-    val steps = new StepRecorder
+    val notices = new NoticeRecorder
     val tool = new StubTool(
       new WeakerOnResumeBackend(
         "not json at all",
@@ -266,12 +281,12 @@ class BaseAgentTest extends munit.FunSuite:
         autoApprove = AutoApprove.Only(Set("read")),
         retrySchedule = Schedule.exponentialBackoff(1.milli).maxRetries(1)
       ),
-      listener = steps.listener,
+      listener = notices.listener,
       prompts = DefaultPrompts
     )
     val _ = tool.resultAs[FixOutcome].autonomous.run("fix compile errors")
     assertEquals(
-      steps.seen,
+      notices.caveats,
       List(
         "Pi cannot hold a Full turn to the tools it was asked to auto-approve" +
           " — the sandbox it runs in is wider than that",
@@ -284,16 +299,16 @@ class BaseAgentTest extends munit.FunSuite:
   // and a backend that encodes no such list runs the agent wider than asked
   // with nothing else saying so.
   test("a Full turn whose Only list isn't encoded is reported"):
-    val steps = new StepRecorder
+    val notices = new NoticeRecorder
     val tool = new StubTool(
       new UngatedBackend("only"),
       toolConfig = AgentConfig(autoApprove = AutoApprove.Only(Set("read"))),
-      listener = steps.listener,
+      listener = notices.listener,
       prompts = DefaultPrompts
     )
     val _ = tool.run("one")
     assertEquals(
-      steps.seen,
+      notices.caveats,
       List(
         "Pi cannot hold a Full turn to the tools it was asked to auto-approve" +
           " — only the turn's own prompt asks it not to"
@@ -304,31 +319,31 @@ class BaseAgentTest extends munit.FunSuite:
   // turn approving everything asked for none, so the same weak declaration must
   // stay silent.
   test("a Full turn approving everything reports no shortfall"):
-    val steps = new StepRecorder
+    val notices = new NoticeRecorder
     val tool = new StubTool(
       new UngatedBackend("only"),
-      listener = steps.listener,
+      listener = notices.listener,
       prompts = DefaultPrompts
     )
     val _ = tool.run("one")
-    assertEquals(steps.seen, Nil)
+    assertEquals(notices.caveats, Nil)
 
   // The log lives on the backend, so two backends of the same kind — a flow
   // that wires its own second one — each say their piece. Documented on
   // `AgentBackend`; pinned here because it is a consequence of where the state
   // sits rather than of anything the notice does.
   test("a second backend of the same kind gives its own notice"):
-    val steps = new StepRecorder
+    val notices = new NoticeRecorder
     def readOnlyTool = new StubTool(
       new UngatedBackend("reply"),
       toolConfig = AgentConfig(tools = ToolSet.ReadOnly),
-      listener = steps.listener,
+      listener = notices.listener,
       prompts = DefaultPrompts
     )
     val _ = readOnlyTool.run("one")
     val _ = readOnlyTool.run("two")
     assertEquals(
-      steps.seen,
+      notices.caveats,
       List.fill(2)(BaseAgentTest.noEditNotice("ReadOnly"))
     )
 
@@ -858,18 +873,21 @@ class BaseAgentTest extends munit.FunSuite:
     )(using ox.Ox): Conversation[BackendTag.Pi.type] =
       throw new UnsupportedOperationException
 
-  /** Collects the `Step` lines a run showed, in order — the notice's
-    * user-facing channel.
+  /** Records every event a run emitted, projected onto the [[caveats]] and
+    * [[steps]] messages in emission order.
     */
-  private class StepRecorder:
-    private val steps =
-      new java.util.concurrent.atomic.AtomicReference[List[String]](Nil)
+  private class NoticeRecorder:
+    private val events =
+      new java.util.concurrent.atomic.AtomicReference[List[OrcaEvent]](Nil)
     val listener: OrcaListener = event =>
-      event match
-        case OrcaEvent.Step(message) =>
-          val _ = steps.updateAndGet(message :: _)
-        case _ => ()
-    def seen: List[String] = steps.get().reverse
+      val _ = events.updateAndGet(event :: _)
+    private def seen: List[OrcaEvent] = events.get().reverse
+    def caveats: List[String] = seen.collect { case c: OrcaEvent.Caveat =>
+      c.message
+    }
+    def steps: List[String] = seen.collect { case s: OrcaEvent.Step =>
+      s.message
+    }
 
   /** Gates nothing mechanically, whichever way the turn dispatches — the
     * condition `EnforcementNotice` exists to report.

--- a/tools/src/test/scala/orca/testkit/StubEnforcementCell.scala
+++ b/tools/src/test/scala/orca/testkit/StubEnforcementCell.scala
@@ -13,10 +13,10 @@ import orca.backend.AgentBackend
 /** Mixed into an `AgentBackend` test double that isn't exercising enforcement.
   *
   * `Hard` rather than `Ignored`: the level decides whether `EnforcementNotice`
-  * speaks, so an unrelated double declaring a weak level would put a Step into
-  * every read-only turn of every suite. The doubles that DO declare something
-  * else override `enforcementCell` themselves, which is what makes them read as
-  * deliberate.
+  * speaks, so an unrelated double declaring a weak level would put a Caveat
+  * into every read-only turn of every suite. The doubles that DO declare
+  * something else override `enforcementCell` themselves, which is what makes
+  * them read as deliberate.
   *
   * Extends `AgentBackend` so `enforcementCell` is a real `override` — as a
   * standalone trait's plain method it would warn on its three unused


### PR DESCRIPTION
When a turn asks for a tool restriction its backend can't apply, orca says so.
That line used to go out as an `OrcaEvent.Step`, which the terminal renders with
the magenta `▶` progress glyph, indented under the open stage. So a fact about
the whole run looked like one more thing the Plan stage just did — and because
the notice is said once per backend, later stages never repeated it.

It now goes out as a new `OrcaEvent.Caveat`, printed un-indented with a yellow
`!`.

Before:

```
▶ Plan
  ▸ Add a variance(values) function to stats.py that returns the population…
  ▶ Codex cannot stop a NetworkOnly turn from editing files or running commands that change state — only the turn's own prompt asks it not to
  ⏺ bash (rtk ls -la && rtk sed -n '1,240p' stats.py …)
```

After:

```
▶ Plan
  ▸ Add a variance(values) function to stats.py that returns the population…
! Codex cannot stop a NetworkOnly turn from editing files or running commands that change state — only the turn's own prompt asks it not to
  ⏺ bash (rtk ls -la && rtk sed -n '1,240p' stats.py …)
```

## Why not print it at run start

The run header knows each role's agent and model, but not the tool tiers: a flow
picks a turn's `ToolSet` when it makes the call (`agent.withNetworkOnly`), and
user flow scripts can pick anything. Predicting at startup would mean naming
every tier, including ones the run never restricts to. So the notice still fires
at the first turn that asks — the earliest point at which it is true — and the
new event is what carries "this is about the run, not this stage" to the
renderer. Nothing dynamic can slip past it: any backend or tier a flow
introduces later announces the same way.

## Also

- Wire-level enforcement is unchanged. Presentation only; the enforcement table
  in AGENTS.md and `EnforcementTableTest` are untouched.
- The trace log mirrors the caveat at INFO. The WARN carrying the cell's
  rationale is still `EnforcementNotice`'s own.
- `!` is documented in the README glyph legend and ADR 0008's glyph table.

Tests: the new render (glyph, zero indent under an open stage, yellow-bold glyph
with a plain body), that the notice no longer travels on the `Step` channel, and
the existing dedup tests re-pointed at the caveat channel.
