### PR TITLE
Tell the user where the run left them

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,16 +341,20 @@ Each `flow(...)` run is bound to exactly one feature branch and one progress log
   failure before it runs the teardown's `git reset --hard` and destroys kept
   modifications to tracked files (kept untracked files survive).
 - **Resume:** a re-run with the same prompt finds the progress log and resumes
-  from the first incomplete stage. A corrupt or truncated progress log is
-  detected at startup — orca warns and starts fresh (previous stages re-run)
-  rather than silently mis-resuming.
+  from the first incomplete stage. It says once which branch it bound, how many
+  stages it is skipping, and that the interrupted stage's uncommitted work was
+  not carried over; a re-seeded agent session is told the same. A corrupt or
+  truncated progress log is detected at startup — orca warns and starts fresh
+  (previous stages re-run) rather than silently mis-resuming.
 - **Success teardown:** remove the progress-log file in a final commit, and push
   it when the remote branch still carries the log (i.e. the flow pushed). A
   throwaway feature branch (no substantive changes vs the starting branch) is
   deleted and HEAD returns to the starting branch. Otherwise the feature branch
   is kept and HEAD **stays on it by default** (so you end on the work); pass
   `returnToStartBranch = true` — for flows that open a PR — to return HEAD to
-  the starting branch instead.
+  the starting branch instead. The run then closes by naming the branch you are
+  left on, how many files changed since the commit it started from, and the
+  `git diff` that shows them.
 - **Failure teardown:** discard the failed stage's uncommitted partial edits —
   `git reset --hard` for tracked files, plus `git clean -fd` for the files it
   newly created; stay on the feature branch so a re-run resumes in place.

--- a/README.md
+++ b/README.md
@@ -342,8 +342,8 @@ Each `flow(...)` run is bound to exactly one feature branch and one progress log
   modifications to tracked files (kept untracked files survive).
 - **Resume:** a re-run with the same prompt finds the progress log and resumes
   from the first incomplete stage. It says once which branch it bound, how many
-  stages it is skipping, and that the interrupted stage's uncommitted work was
-  not carried over; a re-seeded agent session is told the same. A corrupt or
+  stages are already recorded, and that the interrupted stage's uncommitted work
+  was not carried over; a re-seeded agent session is told the same. A corrupt or
   truncated progress log is detected at startup — orca warns and starts fresh
   (previous stages re-run) rather than silently mis-resuming.
 - **Success teardown:** remove the progress-log file in a final commit, and push

--- a/flow/src/main/scala/orca/Flow.scala
+++ b/flow/src/main/scala/orca/Flow.scala
@@ -72,8 +72,10 @@ private def resumeFrom[T: JsonData](id: String, name: String)(using
           )
         catch case NonFatal(_) => None
       decoded.map: value =>
+        // A replayed stage announces itself with the stage markers alone: the
+        // run already said once what it is resuming from, and the markers are
+        // what keeps a renderer's indent depth balanced.
         fc.emit(OrcaEvent.StageStarted(name))
-        fc.emit(OrcaEvent.Step(s"Resuming '$name' from recorded result"))
         fc.emit(OrcaEvent.StageCompleted(name))
         value
 

--- a/flow/src/main/scala/orca/Session.scala
+++ b/flow/src/main/scala/orca/Session.scala
@@ -395,7 +395,9 @@ private def persistResumeWireId[B <: BackendTag](
   * caller's text verbatim and never sees this.
   *
   * The wording stays neutral about interruption because the same preamble
-  * primes a session first used mid-run, after an earlier stage completed.
+  * primes a session first used mid-run, after an earlier stage completed — and
+  * it speaks of a stage that did not complete rather than of uncommitted work
+  * in general, since a stage's own edits ARE committed at its boundary.
   */
 private def progressPreamble(
     log: Option[ProgressLog],
@@ -408,8 +410,9 @@ private def progressPreamble(
       headCommit.fold("")(c => s" The working tree is at commit $c.")
     Some(
       s"Progress so far: completed ${completed.mkString(", ")}.$tree " +
-        "Uncommitted work does not survive between stages, so read the files " +
-        "rather than assuming earlier edits are still there. Continue from here."
+        "Their work is committed; a stage that did not complete left nothing " +
+        "behind. Read the files rather than assuming what earlier stages " +
+        "left. Continue from here."
     )
 
 /** Assemble the final primed prompt from the optional preamble, optional seed,

--- a/flow/src/main/scala/orca/Session.scala
+++ b/flow/src/main/scala/orca/Session.scala
@@ -352,7 +352,7 @@ private def effectivePrompt[B <: BackendTag](
         )
       )
     val seed = record.map(_.seed).filter(_.nonEmpty)
-    val preamble = progressPreamble(log)
+    val preamble = progressPreamble(log, fc.git.headCommit())
     composePrimedPrompt(preamble, seed, text)
 
 /** After a run, persist the backend's now-learned resume wire id (durable
@@ -382,15 +382,34 @@ private def persistResumeWireId[B <: BackendTag](
       record.copy(resumeWireId = Some(wireId.value), backend = healedTag)
     )
 
-/** Compose the progress preamble from completed stage names in the log. Returns
-  * `None` if there are no completed entries (first run).
+/** Compose the progress preamble from completed stage names in the log and the
+  * commit the working tree sits at. Returns `None` if there are no completed
+  * entries (first run).
+  *
+  * `headCommit` is passed in rather than read here, so the rendered text is a
+  * function of the arguments alone.
+  *
+  * This reaches a model only where [[effectivePrompt]] injects it — when the
+  * backend conversation is fresh or lost. That is the common resumed-run case
+  * but not every one: an agent whose conversation is still live gets the
+  * caller's text verbatim and never sees this.
+  *
+  * The wording stays neutral about interruption because the same preamble
+  * primes a session first used mid-run, after an earlier stage completed.
   */
-private def progressPreamble(log: Option[ProgressLog]): Option[String] =
+private def progressPreamble(
+    log: Option[ProgressLog],
+    headCommit: Option[String]
+): Option[String] =
   val completed = log.map(_.entries.map(_.name)).getOrElse(Nil)
   if completed.isEmpty then None
   else
+    val tree =
+      headCommit.fold("")(c => s" The working tree is at commit $c.")
     Some(
-      s"Progress so far: completed ${completed.mkString(", ")}. Continue from here."
+      s"Progress so far: completed ${completed.mkString(", ")}.$tree " +
+        "Uncommitted work does not survive between stages, so read the files " +
+        "rather than assuming earlier edits are still there. Continue from here."
     )
 
 /** Assemble the final primed prompt from the optional preamble, optional seed,

--- a/flow/src/test/scala/orca/FlowSessionTest.scala
+++ b/flow/src/test/scala/orca/FlowSessionTest.scala
@@ -485,7 +485,7 @@ class FlowSessionTest extends FunSuite:
     )
 
   test(
-    "re-seeded session: the preamble names the commit the tree is at and warns that uncommitted work is gone"
+    "re-seeded session: the preamble names the commit the tree is at and says an unfinished stage left nothing"
   ):
     // A real repo, unlike `makeControl`'s bare temp dir, so `headCommit()` has
     // something to report.
@@ -514,8 +514,8 @@ class FlowSessionTest extends FunSuite:
       s"the preamble must name the commit; got: $prompt"
     )
     assert(
-      prompt.contains("Uncommitted work does not survive between stages"),
-      s"the preamble must say earlier edits may be gone; got: $prompt"
+      prompt.contains("a stage that did not complete left nothing behind"),
+      s"the preamble must say an unfinished stage's edits are gone; got: $prompt"
     )
 
   test(

--- a/flow/src/test/scala/orca/FlowSessionTest.scala
+++ b/flow/src/test/scala/orca/FlowSessionTest.scala
@@ -26,7 +26,7 @@ import orca.progress.{
   SessionRecord
 }
 import com.github.plokhotnyuk.jsoniter_scala.core.readFromString
-import orca.testkit.TempDirs
+import orca.testkit.{GitRepo, TempDirs}
 import orca.util.RawJson
 
 /** Tests for [[FlowSession]] — the durable-session handle that owns the probe →
@@ -482,6 +482,40 @@ class FlowSessionTest extends FunSuite:
     assert(
       !prompt.startsWith("---"),
       s"prompt must not start with bare separator; got: $prompt"
+    )
+
+  test(
+    "re-seeded session: the preamble names the commit the tree is at and warns that uncommitted work is gone"
+  ):
+    // A real repo, unlike `makeControl`'s bare temp dir, so `headCommit()` has
+    // something to report.
+    val dir = GitRepo.seeded()
+    val store = ProgressStore.default(dir, "p")
+    store.writeHeader(
+      ProgressHeader("main", "feat/test", "deadbeef", BranchMode.Created)
+    )
+    store.upsertSession(
+      SessionRecord(name = "s", occurrence = 0, id = testSessionId, seed = "")
+    )
+    store.appendEntry(StageEntry("triage#0", "triage", RawJson("null")))
+    val git = new orca.tools.OsGitTool(dir)
+    val fc = new TestFlowControl(
+      new orca.events.EventDispatcher(Nil),
+      git,
+      store,
+      "p"
+    )
+    val agent = new StubAgentForSeeded(existsResult = false)
+    val _ = flowSession(agent).run("continue")(using fc)
+    val prompt = agent.capturedPrompt.getOrElse(fail("no prompt captured"))
+    val head = git.headCommit().getOrElse(fail("no HEAD in the seeded repo"))
+    assert(
+      prompt.contains(s"The working tree is at commit $head."),
+      s"the preamble must name the commit; got: $prompt"
+    )
+    assert(
+      prompt.contains("Uncommitted work does not survive between stages"),
+      s"the preamble must say earlier edits may be gone; got: $prompt"
     )
 
   test(

--- a/flow/src/test/scala/orca/StageRuntimeTest.scala
+++ b/flow/src/test/scala/orca/StageRuntimeTest.scala
@@ -61,6 +61,7 @@ class StageRuntimeTest extends munit.FunSuite:
         "value-42"
 
     val first = runOnce()(using ctx)
+    val afterFirstRun = listener.events.size
     // A second control over the SAME repo + store: a fresh process re-run.
     val (ctx2, _) = reopen(dir, listener)
     val second = runOnce()(using ctx2)
@@ -68,18 +69,15 @@ class StageRuntimeTest extends munit.FunSuite:
     assertEquals(first, "value-42")
     assertEquals(second, "value-42")
     assertEquals(runs.get(), 1, "body must run exactly once across both runs")
-    // A replayed stage prints its markers and nothing else — the run-level
-    // resume announcement covers what was skipped.
+    // A replayed stage emits both markers — which is what keeps a renderer's
+    // indent depth balanced — and nothing else: the run-level resume
+    // announcement covers what was skipped.
     assertEquals(
-      listener.events.count(_ == OrcaEvent.StageStarted("compute")),
-      2
-    )
-    assert(
-      !listener.events.exists:
-        case OrcaEvent.Step(m) => m.contains("compute")
-        case _                 => false
-      ,
-      s"a replayed stage must not add a Step: ${listener.events}"
+      listener.events.drop(afterFirstRun),
+      List(
+        OrcaEvent.StageStarted("compute"),
+        OrcaEvent.StageCompleted("compute")
+      )
     )
 
   test("a crash in a later stage leaves earlier stages committed and recorded"):

--- a/flow/src/test/scala/orca/StageRuntimeTest.scala
+++ b/flow/src/test/scala/orca/StageRuntimeTest.scala
@@ -68,11 +68,18 @@ class StageRuntimeTest extends munit.FunSuite:
     assertEquals(first, "value-42")
     assertEquals(second, "value-42")
     assertEquals(runs.get(), 1, "body must run exactly once across both runs")
+    // A replayed stage prints its markers and nothing else — the run-level
+    // resume announcement covers what was skipped.
+    assertEquals(
+      listener.events.count(_ == OrcaEvent.StageStarted("compute")),
+      2
+    )
     assert(
-      listener.events.contains(
-        OrcaEvent.Step("Resuming 'compute' from recorded result")
-      ),
-      "second run must report a resume"
+      !listener.events.exists:
+        case OrcaEvent.Step(m) => m.contains("compute")
+        case _                 => false
+      ,
+      s"a replayed stage must not add a Step: ${listener.events}"
     )
 
   test("a crash in a later stage leaves earlier stages committed and recorded"):

--- a/runner/src/main/scala/orca/runner/ClosingSummary.scala
+++ b/runner/src/main/scala/orca/runner/ClosingSummary.scala
@@ -2,11 +2,19 @@ package orca.runner
 
 import orca.progress.CommitHash
 
-/** What a run produced, measured against the commit it started from. Absent
-  * when no starting commit is recorded — a resumed run whose recorded commit is
-  * no longer an ancestor of HEAD — where any count would be a guess.
+/** What a run produced, measured against the commit it started from, on the
+  * branch `countedOn` — the feature branch, where the work is. Absent when no
+  * starting commit is recorded — a resumed run whose recorded commit is no
+  * longer an ancestor of HEAD — where any count would be a guess.
+  *
+  * Only tracked files are counted, so the count is exactly what the `git diff`
+  * this summary offers can show.
   */
-private[runner] case class RunChanges(base: CommitHash, filesChanged: Int)
+private[runner] case class RunChanges(
+    base: CommitHash,
+    filesChanged: Int,
+    countedOn: String
+)
 
 /** The block a successful run closes with: where the work ended up, how much of
   * it there is, and the command that shows it.
@@ -18,15 +26,28 @@ private[runner] case class RunChanges(base: CommitHash, filesChanged: Int)
 private[runner] object ClosingSummary:
   /** One line per fact, each emitted as its own `OrcaEvent.Step` so listeners
     * that render an event per line keep them aligned.
+    *
+    * When HEAD has left the branch the count was taken on (a PR flow's
+    * `returnToStartBranch`), the command is a range diff and names that branch
+    * — a plain `git diff <base>` would run against the branch the user landed
+    * on and show none of the work.
     */
   def lines(branch: String, changes: Option[RunChanges]): List[String] =
     val where = s"done — you are on branch '$branch'"
     changes match
-      case None                   => List(where)
-      case Some(RunChanges(_, 0)) => List(where, "no files changed")
-      case Some(RunChanges(base, files)) =>
+      case None                      => List(where)
+      case Some(RunChanges(_, 0, _)) => List(where, "no files changed")
+      case Some(RunChanges(base, files, countedOn)) =>
+        // `countedOn` still exists whenever the range form is reached: the only
+        // branch teardown deletes is a throwaway one, which by definition
+        // carries no committed change against the start branch — and every
+        // tracked change a stage makes is committed by that stage, so a
+        // non-zero count and a throwaway branch don't co-occur.
+        val target =
+          if countedOn == branch then base.short
+          else s"${base.short}..$countedOn"
         List(
           where,
           s"$files file(s) changed since ${base.short}",
-          s"next: git diff ${base.short}"
+          s"next: git diff $target"
         )

--- a/runner/src/main/scala/orca/runner/ClosingSummary.scala
+++ b/runner/src/main/scala/orca/runner/ClosingSummary.scala
@@ -1,0 +1,32 @@
+package orca.runner
+
+import orca.progress.CommitHash
+
+/** What a run produced, measured against the commit it started from. Absent
+  * when no starting commit is recorded — a resumed run whose recorded commit is
+  * no longer an ancestor of HEAD — where any count would be a guess.
+  */
+private[runner] case class RunChanges(base: CommitHash, filesChanged: Int)
+
+/** The block a successful run closes with: where the work ended up, how much of
+  * it there is, and the command that shows it.
+  *
+  * `branch` is the branch HEAD is left on, which is not always the run's
+  * feature branch: a run that produced nothing has its throwaway branch deleted
+  * and ends back on the branch it started from.
+  */
+private[runner] object ClosingSummary:
+  /** One line per fact, each emitted as its own `OrcaEvent.Step` so listeners
+    * that render an event per line keep them aligned.
+    */
+  def lines(branch: String, changes: Option[RunChanges]): List[String] =
+    val where = s"done — you are on branch '$branch'"
+    changes match
+      case None                   => List(where)
+      case Some(RunChanges(_, 0)) => List(where, "no files changed")
+      case Some(RunChanges(base, files)) =>
+        List(
+          where,
+          s"$files file(s) changed since ${base.short}",
+          s"next: git diff ${base.short}"
+        )

--- a/runner/src/main/scala/orca/runner/FlowLifecycle.scala
+++ b/runner/src/main/scala/orca/runner/FlowLifecycle.scala
@@ -20,6 +20,7 @@ import orca.progress.{
   CommitHash,
   FeatureBranch,
   ProgressHeader,
+  ProgressLog,
   ProgressScan,
   ProgressStore,
   ProtectedBranchRefused,
@@ -101,7 +102,8 @@ object FlowLifecycle:
         ctx.emit(
           OrcaEvent.Step(
             "recovering from the failure — discarding uncommitted changes " +
-              "and the files the failed stage created, so a re-run resumes " +
+              "and the files the failed stage created; re-run the same " +
+              "command (the same flow with the same task text) to resume " +
               "from the last completed stage"
           )
         )
@@ -118,7 +120,7 @@ object FlowLifecycle:
               )
             )
         throw f
-    teardownSuccess(ctx.git, flowSetup, returnToStartBranch)
+    teardownSuccess(ctx.git, flowSetup, returnToStartBranch, ctx.emit)
 
   /** Replay the persisted resume-wire-id map (ADR 0018 §2.6) into each
     * session's own agent's in-memory registry, so a resumed run resumes against
@@ -584,7 +586,7 @@ object FlowLifecycle:
         case ProgressStore.LoadResult.Absent =>
           freshBinding(startBranch, protectedBranches, discovered)
         case ProgressStore.LoadResult.Loaded(progressLog) =>
-          resumeBinding(progressLog.header, protectedBranches, discovered)
+          resumeBinding(progressLog, protectedBranches, discovered)
 
     /** The log file exists but didn't parse. No sane way to resume from
       * unparseable data, so this warns loudly — distinguishing a corrupt log
@@ -653,10 +655,11 @@ object FlowLifecycle:
       * 0019): this arm creates no branch, so nothing else would commit it.
       */
     private def resumeBinding(
-        header: ProgressHeader,
+        log: ProgressLog,
         protectedBranches: Set[String],
         discovered: Boolean
     )(using WorkspaceWrite): BranchBinding =
+      val header = log.header
       val featureBranch =
         RecoveryCheck.validateHeader(
           header,
@@ -675,19 +678,56 @@ object FlowLifecycle:
             s"'$current' — was it merged? aborting rather than resuming " +
             "against the wrong branch"
         )
-      if discovered then commitDiscoveredSettings(git, workDir)
       // The FIRST attempt's commit, read back from the header: this attempt's
       // HEAD has moved on by every stage the interrupted run committed, and a
       // whole-run review must still see those. Dropped unless git can still
       // diff against it — a rebase or a fresh clone leaves a hash that would
       // otherwise widen the review to unrelated history.
+      val startingCommit =
+        RecoveryCheck
+          .startingCommit(header)
+          .filter(c => git.isAncestorOfHead(c.value))
+      // Ahead of the settings commit, so the reported HEAD is the tree the
+      // recorded stages left behind rather than orca's own bookkeeping.
+      announceResume(featureBranch, startingCommit, log.entries.size)
+      if discovered then commitDiscoveredSettings(git, workDir)
       BranchBinding(
         featureBranch,
         header.startingBranch,
         header.branchMode,
-        RecoveryCheck
-          .startingCommit(header)
-          .filter(c => git.isAncestorOfHead(c.value))
+        startingCommit
+      )
+
+    /** What a resumed run says about itself, once. `createBranch` and
+      * `checkout` announce the branch on every other path; this arm binds an
+      * existing branch and takes neither, so nothing else would name it.
+      *
+      * `startingCommit` is the post-filter value, so the hash shown is always
+      * one git can still resolve. The second line is the run's whole account of
+      * the replay — each replayed stage prints only its own marker — so it
+      * carries how much is skipped and what state the tree is in.
+      *
+      * "not carried over" rather than "discarded": a run resumed after a clean
+      * failure had that work reset away, but one resumed after a kill has it
+      * auto-stashed instead (ADR 0018 R4), and the cleanliness Step says so.
+      */
+    private def announceResume(
+        branch: FeatureBranch,
+        startingCommit: Option[CommitHash],
+        recordedStages: Int
+    ): Unit =
+      val from =
+        startingCommit.fold("")(c => s" — this run started from ${c.short}")
+      emit(OrcaEvent.Step(s"on branch '${branch.value}'$from"))
+      val at = git
+        .headCommit()
+        .flatMap(CommitHash.from)
+        .fold("")(c => s", tree at ${c.short}")
+      emit(
+        OrcaEvent.Step(
+          s"resuming: $recordedStages stage(s) already recorded$at; the " +
+            "interrupted stage's uncommitted work was not carried over"
+        )
       )
 
   /** Resolve the stack settings for the run (ADR 0019 §7): pass through
@@ -1074,11 +1114,19 @@ object FlowLifecycle:
     * leg for the log line.
     */
   private def bestEffort(what: String)(op: => Unit): Unit =
+    val _ = bestEffortRead(what)(Some(op))
+
+  /** [[bestEffort]] for a leg the closing summary reads a value from: a failure
+    * yields `None`, so a broken git read costs the summary a line rather than
+    * escaping teardown.
+    */
+  private def bestEffortRead[T](what: String)(op: => Option[T]): Option[T] =
     val log = LoggerFactory.getLogger("orca.flow")
     try op
     catch
       case NonFatal(e) =>
         log.debug(s"teardownSuccess: $what failed (cosmetic, swallowed)", e)
+        None
 
   /** Successful teardown (ADR 0018 §2.5): remove the progress-log file in a
     * final commit so a merged branch is clean, push that commit when the branch
@@ -1089,15 +1137,24 @@ object FlowLifecycle:
     * handoff are cosmetic on an already-successful run — every leg runs through
     * [[bestEffort]]. A missing progress-log file (the ordinary "already
     * removed" case) stays fully silent; every other failure is debug-logged.
+    *
+    * The closing summary ([[ClosingSummary]]) straddles the whole sequence: its
+    * change set is counted at the top, while the feature branch is still
+    * checked out, and it is emitted at the very end, once [[finishBranch]] has
+    * settled which branch the user is left on.
     */
   private[orca] def teardownSuccess(
       git: GitTool,
       setup: FlowSetup,
-      returnToStartBranch: Boolean
+      returnToStartBranch: Boolean,
+      emit: OrcaEvent => Unit
   ): Unit =
     // Teardown runs outside any user stage, so it mints its own
     // `WorkspaceWrite`. No LLM call happens here, so `InStage` isn't needed.
     given WorkspaceWrite = RuntimeInStage.workspaceToken()
+    val changes = bestEffortRead("count changed files"):
+      setup.startingCommit.map: base =>
+        RunChanges(base, git.changedFiles(Some(base.value)).size)
     try
       bestEffort("remove progress log"):
         try
@@ -1121,6 +1178,10 @@ object FlowLifecycle:
     finally
       bestEffort("branch handoff"):
         finishBranch(git, setup, returnToStartBranch)
+      bestEffort("closing summary"):
+        ClosingSummary
+          .lines(git.currentBranch(), changes)
+          .foreach(line => emit(OrcaEvent.Step(line)))
 
   /** Where HEAD ends up after a successful run. A throwaway feature branch
     * (only orca bookkeeping, no user code vs the start branch) is deleted and

--- a/runner/src/main/scala/orca/runner/FlowLifecycle.scala
+++ b/runner/src/main/scala/orca/runner/FlowLifecycle.scala
@@ -1139,9 +1139,10 @@ object FlowLifecycle:
     * removed" case) stays fully silent; every other failure is debug-logged.
     *
     * The closing summary ([[ClosingSummary]]) straddles the whole sequence: its
-    * change set is counted at the top, while the feature branch is still
-    * checked out, and it is emitted at the very end, once [[finishBranch]] has
-    * settled which branch the user is left on.
+    * change set is counted first, while the feature branch is still checked
+    * out, and it is emitted last, once [[finishBranch]] has settled which
+    * branch the user is left on — which is why [[RunChanges]] carries the
+    * branch it was counted on.
     */
   private[orca] def teardownSuccess(
       git: GitTool,
@@ -1152,36 +1153,44 @@ object FlowLifecycle:
     // Teardown runs outside any user stage, so it mints its own
     // `WorkspaceWrite`. No LLM call happens here, so `InStage` isn't needed.
     given WorkspaceWrite = RuntimeInStage.workspaceToken()
-    val changes = bestEffortRead("count changed files"):
-      setup.startingCommit.map: base =>
-        RunChanges(base, git.changedFiles(Some(base.value)).size)
-    try
-      bestEffort("remove progress log"):
-        try
-          val _ = os.remove(setup.store.path)
-        catch case _: java.nio.file.NoSuchFileException => ()
-      // Pathspec-scoped to the log file, so uncommitted files the cleanliness
-      // policy left in the tree stay out of this bookkeeping commit;
-      // force-staged, because `.orca/` may be gitignored. A log never
-      // committed, or already removed by an earlier teardown, fails the stage
-      // or the commit — cosmetic, swallowed by bestEffort.
-      bestEffort("commit progress-log removal"):
-        git.forceCommitOnly(setup.store.path, "orca: remove progress log")
-      // Gated on the remote still carrying the log, not on the commit leg
-      // succeeding: a resumed teardown's commit finds nothing to commit yet
-      // may still owe the remote a push. The gate is also what keeps this from
-      // publishing
-      // anything the run didn't — a reused branch that had an upstream before
-      // the run only has the log upstream if this run pushed it there.
-      bestEffort("push progress-log removal"):
-        if git.upstreamHas(setup.store.path) then git.push().orThrow
-    finally
-      bestEffort("branch handoff"):
-        finishBranch(git, setup, returnToStartBranch)
-      bestEffort("closing summary"):
-        ClosingSummary
-          .lines(git.currentBranch(), changes)
-          .foreach(line => emit(OrcaEvent.Step(line)))
+    val changes =
+      try
+        // First, while the feature branch is still checked out: the count is
+        // what `git diff` against the base shows there.
+        val counted = bestEffortRead("count changed files"):
+          setup.startingCommit.map: base =>
+            RunChanges(
+              base,
+              git.trackedChangedFiles(base.value).size,
+              setup.featureBranch.value
+            )
+        bestEffort("remove progress log"):
+          try
+            val _ = os.remove(setup.store.path)
+          catch case _: java.nio.file.NoSuchFileException => ()
+        // Pathspec-scoped to the log file, so uncommitted files the cleanliness
+        // policy left in the tree stay out of this bookkeeping commit;
+        // force-staged, because `.orca/` may be gitignored. A log never
+        // committed, or already removed by an earlier teardown, fails the stage
+        // or the commit — cosmetic, swallowed by bestEffort.
+        bestEffort("commit progress-log removal"):
+          git.forceCommitOnly(setup.store.path, "orca: remove progress log")
+        // Gated on the remote still carrying the log, not on the commit leg
+        // succeeding: a resumed teardown's commit finds nothing to commit yet
+        // may still owe the remote a push. The gate is also what keeps this
+        // from publishing anything the run didn't — a reused branch that had an
+        // upstream before the run only has the log upstream if this run pushed
+        // it there.
+        bestEffort("push progress-log removal"):
+          if git.upstreamHas(setup.store.path) then git.push().orThrow
+        counted
+      finally
+        bestEffort("branch handoff"):
+          finishBranch(git, setup, returnToStartBranch)
+    bestEffort("closing summary"):
+      ClosingSummary
+        .lines(git.currentBranch(), changes)
+        .foreach(line => emit(OrcaEvent.Step(line)))
 
   /** Where HEAD ends up after a successful run. A throwaway feature branch
     * (only orca bookkeeping, no user code vs the start branch) is deleted and

--- a/runner/src/test/scala/orca/runner/FlowLifecycleTest.scala
+++ b/runner/src/test/scala/orca/runner/FlowLifecycleTest.scala
@@ -2904,7 +2904,12 @@ class FlowLifecycleTest extends munit.FunSuite:
       untrackedOnFailure = UntrackedFiles.Remove,
       startingCommit = None
     )
-    FlowLifecycle.teardownSuccess(git, setup, returnToStartBranch = false)
+    FlowLifecycle.teardownSuccess(
+      git,
+      setup,
+      returnToStartBranch = false,
+      _ => ()
+    )
     assert(
       branchNames(workDir).contains("reused-branch"),
       "the reused branch must survive teardown when orca did not create it"
@@ -2982,7 +2987,12 @@ class FlowLifecycleTest extends munit.FunSuite:
     repo.commitLog()
     repo.git.push().orThrow
     FlowLifecycle
-      .teardownSuccess(repo.git, repo.setup, returnToStartBranch = false)
+      .teardownSuccess(
+        repo.git,
+        repo.setup,
+        returnToStartBranch = false,
+        _ => ()
+      )
     val files = remoteFiles(repo.remote)
     assert(!files.linesIterator.contains(repo.logRelPath.toString), files)
 
@@ -2991,7 +3001,12 @@ class FlowLifecycleTest extends munit.FunSuite:
     given WorkspaceWrite = WorkspaceWrite.unsafe
     repo.commitLog()
     FlowLifecycle
-      .teardownSuccess(repo.git, repo.setup, returnToStartBranch = false)
+      .teardownSuccess(
+        repo.git,
+        repo.setup,
+        returnToStartBranch = false,
+        _ => ()
+      )
     assertEquals(remoteRefs(repo.remote).trim, "")
 
   test("teardownSuccess pushes nothing when the upstream never got the log"):
@@ -3004,8 +3019,157 @@ class FlowLifecycleTest extends munit.FunSuite:
     val before = remoteTip(repo.remote)
     repo.commitLog()
     FlowLifecycle
-      .teardownSuccess(repo.git, repo.setup, returnToStartBranch = false)
+      .teardownSuccess(
+        repo.git,
+        repo.setup,
+        returnToStartBranch = false,
+        _ => ()
+      )
     assertEquals(remoteTip(repo.remote), before)
+
+  /** The closing block's Step messages, in emission order, from a direct
+    * `teardownSuccess` over `setup`.
+    */
+  private def closingSummary(
+      git: OsGitTool,
+      setup: FlowLifecycle.FlowSetup
+  ): List[String] =
+    val emitted = new AtomicReference[List[OrcaEvent]](Nil)
+    FlowLifecycle.teardownSuccess(
+      git,
+      setup,
+      returnToStartBranch = false,
+      e => { val _ = emitted.updateAndGet(e :: _) }
+    )
+    emitted.get().reverse.collect { case s: OrcaEvent.Step => s.message }
+
+  private def closingSetup(
+      store: ProgressStore,
+      branch: String,
+      branchMode: BranchMode,
+      startingCommit: Option[orca.progress.CommitHash]
+  ): FlowLifecycle.FlowSetup =
+    FlowLifecycle.FlowSetup(
+      store = store,
+      featureBranch =
+        FeatureBranch.resolveReused(branch, Set.empty).toOption.get,
+      startBranch = "main",
+      stackSettings = StackSettings.empty,
+      branchMode = branchMode,
+      untrackedOnFailure = UntrackedFiles.Remove,
+      startingCommit = startingCommit
+    )
+
+  test(
+    "closing summary: names the branch the run ends on, the file count and the diff command"
+  ):
+    val workDir = GitRepo.seeded()
+    val git = new OsGitTool(workDir)
+    given WorkspaceWrite = WorkspaceWrite.unsafe
+    val base = git.headCommit().flatMap(orca.progress.CommitHash.from).get
+    val _ = git.createBranch("closing-work")
+    os.write(workDir / "a.txt", "one")
+    os.write(workDir / "b.txt", "two")
+    assert(git.commit("the run's work").isRight)
+    val setup = closingSetup(
+      ProgressStore.default(workDir, "closing-work"),
+      "closing-work",
+      BranchMode.Created,
+      Some(base)
+    )
+    assertEquals(
+      closingSummary(git, setup),
+      List(
+        "done — you are on branch 'closing-work'",
+        s"2 file(s) changed since ${base.short}",
+        s"next: git diff ${base.short}"
+      )
+    )
+
+  test(
+    "closing summary: a throwaway branch is deleted first, so the block names the branch the user is left on"
+  ):
+    val workDir = GitRepo.seeded()
+    val git = new OsGitTool(workDir)
+    given WorkspaceWrite = WorkspaceWrite.unsafe
+    val base = git.headCommit().flatMap(orca.progress.CommitHash.from).get
+    val _ = git.createBranch("closing-throwaway") // no user code on it
+    val setup = closingSetup(
+      ProgressStore.default(workDir, "closing-throwaway"),
+      "closing-throwaway",
+      BranchMode.Created,
+      Some(base)
+    )
+    assertEquals(
+      closingSummary(git, setup),
+      List("done — you are on branch 'main'", "no files changed")
+    )
+    assert(!branchNames(workDir).contains("closing-throwaway"))
+
+  test("closing summary: no recorded starting commit omits the file count"):
+    val workDir = GitRepo.seeded()
+    val git = new OsGitTool(workDir)
+    given WorkspaceWrite = WorkspaceWrite.unsafe
+    val _ = git.createBranch("closing-no-base")
+    os.write(workDir / "a.txt", "one")
+    assert(git.commit("the run's work").isRight)
+    val setup = closingSetup(
+      ProgressStore.default(workDir, "closing-no-base"),
+      "closing-no-base",
+      BranchMode.Reused,
+      startingCommit = None
+    )
+    assertEquals(
+      closingSummary(git, setup),
+      List("done — you are on branch 'closing-no-base'")
+    )
+
+  test(
+    "resume: setup names the branch it bound and what the replay carries over"
+  ):
+    val workDir = GitRepo.seeded()
+    val prompt = "resume-announcement"
+    val store = ProgressStore.default(workDir, prompt)
+    val git = new OsGitTool(workDir)
+    given WorkspaceWrite = WorkspaceWrite.unsafe
+    val base = git.headCommit().flatMap(orca.progress.CommitHash.from).get
+    val _ = git.createBranch("resumed-work")
+    store.writeHeader(
+      ProgressHeader(
+        startingBranch = "main",
+        branch = "resumed-work",
+        promptHash = ProgressStore.hashPrompt(prompt),
+        branchMode = BranchMode.Created,
+        startingCommit = Some(base.value)
+      )
+    )
+    store.appendEntry(StageEntry("plan#0", "plan", RawJson("\"done\"")))
+    git.forceAdd(store.path)
+    val _ = git.commit("orca: progress log")
+    val head = git.headCommit().flatMap(orca.progress.CommitHash.from).get
+    val emitted = new AtomicReference[List[OrcaEvent]](Nil)
+    val setup = setupForSettings(
+      workDir,
+      settingsOverride = Some(StackSettings.empty),
+      prompt = prompt,
+      emit = e => { val _ = emitted.updateAndGet(e :: _) }
+    )
+    assertEquals(setup.startingCommit, Some(base))
+    val steps =
+      emitted.get().reverse.collect { case s: OrcaEvent.Step => s.message }
+    assert(
+      steps.contains(
+        s"on branch 'resumed-work' — this run started from ${base.short}"
+      ),
+      s"the resumed arm must name its branch: $steps"
+    )
+    assert(
+      steps.contains(
+        s"resuming: 1 stage(s) already recorded, tree at ${head.short}; " +
+          "the interrupted stage's uncommitted work was not carried over"
+      ),
+      s"the resumed arm must say what it carries over: $steps"
+    )
 
   test(
     "resume after a skip-branch run on a mixed-case/slashed branch name works"
@@ -3391,6 +3555,10 @@ class FlowLifecycleTest extends munit.FunSuite:
         _.message.contains("recovering from the failure")
       ),
       s"expected an explanatory Step ahead of the reset: $steps"
+    )
+    assert(
+      steps.exists(_.message.contains("re-run the same command")),
+      s"the recovery Step must name what resumes the run: $steps"
     )
 
   // --- flow() reentrancy/concurrency guards --------------------------------

--- a/runner/src/test/scala/orca/runner/FlowLifecycleTest.scala
+++ b/runner/src/test/scala/orca/runner/FlowLifecycleTest.scala
@@ -66,9 +66,10 @@ class FlowLifecycleTest extends munit.FunSuite:
 
   test("success teardown: ends on start branch and removes progress-log file"):
     val workDir = GitRepo.seeded()
+    val out = new ByteArrayOutputStream()
     supervised:
       val interaction = TerminalInteraction.start(
-        out = new PrintStream(new ByteArrayOutputStream()),
+        out = new PrintStream(out),
         useColor = false,
         animated = false
       )
@@ -89,6 +90,12 @@ class FlowLifecycleTest extends munit.FunSuite:
     assertEquals(branch, "main")
     val store = ProgressStore.default(workDir, "lifecycle-success")
     assert(!os.exists(store.path), s"progress log ${store.path} should be gone")
+    // The one call site that wires the closing block to a real listener.
+    val rendered = out.toString(java.nio.charset.StandardCharsets.UTF_8)
+    assert(
+      rendered.contains("done — you are on branch 'main'"),
+      s"the closing block must reach the terminal: $rendered"
+    )
 
   test(
     "failure teardown: stays on feature branch with clean working tree and earlier commit present"
@@ -3032,13 +3039,14 @@ class FlowLifecycleTest extends munit.FunSuite:
     */
   private def closingSummary(
       git: OsGitTool,
-      setup: FlowLifecycle.FlowSetup
+      setup: FlowLifecycle.FlowSetup,
+      returnToStartBranch: Boolean
   ): List[String] =
     val emitted = new AtomicReference[List[OrcaEvent]](Nil)
     FlowLifecycle.teardownSuccess(
       git,
       setup,
-      returnToStartBranch = false,
+      returnToStartBranch,
       e => { val _ = emitted.updateAndGet(e :: _) }
     )
     emitted.get().reverse.collect { case s: OrcaEvent.Step => s.message }
@@ -3061,8 +3069,39 @@ class FlowLifecycleTest extends munit.FunSuite:
     )
 
   test(
-    "closing summary: names the branch the run ends on, the file count and the diff command"
+    "closing summary: HEAD staying on the feature branch gets the plain base diff"
   ):
+    // The default path: the branch the count was taken on is the one the user
+    // is left on, so `git diff <base>` there already shows the work.
+    val workDir = GitRepo.seeded()
+    val git = new OsGitTool(workDir)
+    given WorkspaceWrite = WorkspaceWrite.unsafe
+    val base = git.headCommit().flatMap(orca.progress.CommitHash.from).get
+    val _ = git.createBranch("closing-stay")
+    os.write(workDir / "a.txt", "one")
+    os.write(workDir / "b.txt", "two")
+    assert(git.commit("the run's work").isRight)
+    val setup = closingSetup(
+      ProgressStore.default(workDir, "closing-stay"),
+      "closing-stay",
+      BranchMode.Created,
+      Some(base)
+    )
+    assertEquals(
+      closingSummary(git, setup, returnToStartBranch = false),
+      List(
+        "done — you are on branch 'closing-stay'",
+        s"2 file(s) changed since ${base.short}",
+        s"next: git diff ${base.short}"
+      )
+    )
+
+  test(
+    "closing summary: a PR flow's return to the start branch still points the diff at the work"
+  ):
+    // Both halves of the straddle in one run: the branch line is read after the
+    // handoff (so it says 'main'), while the count and the command are taken on
+    // the feature branch — a `git diff <base>` on 'main' would print nothing.
     val workDir = GitRepo.seeded()
     val git = new OsGitTool(workDir)
     given WorkspaceWrite = WorkspaceWrite.unsafe
@@ -3078,11 +3117,11 @@ class FlowLifecycleTest extends munit.FunSuite:
       Some(base)
     )
     assertEquals(
-      closingSummary(git, setup),
+      closingSummary(git, setup, returnToStartBranch = true),
       List(
-        "done — you are on branch 'closing-work'",
+        "done — you are on branch 'main'",
         s"2 file(s) changed since ${base.short}",
-        s"next: git diff ${base.short}"
+        s"next: git diff ${base.short}..closing-work"
       )
     )
 
@@ -3101,10 +3140,9 @@ class FlowLifecycleTest extends munit.FunSuite:
       Some(base)
     )
     assertEquals(
-      closingSummary(git, setup),
+      closingSummary(git, setup, returnToStartBranch = false),
       List("done — you are on branch 'main'", "no files changed")
     )
-    assert(!branchNames(workDir).contains("closing-throwaway"))
 
   test("closing summary: no recorded starting commit omits the file count"):
     val workDir = GitRepo.seeded()
@@ -3120,7 +3158,7 @@ class FlowLifecycleTest extends munit.FunSuite:
       startingCommit = None
     )
     assertEquals(
-      closingSummary(git, setup),
+      closingSummary(git, setup, returnToStartBranch = false),
       List("done — you are on branch 'closing-no-base'")
     )
 
@@ -3147,16 +3185,23 @@ class FlowLifecycleTest extends munit.FunSuite:
     git.forceAdd(store.path)
     val _ = git.commit("orca: progress log")
     val head = git.headCommit().flatMap(orca.progress.CommitHash.from).get
-    val emitted = new AtomicReference[List[OrcaEvent]](Nil)
-    val setup = setupForSettings(
-      workDir,
-      settingsOverride = Some(StackSettings.empty),
-      prompt = prompt,
-      emit = e => { val _ = emitted.updateAndGet(e :: _) }
+    // No settings file, so this resume arm rediscovers and commits one, moving
+    // HEAD: naming the pre-settings commit is what pins the announcement ahead
+    // of orca's own bookkeeping.
+    val canned = StackDiscoveryResult(
+      format = DiscoveredTask(commands =
+        List(DiscoveredCommand("echo fmt", "seed.txt"))
+      ),
+      lint = DiscoveredTask(),
+      test = DiscoveredTask()
     )
-    assertEquals(setup.startingCommit, Some(base))
-    val steps =
-      emitted.get().reverse.collect { case s: OrcaEvent.Step => s.message }
+    val (_, steps) =
+      setupDiscovering(workDir, CannedDiscoveryAgent(canned), prompt)
+    assertNotEquals(
+      git.headCommit().flatMap(orca.progress.CommitHash.from),
+      Some(head),
+      "the fixture must move HEAD, or the ordering isn't exercised"
+    )
     assert(
       steps.contains(
         s"on branch 'resumed-work' — this run started from ${base.short}"

--- a/tools/src/main/scala/orca/tools/GitTool.scala
+++ b/tools/src/main/scala/orca/tools/GitTool.scala
@@ -337,6 +337,17 @@ trait GitTool:
     */
   def changedFiles(since: Option[String] = None): List[String]
 
+  /** [[changedFiles]] restricted to tracked paths: exactly the files `git diff
+    * <since>` renders.
+    *
+    * This exists so that a caller which prints a count NEXT TO that command
+    * prints one the command can show — orca's closing summary does. Unioning
+    * untracked paths in here (as [[changedFiles]] does, for callers that render
+    * them separately) would reintroduce the mismatch: a count of 2 above a diff
+    * showing 1.
+    */
+  def trackedChangedFiles(since: String): List[String]
+
   /** The change set a reviewer should see, as diff text and as the list of
     * paths in it — what a caller rendering a bounded diff needs, since it has
     * to name the files its diff leaves out (see `orca.BoundedDiff`).
@@ -685,6 +696,9 @@ private[orca] class OsGitTool(
 
   def changedFiles(since: Option[String]): List[String] =
     allFileStats(since, untrackedPaths()).map(_.path)
+
+  def trackedChangedFiles(since: String): List[String] =
+    allFileStats(Some(since), Nil).map(_.path)
 
   def reviewChanges(since: Option[String]): ReviewSample =
     val untracked = untrackedPaths()


### PR DESCRIPTION
Fourth of five PRs from `docs/plans/run-quality/` (spec and plan are on master). Independent of #163.

A run used to end with a bookkeeping commit line and a cost table. After 1100 lines and $77 the user was not told which branch the work was on, what changed, or what to do next — and a resumed run never named its branch at all, because the branch line only fires when a branch is created.

- A successful run now ends with a closing block: the branch the user is actually left on, how many files changed since the run's starting commit, and the command that shows them. The facts are gathered while the feature branch is still checked out, but the block is emitted after teardown decides the branch's fate, so it never names a branch that was just deleted.
- The `next:` command points at the work in both configurations. When the flow returns to the start branch — what flows that open a PR do — it emits a range diff naming the feature branch, because a plain base diff taken on the start branch shows nothing. Review caught that; it had shipped a file count above a command that printed zero of it.
- The file count is tracked-only, so the number agrees with the diff the block offers.
- A resumed run says which branch it is on, which commit the run started from, how many stages are already recorded, and that an incomplete stage's work was not carried over. Replayed stages print one line each instead of two.
- The coder is told the same through its session preamble, so it does not report work it can no longer see as done — the traces show a coder claiming a task was "already complete in the working tree" and discovering twelve seconds later that it was not.
- A failure's recovery message now names the command that resumes.

No commit count and no findings tally: a run has several review loops and `IgnoredIssue` carries no structured cause, so a run-level number would be double-counted and mislabelled.
