### PR TITLE
Name the role agents so the cost summary answers what planning cost

### DIFF
--- a/flow/src/main/scala/orca/events/CostTracker.scala
+++ b/flow/src/main/scala/orca/events/CostTracker.scala
@@ -31,11 +31,6 @@ class CostTracker(pricingAsOf: LocalDate) extends OrcaListener:
   private case class State(
       byAgent: Map[String, Tally] = Map.empty,
       byModel: Map[Option[Model], Tally] = Map.empty,
-      /** The role last recorded for a given agent, for display/subtotal lookup.
-        * `TokensUsed.role` is constant per agent in practice, so last-write and
-        * first-write agree. See [[byRole]] for the subtotal axis.
-        */
-      agentRoles: Map[String, Option[String]] = Map.empty,
       byRole: Map[Option[String], Tally] = Map.empty,
       /** Whether any turn spent tokens the run could not price. A bucket mixing
         * priced and unpriced turns still has a `Tally.cost`, so this cannot be
@@ -54,7 +49,6 @@ class CostTracker(pricingAsOf: LocalDate) extends OrcaListener:
       copy(
         byAgent = add(byAgent, agent, tally),
         byModel = add(byModel, model, tally),
-        agentRoles = agentRoles.updated(agent, role),
         byRole = add(byRole, role, tally),
         // A turn that spent nothing has nothing to price, so it is not a gap.
         anyUnpriced = anyUnpriced || (cost.isEmpty && usage.spentTokens)
@@ -117,18 +111,20 @@ class CostTracker(pricingAsOf: LocalDate) extends OrcaListener:
   private def costsOf[K](buckets: Map[K, Tally]): Map[K, Cost] =
     buckets.collect { case (key, Tally(_, Some(cost))) => key -> cost }
 
-  /** Two or three sections — by-agent, by-model and by-role — each sorted
-    * alphabetically by its rendered label. The by-role section appears only
+  /** One or two sections — by-role and by-model — each sorted alphabetically by
+    * its rendered label, then the run's total. The by-role section appears only
     * when some call carried a [[orca.agents.Agent.role]] tag, and then includes
-    * the `(no role)` bucket too, so it still sums to the run's total. Each
-    * by-agent line is prefixed with that agent's role when it has one (e.g.
-    * `reviewer: performance`). Cache reads, cache writes and reasoning tokens
-    * are shown parenthetically when non-zero. Token counts are rendered
-    * compactly (`1K`, `103.8K`, `3.2M`) from 1000 up, a count and its
-    * parenthetical breakdown at one shared unit (`1.63M in (1.15M cache read,
-    * 0.48M cache write)`); cost (when known) stays exact and is appended as
-    * `$X.XXXX`, with an asterisk marking an estimated figure and a trailing
-    * legend line when any estimate is present.
+    * the `(no role)` bucket too, so it still sums to the run's total. Cache
+    * reads, cache writes and reasoning tokens are shown parenthetically when
+    * non-zero. Token counts are rendered compactly (`1K`, `103.8K`, `3.2M`)
+    * from 1000 up, a count and its parenthetical breakdown at one shared unit
+    * (`1.63M in (1.15M cache read, 0.48M cache write)`); cost (when known)
+    * stays exact and is appended as `$X.XXXX`, with an asterisk marking an
+    * estimated figure and a trailing legend line when any estimate is present.
+    *
+    * Per-agent spend is deliberately absent: this block is read at the moment
+    * the user wants a verdict, and the run's `<id>-cost.jsonl` carries `agent`
+    * on every turn for anyone who wants that fold.
     *
     * A turn that spent tokens but resolved to no cost contributes nothing to
     * the total, so the total's label carries `(some turns unpriced)` and gains
@@ -141,32 +137,25 @@ class CostTracker(pricingAsOf: LocalDate) extends OrcaListener:
     val s = state.get()
     if s.byAgent.isEmpty then ""
     else
-      val agentLines = s.byAgent.toList
-        .sortBy((agent, _) => agentLabel(agent, s.agentRoles))
-        .map: (agent, t) =>
-          s"  ${agentLabel(agent, s.agentRoles)}: ${formatLine(t)}"
-      val modelLines = s.byModel.toList
-        .sortBy((model, _) => modelLabel(model))
-        .map: (model, t) =>
-          s"  ${modelLabel(model)}: ${formatLine(t)}"
       val roleLines = s.byRole.toList
         .sortBy((role, _) => roleLabel(role))
         .map: (role, t) =>
           s"  ${roleLabel(role)}: ${formatLine(t)}"
+      val modelLines = s.byModel.toList
+        .sortBy((model, _) => modelLabel(model))
+        .map: (model, t) =>
+          s"  ${modelLabel(model)}: ${formatLine(t)}"
       val anyRoleTagged = s.byRole.keys.exists(_.isDefined)
       val roleSection =
         if !anyRoleTagged then ""
-        else s"""
-                 |
-                 |By role:
-                 |${roleLines.mkString("\n")}""".stripMargin
-      s"""By agent:
-         |${agentLines.mkString("\n")}
-         |
-         |By model:
+        else s"""By role:
+                |${roleLines.mkString("\n")}
+                |
+                |""".stripMargin
+      s"""${roleSection}By model:
          |${modelLines.mkString(
           "\n"
-        )}$roleSection${totalLine(s)}${legend(s)}""".stripMargin
+        )}${totalLine(s)}${legend(s)}""".stripMargin
 
   /** The run's total, qualified when some turns could not be priced. */
   private def totalLine(s: State): String =
@@ -208,16 +197,6 @@ class CostTracker(pricingAsOf: LocalDate) extends OrcaListener:
     */
   private def roleLabel(role: Option[String]): String =
     role.getOrElse("(no role)")
-
-  /** Render a by-agent line's label: the bare agent name, prefixed with its
-    * role (looked up in `agentRoles`) when it has one. The `"reviewer: "`
-    * prefix is derived purely for display, never baked into `agent` itself.
-    */
-  private def agentLabel(
-      agent: String,
-      agentRoles: Map[String, Option[String]]
-  ): String =
-    agentRoles.get(agent).flatten.fold(agent)(role => s"$role: $agent")
 
   private def formatLine(tally: Tally): String =
     val tokens = formatUsage(tally.usage)

--- a/flow/src/main/scala/orca/events/CostTracker.scala
+++ b/flow/src/main/scala/orca/events/CostTracker.scala
@@ -146,16 +146,11 @@ class CostTracker(pricingAsOf: LocalDate) extends OrcaListener:
         .map: (model, t) =>
           s"  ${modelLabel(model)}: ${formatLine(t)}"
       val anyRoleTagged = s.byRole.keys.exists(_.isDefined)
-      val roleSection =
-        if !anyRoleTagged then ""
-        else s"""By role:
-                |${roleLines.mkString("\n")}
-                |
-                |""".stripMargin
-      s"""${roleSection}By model:
-         |${modelLines.mkString(
-          "\n"
-        )}${totalLine(s)}${legend(s)}""".stripMargin
+      val sections = List(
+        Option.when(anyRoleTagged)(s"By role:\n${roleLines.mkString("\n")}"),
+        Some(s"By model:\n${modelLines.mkString("\n")}")
+      ).flatten
+      s"${sections.mkString("\n\n")}${totalLine(s)}${legend(s)}"
 
   /** The run's total, qualified when some turns could not be priced. */
   private def totalLine(s: State): String =

--- a/flow/src/main/scala/orca/events/Pricing.scala
+++ b/flow/src/main/scala/orca/events/Pricing.scala
@@ -184,6 +184,10 @@ object Pricing:
       // surface the field — and the CLI computes that figure at these same
       // sticker rates.
       Model("claude-fable-5") -> anthropic(10),
+      // Invitation-only, so no backend default pins it and
+      // `DefaultModelsPricedTest` never reaches this row — without it a mythos
+      // turn shows tokens against no dollars.
+      Model("claude-mythos-5") -> anthropic(10),
       Model("claude-opus-5") -> anthropic(5),
       Model("claude-opus-4-8") -> anthropic(5),
       Model("claude-opus-4-7") -> anthropic(5),
@@ -263,5 +267,5 @@ object Pricing:
         cacheWriteUsdPerMillion = 0.30
       )
     ),
-    lastUpdated = LocalDate.of(2026, 8, 2)
+    lastUpdated = LocalDate.of(2026, 8, 27)
   )

--- a/flow/src/main/scala/orca/review/ReviewerSelector.scala
+++ b/flow/src/main/scala/orca/review/ReviewerSelector.scala
@@ -49,6 +49,13 @@ trait ReviewerSelector:
 
 object ReviewerSelector:
 
+  /** Identity the default picker's turn is billed under, beside the reviewers
+    * it selects (`lint` is the other such non-reviewer under that role). It is
+    * a whole turn per loop, so it gets its own line in the run's cost log
+    * rather than disappearing into the review agent's own spend.
+    */
+  val PickerName: String = "picker"
+
   /** [[reviewAndFixLoop]]'s shipped default: [[agentDriven]] picks the set once
     * at loop start, and [[narrowingAcrossRounds]] then re-runs, each later
     * round, only the reviewers that reported something in the previous round.
@@ -76,10 +83,11 @@ object ReviewerSelector:
 
   /** Asks a picker LLM which reviewers are worth running for a given task. The
     * parameterless form — `reviewAndFixLoop`'s default — resolves the picker at
-    * loop start as [[orca.FlowContext.reviewAgent]]`.cheap`; the overload below
-    * takes the picker (and optionally retuned prompts/descriptions) explicitly.
-    * The selection is computed once, at loop start — task context doesn't
-    * change mid-loop — and the returned per-round function replays it, ignoring
+    * loop start as [[orca.FlowContext.reviewAgent]]`.cheap`, tagged
+    * [[PickerName]] under the reviewer cost role; the overload below takes the
+    * picker (and optionally retuned prompts/descriptions) explicitly. The
+    * selection is computed once, at loop start — task context doesn't change
+    * mid-loop — and the returned per-round function replays it, ignoring
     * history.
     *
     * The picker sees each reviewer as a `(name, description)` pair.
@@ -116,7 +124,11 @@ object ReviewerSelector:
         ctx: FlowContext,
         ev: InStage
     ): List[ReviewBatch] -> List[RosterEntry] =
-      agentDriven(ctx.reviewAgent.cheap).prepare(all, taskTitle, changedFiles)
+      agentDriven(
+        ctx.reviewAgent.cheap
+          .withName(PickerName)
+          .withRole(ReviewerPrompts.Role)
+      ).prepare(all, taskTitle, changedFiles)
 
   /** See the parameterless [[agentDriven]] above for the full description. Wrap
     * the result in [[narrowingAcrossRounds]] to also narrow across rounds, as

--- a/flow/src/main/scala/orca/review/ReviewerSelector.scala
+++ b/flow/src/main/scala/orca/review/ReviewerSelector.scala
@@ -49,12 +49,12 @@ trait ReviewerSelector:
 
 object ReviewerSelector:
 
-  /** Identity the default picker's turn is billed under, beside the reviewers
-    * it selects (`lint` is the other such non-reviewer under that role). It is
-    * a whole turn per loop, so it gets its own line in the run's cost log
-    * rather than disappearing into the review agent's own spend.
+  /** Identity the picker's turn is billed under, beside the reviewers it
+    * selects (`lint` is the other such non-reviewer under that role). It is a
+    * whole turn per loop, so it gets its own line in the run's cost log rather
+    * than disappearing into the review agent's own spend.
     */
-  val PickerName: String = "picker"
+  private[review] val PickerName: String = "picker"
 
   /** [[reviewAndFixLoop]]'s shipped default: [[agentDriven]] picks the set once
     * at loop start, and [[narrowingAcrossRounds]] then re-runs, each later
@@ -83,11 +83,11 @@ object ReviewerSelector:
 
   /** Asks a picker LLM which reviewers are worth running for a given task. The
     * parameterless form — `reviewAndFixLoop`'s default — resolves the picker at
-    * loop start as [[orca.FlowContext.reviewAgent]]`.cheap`, tagged
-    * [[PickerName]] under the reviewer cost role; the overload below takes the
-    * picker (and optionally retuned prompts/descriptions) explicitly. The
-    * selection is computed once, at loop start — task context doesn't change
-    * mid-loop — and the returned per-round function replays it, ignoring
+    * loop start as [[orca.FlowContext.reviewAgent]]`.cheap`; the overload below
+    * takes the picker (and optionally retuned prompts/descriptions) explicitly.
+    * Either way the turn is billed as [[PickerName]] under the reviewer cost
+    * role. The selection is computed once, at loop start — task context doesn't
+    * change mid-loop — and the returned per-round function replays it, ignoring
     * history.
     *
     * The picker sees each reviewer as a `(name, description)` pair.
@@ -124,11 +124,7 @@ object ReviewerSelector:
         ctx: FlowContext,
         ev: InStage
     ): List[ReviewBatch] -> List[RosterEntry] =
-      agentDriven(
-        ctx.reviewAgent.cheap
-          .withName(PickerName)
-          .withRole(ReviewerPrompts.Role)
-      ).prepare(all, taskTitle, changedFiles)
+      agentDriven(ctx.reviewAgent.cheap).prepare(all, taskTitle, changedFiles)
 
   /** See the parameterless [[agentDriven]] above for the full description. Wrap
     * the result in [[narrowingAcrossRounds]] to also narrow across rounds, as
@@ -175,6 +171,8 @@ object ReviewerSelector:
           // Read-only: the picker decides which reviewers to run and must not
           // edit files during selection (reading context is fine).
           agent.withReadOnly
+            .withName(PickerName)
+            .withRole(ReviewerPrompts.Role)
             .resultAs[SelectedReviewers]
             .autonomous
             .run(request, emitPrompt = false)

--- a/flow/src/main/scala/orca/review/Reviewers.scala
+++ b/flow/src/main/scala/orca/review/Reviewers.scala
@@ -41,12 +41,13 @@ case class Reviewer(
   */
 object ReviewerPrompts:
 
-  /** Role tag applied to a reviewer's agent via `Agent.withRole` only at the
-    * loop's emission edge, never baked into the agent's `name`/identity — the
-    * roster, session map, picker, and outcomes all keep using the bare slug.
-    * Its sole job is cost attribution: `CostTracker` groups every `TokensUsed`
-    * event carrying this role and derives the `"reviewer: <slug>"` display line
-    * from it.
+  /** Role tag that gathers the whole review side of a run into one by-role
+    * subtotal: every reviewer's turn, lint, the picker, and the run's review
+    * role agent.
+    *
+    * A reviewer gets it via `Agent.withRole` at the loop's emission edge only,
+    * never baked into the agent's `name`/identity — the roster, session map,
+    * picker, and outcomes all keep using the bare slug.
     */
   val Role: String = "reviewer"
 

--- a/flow/src/test/scala/orca/CostTrackerTest.scala
+++ b/flow/src/test/scala/orca/CostTrackerTest.scala
@@ -184,7 +184,7 @@ class CostTrackerTest extends munit.FunSuite:
       )
     )
     assert(
-      tracker.summary.contains("claude: 30K in (29K cache write), 500 out"),
+      tracker.summary.contains("opus: 30K in (29K cache write), 500 out"),
       tracker.summary
     )
 
@@ -346,8 +346,8 @@ class CostTrackerTest extends munit.FunSuite:
       tokens("performance", Some("haiku"), usage(1_000_000L, 0L, None))
     )
     val out = tracker.summary
-    assert(out.contains("claude: 10 in, 5 out ($0.1000)"), out)
-    assert(out.contains("performance: 1M in, 0 out ($1.0000*)"), out)
+    assert(out.contains("opus: 10 in, 5 out ($0.1000)"), out)
+    assert(out.contains("haiku: 1M in, 0 out ($1.0000*)"), out)
     // Mixed → aggregate is estimated → prefix shifts; asterisk on the
     // amount drops since the word already says it.
     assert(out.contains("Estimated total: $1.1000"), out)
@@ -365,7 +365,7 @@ class CostTrackerTest extends munit.FunSuite:
       val tracker = new CostTracker(pricingAsOf)
       tracker.onEvent(tokens("claude", Some("opus"), usage(n, 0L, None)))
       assert(
-        tracker.summary.contains(s"claude: $expected in"),
+        tracker.summary.contains(s"opus: $expected in"),
         tracker.summary
       )
 
@@ -387,7 +387,7 @@ class CostTrackerTest extends munit.FunSuite:
     )
     assert(
       tracker.summary.contains(
-        "claude: 50K in (40K cache read, 5K cache write), " +
+        "opus: 50K in (40K cache read, 5K cache write), " +
           "12.5K out (1.2K reasoning)"
       ),
       tracker.summary
@@ -411,7 +411,7 @@ class CostTrackerTest extends munit.FunSuite:
     )
     assert(
       tracker.summary.contains(
-        "claude: 1.63M in (1.15M cache read, 0.48M cache write), 30.2K out"
+        "opus: 1.63M in (1.15M cache read, 0.48M cache write), 30.2K out"
       ),
       tracker.summary
     )
@@ -433,7 +433,7 @@ class CostTrackerTest extends munit.FunSuite:
       )
     )
     assert(
-      tracker.summary.contains("claude: 2M in (900 cache write), 0 out"),
+      tracker.summary.contains("opus: 2M in (900 cache write), 0 out"),
       tracker.summary
     )
 
@@ -458,7 +458,7 @@ class CostTrackerTest extends munit.FunSuite:
     )
     assert(
       tracker.summary.contains(
-        "claude: 12.41M in (11.90M cache read, 0.51M cache write), 100 out"
+        "opus: 12.41M in (11.90M cache read, 0.51M cache write), 100 out"
       ),
       tracker.summary
     )
@@ -474,7 +474,7 @@ class CostTrackerTest extends munit.FunSuite:
         usage(input = 3_000_000L, output = 100L, cost = None)
       )
     )
-    assert(tracker.summary.contains("claude: 3M in, 100 out"), tracker.summary)
+    assert(tracker.summary.contains("opus: 3M in, 100 out"), tracker.summary)
 
   test("summary drops the cache-write part when a backend reports no writes"):
     val tracker = new CostTracker(pricingAsOf)
@@ -491,31 +491,20 @@ class CostTrackerTest extends munit.FunSuite:
       )
     )
     assert(
-      tracker.summary.contains("codex: 50K in (40K cache read), 100 out"),
+      tracker.summary.contains("opus: 50K in (40K cache read), 100 out"),
       tracker.summary
     )
 
-  test("summary lists By agent lines alphabetically by their rendered label"):
-    // Sorting on the raw agent name would slot an unprefixed agent between
-    // role-prefixed ones (`reviewer: lint` < main < `reviewer: readability`
-    // by name); the reader sees labels, so labels drive the order.
+  test("summary leaves per-agent spend to the run's cost log"):
+    // The block is read at the point the user wants a verdict; the cost log
+    // carries `agent` on every turn for anyone who wants that fold.
     val tracker = new CostTracker(pricingAsOf)
     tracker.onEvent(
       tokens("lint", Some("opus"), usage(1L, 1L, None), role = Some("reviewer"))
     )
-    tracker.onEvent(tokens("main", Some("opus"), usage(1L, 1L, None)))
-    tracker.onEvent(
-      tokens(
-        "readability",
-        Some("opus"),
-        usage(1L, 1L, None),
-        role = Some("reviewer")
-      )
-    )
-    assertLabelsInOrder(
-      tracker.summary,
-      List("main", "reviewer: lint", "reviewer: readability")
-    )
+    val out = tracker.summary
+    assert(!out.contains("By agent:"), out)
+    assert(!out.contains("lint"), out)
 
   test("summary lists By model lines alphabetically by model label"):
     val tracker = new CostTracker(pricingAsOf)
@@ -590,11 +579,7 @@ class CostTrackerTest extends munit.FunSuite:
     )
     assertEquals(tracker.perRole(None), usage(100L, 50L, None))
 
-  test(
-    "summary derives a display-only role prefix per agent and adds a By role subtotal section"
-  ):
-    // `agent` stays bare; the summary derives the "reviewer: <slug>" display
-    // text purely from `role`, and adds a "By role:" subtotal section.
+  test("summary adds a By role section once some call carried a role"):
     val tracker = new CostTracker(pricingAsOf)
     tracker.onEvent(
       tokens(
@@ -606,14 +591,6 @@ class CostTrackerTest extends munit.FunSuite:
     )
     tracker.onEvent(tokens("claude", Some("opus"), usage(100L, 50L, None)))
     val out = tracker.summary
-    assert(
-      out.contains("reviewer: performance:"),
-      s"expected a role-derived display prefix; got: $out"
-    )
-    assert(
-      out.contains("  claude:"),
-      s"claude's line must stay bare; got: $out"
-    )
     assert(out.contains("By role:"), out)
     assert(out.contains("  reviewer:"), out)
 

--- a/flow/src/test/scala/orca/PricingTest.scala
+++ b/flow/src/test/scala/orca/PricingTest.scala
@@ -65,9 +65,6 @@ class PricingTest extends munit.FunSuite:
     )
 
   test("the shipped table prices claude-mythos-5"):
-    // Invitation-only, so no backend default pins it and
-    // `DefaultModelsPricedTest` can't reach the row; without this a mythos turn
-    // would show tokens against no dollars.
     assertEquals(
       Pricing.resolve(
         Pricing.default.table,

--- a/flow/src/test/scala/orca/PricingTest.scala
+++ b/flow/src/test/scala/orca/PricingTest.scala
@@ -63,3 +63,16 @@ class PricingTest extends munit.FunSuite:
       ),
       Some(Cost(BigDecimal("0.42"), estimated = false))
     )
+
+  test("the shipped table prices claude-mythos-5"):
+    // Invitation-only, so no backend default pins it and
+    // `DefaultModelsPricedTest` can't reach the row; without this a mythos turn
+    // would show tokens against no dollars.
+    assertEquals(
+      Pricing.resolve(
+        Pricing.default.table,
+        Some(Model("claude-mythos-5")),
+        usage(input = 1_000_000L, output = 0L)
+      ),
+      Some(Cost(BigDecimal("10"), estimated = true))
+    )

--- a/flow/src/test/scala/orca/review/ReviewerSelectorTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewerSelectorTest.scala
@@ -3,6 +3,7 @@ package orca.review
 import orca.{FlowContext, TestFlowContext}
 import orca.events.EventDispatcher
 import orca.agents.{
+  Agent,
   AgentInput,
   Announce,
   AutonomousAgentCall,
@@ -43,6 +44,40 @@ private class RecordingPicker(
                 captured.set(Some(r))
               case _ => ()
             response.asInstanceOf[O]
+      def interactive
+          : orca.agents.InteractiveAgentCall[BackendTag.ClaudeCode.type, O] =
+        ???
+
+/** Records the `(name, role)` its agent carried when the picker turn ran. The
+  * parameterless [[ReviewerSelector.agentDriven]] derives its picker from
+  * `ctx.reviewAgent`, so the tagging is only observable on the derived copy —
+  * hence the honoured `withName`/`withRole` (the [[StubAgent]] base returns
+  * `this`).
+  */
+private class TaggingPicker(
+    seen: AtomicReference[Option[(String, Option[String])]],
+    agentName: String = "review",
+    roleTag: Option[String] = None
+) extends StubAgent(agentName):
+  override def role: Option[String] = roleTag
+  override def withName(n: String): Agent[BackendTag.ClaudeCode.type] =
+    new TaggingPicker(seen, n, roleTag)
+  override def withRole(r: String): Agent[BackendTag.ClaudeCode.type] =
+    new TaggingPicker(seen, agentName, Some(r))
+  def resultAs[O: JsonData: Announce]
+      : AgentCall[BackendTag.ClaudeCode.type, O] =
+    new AgentCall[BackendTag.ClaudeCode.type, O]:
+      val autonomous: AutonomousAgentCall[BackendTag.ClaudeCode.type, O] =
+        new AutonomousAgentCall[BackendTag.ClaudeCode.type, O]:
+          private[orca] def runWithSession[I: AgentInput](
+              input: I,
+              session: SessionId[BackendTag.ClaudeCode.type],
+              sessionName: Option[String],
+              config: Option[AgentConfig],
+              emitPrompt: Boolean
+          )(using orca.InStage): O =
+            seen.set(Some((name, role)))
+            SelectedReviewers(Nil).asInstanceOf[O]
       def interactive
           : orca.agents.InteractiveAgentCall[BackendTag.ClaudeCode.type, O] =
         ???
@@ -215,6 +250,23 @@ class ReviewerSelectorTest extends munit.FunSuite:
         _ == "reviewer selection: picker named scla-fp, matching no reviewer"
       ),
       capture.messages.mkString("\n")
+    )
+
+  test(
+    "the default picker's turn is billed as a reviewer-role turn of its own"
+  ):
+    val seen = new AtomicReference[Option[(String, Option[String])]](None)
+    val picker = new TaggingPicker(seen)
+    val pickerCtx: FlowContext = new TestFlowContext(new EventDispatcher(Nil)):
+      override lazy val reviewAgent: Agent[ReviewB] = picker
+    val _ = ReviewerSelector.agentDriven
+      .prepare(all, Title("any"), List("src/main/scala/Foo.scala"))(using
+        pickerCtx,
+        summon[orca.InStage]
+      )(Nil)
+    assertEquals(
+      seen.get(),
+      Some((ReviewerSelector.PickerName, Some(ReviewerPrompts.Role)))
     )
 
   test("selector skips the picker LLM entirely when no reviewer is eligible"):

--- a/flow/src/test/scala/orca/review/ReviewerSelectorTest.scala
+++ b/flow/src/test/scala/orca/review/ReviewerSelectorTest.scala
@@ -18,14 +18,28 @@ import orca.plan.Title
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 
 /** Captures every `ReviewerSelectionRequest` handed to the picker and replies
-  * with a scripted `SelectedReviewers`, counting each call. Other `Agent`
-  * surface is unused.
+  * with a scripted `SelectedReviewers`, counting each call and recording the
+  * `(name, role)` the agent carried when the turn ran.
+  *
+  * `withName`/`withRole` are honoured — the [[StubAgent]] base returns `this`,
+  * so the tags [[ReviewerSelector.agentDriven]] applies are only observable on
+  * a copy that actually keeps them.
   */
 private class RecordingPicker(
     response: SelectedReviewers,
-    captured: AtomicReference[Option[ReviewerSelectionRequest]],
-    calls: AtomicInteger = new AtomicInteger(0)
-) extends StubAgent("picker"):
+    captured: AtomicReference[Option[ReviewerSelectionRequest]] =
+      new AtomicReference[Option[ReviewerSelectionRequest]](None),
+    calls: AtomicInteger = new AtomicInteger(0),
+    identity: AtomicReference[Option[(String, Option[String])]] =
+      new AtomicReference[Option[(String, Option[String])]](None),
+    agentName: String = "review",
+    roleTag: Option[String] = None
+) extends StubAgent(agentName):
+  override def role: Option[String] = roleTag
+  override def withName(n: String): Agent[BackendTag.ClaudeCode.type] =
+    new RecordingPicker(response, captured, calls, identity, n, roleTag)
+  override def withRole(r: String): Agent[BackendTag.ClaudeCode.type] =
+    new RecordingPicker(response, captured, calls, identity, agentName, Some(r))
   def resultAs[O: JsonData: Announce]
       : AgentCall[BackendTag.ClaudeCode.type, O] =
     new AgentCall[BackendTag.ClaudeCode.type, O]:
@@ -39,45 +53,12 @@ private class RecordingPicker(
               emitPrompt: Boolean
           )(using orca.InStage): O =
             val _ = calls.incrementAndGet()
+            identity.set(Some((name, role)))
             input match
               case r: ReviewerSelectionRequest =>
                 captured.set(Some(r))
               case _ => ()
             response.asInstanceOf[O]
-      def interactive
-          : orca.agents.InteractiveAgentCall[BackendTag.ClaudeCode.type, O] =
-        ???
-
-/** Records the `(name, role)` its agent carried when the picker turn ran. The
-  * parameterless [[ReviewerSelector.agentDriven]] derives its picker from
-  * `ctx.reviewAgent`, so the tagging is only observable on the derived copy —
-  * hence the honoured `withName`/`withRole` (the [[StubAgent]] base returns
-  * `this`).
-  */
-private class TaggingPicker(
-    seen: AtomicReference[Option[(String, Option[String])]],
-    agentName: String = "review",
-    roleTag: Option[String] = None
-) extends StubAgent(agentName):
-  override def role: Option[String] = roleTag
-  override def withName(n: String): Agent[BackendTag.ClaudeCode.type] =
-    new TaggingPicker(seen, n, roleTag)
-  override def withRole(r: String): Agent[BackendTag.ClaudeCode.type] =
-    new TaggingPicker(seen, agentName, Some(r))
-  def resultAs[O: JsonData: Announce]
-      : AgentCall[BackendTag.ClaudeCode.type, O] =
-    new AgentCall[BackendTag.ClaudeCode.type, O]:
-      val autonomous: AutonomousAgentCall[BackendTag.ClaudeCode.type, O] =
-        new AutonomousAgentCall[BackendTag.ClaudeCode.type, O]:
-          private[orca] def runWithSession[I: AgentInput](
-              input: I,
-              session: SessionId[BackendTag.ClaudeCode.type],
-              sessionName: Option[String],
-              config: Option[AgentConfig],
-              emitPrompt: Boolean
-          )(using orca.InStage): O =
-            seen.set(Some((name, role)))
-            SelectedReviewers(Nil).asInstanceOf[O]
       def interactive
           : orca.agents.InteractiveAgentCall[BackendTag.ClaudeCode.type, O] =
         ???
@@ -252,11 +233,9 @@ class ReviewerSelectorTest extends munit.FunSuite:
       capture.messages.mkString("\n")
     )
 
-  test(
-    "the default picker's turn is billed as a reviewer-role turn of its own"
-  ):
+  test("the picker's turn is billed as a reviewer-role turn of its own"):
     val seen = new AtomicReference[Option[(String, Option[String])]](None)
-    val picker = new TaggingPicker(seen)
+    val picker = new RecordingPicker(SelectedReviewers(Nil), identity = seen)
     val pickerCtx: FlowContext = new TestFlowContext(new EventDispatcher(Nil)):
       override lazy val reviewAgent: Agent[ReviewB] = picker
     val _ = ReviewerSelector.agentDriven

--- a/runner/src/main/scala/orca/runner/RoleAgents.scala
+++ b/runner/src/main/scala/orca/runner/RoleAgents.scala
@@ -178,7 +178,7 @@ private[orca] object RoleAgents:
       overrideSelect: Option[AgentSet => Agent[?]],
       agents: WiredAgents
   ): RoleChoice =
-    overrideSelect match
+    val choice = overrideSelect match
       case Some(select) =>
         val agent = select(agents)
         val (harness, model) = harnessAndModel(agent, None)
@@ -209,6 +209,33 @@ private[orca] object RoleAgents:
               model,
               foreign = false
             )
+    choice.copy(agent = tagged(choice.label, choice.agent, agents))
+
+  /** Stamp the role's label onto its agent as both the cost-report `name` and
+    * the `role` axis, so the run's spend separates planning from coding from
+    * review. Done here rather than in the shipped flows because a user-written
+    * flow, the shell, and the runtime's own cheap one-shots (branch naming,
+    * default commit messages) never pass through one; `Agent.cheap` carries
+    * name and role over, so those sub-calls are covered by tagging the role
+    * agent itself.
+    *
+    * Skipped when the agent already carries a name of its own — a programmatic
+    * override may set one (`flow(codingAgent =
+    * Some(_.claude.withName("bob")))`) and that name is the identity sessions
+    * and selectors key off. "Of its own" is decided against the wired agent for
+    * this agent's OWN backend rather than a list of default names, which would
+    * go stale: the five wired defaults do not agree (pi's is `pi`, the rest
+    * `main`). An agent reporting no backend tag can't be checked this way, so
+    * it is left alone.
+    */
+  private def tagged(
+      label: String,
+      agent: Agent[?],
+      agents: WiredAgents
+  ): Agent[?] =
+    if agent.backendTag.map(agents.agentFor).exists(_.name == agent.name) then
+      agent.withName(label).withRole(label)
+    else agent
 
   /** Stands in for a role where nothing orca can see pins a model — neither the
     * settings nor the wired agent (pi and opencode pin no default). The harness

--- a/runner/src/main/scala/orca/runner/RoleAgents.scala
+++ b/runner/src/main/scala/orca/runner/RoleAgents.scala
@@ -11,6 +11,7 @@ import orca.agents.{
   OpencodeAgent,
   PiAgent
 }
+import orca.review.ReviewerPrompts
 import orca.settings.{AgentSettings, AgentSpec}
 
 /** The three role agents resolved for one run — every field an existentially
@@ -64,17 +65,6 @@ private[orca] object RoleAgents:
       globalSpec: Option[AgentSpec]
   ): Option[AgentSpec] = projectSpec.orElse(globalSpec)
 
-  /** Resolve the three role agents against the run's wired set — every role
-    * shares a wired backend, so events and close() behave exactly as for the
-    * wired five. An unset role defaults to claude with no model pin.
-    */
-  def resolve(settings: AgentSettings, agents: WiredAgents): ResolvedRoles =
-    ResolvedRoles(
-      planning = one(settings.planning, agents),
-      coding = one(settings.coding, agents),
-      review = one(settings.review, agents)
-    )
-
   /** Resolve all three roles AND everything derived from that resolution, so
     * the override>project>global>default precedence is encoded once. Per role:
     * apply the programmatic override if present (winning over both files), else
@@ -101,29 +91,34 @@ private[orca] object RoleAgents:
   ): RoleResolution =
     val planning =
       resolveOne(
-        "planning",
-        project.planning,
-        global.planning,
-        overrides.planning,
-        agents
+        label = "planning",
+        costRole = "planning",
+        projectSpec = project.planning,
+        globalSpec = global.planning,
+        overrideSelect = overrides.planning,
+        agents = agents
       )
     onRoleResolved(planning.agent)
     val coding =
       resolveOne(
-        "coding",
-        project.coding,
-        global.coding,
-        overrides.coding,
-        agents
+        label = "coding",
+        costRole = "coding",
+        projectSpec = project.coding,
+        globalSpec = global.coding,
+        overrideSelect = overrides.coding,
+        agents = agents
       )
     onRoleResolved(coding.agent)
     val review =
       resolveOne(
-        "review",
-        project.review,
-        global.review,
-        overrides.review,
-        agents
+        label = "review",
+        // The reviewers, lint and the picker already bill under this tag; one
+        // concept gets one bucket in the by-role block.
+        costRole = ReviewerPrompts.Role,
+        projectSpec = project.review,
+        globalSpec = global.review,
+        overrideSelect = overrides.review,
+        agents = agents
       )
     onRoleResolved(review.agent)
     val all = List(planning, coding, review)
@@ -173,6 +168,7 @@ private[orca] object RoleAgents:
 
   private def resolveOne(
       label: String,
+      costRole: String,
       projectSpec: Option[AgentSpec],
       globalSpec: Option[AgentSpec],
       overrideSelect: Option[AgentSet => Agent[?]],
@@ -209,32 +205,38 @@ private[orca] object RoleAgents:
               model,
               foreign = false
             )
-    choice.copy(agent = tagged(choice.label, choice.agent, agents))
+    choice.copy(agent = tagged(choice.label, costRole, choice.agent, agents))
 
-  /** Stamp the role's label onto its agent as both the cost-report `name` and
-    * the `role` axis, so the run's spend separates planning from coding from
-    * review. Done here rather than in the shipped flows because a user-written
+  /** Stamp the role onto its agent as the cost-report `name` (the role's label)
+    * and the `role` axis (`costRole`, which for review is the reviewers' own
+    * tag). Done here rather than in the shipped flows because a user-written
     * flow, the shell, and the runtime's own cheap one-shots (branch naming,
     * default commit messages) never pass through one; `Agent.cheap` carries
     * name and role over, so those sub-calls are covered by tagging the role
     * agent itself.
     *
-    * Skipped when the agent already carries a name of its own — a programmatic
-    * override may set one (`flow(codingAgent =
-    * Some(_.claude.withName("bob")))`) and that name is the identity sessions
-    * and selectors key off. "Of its own" is decided against the wired agent for
-    * this agent's OWN backend rather than a list of default names, which would
-    * go stale: the five wired defaults do not agree (pi's is `pi`, the rest
-    * `main`). An agent reporting no backend tag can't be checked this way, so
-    * it is left alone.
+    * Guards ONE channel: a role override that renames a wired agent
+    * (`flow(codingAgent = Some(_.claude.withName("bob")))`) keeps its name,
+    * since the resolved agent's name then differs from that of the wired agent
+    * for its backend. Nothing else is guarded — a name given at WIRING time
+    * (`flow(claude = Some(w => ClaudeAgents.default(w).withName("bob")))`) is
+    * the wired agent's own name, so the comparison passes and the name is
+    * replaced by the role's label. `Agent` carries no record of who set its
+    * name, and what a wrong answer costs is a mislabelled cost line and
+    * terminal attribution: nothing behavioural reads `Agent.name` (sessions key
+    * off `FlowSession.name`, rehydration off `BackendTag`).
+    *
+    * An agent reporting no backend tag has no wired agent to compare against,
+    * so it is left alone.
     */
   private def tagged(
       label: String,
+      costRole: String,
       agent: Agent[?],
       agents: WiredAgents
   ): Agent[?] =
     if agent.backendTag.map(agents.agentFor).exists(_.name == agent.name) then
-      agent.withName(label).withRole(label)
+      agent.withName(label).withRole(costRole)
     else agent
 
   /** Stands in for a role where nothing orca can see pins a model — neither the

--- a/runner/src/main/scala/orca/runner/manifest/CostLog.scala
+++ b/runner/src/main/scala/orca/runner/manifest/CostLog.scala
@@ -60,18 +60,21 @@ private[orca] enum CostRecord:
   case Run(orcaVersion: String, flow: Option[String], workDir: String)
 
   /** One LLM turn, carrying every axis an aggregate needs: total, by-role,
-    * by-agent and by-stage are all folds over these lines, so an axis missing
-    * here cannot be recovered.
+    * by-agent, by-model and by-stage are all folds over these lines, so an axis
+    * missing here cannot be recovered.
     *
-    * `cost` is `None` for a model absent from the pricing table, so such a turn
-    * shows tokens against no dollars. `attempt` is the turn's 1-based position
-    * among the turns of its call, so retried spend is separable. `session` is
-    * the key the conversation is recorded under in [[RunManifest.sessions]].
+    * `model` is `None` when the backend reported none and the caller pinned
+    * none, mirroring `OrcaEvent.TokensUsed.model`. `cost` is `None` for a model
+    * absent from the pricing table, so such a turn shows tokens against no
+    * dollars. `attempt` is the turn's 1-based position among the turns of its
+    * call, so retried spend is separable. `session` is the key the conversation
+    * is recorded under in [[RunManifest.sessions]].
     */
   case Turn(
       at: Instant,
       agent: String,
       role: Option[String],
+      model: Option[String],
       stage: Option[String],
       attempt: Int,
       apiCalls: Option[Long],

--- a/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
+++ b/runner/src/main/scala/orca/runner/manifest/RunManifestWriter.scala
@@ -175,6 +175,7 @@ private[runner] class RunManifestWriterState(
             at = clock(),
             agent = t.agent,
             role = t.role,
+            model = t.model.map(_.name),
             stage = state.stageStack.headOption,
             attempt = t.attempt,
             apiCalls = t.usage.apiCalls,

--- a/runner/src/test/scala/orca/runner/RoleAgentsTest.scala
+++ b/runner/src/test/scala/orca/runner/RoleAgentsTest.scala
@@ -232,6 +232,54 @@ class RoleAgentsTest extends munit.FunSuite:
       "a wired override is not foreign"
     )
 
+  test("resolveAll tags each role's agent with its label, for the cost report"):
+    val resolution = RoleAgents.resolveAll(
+      project = AgentSettings.empty,
+      global = AgentSettings.empty,
+      overrides = RoleOverrides(None, None, None),
+      agents = wiredAgents(claude = new TaggableClaude("claude")),
+      onRoleResolved = _ => ()
+    )
+    val roles = resolution.roles
+    assertEquals(
+      List(roles.planning, roles.coding, roles.review)
+        .map(a => (a.name, a.role)),
+      List(
+        ("planning", Some("planning")),
+        ("coding", Some("coding")),
+        ("review", Some("review"))
+      )
+    )
+
+  test("a name a programmatic override set deliberately is not overwritten"):
+    // The name is what sessions and selectors key off, so an override that
+    // picked one keeps it.
+    val resolution = RoleAgents.resolveAll(
+      project = AgentSettings.empty,
+      global = AgentSettings.empty,
+      overrides = RoleOverrides(
+        None,
+        Some((a: orca.AgentSet) => a.claude.withName("bob")),
+        None
+      ),
+      agents = wiredAgents(claude = new TaggableClaude("claude")),
+      onRoleResolved = _ => ()
+    )
+    assertEquals(resolution.roles.coding.name, "bob")
+
+  test("a pi-backed role is tagged too, though pi's wired default is not main"):
+    // The "still carries its backend's own default name" check reads that name
+    // off the wired agent, so a backend naming its default something else is
+    // covered without a list of names to keep in step.
+    val resolution = RoleAgents.resolveAll(
+      project = AgentSettings(coding = Some(AgentSpec(BackendTag.Pi, None))),
+      global = AgentSettings.empty,
+      overrides = RoleOverrides(None, None, None),
+      agents = wiredAgents(),
+      onRoleResolved = _ => ()
+    )
+    assertEquals(resolution.roles.coding.name, "coding")
+
   test("resolveAll warns for an override that escapes the wired set"):
     val foreign = new RecordingModelClaude(new AnyRef)
     val resolution = RoleAgents.resolveAll(
@@ -301,6 +349,22 @@ class RoleAgentsTest extends munit.FunSuite:
         : AgentCall[BackendTag.Opencode.type, O] =
       throw new UnsupportedOperationException
 
+  /** A `ClaudeAgent` stub that reports a real backend tag and actually applies
+    * `withName`/`withRole` — [[StubClaudeAgent]]'s builders return `this`, so
+    * the cost-report tagging is invisible through them.
+    */
+  private class TaggableClaude(
+      agentName: String,
+      roleTag: Option[String] = None
+  ) extends StubClaudeAgent(agentName):
+    override def role: Option[String] = roleTag
+    override private[orca] def backendTag: Option[BackendTag] =
+      Some(BackendTag.ClaudeCode)
+    override def withName(name: String): ClaudeAgent =
+      new TaggableClaude(name, roleTag)
+    override def withRole(role: String): ClaudeAgent =
+      new TaggableClaude(agentName, Some(role))
+
   /** A `ClaudeAgent` stub whose `configuredModel` mirrors the real wired
     * default (claude's Opus1M pin) — [[StubClaudeAgent]]'s bare default has
     * none, so the announcement's "show the wired default model" path needs this
@@ -354,17 +418,24 @@ class RoleAgentsTest extends munit.FunSuite:
         : AgentCall[BackendTag.Opencode.type, O] =
       throw new UnsupportedOperationException
 
-  private object NoopPi extends PiAgent:
-    val name = "noop-pi"
+  /** Named like the real wired pi (`pi`, not `main`) and honouring `withName`,
+    * so a role landing on pi exercises the tagging check against a backend
+    * whose default name differs from the others'.
+    */
+  private class NoopPiAgent(val name: String) extends PiAgent:
+    override private[orca] def backendTag: Option[BackendTag] =
+      Some(BackendTag.Pi)
     def withModel(model: Model): PiAgent = this
     def withConfig(config: AgentConfig): PiAgent = this
     def withSystemPrompt(prompt: String): PiAgent = this
-    def withName(name: String): PiAgent = this
+    def withName(newName: String): PiAgent = new NoopPiAgent(newName)
     def withTools(tools: ToolSet): PiAgent = this
     def autonomous: AutonomousTextCall[BackendTag.Pi.type] =
       throw new UnsupportedOperationException
     def resultAs[O: JsonData: Announce]: AgentCall[BackendTag.Pi.type, O] =
       throw new UnsupportedOperationException
+
+  private object NoopPi extends NoopPiAgent("pi")
 
   private object NoopGemini extends GeminiAgent:
     val name = "noop-gemini"

--- a/runner/src/test/scala/orca/runner/RoleAgentsTest.scala
+++ b/runner/src/test/scala/orca/runner/RoleAgentsTest.scala
@@ -15,40 +15,46 @@ import orca.agents.{
   PiAgent,
   ToolSet
 }
+import orca.review.ReviewerPrompts
 import orca.settings.{AgentSettings, AgentSpec}
 
-/** Pins [[RoleAgents.resolve]]'s pure mapping from settings to the run's
+/** Pins [[RoleAgents.resolveAll]]'s mapping from settings to the run's
   * [[WiredAgents]]: unset stays claude, a bare spec picks the matching wired
-  * backend by reference, and a model pin produces a `withModel` sibling that
-  * still shares the wired backend's identity — the same sharing
-  * [[LeadAgentIdentityTest]] pins for the `_.claude.opus` selector shape, here
-  * exercised through settings-driven resolution instead of a flow selector.
+  * backend, and a model pin produces a `withModel` sibling that still shares
+  * the wired backend's identity — the same sharing [[LeadAgentIdentityTest]]
+  * pins for the `_.claude.opus` selector shape, here exercised through
+  * settings-driven resolution instead of a flow selector.
+  *
+  * Resolution tags each role's agent, so "came from the wired agent" is
+  * asserted as shared `backendIdentity` rather than reference equality.
   */
 class RoleAgentsTest extends munit.FunSuite:
 
-  test("unset settings resolve every role to the wired claude, unchanged"):
-    val wired = wiredAgents()
-    val resolved = RoleAgents.resolve(AgentSettings.empty, wired)
-    assert(
-      resolved.planning.eq(wired.claude),
-      "planning must be the wired claude"
+  test("unset settings resolve every role to the wired claude"):
+    val token = new AnyRef
+    val roles = resolvedRoles(
+      AgentSettings.empty,
+      wiredAgents(claude = new RecordingModelClaude(token))
     )
-    assert(resolved.coding.eq(wired.claude), "coding must be the wired claude")
-    assert(resolved.review.eq(wired.claude), "review must be the wired claude")
+    assertEquals(
+      List(roles.planning, roles.coding, roles.review).map(_.backendIdentity),
+      List(Some(token), Some(token), Some(token))
+    )
 
-  test("a bare per-role spec picks the matching wired backend by reference"):
-    val wired = wiredAgents()
-    val settings = AgentSettings(
-      coding = Some(AgentSpec(BackendTag.Codex, None))
+  test("a bare per-role spec picks the matching wired backend"):
+    val token = new AnyRef
+    val roles = resolvedRoles(
+      AgentSettings(coding = Some(AgentSpec(BackendTag.Codex, None))),
+      wiredAgents(claude = new RecordingModelClaude(token))
     )
-    val resolved = RoleAgents.resolve(settings, wired)
-    assert(resolved.coding.eq(wired.codex), "coding must be the wired codex")
-    assert(
-      resolved.planning.eq(wired.claude),
-      "an unset role still defaults to the wired claude"
+    assertEquals(
+      roles.coding.backendTag,
+      Some(BackendTag.Codex),
+      "coding must be the wired codex"
     )
-    assert(
-      resolved.review.eq(wired.claude),
+    assertEquals(
+      List(roles.planning, roles.review).map(_.backendIdentity),
+      List(Some(token), Some(token)),
       "an unset role still defaults to the wired claude"
     )
 
@@ -58,22 +64,21 @@ class RoleAgentsTest extends munit.FunSuite:
   ):
     val token = new AnyRef
     val wiredClaude = new RecordingModelClaude(token)
-    val wired = wiredAgents(claude = wiredClaude)
     val settings = AgentSettings(
       planning = Some(AgentSpec(BackendTag.ClaudeCode, Some("claude-opus-x")))
     )
-    val resolved = RoleAgents.resolve(settings, wired)
+    val roles = resolvedRoles(settings, wiredAgents(claude = wiredClaude))
     assert(
-      !resolved.planning.eq(wiredClaude),
+      !roles.planning.eq(wiredClaude),
       "a model pin must produce a new sibling instance, not the wired agent " +
         "itself"
     )
     assertEquals(
-      resolved.planning.backendIdentity,
+      roles.planning.backendIdentity,
       Some(token),
       "the sibling must still share the wired backend's identity"
     )
-    resolved.planning match
+    roles.planning match
       case sibling: RecordingModelClaude =>
         assertEquals(sibling.pinnedModel, Some(Model("claude-opus-x")))
       case other =>
@@ -84,18 +89,17 @@ class RoleAgentsTest extends munit.FunSuite:
   ):
     val token = new AnyRef
     val wiredOpencode = new RecordingOpencode(token)
-    val wired = wiredAgents(opencode = wiredOpencode)
     val settings = AgentSettings(
       review = Some(AgentSpec(BackendTag.Opencode, Some("ollama/qwen-coder")))
     )
-    val resolved = RoleAgents.resolve(settings, wired)
+    val roles = resolvedRoles(settings, wiredAgents(opencode = wiredOpencode))
     assert(
-      !resolved.review.eq(wiredOpencode),
+      !roles.review.eq(wiredOpencode),
       "a model pin must produce a new sibling instance, not the wired agent " +
         "itself"
     )
-    assertEquals(resolved.review.backendIdentity, Some(token))
-    resolved.review match
+    assertEquals(roles.review.backendIdentity, Some(token))
+    roles.review match
       case sibling: RecordingOpencode =>
         assertEquals(sibling.pinnedModel, Some("ollama/qwen-coder"))
       case other =>
@@ -233,21 +237,20 @@ class RoleAgentsTest extends munit.FunSuite:
     )
 
   test("resolveAll tags each role's agent with its label, for the cost report"):
-    val resolution = RoleAgents.resolveAll(
-      project = AgentSettings.empty,
-      global = AgentSettings.empty,
-      overrides = RoleOverrides(None, None, None),
-      agents = wiredAgents(claude = new TaggableClaude("claude")),
-      onRoleResolved = _ => ()
+    val roles = resolvedRoles(
+      AgentSettings.empty,
+      wiredAgents(claude = new TaggableClaude("claude"))
     )
-    val roles = resolution.roles
+    // The review role's cost tag is the reviewers' own, not its label: the
+    // reviewers, lint and the picker all bill under it, and the by-role block
+    // must not grow a second bucket for the same concept.
     assertEquals(
       List(roles.planning, roles.coding, roles.review)
         .map(a => (a.name, a.role)),
       List(
         ("planning", Some("planning")),
         ("coding", Some("coding")),
-        ("review", Some("review"))
+        ("review", Some(ReviewerPrompts.Role))
       )
     )
 
@@ -296,6 +299,23 @@ class RoleAgentsTest extends munit.FunSuite:
       ),
       s"expected a foreign-agent warning: ${resolution.foreignWarnings}"
     )
+
+  /** [[RoleAgents.resolveAll]] with no global settings and no programmatic
+    * override — the settings-only path the mapping tests exercise.
+    */
+  private def resolvedRoles(
+      settings: AgentSettings,
+      agents: WiredAgents
+  ): ResolvedRoles =
+    RoleAgents
+      .resolveAll(
+        project = settings,
+        global = AgentSettings.empty,
+        overrides = RoleOverrides(None, None, None),
+        agents = agents,
+        onRoleResolved = _ => ()
+      )
+      .roles
 
   private def wiredAgents(
       claude: ClaudeAgent = StubAgent.claude,

--- a/runner/src/test/scala/orca/runner/manifest/CostLogTest.scala
+++ b/runner/src/test/scala/orca/runner/manifest/CostLogTest.scala
@@ -209,6 +209,29 @@ class CostLogTest extends munit.FunSuite:
     )
     assertEquals(turn.cost, Some(resolved))
 
+  /** Without the model on the line, the by-model split the run printed cannot
+    * be reproduced from the file — which the record's own contract promises.
+    */
+  test("a turn records the model, or None when the backend reported none"):
+    val workDir = TempDirs.dir()
+    val writer = newWriter(workDir)
+    writer.onEvent(
+      OrcaEvent.TokensUsed(
+        agent = "claude",
+        model = Some(Model("claude-sonnet-5")),
+        usage = usage(10, 1, None),
+        role = None,
+        cost = None
+      )
+    )
+    writer.onEvent(
+      OrcaEvent.TokensUsed("claude", None, usage(10, 1, None), cost = None)
+    )
+    assertEquals(
+      turns(workDir).map(_.model),
+      List(Some("claude-sonnet-5"), None)
+    )
+
   /** The run total is a read-time fold, so this pins that the lines carry
     * enough to compute one — including `estimated` surviving the addition, so a
     * mixed total can't be read as a billed figure.


### PR DESCRIPTION
Last of five PRs from `docs/plans/run-quality/` (spec and plan are on master). Independent of #163 and #164.

The cost summary could not answer the question people actually ask it. Every role agent was named `main` and cheap sub-calls inherited that name, so planning and coding shared one bucket: in one measured run `main`'s $37.09 was really $3.42 of planning, $32.96 of coding and $0.71 of incidental cheap calls, with no way to tell from the output.

- The role agents are named and role-tagged where they are resolved, not in the flows — so user-written flows, the shell, and the runtime's own cheap one-shots (branch naming, default commit messages, stack discovery) all get the right attribution for free, since `Agent.cheap` inherits both.
- A name set deliberately through the role-override channel is not clobbered. The guard's scaladoc says exactly which channel it protects and which it cannot, rather than implying more.
- The reviewer-picker carries the reviewer role and its own name, so its spend stops landing under `main`. Both `agentDriven` forms tag identically.
- One vocabulary for review: reviewers, lint, the picker and the review role agent all report under one subtotal. Review caught this — the block was about to ship with `review:` and `reviewer:` as sibling buckets, one letter apart, for the same concept.
- The summary prints the total, the split by role and the split by model. The per-agent view moves to the run's cost log, which now records the model — the log's own contract says every axis an aggregate needs must be recoverable from it, and by-model previously was not.
- `claude-mythos-5` is added to the price table; it was absent and would have fallen through as unpriced.

`RoleAgents.resolve` is deleted: it had no production callers, did not tag, and the next caller reaching for the shorter name would have lost attribution silently.

Note this changes the terminal's emitting-agent prefix as well — in a stage where several agents emit, lines that read `main:` now read `planning:` / `coding:` / `review:`.
