### PR TITLE
Collapse read-only tool lines; fit lines to their budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -882,7 +882,7 @@ are indented.
 | `▶` | Stage start, or a `Step` (single-line note like a branch switch) |
 | `▸` | User's prompt at the start of an interactive session |
 | `●` | Assistant prose |
-| `⏺` | Tool call (path / command / query in grey). Read-only calls show as a bare `⏺ read`; the trace file has the filenames |
+| `⏺` | Tool call (path / command / query in grey). In an autonomous run a read-only call shows as a bare `⏺ read`, with no filename and no agent name, so a burst of them folds into one line; the trace file has both. Interactive calls always show the argument |
 | `⎿` | How many times the line above repeated (`⎿ ×12`), or a tool result truncated to one line (interactive calls only) |
 | `✖` | Error |
 | `?` | Approval request, or a question for you (interactive calls only) |

--- a/README.md
+++ b/README.md
@@ -882,8 +882,8 @@ are indented.
 | `▶` | Stage start, or a `Step` (single-line note like a branch switch) |
 | `▸` | User's prompt at the start of an interactive session |
 | `●` | Assistant prose |
-| `⏺` | Tool call (path / command / query in grey) |
-| `⎿` | Tool result, truncated to one line (interactive calls only) |
+| `⏺` | Tool call (path / command / query in grey). Read-only calls show as a bare `⏺ read`; the trace file has the filenames |
+| `⎿` | How many times the line above repeated (`⎿ ×12`), or a tool result truncated to one line (interactive calls only) |
 | `✖` | Error |
 | `?` | Approval request, or a question for you (interactive calls only) |
 | `!` | Caveat about what Orca can enforce for this run (never indented under a stage) |

--- a/adr/0008-terminal-output-design.md
+++ b/adr/0008-terminal-output-design.md
@@ -88,7 +88,7 @@ Used in the event log:
 | `▶` | magenta, bold | Stage start, or a `Step` (single-line note: branch switch, "discarded N issues"). No closing glyph for either. |
 | `▸` | cyan, bold | The user's prompt at the start of an interactive session. |
 | `●` | magenta, bold | An assistant prose message. In structured-output mode the JSON is suppressed during streaming and surfaced via `OrcaEvent.StructuredResult`; the listener renders the `Announce[O]` summary as `▶` if available, nothing for a deliberately-silent summary, and falls back to the raw payload under `●` only when no `Announce[O]` exists. |
-| `⏺` | yellow, bold | A tool call the agent is making. The headline argument follows in grey. A read-only call shows no argument (see the 2026-08-27 amendment). |
+| `⏺` | yellow, bold | A tool call the agent is making. The headline argument follows in grey. In the autonomous event log a read-only call shows neither argument nor agent name (see the 2026-08-27 amendment). |
 | `⎿` | grey | In an autonomous run: how many times the line above it repeated (`⎿ ×12`). On the interactive path it is instead the result of the preceding tool call, truncated to one line. |
 | `✖` | red | An error — either an `OrcaEvent.Error` from a stage that threw, or a non-fatal mid-session error. |
 | `?` | yellow | Approval request — the agent wants a tool that isn't auto-approved. |
@@ -171,21 +171,32 @@ identical, so captured CI logs read the same as a live terminal.
 
 Two rules the glyph table above doesn't imply:
 
-**A read-only tool call renders as the constant line `⏺ read`, with no
-argument.** Reads were about half of every run's log lines while saying only
-that the agent is still working — which the status row already says. Rendering
-them identically lets the event log's existing repeat-collapse fold a run of
-them into one line plus `⎿ ×N`, in animated and captured modes alike. The
-filename is not lost: the trace file records every call, with its arguments, at
-DEBUG. The name set (`orca.runner.terminal.ReadOnlyTools`) is display-only and
-best-effort — an unrecognised name is treated as mutating and printed in full,
-since a write shown as a read is the harmful direction.
+**In the event log, a read-only tool call renders as the constant line `⏺
+read`.** No argument, and no agent prefix either — the line is identical
+whichever agent made the call. Reads were about half of every run's log lines
+while saying only that the agent is still working, which the status row already
+says. Rendering them identically lets the event log's existing repeat-collapse
+fold a run of them into one line plus `⎿ ×N`, in animated and captured modes
+alike. Dropping the agent name is what makes that hold in the reviewer fan-out,
+where reads are densest and several agents interleave: a `name: ` prefix would
+make every line distinct again and collapse nothing. Neither the filename nor
+the name is lost — the trace file records every call, with its arguments and
+its agent, at DEBUG. The name set (`orca.runner.terminal.ReadOnlyTools`) is
+display-only and best-effort: an unrecognised name is treated as mutating and
+printed in full, since a write shown as a read is the harmful direction. The
+interactive renderer (`ConversationRenderer`) is untouched — it still shows
+`⏺ Read (stats.py)` and the `⎿` result under it.
 
-**Truncation caps bound the rendered line, not the text.** The stage indent,
+**Truncation caps bound the rendered line, not the text — on the event log's
+own lines and on the tool-call line both surfaces share.** The stage indent,
 the glyph and any agent prefix come out of the body's budget, floored at 24
-characters so a deeply nested line still shows something. A path over budget is
-truncated in the MIDDLE, keeping the leading `/` that marks it as outside the
-working directory and the filename that identifies it.
+characters so a deeply nested line still shows something. That is
+`TerminalEventListener`'s prose and structured-result caps plus
+`ToolCallLine`'s argument cap. The interactive renderer's other lines — the
+user's message, the `⎿` tool result, the approval prompt — still spend their
+whole cap on the body; carrying the budget into them is a separate change. A
+path over budget is truncated in the MIDDLE, keeping the leading `/` that marks
+it as outside the working directory and the filename that identifies it.
 
 ## Testing
 

--- a/adr/0008-terminal-output-design.md
+++ b/adr/0008-terminal-output-design.md
@@ -85,12 +85,11 @@ Used in the event log:
 
 | Glyph | Colour | Meaning |
 | ----- | ------ | ------- |
-| `▶` | cyan | Stage start, or a `Step` (single-line note: branch switch, "discarded N issues"). No closing glyph for either. |
+| `▶` | magenta, bold | Stage start, or a `Step` (single-line note: branch switch, "discarded N issues"). No closing glyph for either. |
 | `▸` | cyan, bold | The user's prompt at the start of an interactive session. |
 | `●` | magenta, bold | An assistant prose message. In structured-output mode the JSON is suppressed during streaming and surfaced via `OrcaEvent.StructuredResult`; the listener renders the `Announce[O]` summary as `▶` if available, nothing for a deliberately-silent summary, and falls back to the raw payload under `●` only when no `Announce[O]` exists. |
-| `·` | grey | Assistant "thinking" prose. Hidden by default; `showThinking = true` reveals it. |
-| `⏺` | blue, bold | A tool call the agent is making. The headline argument follows in grey. |
-| `⎿` | grey | The result of the preceding tool call, truncated to one line. |
+| `⏺` | yellow, bold | A tool call the agent is making. The headline argument follows in grey. A read-only call shows no argument (see the 2026-08-27 amendment). |
+| `⎿` | grey | In an autonomous run: how many times the line above it repeated (`⎿ ×12`). On the interactive path it is instead the result of the preceding tool call, truncated to one line. |
 | `✖` | red | An error — either an `OrcaEvent.Error` from a stage that threw, or a non-fatal mid-session error. |
 | `?` | yellow | Approval request — the agent wants a tool that isn't auto-approved. |
 | `!` | yellow, bold | An `OrcaEvent.Caveat` — something true of the whole run, today a restriction a backend cannot apply mechanically. |
@@ -109,7 +108,8 @@ Glyph choices are pragmatic:
 - `▸` (vs `▶`) for the user marks the human's turn distinctly without
   introducing a third arrow shape.
 - `⏺` / `⎿` for tool call / result echo the Claude Code aesthetic;
-  changing them is fine but they should stay paired.
+  changing them is fine but they should stay paired. `⎿` also carries the
+  repeat count, so it always reads as "belonging to the line above".
 - `!` is ASCII punctuation like `?`, marking a line that isn't progress.
   It is also the one event-log line printed at zero indent whatever stage
   is open, since the caveat's scope is the run.
@@ -166,6 +166,26 @@ identical, so captured CI logs read the same as a live terminal.
   brought the bar down, the next start brought it back up) and
   doubled lines for the user without adding signal. Removing `✔`
   entirely is cleaner.
+
+## Amendment (2026-08-27): read-only calls, and budgets that count the prefix
+
+Two rules the glyph table above doesn't imply:
+
+**A read-only tool call renders as the constant line `⏺ read`, with no
+argument.** Reads were about half of every run's log lines while saying only
+that the agent is still working — which the status row already says. Rendering
+them identically lets the event log's existing repeat-collapse fold a run of
+them into one line plus `⎿ ×N`, in animated and captured modes alike. The
+filename is not lost: the trace file records every call, with its arguments, at
+DEBUG. The name set (`orca.runner.terminal.ReadOnlyTools`) is display-only and
+best-effort — an unrecognised name is treated as mutating and printed in full,
+since a write shown as a read is the harmful direction.
+
+**Truncation caps bound the rendered line, not the text.** The stage indent,
+the glyph and any agent prefix come out of the body's budget, floored at 24
+characters so a deeply nested line still shows something. A path over budget is
+truncated in the MIDDLE, keeping the leading `/` that marks it as outside the
+working directory and the filename that identifies it.
 
 ## Testing
 

--- a/flow/src/main/scala/orca/events/EventDispatcher.scala
+++ b/flow/src/main/scala/orca/events/EventDispatcher.scala
@@ -47,8 +47,8 @@ class EventDispatcher(listeners: List[OrcaListener]) extends OrcaListener:
               // failure isn't lost. Raw stderr may tear the status row, but this
               // path fires only when a listener is broken.
               val payload = event match
-                case OrcaEvent.Error(message) => s" (event error: $message)"
-                case _                        => ""
+                case OrcaEvent.Error(message, _) => s" (event error: $message)"
+                case _                           => ""
               System.err.println(
                 s"[orca] listener ${l.getClass.getName} failed on " +
                   s"${event.getClass.getSimpleName}: ${e.getMessage}$payload (listener disabled)"

--- a/flow/src/test/scala/orca/FlowTest.scala
+++ b/flow/src/test/scala/orca/FlowTest.scala
@@ -41,7 +41,7 @@ class FlowTest extends munit.FunSuite:
       stage[String]("risky")(throw new RuntimeException("kaboom"))
     assert(
       listener.events.exists {
-        case OrcaEvent.Error(msg) =>
+        case OrcaEvent.Error(msg, _) =>
           msg.contains("risky") && msg.contains("kaboom")
         case _ => false
       },

--- a/runner/src/main/scala/orca/runner/LoggingListener.scala
+++ b/runner/src/main/scala/orca/runner/LoggingListener.scala
@@ -21,8 +21,10 @@ private[orca] class LoggingListener extends OrcaListener:
     case OrcaEvent.StageStarted(name)   => log.info("stage start: {}", name)
     case OrcaEvent.StageCompleted(name) => log.info("stage done:  {}", name)
     case OrcaEvent.Step(message)        => log.info("step: {}", message)
-    case OrcaEvent.Caveat(message)      => log.info("caveat: {}", message)
-    case OrcaEvent.UserPrompt(text)     => log.debug("prompt sent:\n{}", text)
+    case OrcaEvent.Bookkeeping(message) =>
+      log.info("bookkeeping: {}", message)
+    case OrcaEvent.Caveat(message)  => log.info("caveat: {}", message)
+    case OrcaEvent.UserPrompt(text) => log.debug("prompt sent:\n{}", text)
     case OrcaEvent.AssistantMessage(text, agent) =>
       log.debug("assistant ({}): {}", agent.getOrElse("?"), text)
     case OrcaEvent.ToolUse(tool, args, agent) =>

--- a/runner/src/main/scala/orca/runner/LoggingListener.scala
+++ b/runner/src/main/scala/orca/runner/LoggingListener.scala
@@ -46,7 +46,8 @@ private[orca] class LoggingListener extends OrcaListener:
         t.cost.fold("(none)")(_.amount.toString),
         t.usage
       )
-    case OrcaEvent.Error(message) => log.error("error: {}", message)
+    case OrcaEvent.Error(message, agent) =>
+      log.error("error ({}): {}", agent.getOrElse("flow"), message)
     case e: OrcaEvent.SessionCommitted =>
       log.debug(
         "session committed: harness={} clientId={} wireId={} sessionName={} agent={} role={}",

--- a/runner/src/main/scala/orca/runner/terminal/AgentAttribution.scala
+++ b/runner/src/main/scala/orca/runner/terminal/AgentAttribution.scala
@@ -10,9 +10,19 @@ private[terminal] object AgentAttribution:
     */
   val Style: fansi.Attrs = fansi.Color.DarkGray
 
+  /** The prefix as the reader sees it, before painting — the one place its
+    * shape is decided.
+    */
+  private def plain(name: String): String = s"$name: "
+
   /** The rendered prefix, or "" when the line needs no attribution. */
   def prefix(
       agent: Option[String],
       paint: (fansi.Attrs, String) => String
   ): String =
-    agent.fold("")(name => paint(Style, s"$name: "))
+    agent.fold("")(name => paint(Style, plain(name)))
+
+  /** Columns [[prefix]] takes — 0 when the line isn't attributed. Measured on
+    * the unpainted form: ANSI escapes take no columns.
+    */
+  def width(agent: Option[String]): Int = agent.fold(0)(plain(_).length)

--- a/runner/src/main/scala/orca/runner/terminal/ConversationRenderer.scala
+++ b/runner/src/main/scala/orca/runner/terminal/ConversationRenderer.scala
@@ -99,7 +99,10 @@ private[terminal] class ConversationRenderer(
 
   private def renderToolCall(name: String, input: String): Unit =
     enterSection(Section.Tool)
-    appendBlock(ToolCallLine.format(name, input, paint, workDir, agent = None))
+    appendBlock(
+      ToolCallLine
+        .format(name, input, paint, workDir, agent = None, currentIndent())
+    )
 
   private def renderToolResult(ok: Boolean, content: String): Unit =
     enterSection(Section.Tool)

--- a/runner/src/main/scala/orca/runner/terminal/LineBudget.scala
+++ b/runner/src/main/scala/orca/runner/terminal/LineBudget.scala
@@ -1,0 +1,30 @@
+package orca.runner.terminal
+
+/** How many characters of a line's BODY are left once everything printed ahead
+  * of it is paid for. The caps ([[ConversationRenderer.MaxInlineInputLength]],
+  * [[TerminalEventListener.MaxAssistantMessageLength]]) bound the whole
+  * rendered line, but the body is written after a stage indent, a glyph and
+  * sometimes an agent name — spending the full cap on the body puts a line
+  * meant to be one line onto two.
+  */
+private[terminal] object LineBudget:
+
+  /** Never leave less than this, however deep the stage nesting: a line showing
+    * a few characters and an ellipsis is worth more than the alignment.
+    */
+  val Floor: Int = 24
+
+  /** `max` less every prefix width passed, floored at [[Floor]]. Widths are
+    * measured on unpainted text — ANSI escapes take no columns.
+    */
+  def remaining(max: Int, prefixes: Int*): Int =
+    math.max(Floor, max - prefixes.sum)
+
+  /** Columns a `glyph ` prefix takes: the glyph plus its separating space. */
+  def glyphWidth(glyph: String): Int = glyph.length + 1
+
+  /** Columns [[AgentAttribution.prefix]] takes — 0 when the line isn't
+    * attributed.
+    */
+  def attributionWidth(agent: Option[String]): Int =
+    agent.fold(0)(_.length + ": ".length)

--- a/runner/src/main/scala/orca/runner/terminal/LineBudget.scala
+++ b/runner/src/main/scala/orca/runner/terminal/LineBudget.scala
@@ -20,11 +20,8 @@ private[terminal] object LineBudget:
   def remaining(max: Int, prefixes: Int*): Int =
     math.max(Floor, max - prefixes.sum)
 
-  /** Columns a `glyph ` prefix takes: the glyph plus its separating space. */
-  def glyphWidth(glyph: String): Int = glyph.length + 1
-
-  /** Columns [[AgentAttribution.prefix]] takes — 0 when the line isn't
-    * attributed.
+  /** Columns a `glyph ` prefix takes: the glyph plus its separating space.
+    * Derived from the glyph the renderer prints rather than fixed at 2, so a
+    * marker wider than one character can't silently overrun the budget.
     */
-  def attributionWidth(agent: Option[String]): Int =
-    agent.fold(0)(_.length + ": ".length)
+  def glyphWidth(glyph: String): Int = glyph.length + 1

--- a/runner/src/main/scala/orca/runner/terminal/ReadOnlyTools.scala
+++ b/runner/src/main/scala/orca/runner/terminal/ReadOnlyTools.scala
@@ -6,9 +6,12 @@ package orca.runner.terminal
   * Reading is what an agent does most — about half of a run's log lines — and
   * each line says only that it is still working, which the status row already
   * says. Rendering them all identically lets [[TerminalOutputState]]'s
-  * repeat-collapse fold a run of them into one line plus `⎿ ×N`. The filename
-  * is not lost: `LoggingListener` records every call at DEBUG in the trace file
-  * whose path the run banner prints.
+  * repeat-collapse fold a run of them into one line plus `⎿ ×N`. The emitting
+  * agent's name is dropped for the same reason: the reviewer fan-out is where
+  * reads are densest, and a `name: ` prefix would make every line distinct
+  * again and collapse nothing. The filename and the name are not lost:
+  * `LoggingListener` records every call at DEBUG in the trace file whose path
+  * the run banner prints.
   *
   * Display-only and best-effort. An unrecognised name is treated as mutating
   * and printed in full — a write shown as a read is the harmful direction, and

--- a/runner/src/main/scala/orca/runner/terminal/ReadOnlyTools.scala
+++ b/runner/src/main/scala/orca/runner/terminal/ReadOnlyTools.scala
@@ -1,0 +1,44 @@
+package orca.runner.terminal
+
+/** Which tool names the event log renders as the constant `⏺ read` line instead
+  * of naming the file each call touched.
+  *
+  * Reading is what an agent does most — about half of a run's log lines — and
+  * each line says only that it is still working, which the status row already
+  * says. Rendering them all identically lets [[TerminalOutputState]]'s
+  * repeat-collapse fold a run of them into one line plus `⎿ ×N`. The filename
+  * is not lost: `LoggingListener` records every call at DEBUG in the trace file
+  * whose path the run banner prints.
+  *
+  * Display-only and best-effort. An unrecognised name is treated as mutating
+  * and printed in full — a write shown as a read is the harmful direction, and
+  * backends add tools without telling orca. codex is deliberately absent: its
+  * reads run through `bash`, which also writes.
+  */
+private[terminal] object ReadOnlyTools:
+
+  /** The line a read-only call renders as, in place of its own name. */
+  val DisplayName: String = "read"
+
+  /** Lower-cased so one entry covers claude's `Read` and opencode's `read`.
+    * Grouped by the backend that emits them (several are shared).
+    */
+  private val Names: Set[String] = Set(
+    // claude
+    "read",
+    "grep",
+    "glob",
+    // pi
+    "find",
+    "ls",
+    // opencode
+    "list",
+    // gemini
+    "read_file",
+    "read_many_files",
+    "search_file_content",
+    "list_directory"
+  )
+
+  def contains(toolName: String): Boolean =
+    Names.contains(toolName.toLowerCase)

--- a/runner/src/main/scala/orca/runner/terminal/TerminalEventListener.scala
+++ b/runner/src/main/scala/orca/runner/terminal/TerminalEventListener.scala
@@ -26,6 +26,7 @@ private[runner] class TerminalEventListener(
     ErrorGlyph,
     MaxAssistantMessageLength,
     MaxStructuredResultRawLength,
+    OrcaCommitStep,
     StageEmitters,
     StageStartGlyph,
     StepGlyphStyle,
@@ -58,14 +59,31 @@ private[runner] class TerminalEventListener(
       stageEmitters.set(StageEmitters.Silent)
       output.setStatus(stack.headOption)
     case OrcaEvent.ToolUse(tool, args, agent) =>
-      val line = formatIndented(
-        ToolCallLine.format(tool, args, paint, workDir, attribution(agent))
+      // A read-only call renders as one constant line, so a run of them
+      // collapses in `TerminalOutput` (see `ReadOnlyTools`); everything else
+      // shows what it acted on.
+      val (name, input) =
+        if ReadOnlyTools.contains(tool) then (ReadOnlyTools.DisplayName, "{}")
+        else (tool, args)
+      output.log(
+        formatIndented(
+          ToolCallLine.format(
+            name,
+            input,
+            paint,
+            workDir,
+            attribution(agent),
+            currentIndent
+          )
+        )
       )
-      output.log(line)
     case _: OrcaEvent.TokensUsed =>
       () // Token accounting is owned by CostTracker.
     case OrcaEvent.Step(message) =>
-      output.log(formatStepLine(message))
+      // Orca's own bookkeeping commits are the runtime's, not the user's work:
+      // they'd read as progress on the task. The trace file keeps them.
+      if !message.startsWith(OrcaCommitStep) then
+        output.log(formatStepLine(message))
     case OrcaEvent.Caveat(message) =>
       // No `formatIndented`, unlike every sibling arm: it is run-scoped.
       output.log(paint(CaveatStyle, s"$CaveatGlyph ") + message)
@@ -80,27 +98,44 @@ private[runner] class TerminalEventListener(
         case Some("") => ()
         case Some(s)  => output.log(formatStepLine(s))
         case None =>
-          val collapsed = Text.oneLine(raw, MaxStructuredResultRawLength)
+          val collapsed = Text.oneLine(
+            raw,
+            bodyBudget(MaxStructuredResultRawLength, AssistantGlyph, None)
+          )
           val glyph = paint(AssistantGlyphStyle, s"$AssistantGlyph ")
           output.log(formatIndented(glyph + collapsed))
     case OrcaEvent.UserPrompt(text) =>
       // One line so a long task description doesn't dominate the log; empty
       // payloads dropped.
-      val collapsed = Text.oneLine(text, MaxAssistantMessageLength)
+      val collapsed = Text.oneLine(
+        text,
+        bodyBudget(MaxAssistantMessageLength, UserPromptGlyph, None)
+      )
       if collapsed.nonEmpty then
         val glyph = paint(UserPromptStyle, s"$UserPromptGlyph ")
         output.log(formatIndented(glyph + collapsed))
     case OrcaEvent.AssistantMessage(text, agent) =>
       // One line per prose turn; empty payloads (turn-without-prose) dropped.
-      val collapsed = Text.oneLine(text, MaxAssistantMessageLength)
+      val who = attribution(agent)
+      val collapsed =
+        Text.oneLine(
+          text,
+          bodyBudget(MaxAssistantMessageLength, AssistantGlyph, who)
+        )
       if collapsed.nonEmpty then
         val glyph = paint(AssistantGlyphStyle, s"$AssistantGlyph ")
-        val who = AgentAttribution.prefix(attribution(agent), paint)
-        output.log(formatIndented(glyph + who + collapsed))
-    case OrcaEvent.Error(message) =>
-      output.log(
-        formatIndented(paint(fansi.Color.Red, s"$ErrorGlyph $message"))
-      )
+        output.log(
+          formatIndented(
+            glyph + AgentAttribution.prefix(who, paint) + collapsed
+          )
+        )
+    case OrcaEvent.Error(message, agent) =>
+      // Named even when it is the stage's only emitter, unlike every other
+      // arm: the line exists to say WHICH agent failed, and the stage error
+      // that follows carries no name of its own.
+      val glyph = paint(fansi.Color.Red, s"$ErrorGlyph ")
+      val who = AgentAttribution.prefix(agent, paint)
+      output.log(formatIndented(glyph + who + paint(fansi.Color.Red, message)))
     case _: OrcaEvent.SessionCommitted =>
       () // Session/manifest tracking (ADR 0021 §8) is RunManifestWriter's job.
 
@@ -122,6 +157,22 @@ private[runner] class TerminalEventListener(
       stageEmitters.updateAndGet(_.plus(name)) match
         case StageEmitters.One(_) => None
         case _                    => Some(name)
+
+  /** What is left of `max` for a line's body once the stage indent, the glyph
+    * and any agent prefix are paid for — the caps bound the rendered line, not
+    * the text alone.
+    */
+  private def bodyBudget(
+      max: Int,
+      glyph: String,
+      agent: Option[String]
+  ): Int =
+    LineBudget.remaining(
+      max,
+      currentIndent.length,
+      LineBudget.glyphWidth(glyph),
+      LineBudget.attributionWidth(agent)
+    )
 
   /** A `▶` step line: magenta-bold glyph, neutral body — matching the
     * assistant-prose styling so the "primary content" accent stays consistent.
@@ -155,7 +206,12 @@ private[runner] object TerminalEventListener:
       case _                      => Many
 
   val StageStartGlyph: String = "▶"
+
+  /** Never rendered — it exists so the tests that pin ADR 0008's "no `✔` ever
+    * appears in the log" invariant have the glyph to assert the absence of.
+    */
   val StageDoneGlyph: String = "✔"
+
   val ErrorGlyph: String = "✖"
   val AssistantGlyph: String = "●"
 
@@ -196,3 +252,9 @@ private[runner] object TerminalEventListener:
     * `Announce[O]` summary was provided (ADR 0008).
     */
   val MaxStructuredResultRawLength: Int = 200
+
+  /** `Step` messages starting with this are orca's own bookkeeping commits
+    * (`GitTool.commit`'s `Committed: ` echo of an `orca: `-prefixed message),
+    * which the log leaves out.
+    */
+  private val OrcaCommitStep: String = "Committed: orca: "

--- a/runner/src/main/scala/orca/runner/terminal/TerminalEventListener.scala
+++ b/runner/src/main/scala/orca/runner/terminal/TerminalEventListener.scala
@@ -26,7 +26,6 @@ private[runner] class TerminalEventListener(
     ErrorGlyph,
     MaxAssistantMessageLength,
     MaxStructuredResultRawLength,
-    OrcaCommitStep,
     StageEmitters,
     StageStartGlyph,
     StepGlyphStyle,
@@ -59,31 +58,31 @@ private[runner] class TerminalEventListener(
       stageEmitters.set(StageEmitters.Silent)
       output.setStatus(stack.headOption)
     case OrcaEvent.ToolUse(tool, args, agent) =>
-      // A read-only call renders as one constant line, so a run of them
-      // collapses in `TerminalOutput` (see `ReadOnlyTools`); everything else
-      // shows what it acted on.
-      val (name, input) =
-        if ReadOnlyTools.contains(tool) then (ReadOnlyTools.DisplayName, "{}")
-        else (tool, args)
-      output.log(
-        formatIndented(
+      // Recorded before the branch: an agent whose reads go out unnamed is
+      // still an emitter, so its prose and writes get named once the stage has
+      // several (see `attribution`).
+      val who = attribution(agent)
+      val line =
+        // A read-only call renders as one constant line — no file, no agent —
+        // so a burst from any mix of agents collapses in `TerminalOutput` (see
+        // `ReadOnlyTools`); everything else shows what it acted on and who.
+        if ReadOnlyTools.contains(tool) then
           ToolCallLine.format(
-            name,
-            input,
+            ReadOnlyTools.DisplayName,
+            "{}",
             paint,
             workDir,
-            attribution(agent),
+            agent = None,
             currentIndent
           )
-        )
-      )
+        else ToolCallLine.format(tool, args, paint, workDir, who, currentIndent)
+      output.log(formatIndented(line))
     case _: OrcaEvent.TokensUsed =>
       () // Token accounting is owned by CostTracker.
     case OrcaEvent.Step(message) =>
-      // Orca's own bookkeeping commits are the runtime's, not the user's work:
-      // they'd read as progress on the task. The trace file keeps them.
-      if !message.startsWith(OrcaCommitStep) then
-        output.log(formatStepLine(message))
+      output.log(formatStepLine(message))
+    case _: OrcaEvent.Bookkeeping =>
+      () // Not the user's work; it would read as progress. The trace keeps it.
     case OrcaEvent.Caveat(message) =>
       // No `formatIndented`, unlike every sibling arm: it is run-scoped.
       output.log(paint(CaveatStyle, s"$CaveatGlyph ") + message)
@@ -150,7 +149,10 @@ private[runner] class TerminalEventListener(
     * agent's earlier lines stay bare — the log is append-only, so nothing
     * already printed can be prefixed after the fact.
     *
-    * An event carrying no agent name never counts as an emitter.
+    * An event carrying no agent name never counts as an emitter. A read-only
+    * tool line is the one that counts its emitter and then prints bare anyway:
+    * it is deliberately identical whoever made the call, so that a burst of
+    * them collapses ([[ReadOnlyTools]]).
     */
   private def attribution(agent: Option[String]): Option[String] =
     agent.flatMap: name =>
@@ -171,7 +173,7 @@ private[runner] class TerminalEventListener(
       max,
       currentIndent.length,
       LineBudget.glyphWidth(glyph),
-      LineBudget.attributionWidth(agent)
+      AgentAttribution.width(agent)
     )
 
   /** A `▶` step line: magenta-bold glyph, neutral body — matching the
@@ -252,9 +254,3 @@ private[runner] object TerminalEventListener:
     * `Announce[O]` summary was provided (ADR 0008).
     */
   val MaxStructuredResultRawLength: Int = 200
-
-  /** `Step` messages starting with this are orca's own bookkeeping commits
-    * (`GitTool.commit`'s `Committed: ` echo of an `orca: `-prefixed message),
-    * which the log leaves out.
-    */
-  private val OrcaCommitStep: String = "Committed: orca: "

--- a/runner/src/main/scala/orca/runner/terminal/Text.scala
+++ b/runner/src/main/scala/orca/runner/terminal/Text.scala
@@ -22,18 +22,23 @@ private[terminal] object Text:
   /** Cut `s` to at most `max` characters by removing its MIDDLE: head, an
     * ellipsis, then tail. For a path this keeps both ends that identify it —
     * the leading `/` that marks it as outside the working directory, and the
-    * filename that [[truncate]] would eat. The whole trailing segment is kept
-    * when it fits, so the filename survives intact wherever it can.
+    * filename that [[truncate]] would eat. The whole trailing segment — its
+    * leading `/` included — is kept when it fits, so the filename survives
+    * intact wherever it can.
     */
   def middleTruncate(s: String, max: Int): String =
     if s.length <= max then s
-    else if max < 3 then truncate(s, max)
     else
       val keep = max - 1 // the ellipsis costs one
-      val lastSegment = s.length - s.lastIndexOf('/') - 1
+      val half = keep / 2
+      // Counted WITH its leading `/`, so the cut lands before the separator and
+      // the result still reads as a path rather than one run-on token.
+      val lastSlash = s.lastIndexOf('/')
+      val lastSegment = if lastSlash < 0 then s.length else s.length - lastSlash
+      // The whole trailing segment whenever something is left for the head; a
+      // segment that fills the budget on its own falls back to an even split.
       val tail =
-        if lastSegment <= keep - 1 then math.max(lastSegment, keep / 2)
-        else keep / 2
+        if lastSegment < keep then math.max(lastSegment, half) else half
       s"${s.take(keep - tail)}…${s.takeRight(tail)}"
 
   /** Collapse all runs of whitespace to a single space and trim. Use before

--- a/runner/src/main/scala/orca/runner/terminal/Text.scala
+++ b/runner/src/main/scala/orca/runner/terminal/Text.scala
@@ -19,6 +19,23 @@ private[terminal] object Text:
     if s.length <= max then s
     else s"${s.take(max - 1)}…"
 
+  /** Cut `s` to at most `max` characters by removing its MIDDLE: head, an
+    * ellipsis, then tail. For a path this keeps both ends that identify it —
+    * the leading `/` that marks it as outside the working directory, and the
+    * filename that [[truncate]] would eat. The whole trailing segment is kept
+    * when it fits, so the filename survives intact wherever it can.
+    */
+  def middleTruncate(s: String, max: Int): String =
+    if s.length <= max then s
+    else if max < 3 then truncate(s, max)
+    else
+      val keep = max - 1 // the ellipsis costs one
+      val lastSegment = s.length - s.lastIndexOf('/') - 1
+      val tail =
+        if lastSegment <= keep - 1 then math.max(lastSegment, keep / 2)
+        else keep / 2
+      s"${s.take(keep - tail)}…${s.takeRight(tail)}"
+
   /** Collapse all runs of whitespace to a single space and trim. Use before
     * spending a width budget: an embedded newline or tab costs a character the
     * reader never sees, and breaks the single-line discipline.

--- a/runner/src/main/scala/orca/runner/terminal/ToolCallLine.scala
+++ b/runner/src/main/scala/orca/runner/terminal/ToolCallLine.scala
@@ -31,9 +31,8 @@ private[terminal] object ToolCallLine:
       MaxInlineInputLength,
       indent.length,
       LineBudget.glyphWidth(ToolCallGlyph),
-      LineBudget.attributionWidth(agent),
-      name.length + 1, // the space between the tool name and its args
-      2 // the brackets `summarise` wraps its headline in
+      AgentAttribution.width(agent),
+      name.length + 1 // the space between the tool name and its args
     )
     val args = ToolInputSummary.summarise(rawInput, budget, workDir)
     val head = paint(ToolNameStyle, s"$ToolCallGlyph ") +

--- a/runner/src/main/scala/orca/runner/terminal/ToolCallLine.scala
+++ b/runner/src/main/scala/orca/runner/terminal/ToolCallLine.scala
@@ -15,16 +15,27 @@ private[terminal] object ToolCallLine:
 
   /** `agent` names the emitting agent when the line needs attributing (see
     * [[AgentAttribution]]); `None` renders the bare `⏺ name (args)` form.
+    * `indent` is the stage indent the caller will prepend — passed rather than
+    * applied here, since everything ahead of the args eats into their width
+    * budget ([[LineBudget]]).
     */
   def format(
       name: String,
       rawInput: String,
       paint: (fansi.Attrs, String) => String,
       workDir: Option[os.Path],
-      agent: Option[String]
+      agent: Option[String],
+      indent: String
   ): String =
-    val args =
-      ToolInputSummary.summarise(rawInput, MaxInlineInputLength, workDir)
+    val budget = LineBudget.remaining(
+      MaxInlineInputLength,
+      indent.length,
+      LineBudget.glyphWidth(ToolCallGlyph),
+      LineBudget.attributionWidth(agent),
+      name.length + 1, // the space between the tool name and its args
+      2 // the brackets `summarise` wraps its headline in
+    )
+    val args = ToolInputSummary.summarise(rawInput, budget, workDir)
     val head = paint(ToolNameStyle, s"$ToolCallGlyph ") +
       AgentAttribution.prefix(agent, paint) + paint(ToolNameStyle, name)
     if args.isEmpty then head else head + " " + paint(ToolArgsStyle, args)

--- a/runner/src/main/scala/orca/runner/terminal/ToolInputSummary.scala
+++ b/runner/src/main/scala/orca/runner/terminal/ToolInputSummary.scala
@@ -95,7 +95,13 @@ private[terminal] object ToolInputSummary:
       workDir: Option[os.Path]
   ): String = kind match
     case HeadlineKind.Path =>
-      Text.oneLine(relativise(value, workDir), maxLength)
+      // Middle-truncated, not end-truncated: a path over budget is one left
+      // absolute by `relativise`, and cutting its tail drops the filename —
+      // the only part that says which file the call touched.
+      Text.middleTruncate(
+        Text.collapseWhitespace(relativise(value, workDir)),
+        maxLength
+      )
     case HeadlineKind.Command => CommandHeadline.render(value, maxLength)
     case HeadlineKind.Search =>
       Text.oneLine(scopedPattern(value, json, workDir), maxLength)

--- a/runner/src/main/scala/orca/runner/terminal/ToolInputSummary.scala
+++ b/runner/src/main/scala/orca/runner/terminal/ToolInputSummary.scala
@@ -47,8 +47,12 @@ private[terminal] object ToolInputSummary:
       "description" -> HeadlineKind.Plain
     )
 
+  /** Columns the headline's wrapping `(`/`)` take. */
+  private val Brackets: Int = 2
+
   /** Returns an already-truncated headline suitable for rendering after the
-    * tool name. Empty string means "no args to show".
+    * tool name, at most `maxLength` characters INCLUDING the brackets a
+    * headline is wrapped in. Empty string means "no args to show".
     */
   def summarise(
       rawJson: String,
@@ -72,7 +76,7 @@ private[terminal] object ToolInputSummary:
             kind,
             value = value,
             json = collapsed,
-            maxLength = maxLength,
+            maxLength = maxLength - Brackets,
             workDir = workDir
           )
           s"($text)"
@@ -95,9 +99,9 @@ private[terminal] object ToolInputSummary:
       workDir: Option[os.Path]
   ): String = kind match
     case HeadlineKind.Path =>
-      // Middle-truncated, not end-truncated: a path over budget is one left
-      // absolute by `relativise`, and cutting its tail drops the filename —
-      // the only part that says which file the call touched.
+      // Middle-truncated, not end-truncated: cutting the tail off any path —
+      // relative ones overflow at depth too — drops the filename, the only
+      // part that says which file the call touched.
       Text.middleTruncate(
         Text.collapseWhitespace(relativise(value, workDir)),
         maxLength

--- a/runner/src/test/scala/orca/runner/terminal/TerminalEventListenerTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/TerminalEventListenerTest.scala
@@ -132,22 +132,37 @@ class TerminalEventListenerTest extends munit.FunSuite:
       s"⏺ read\n  ⎿ ×3\n${TerminalEventListener.StageStartGlyph} done\n"
     )
 
-  test("read-only calls collapse in animated mode too"):
-    val output = renderWith(
-      animated = true,
+  test("read-only calls from several agents still collapse into one line"):
+    // The reviewer fan-out interleaves emitters, so a `name: ` prefix on these
+    // lines would make every one of them distinct and collapse nothing —
+    // exactly where reads are densest.
+    val output = renderEvents(
       List(
-        OrcaEvent.StageStarted("task"),
-        OrcaEvent.ToolUse("Read", """{"file_path":"stats.py"}"""),
-        OrcaEvent.ToolUse("Read", """{"file_path":"other.py"}"""),
+        OrcaEvent
+          .ToolUse("Read", """{"file_path":"stats.py"}""", Some("alpha")),
+        OrcaEvent.ToolUse("Grep", """{"pattern":"variance"}""", Some("beta")),
+        OrcaEvent
+          .ToolUse("Read", """{"file_path":"other.py"}""", Some("alpha")),
         OrcaEvent.Step("done")
       )
     )
     assertEquals(
-      output.sliding("⏺ read".length).count(_ == "⏺ read"),
-      1,
-      output
+      output,
+      s"⏺ read\n  ⎿ ×3\n${TerminalEventListener.StageStartGlyph} done\n"
     )
-    assert(output.contains("⎿ ×2"), output)
+
+  test("an agent that only read is still counted as an emitter"):
+    // Its own lines went out bare, but the stage now has two emitters, so the
+    // next line that CAN carry a name must carry one.
+    val output = renderEvents(
+      List(
+        OrcaEvent.StageStarted("task"),
+        OrcaEvent
+          .ToolUse("Read", """{"file_path":"stats.py"}""", Some("alpha")),
+        OrcaEvent.AssistantMessage("reviewed it", Some("beta"))
+      )
+    )
+    assert(output.contains("● beta: reviewed it"), output)
 
   test("an unrecognised tool name is treated as mutating and printed in full"):
     // The classification is best-effort; a write shown as a read is the
@@ -157,16 +172,19 @@ class TerminalEventListenerTest extends munit.FunSuite:
     )
     assert(output.contains("⏺ mcp__docs__search (variance)"), output)
 
-  test("orca's own bookkeeping commits stay out of the log"):
+  test("orca's own bookkeeping stays out of the log"):
+    // The second commit is an agent's, and orca is developed with orca — its
+    // message reads exactly like the runtime's, so only the event tells them
+    // apart.
     val output = renderEvents(
       List(
-        OrcaEvent.Step("Committed: orca: progress log"),
-        OrcaEvent.Step("Committed: add the variance helper")
+        OrcaEvent.Bookkeeping("Committed: orca: progress log"),
+        OrcaEvent.Step("Committed: orca: fix the terminal renderer")
       )
     )
     assertEquals(
       output,
-      s"${TerminalEventListener.StageStartGlyph} Committed: add the variance helper\n"
+      s"${TerminalEventListener.StageStartGlyph} Committed: orca: fix the terminal renderer\n"
     )
 
   test("an error carrying an agent name is attributed to it"):
@@ -183,11 +201,6 @@ class TerminalEventListenerTest extends munit.FunSuite:
       "✖ readability: turn failed: rate limited\n" +
         "✖ Stage 'review' failed: turn failed: rate limited\n"
     )
-
-  test("errors are prefixed with an error marker"):
-    val output = renderEvents(List(OrcaEvent.Error("boom")))
-    assert(output.contains(TerminalEventListener.ErrorGlyph))
-    assert(output.contains("boom"))
 
   test("errors with backend terminal controls do not crash colored output"):
     val output = renderWith(
@@ -240,7 +253,10 @@ class TerminalEventListenerTest extends munit.FunSuite:
         OrcaEvent.StageStarted("middle"),
         OrcaEvent.StageStarted("inner"),
         OrcaEvent.AssistantMessage("first", Some("main")),
-        OrcaEvent.AssistantMessage("y" * 200, Some("readability"))
+        OrcaEvent.AssistantMessage(
+          "y" * (TerminalEventListener.MaxAssistantMessageLength * 2),
+          Some("readability")
+        )
       )
     )
     val line = output

--- a/runner/src/test/scala/orca/runner/terminal/TerminalEventListenerTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/TerminalEventListenerTest.scala
@@ -117,6 +117,73 @@ class TerminalEventListenerTest extends munit.FunSuite:
     assert(line.startsWith(glyph), line)
     assertEquals(line.stripPrefix(glyph), "no gate here")
 
+  test("a run of read-only calls collapses to one line plus a repeat count"):
+    // The count lands once a different line closes the run — here the Step.
+    val output = renderEvents(
+      List(
+        OrcaEvent.ToolUse("Read", """{"file_path":"stats.py"}"""),
+        OrcaEvent.ToolUse("Grep", """{"pattern":"variance"}"""),
+        OrcaEvent.ToolUse("Glob", """{"pattern":"**/*.py"}"""),
+        OrcaEvent.Step("done")
+      )
+    )
+    assertEquals(
+      output,
+      s"⏺ read\n  ⎿ ×3\n${TerminalEventListener.StageStartGlyph} done\n"
+    )
+
+  test("read-only calls collapse in animated mode too"):
+    val output = renderWith(
+      animated = true,
+      List(
+        OrcaEvent.StageStarted("task"),
+        OrcaEvent.ToolUse("Read", """{"file_path":"stats.py"}"""),
+        OrcaEvent.ToolUse("Read", """{"file_path":"other.py"}"""),
+        OrcaEvent.Step("done")
+      )
+    )
+    assertEquals(
+      output.sliding("⏺ read".length).count(_ == "⏺ read"),
+      1,
+      output
+    )
+    assert(output.contains("⎿ ×2"), output)
+
+  test("an unrecognised tool name is treated as mutating and printed in full"):
+    // The classification is best-effort; a write shown as a read is the
+    // harmful direction, so anything unknown keeps its name and arguments.
+    val output = renderEvents(
+      List(OrcaEvent.ToolUse("mcp__docs__search", """{"query":"variance"}"""))
+    )
+    assert(output.contains("⏺ mcp__docs__search (variance)"), output)
+
+  test("orca's own bookkeeping commits stay out of the log"):
+    val output = renderEvents(
+      List(
+        OrcaEvent.Step("Committed: orca: progress log"),
+        OrcaEvent.Step("Committed: add the variance helper")
+      )
+    )
+    assertEquals(
+      output,
+      s"${TerminalEventListener.StageStartGlyph} Committed: add the variance helper\n"
+    )
+
+  test("an error carrying an agent name is attributed to it"):
+    // The stage error that follows carries no name, which is what tells the
+    // agent's own failure apart from the stage's report of it.
+    val output = renderEvents(
+      List(
+        OrcaEvent.Error("turn failed: rate limited", Some("readability")),
+        OrcaEvent.Error("Stage 'review' failed: turn failed: rate limited")
+      )
+    )
+    assertEquals(
+      output,
+      "✖ readability: turn failed: rate limited\n" +
+        "✖ Stage 'review' failed: turn failed: rate limited\n"
+    )
+
   test("errors are prefixed with an error marker"):
     val output = renderEvents(List(OrcaEvent.Error("boom")))
     assert(output.contains(TerminalEventListener.ErrorGlyph))
@@ -155,14 +222,32 @@ class TerminalEventListenerTest extends munit.FunSuite:
     val long = "x" * (TerminalEventListener.MaxAssistantMessageLength + 50)
     val output = renderEvents(List(OrcaEvent.AssistantMessage(long)))
     assert(output.contains("…"), output)
-    // Truncated form is bounded by the cap (plus glyph + indent).
+    // The cap bounds the whole rendered line, glyph included.
     val bodyLines = output.split('\n').filter(_.contains("x"))
     assert(
       bodyLines.forall(
-        _.length <= TerminalEventListener.MaxAssistantMessageLength + 10
+        _.length <= TerminalEventListener.MaxAssistantMessageLength
       ),
       bodyLines.toList
     )
+
+  test("an indented, agent-prefixed prose line still fits the cap"):
+    // Depth 3 plus a `name: ` prefix is the worst case in a review fan-out:
+    // indent, glyph and prefix all come out of the body's budget.
+    val output = renderEvents(
+      List(
+        OrcaEvent.StageStarted("outer"),
+        OrcaEvent.StageStarted("middle"),
+        OrcaEvent.StageStarted("inner"),
+        OrcaEvent.AssistantMessage("first", Some("main")),
+        OrcaEvent.AssistantMessage("y" * 200, Some("readability"))
+      )
+    )
+    val line = output
+      .split('\n')
+      .find(_.contains("readability:"))
+      .getOrElse(fail(s"missing the attributed line; got: $output"))
+    assertEquals(line.length, TerminalEventListener.MaxAssistantMessageLength)
 
   test("AssistantMessage with whitespace-only body emits nothing"):
     val output = renderEvents(List(OrcaEvent.AssistantMessage("   \n\t  ")))
@@ -172,8 +257,9 @@ class TerminalEventListenerTest extends munit.FunSuite:
     val output = renderEvents(
       List(
         OrcaEvent.StageStarted("task"),
-        OrcaEvent.ToolUse("Read", """{"file_path":"stats.py"}""", Some("main")),
-        OrcaEvent.ToolUse("Read", """{"file_path":"other.py"}""", Some("main"))
+        OrcaEvent
+          .ToolUse("Write", """{"file_path":"stats.py"}""", Some("main")),
+        OrcaEvent.ToolUse("Write", """{"file_path":"other.py"}""", Some("main"))
       )
     )
     assert(!output.contains("main:"), output)
@@ -182,12 +268,13 @@ class TerminalEventListenerTest extends munit.FunSuite:
     val output = renderEvents(
       List(
         OrcaEvent.StageStarted("task"),
-        OrcaEvent.ToolUse("Read", """{"file_path":"stats.py"}""", Some("main")),
         OrcaEvent
-          .ToolUse("Read", """{"file_path":"stats.py"}""", Some("readability"))
+          .ToolUse("Write", """{"file_path":"stats.py"}""", Some("main")),
+        OrcaEvent
+          .ToolUse("Write", """{"file_path":"stats.py"}""", Some("readability"))
       )
     )
-    assert(output.contains("⏺ readability: Read (stats.py)"), output)
+    assert(output.contains("⏺ readability: Write (stats.py)"), output)
 
   test("a second agent's prose line is prefixed with its name"):
     val output = renderEvents(

--- a/runner/src/test/scala/orca/runner/terminal/TextTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/TextTest.scala
@@ -1,0 +1,20 @@
+package orca.runner.terminal
+
+class TextTest extends munit.FunSuite:
+
+  test("middleTruncate keeps a trailing segment longer than half the budget"):
+    // The `/Main…` segment is 25 characters against a 29-character keep, so it
+    // is what decides the split — an even one would cut the filename in half.
+    val path = "/home/user/project/src/AbsolutelyLongName.scala"
+    assertEquals(
+      Text.middleTruncate(path, 30),
+      "/hom…/AbsolutelyLongName.scala"
+    )
+
+  test("middleTruncate splits evenly when the trailing segment alone overruns"):
+    // Nothing is left for the head if the whole segment is kept, so the head
+    // wins back half the budget and the filename takes the loss.
+    assertEquals(
+      Text.middleTruncate(s"/a/${"x" * 40}", 20),
+      s"/a/${"x" * 7}…${"x" * 9}"
+    )

--- a/runner/src/test/scala/orca/runner/terminal/ToolInputSummaryTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/ToolInputSummaryTest.scala
@@ -30,6 +30,17 @@ class ToolInputSummaryTest extends munit.FunSuite:
     val out = ToolInputSummary.summarise(raw, maxLen, Some(workDir))
     assertEquals(out, "(.)")
 
+  test("summarise middle-truncates a path too long for the budget"):
+    // Out-of-workDir paths stay absolute (ADR 0008), so an over-budget path is
+    // the case that matters: both the leading `/` and the filename survive.
+    val raw =
+      s"""{"file_path":"/home/user/${"nested/" * 10}Main.scala"}"""
+    val out = ToolInputSummary.summarise(raw, 40)
+    assert(out.startsWith("(/home/user/"), out)
+    assert(out.endsWith("Main.scala)"), out)
+    assert(out.contains("…"), out)
+    assertEquals(out.length, 42) // 40 plus the wrapping brackets
+
   test("summarise extracts a field written with a space after the colon"):
     val raw = """{"file_path": "/tmp/foo.txt"}"""
     assertEquals(ToolInputSummary.summarise(raw, maxLen), "(/tmp/foo.txt)")

--- a/runner/src/test/scala/orca/runner/terminal/ToolInputSummaryTest.scala
+++ b/runner/src/test/scala/orca/runner/terminal/ToolInputSummaryTest.scala
@@ -32,14 +32,14 @@ class ToolInputSummaryTest extends munit.FunSuite:
 
   test("summarise middle-truncates a path too long for the budget"):
     // Out-of-workDir paths stay absolute (ADR 0008), so an over-budget path is
-    // the case that matters: both the leading `/` and the filename survive.
+    // the case that matters: both the leading `/` and the filename survive,
+    // and the 40 covers the brackets too.
     val raw =
       s"""{"file_path":"/home/user/${"nested/" * 10}Main.scala"}"""
-    val out = ToolInputSummary.summarise(raw, 40)
-    assert(out.startsWith("(/home/user/"), out)
-    assert(out.endsWith("Main.scala)"), out)
-    assert(out.contains("…"), out)
-    assertEquals(out.length, 42) // 40 plus the wrapping brackets
+    assertEquals(
+      ToolInputSummary.summarise(raw, 40),
+      "(/home/user/nested/n…/nested/Main.scala)"
+    )
 
   test("summarise extracts a field written with a space after the colon"):
     val raw = """{"file_path": "/tmp/foo.txt"}"""
@@ -63,9 +63,9 @@ class ToolInputSummaryTest extends munit.FunSuite:
     val body = List.fill(60)("line").mkString("\n")
     val raw = s"""{"description":"${body.replace("\n", "\\n")}"}"""
     val out = ToolInputSummary.summarise(raw, maxLen)
-    // 24 words ("line " × 24, less the trailing space) fill the 120-char
-    // budget, and the cut character becomes the ellipsis.
-    assertEquals(out, s"(${List.fill(24)("line").mkString(" ")}…)")
+    // 23 words and two characters of the 24th fill the 118 the brackets leave
+    // of the budget, and the cut character becomes the ellipsis.
+    assertEquals(out, s"(${List.fill(23)("line").mkString(" ")} li…)")
 
   test("summarise heads a search with its pattern, scoped to a subtree"):
     val workDir = os.Path("/tmp/orca-AbC")
@@ -134,7 +134,7 @@ class ToolInputSummaryTest extends munit.FunSuite:
     val raw = s"""{"command":"$command"}"""
     val out = ToolInputSummary.summarise(raw, maxLen)
     assert(out.endsWith("token…)"), s"cut mid-token; got: $out")
-    assert(out.length <= maxLen + 2, s"headline exceeded the cap; got: $out")
+    assert(out.length <= maxLen, s"headline exceeded the cap; got: $out")
 
   test("summarise leaves command/pattern/query unchanged when they look pathy"):
     val workDir = os.Path("/tmp/orca-AbC")

--- a/tools/src/main/scala/orca/backend/Conversations.scala
+++ b/tools/src/main/scala/orca/backend/Conversations.scala
@@ -9,16 +9,17 @@ import ox.{Ox, supervised}
 /** Drains a [[Conversation]] for the autonomous path, mapping conversation
   * events to [[OrcaEvent]]s and returning the awaited `AgentResult`.
   *
-  * A structured call whose payload arrives as reply text withholds the closing
-  * assistant turn so the JSON doesn't surface as an `AssistantMessage` — the
-  * caller emits it via `OrcaEvent.StructuredResult` instead. The withheld-turn
+  * A structured call withholds its closing assistant turn — the caller emits
+  * the result via `OrcaEvent.StructuredResult` instead. Where the payload
+  * arrives as reply text (`StructuredOutputMode.RawText`) that turn IS the
+  * JSON; where it arrives as a tool call (claude's `--json-schema` exit call,
+  * `StructuredOutputMode.Tool`) it is the model's sign-off restating what the
+  * `StructuredResult` states in full. Both `Tool`-mode drivers suppress the
+  * exit call itself (`ClaudeConversation.handleAssistantTurn`,
+  * `OpencodeConversation.isStructuredOutputEcho`), so no turn-opening event
+  * follows the sign-off to release it. Mid-turn narration is unaffected — a
+  * real tool call still releases the turn that announced it. The withheld-turn
   * state machine lives in [[TurnBuffer]].
-  *
-  * A backend whose structured payload arrives as a tool call instead (claude's
-  * `--json-schema` exit call, `StructuredOutputMode.Tool`) never streams it as
-  * prose, so nothing is withheld and `StructuredResult.raw` is the sole
-  * carrier. Whether that raw payload gets echoed is `Announce[O]`'s contract
-  * (ADR 0008/0009), not this drain's.
   *
   * Interactive-only events that reach this drain are handled explicitly to
   * avoid blocking the subprocess: `ApproveTool` is auto-denied and
@@ -33,23 +34,14 @@ private[orca] object Conversations:
   private enum ClosingProse:
     case Withhold, Render
 
-  /** Whether an autonomous call's closing prose turn is the structured payload:
-    * it is what the backend's wire delivers, the same fact `Prompts.autonomous`
-    * picks its delivery instruction from.
+  /** A structured call withholds its closing prose turn; a call with no schema
+    * renders it. The wire's [[StructuredOutputMode]] doesn't come into it on
+    * either path: in `RawText` the closing turn IS the payload, in `Tool` it is
+    * the sign-off restating the payload the caller emits as `StructuredResult`
+    * (see the object scaladoc), and `Prompts.interactive` asks every backend
+    * for a JSON-only final message regardless.
     */
-  private def autonomousClosingProse(conv: Conversation[?]): ClosingProse =
-    if conv.outputSchema.isEmpty then ClosingProse.Render
-    else
-      conv.structuredOutputMode match
-        case StructuredOutputMode.RawText => ClosingProse.Withhold
-        case StructuredOutputMode.Tool    => ClosingProse.Render
-
-  /** Whether an interactive call's closing prose turn is the structured
-    * payload. `Prompts.interactive` asks every backend for a JSON-only final
-    * message — it doesn't branch on `StructuredOutputMode` — so here a schema
-    * alone decides.
-    */
-  private def interactiveClosingProse(conv: Conversation[?]): ClosingProse =
+  private def closingProse(conv: Conversation[?]): ClosingProse =
     if conv.outputSchema.isDefined then ClosingProse.Withhold
     else ClosingProse.Render
 
@@ -134,7 +126,7 @@ private[orca] object Conversations:
       events: OrcaListener = OrcaListener.noop
   )(using Ox): AgentResult[B] =
     val buffer = new TurnBuffer(
-      autonomousClosingProse(conv),
+      closingProse(conv),
       text => events.onEvent(OrcaEvent.AssistantMessage(text))
     )
     try
@@ -246,10 +238,10 @@ private[orca] object Conversations:
     * boundary that closes them) is translated into `OrcaEvent.AssistantMessage`
     * on `events` — exactly like [[drainAutonomous]] — instead of being exposed
     * on the conversation's own event stream. A structured call has its closing
-    * turn withheld the same way `TurnBuffer` does (see
-    * [[interactiveClosingProse]] for why the backend's wire doesn't come into
-    * it here); the caller re-surfaces the payload via
-    * `OrcaEvent.StructuredResult` instead (see `AgentCall.runInteractiveOnce`).
+    * turn withheld the same way `TurnBuffer` does (see [[closingProse]] for why
+    * the backend's wire doesn't come into it); the caller re-surfaces the
+    * payload via `OrcaEvent.StructuredResult` instead (see
+    * `AgentCall.runInteractiveOnce`).
     *
     * Every OTHER event (tool calls/results, approvals, questions, errors, the
     * user's own messages) passes through to the returned conversation's
@@ -273,7 +265,7 @@ private[orca] object Conversations:
       def events(using Ox): Iterator[ConversationEvent] =
         ProseWithholdingIterator(
           conv.events,
-          interactiveClosingProse(conv),
+          closingProse(conv),
           text => listener.onEvent(OrcaEvent.AssistantMessage(text))
         )
 

--- a/tools/src/main/scala/orca/backend/Conversations.scala
+++ b/tools/src/main/scala/orca/backend/Conversations.scala
@@ -95,9 +95,14 @@ private[orca] object Conversations:
       withheld = None
       flushCurrent()
 
-    /** Abnormal end (the drain threw mid-stream): nothing is reliably the
-      * payload, so flush everything rather than drop prose. Worst case the user
-      * sees a JSON blob once.
+    /** The drain threw while reading the stream: the turn boundary that would
+      * have told the payload from narration never arrived, so flush everything
+      * rather than drop prose. Worst case the user sees a JSON blob once.
+      *
+      * Only a throw from the iterator lands here. A failure the wire reports
+      * (an `is_error` result) closes the stream normally, so [[finishNormally]]
+      * runs and the parked turn is dropped like any other closing turn — an
+      * unfinished one still flushes from `current`.
       */
     def finishAbnormally(): Unit =
       withheld.foreach(emit)

--- a/tools/src/main/scala/orca/events/OrcaEvent.scala
+++ b/tools/src/main/scala/orca/events/OrcaEvent.scala
@@ -115,7 +115,12 @@ enum OrcaEvent:
     */
   case AssistantMessage(text: String, agent: Option[String] = None)
 
-  case Error(message: String)
+  /** A failure worth showing. `agent` names the agent whose turn produced it,
+    * carrying the same attribution as [[ToolUse]]; `None` for a failure of the
+    * flow itself (a stage that threw, `fail(...)`), which is what tells the two
+    * apart when an agent failure is followed by the stage error it caused.
+    */
+  case Error(message: String, agent: Option[String] = None)
 
   /** Fires once [[orca.backend.SessionSupport]] commits a session's client→wire
     * id mapping ([[orca.backend.SessionSupport.commit]] / `commitAfterDrain`) —
@@ -174,15 +179,18 @@ object OrcaListener:
     */
   val noop: OrcaListener = (_: OrcaEvent) => ()
 
-  /** Stamps `agentName` onto the two display events a turn produces
-    * ([[OrcaEvent.ToolUse]], [[OrcaEvent.AssistantMessage]]) on their way to
-    * `downstream`; every other event passes through untouched. Wrapped around
-    * the listener handed to a backend drain, which emits those events without
-    * knowing which agent it is running for.
+  /** Stamps `agentName` onto the three display events a turn produces
+    * ([[OrcaEvent.ToolUse]], [[OrcaEvent.AssistantMessage]],
+    * [[OrcaEvent.Error]]) on their way to `downstream`; every other event
+    * passes through untouched. Wrapped around the listener handed to a backend
+    * drain, which emits those events without knowing which agent it is running
+    * for.
     */
   def attributedTo(downstream: OrcaListener, agentName: String): OrcaListener =
     case e: OrcaEvent.ToolUse =>
       downstream.onEvent(e.copy(agent = Some(agentName)))
     case e: OrcaEvent.AssistantMessage =>
+      downstream.onEvent(e.copy(agent = Some(agentName)))
+    case e: OrcaEvent.Error =>
       downstream.onEvent(e.copy(agent = Some(agentName)))
     case other => downstream.onEvent(other)

--- a/tools/src/main/scala/orca/events/OrcaEvent.scala
+++ b/tools/src/main/scala/orca/events/OrcaEvent.scala
@@ -35,6 +35,15 @@ enum OrcaEvent:
     */
   case Step(message: String)
 
+  /** Orca's own housekeeping on the user's branch — today the progress-log and
+    * settings commits ([[orca.tools.GitTool.commitOnly]] / `forceCommitOnly`).
+    * Distinct from [[Step]] because none of it is work on the task: the
+    * terminal log leaves it out, where it would read as progress, while the
+    * trace file keeps it. A message is never matched to decide this — the
+    * emitter picks the case.
+    */
+  case Bookkeeping(message: String)
+
   /** Something true of the whole run rather than of the stage it surfaced in —
     * today, a restriction a backend cannot apply mechanically
     * ([[orca.agents.EnforcementNotice]]). Distinct from [[Step]] because a

--- a/tools/src/main/scala/orca/sweep/EnvCookieSweep.scala
+++ b/tools/src/main/scala/orca/sweep/EnvCookieSweep.scala
@@ -110,8 +110,11 @@ private[orca] object EnvCookieSweep:
     log.warn(message)
     events.onEvent(OrcaEvent.Step(message))
 
-  /** The command is unreadable for a process that exited between the scan and
-    * this call.
+  /** The pid is what the reader acts on; the command is only there to recognise
+    * it, so the executable's basename says as much as its install path (a JDK
+    * path is half a terminal row on its own). Unreadable for a process that
+    * exited between the scan and this call.
     */
   private def describe(handle: ProcessHandle): String =
-    s"${handle.pid} (${handle.info.command.orElse("?")})"
+    val command = handle.info.command.orElse("?")
+    s"${handle.pid} (${command.drop(command.lastIndexOf('/') + 1)})"

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -217,6 +217,11 @@ trait GitTool:
     * anything else dirty or untracked stays out, in contrast to [[commit]]'s
     * `add -A`. Throws `OrcaFlowException` when the path has no changes to
     * commit or on system-level failures.
+    *
+    * For the runtime's own files (the progress log, the discovered settings),
+    * so it announces itself as [[orca.events.OrcaEvent.Bookkeeping]] rather
+    * than as a [[orca.events.OrcaEvent.Step]]. Committing the flow's work is
+    * [[commit]]'s job.
     */
   def commitOnly(path: os.Path, message: String)(using WorkspaceWrite): Unit
 
@@ -472,7 +477,8 @@ trait GitTool:
   * subprocess plumbing.
   *
   * `events` publishes [[OrcaEvent.Step]]s for operations shown in the event log
-  * (branch switches, commits, pushes). Optional — defaults to
+  * (branch switches, commits, pushes), and [[OrcaEvent.Bookkeeping]] for the
+  * pathspec commits of orca's own files. Optional — defaults to
   * `OrcaListener.noop`.
   */
 private[orca] class OsGitTool(
@@ -550,7 +556,7 @@ private[orca] class OsGitTool(
     */
   private def commitPathspec(path: os.Path, message: String): Unit =
     val _ = git("commit", "-m", message, "--", path.toString)
-    step(s"Committed: $message")
+    events.onEvent(OrcaEvent.Bookkeeping(s"Committed: $message"))
 
   def forceAdd(path: os.Path)(using WorkspaceWrite): Unit =
     val _ = git("add", "-f", path.toString)

--- a/tools/src/test/scala/orca/backend/ConversationsTest.scala
+++ b/tools/src/test/scala/orca/backend/ConversationsTest.scala
@@ -346,8 +346,8 @@ class ConversationsTest extends munit.FunSuite:
       case other      => fail(s"expected one answer; got $other")
     assert(
       recorder.events.exists {
-        case OrcaEvent.Error(msg) => msg.contains("ask_user")
-        case _                    => false
+        case OrcaEvent.Error(msg, _) => msg.contains("ask_user")
+        case _                       => false
       },
       recorder.events
     )
@@ -551,13 +551,19 @@ class ConversationsTest extends munit.FunSuite:
       )
     )
 
-  test("a Tool-mode structured call renders its closing prose turn"):
-    // In Tool mode the payload never streams as reply text, so withholding the
-    // closing turn would only lose genuine narration.
+  test("a Tool-mode structured call withholds its closing prose turn"):
+    // That turn signs off on work the StructuredResult states in full. Both
+    // Tool-mode drivers suppress the schema-exit tool call itself, so nothing
+    // turn-opening follows the sign-off to release it — while the narration
+    // ahead of a real tool call still renders.
     val recorder = new RecordingListener
     val conv = new ScriptedConversation(
       List(
-        ConversationEvent.AssistantTextDelta("Writing the plan now."),
+        ConversationEvent.AssistantTextDelta("Reading the file first."),
+        ConversationEvent.AssistantTurnEnd,
+        ConversationEvent.AssistantToolCall("Read", """{"file":"stats.py"}"""),
+        ConversationEvent.AssistantTurnEnd,
+        ConversationEvent.AssistantTextDelta("Reviewed it; no issues found."),
         ConversationEvent.AssistantTurnEnd
       ),
       Right(sampleResult),
@@ -568,7 +574,10 @@ class ConversationsTest extends munit.FunSuite:
       supervised(Conversations.drainAutonomous(conv, AutoApprove.All, recorder))
     assertEquals(
       recorder.events,
-      List(OrcaEvent.AssistantMessage("Writing the plan now."))
+      List(
+        OrcaEvent.AssistantMessage("Reading the file first."),
+        OrcaEvent.ToolUse("Read", """{"file":"stats.py"}""")
+      )
     )
 
   test(

--- a/tools/src/test/scala/orca/backend/ConversationsTest.scala
+++ b/tools/src/test/scala/orca/backend/ConversationsTest.scala
@@ -554,14 +554,11 @@ class ConversationsTest extends munit.FunSuite:
   test("a Tool-mode structured call withholds its closing prose turn"):
     // That turn signs off on work the StructuredResult states in full. Both
     // Tool-mode drivers suppress the schema-exit tool call itself, so nothing
-    // turn-opening follows the sign-off to release it — while the narration
-    // ahead of a real tool call still renders.
+    // turn-opening follows the sign-off to release it.
     val recorder = new RecordingListener
     val conv = new ScriptedConversation(
       List(
         ConversationEvent.AssistantTextDelta("Reading the file first."),
-        ConversationEvent.AssistantTurnEnd,
-        ConversationEvent.AssistantToolCall("Read", """{"file":"stats.py"}"""),
         ConversationEvent.AssistantTurnEnd,
         ConversationEvent.AssistantTextDelta("Reviewed it; no issues found."),
         ConversationEvent.AssistantTurnEnd
@@ -574,10 +571,7 @@ class ConversationsTest extends munit.FunSuite:
       supervised(Conversations.drainAutonomous(conv, AutoApprove.All, recorder))
     assertEquals(
       recorder.events,
-      List(
-        OrcaEvent.AssistantMessage("Reading the file first."),
-        OrcaEvent.ToolUse("Read", """{"file":"stats.py"}""")
-      )
+      List(OrcaEvent.AssistantMessage("Reading the file first."))
     )
 
   test(

--- a/tools/src/test/scala/orca/events/OrcaListenerTest.scala
+++ b/tools/src/test/scala/orca/events/OrcaListenerTest.scala
@@ -1,0 +1,21 @@
+package orca.events
+
+import java.util.concurrent.atomic.AtomicReference
+
+class OrcaListenerTest extends munit.FunSuite:
+
+  test("attributedTo stamps an Error and leaves a non-display event alone"):
+    val seen = new AtomicReference[List[OrcaEvent]](Nil)
+    val listener = OrcaListener.attributedTo(
+      e => seen.updateAndGet(_ :+ e): Unit,
+      "readability"
+    )
+    listener.onEvent(OrcaEvent.Error("turn failed"))
+    listener.onEvent(OrcaEvent.Step("Switched to branch 'main'"))
+    assertEquals(
+      seen.get(),
+      List(
+        OrcaEvent.Error("turn failed", Some("readability")),
+        OrcaEvent.Step("Switched to branch 'main'")
+      )
+    )


### PR DESCRIPTION
Third of five PRs from `docs/plans/run-quality/` (spec and plan are on master). Independent of #162.

Half of every run's output was read-only tool calls — 395 of 542 lines in one measured run were `Read`/`Grep`/`Glob` echoes that nobody acts on, while the write-shaped calls a reader does want were visually identical to them.

- A read-only call now renders as a constant `⏺ read` line, so the **existing** repeat-collapse folds a burst into one line plus `⎿ ×N`. No new rendering mechanism. The line is identical whichever agent emitted it, so a parallel reviewer fan-out — where read volume is highest — folds too; the agent is still recorded as an emitter, so its prose and mutating calls stay named. An unrecognised tool name still prints in full, the safe direction.
- A reviewer's closing prose is withheld when a structured result follows and says the same thing better. Mid-turn narration is untouched. Verified per driver: both `Tool`-mode backends suppress the injected exit call and its echo, so nothing turn-opening can release the parked prose.
- Truncation budgets subtract indent, glyph and agent prefix, so a line meant to be one line is one line; long paths middle-truncate and keep their filename.
- `OrcaEvent.Error` carries the agent that failed, so a per-agent failure is distinguishable from the stage error that follows it — previously both rendered as unlabelled `✖` lines.
- Orca's own bookkeeping commits no longer render as if they were the user's work. They are marked at the emitter with a new `OrcaEvent.Bookkeeping`, not matched by message text — orca is developed with orca, and an agent committing an `orca:`-prefixed message would otherwise have its step silently dropped.

ADR 0008's glyph table is corrected against the code: `▶` is magenta not cyan, `⏺` is yellow not blue, the thinking row describes something that never renders, and `⎿` means the repeat count in an autonomous run.

Review found the collapse did not fire in the parallel fan-out — where it was aimed — because the agent prefix made the lines non-identical, leaving bursts uncollapsed *and* stripped of their filenames. Fixed and pinned by a multi-agent test; the original test used one emitter and could not catch it.
