### PR TITLE
Make the refused --worktree flag pairs unrepresentable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ site rather than rewiring modules.
 The user-facing surface lives in `package orca` (the `flow` entry, the tool
 accessors — including `planningAgent`/`codingAgent`/`reviewAgent`, the
 backend-agnostic role accessors (ADR 0020) — `stage`/`display`/`fail`,
-`JsonData`, `OrcaArgs`). Implementations live in
+`JsonData`, `OrcaArgs` and the `RunTarget` its flags parse into).
+Implementations live in
 focused subpackages: `orca.tools` (os-backed git/gh/fs impls + their traits),
 `orca.agents` + `orca.backend` (LLM SPI, `SessionSupport`,
 conversation driver), `orca.subprocess` (subprocess shim), `orca.sweep`

--- a/README.md
+++ b/README.md
@@ -325,31 +325,36 @@ Each `flow(...)` run is bound to exactly one feature branch and one progress log
 
 - **Start:** stash a dirty working tree with a warning (recover with `git stash
   pop`); create + checkout the feature branch; write and commit the progress log
-  header. `--skip-branch` (`OrcaArgs.skipBranch`) binds the run to the CURRENT
+  header. The three flags below reach a flow as one `OrcaArgs.target`
+  (`RunTarget`), which has no case for a combination orca refuses.
+  `--skip-branch` (`RunTarget.CurrentBranch`) binds the run to the CURRENT
   branch instead of creating one — for continuing work already planned on a
   branch — refusing on a protected branch or detached HEAD. On a FRESH
   `--skip-branch` run a dirty tree is tolerated, not stashed: uncommitted or
   untracked files (e.g. plan files left by a planning harness) stay in place for
   the flow, and get swept into the first stage's commit. `--keep-changes`
-  (`OrcaArgs.keepChanges`) does the same on a FRESH run in either branch mode —
-  in normal mode the files survive branch creation and reach the new branch in
-  that first stage commit. With neither flag, a dirty tree on a fresh run is put
-  to the user: stash (the default), keep, or abort; with no terminal to ask, it
-  stashes. A run that already has a progress log — a resume, or one too broken
-  to read — always stashes and ignores `--keep-changes`, so an interrupted
-  stage's partial work can't leak into the stage that re-runs.
-  `--worktree` (`OrcaArgs.worktree`) runs the whole flow in
+  (`Uncommitted.Keep` on either branch case) does the same on a FRESH run in
+  either branch mode — in normal mode the files survive branch creation and
+  reach the new branch in that first stage commit. With neither flag, a dirty
+  tree on a fresh run is put to the user: stash (the default), keep, or abort;
+  with no terminal to ask, it stashes. A run that already has a progress log —
+  a resume, or one too broken to read — always stashes and ignores
+  `--keep-changes`, so an interrupted stage's partial work can't leak into the
+  stage that re-runs.
+  `--worktree` (`RunTarget.Worktree`) runs the whole flow in
   `.orca/worktrees/<hash>` of this repository — a second checkout, keyed on the
   same prompt hash as the progress log, created on the first run and reused by
   every later one for that task. It isolates the run: two tasks can run at once
   without sharing a checkout or a branch. Uncommitted work does NOT come along —
   a worktree is made from a commit — so `--worktree` is refused with
-  `--skip-branch` and with `--keep-changes`. The first run in a worktree pays a
-  cold build (no build outputs, no dependencies, none of the untracked local
-  config a project may need), an editor or indexer that ignores `.gitignore`
-  will see the second checkout, and orca never removes it. The run starts on an
-  `orca-worktree-<hash>` branch orca also never deletes, so full cleanup is `git
-  worktree remove .orca/worktrees/<hash>` **and** `git branch -d
+  `--skip-branch` and with `--keep-changes`: `RunTarget.Worktree` carries
+  neither a branch mode nor an `Uncommitted`, so the pair is refused while argv
+  is parsed and has no representation after that. The first run in a worktree
+  pays a cold build (no build outputs, no dependencies, none of the untracked
+  local config a project may need), an editor or indexer that ignores
+  `.gitignore` will see the second checkout, and orca never removes it. The run
+  starts on an `orca-worktree-<hash>` branch orca also never deletes, so full
+  cleanup is `git worktree remove .orca/worktrees/<hash>` **and** `git branch -d
   orca-worktree-<hash>`; a re-run of the task refuses rather than moving that
   branch if it has gained commits since.
   Sharp edge: kept files are unprotected until that first stage commit — a

--- a/adr/0018-stage-bound-flow-runtime.md
+++ b/adr/0018-stage-bound-flow-runtime.md
@@ -454,6 +454,12 @@ the wrong branch.
   > `--skip-branch` (git will not check the current branch out a second time in
   > a new worktree). Both refusals happen in `OrcaArgs.parse`, before setup, the
   > banner, or any git call.
+
+  > **Amendment (2026-08-28).** The three flags above no longer reach a run as
+  > separate fields: `OrcaArgs.target` is one `RunTarget` —
+  > `NewBranch(Uncommitted)`, `CurrentBranch(Uncommitted)` or `Worktree`, which
+  > carries neither — so a refused pair has no representation past
+  > `OrcaArgs.parse`, which is where it is still refused.
 - **R5** — On **successful** exit the progress-log file is removed in a final
   commit, and a feature branch left with no changes other than the progress log is
   deleted (throwaway-branch cleanup). That removal commit is also pushed, but only

--- a/adr/0021-orca-shell.md
+++ b/adr/0021-orca-shell.md
@@ -905,6 +905,12 @@ harness/model/yolo flag exists for either.
 > (`OrcaArgs.worktreeRefusal`), so neither the wording nor the set of refused
 > pairs can drift.
 
+> **Amendment (2026-08-28).** That shared decision is now `RunTarget.from`,
+> which returns the run's destination as one value instead of an optional
+> refusal string. Both parsers convert their raw flags through it, so a refused
+> pair cannot be carried past argv — `FlowFlags` holds a `RunTarget`, and every
+> launch path takes one.
+
 Both entry points call a shared `orca.shell.actions` package (`FlowResolution`,
 `RunAction`, `ViewAction`, `EditAction`, `AuthorAction`, `SessionAction`,
 `ConfigAction`, `StackAction`): each takes fully-resolved parameters and does

--- a/runner/src/main/scala/orca/OrcaArgs.scala
+++ b/runner/src/main/scala/orca/OrcaArgs.scala
@@ -2,8 +2,12 @@ package orca
 
 import mainargs.{Flag, ParserForClass, arg}
 
-/** Parsed command-line arguments for the `orca` entry point. */
-case class OrcaArgs(
+/** The argv shape mainargs parses: one raw flag per `--`-spelled option,
+  * including the `--worktree` combinations orca refuses. [[OrcaArgs.parse]] is
+  * its only consumer, and turns the three run-destination flags into a
+  * [[RunTarget]] — so nothing beyond the parse boundary holds them separately.
+  */
+private[orca] case class RawArgs(
     @arg(positional = true, doc = "task description")
     userPrompt: String = "",
     @arg(doc = "print a stack trace if the flow aborts")
@@ -20,53 +24,31 @@ case class OrcaArgs(
     worktree: Flag = Flag()
 )
 
+/** Parsed command-line arguments for the `orca` entry point. */
+case class OrcaArgs(
+    userPrompt: String = "",
+    verbose: Boolean = false,
+    target: RunTarget = RunTarget.NewBranch(Uncommitted.Stash)
+)
+
 object OrcaArgs:
-  given ParserForClass[OrcaArgs] = ParserForClass[OrcaArgs]
-
-  private val worktreeWithSkipBranchRefusal: String =
-    "--worktree cannot be combined with --skip-branch: --skip-branch runs on " +
-      "the branch checked out now, and git will not check that branch out a " +
-      "second time in a new worktree"
-
-  private val worktreeWithKeepChangesRefusal: String =
-    "--worktree cannot be combined with --keep-changes: --keep-changes works " +
-      "on uncommitted files, which stay behind in the invoking checkout — a " +
-      "worktree is created from a commit and starts clean"
-
-  /** Why these flags cannot be combined, or `None` when they can — asked of a
-    * whole `OrcaArgs`, so neither [[parse]] nor `flow()` spells out a triple of
-    * same-typed booleans that a transposition would silently reorder.
-    */
-  private[orca] def worktreeRefusal(args: OrcaArgs): Option[String] =
-    worktreeRefusal(
-      worktree = args.worktree.value,
-      skipBranch = args.skipBranch.value,
-      keepChanges = args.keepChanges.value
-    )
-
-  /** The same question over loose booleans, for the shell — it holds
-    * `FlowFlags`, not an `OrcaArgs`, and refuses the pair before it spawns a
-    * flow at all. What must not drift is which pairs are refused, not only how
-    * each refusal reads.
-    */
-  private[orca] def worktreeRefusal(
-      worktree: Boolean,
-      skipBranch: Boolean,
-      keepChanges: Boolean
-  ): Option[String] =
-    if !worktree then None
-    else if skipBranch then Some(worktreeWithSkipBranchRefusal)
-    else if keepChanges then Some(worktreeWithKeepChangesRefusal)
-    else None
+  private given ParserForClass[RawArgs] = ParserForClass[RawArgs]
 
   /** Parse the given argv or return a human-readable error — including for a
     * contradictory `--worktree` pair, refused here so it fails at parse, before
     * the banner and before anything touches git.
     */
   def parse(args: Seq[String]): Either[String, OrcaArgs] =
-    summon[ParserForClass[OrcaArgs]]
+    summon[ParserForClass[RawArgs]]
       .constructEither(args.toList)
-      .flatMap(parsed => worktreeRefusal(parsed).toLeft(parsed))
+      .flatMap: raw =>
+        RunTarget
+          .from(
+            worktree = raw.worktree.value,
+            skipBranch = raw.skipBranch.value,
+            keepChanges = raw.keepChanges.value
+          )
+          .map(OrcaArgs(raw.userPrompt, raw.verbose.value, _))
 
   /** Overload for scala-cli flow scripts, whose top-level `args` is
     * `Array[String]`. Throws `OrcaFlowException` on a parse failure.

--- a/runner/src/main/scala/orca/RunTarget.scala
+++ b/runner/src/main/scala/orca/RunTarget.scala
@@ -1,0 +1,90 @@
+package orca
+
+/** What a run does with uncommitted and untracked files it finds in the working
+  * tree at start (`--keep-changes` asks for [[Uncommitted.Keep]]).
+  */
+enum Uncommitted:
+  /** Stash them, so the run starts from committed content. */
+  case Stash
+
+  /** Leave them in place for the flow to work on and commit. */
+  case Keep
+
+/** Where a run's work goes: which branch it commits onto, and — in the cases
+  * where the question arises at all — what happens to uncommitted files.
+  *
+  * This is what `--skip-branch`, `--keep-changes` and `--worktree` become once
+  * argv is parsed. `--worktree` combines with neither of the other two (a
+  * worktree is created from a commit, so it starts clean and checks out a
+  * branch of its own), so [[Worktree]] carries no `Uncommitted` and is not a
+  * branch mode: the refused combinations have no representation here, and
+  * [[RunTarget.from]] — the only way in from raw flags — is where they are
+  * refused.
+  */
+enum RunTarget:
+  /** A branch orca creates in the invoking checkout — the default. */
+  case NewBranch(uncommitted: Uncommitted)
+
+  /** The branch checked out now; the flow commits onto it (`--skip-branch`). */
+  case CurrentBranch(uncommitted: Uncommitted)
+
+  /** A separate checkout under `.orca/worktrees/` (`--worktree`). */
+  case Worktree
+
+  /** Runs on the branch already checked out, instead of creating one. */
+  def skipBranch: Boolean = this match
+    case CurrentBranch(_)        => true
+    case NewBranch(_) | Worktree => false
+
+  /** Leaves uncommitted files in the tree instead of stashing them. */
+  def keepChanges: Boolean = this match
+    case NewBranch(uncommitted)     => uncommitted == Uncommitted.Keep
+    case CurrentBranch(uncommitted) => uncommitted == Uncommitted.Keep
+    case Worktree                   => false
+
+  /** The flags [[OrcaArgs]] parses back, in the order the shell appends them
+    * after `--` when it spawns a flow child. Rendering lives next to the parser
+    * so both directions of one flag spelling are in a single file.
+    */
+  def toArgv: Seq[String] = this match
+    case NewBranch(Uncommitted.Stash)     => Nil
+    case NewBranch(Uncommitted.Keep)      => Seq("--keep-changes")
+    case CurrentBranch(Uncommitted.Stash) => Seq("--skip-branch")
+    case CurrentBranch(Uncommitted.Keep) =>
+      Seq("--skip-branch", "--keep-changes")
+    case Worktree => Seq("--worktree")
+
+object RunTarget:
+
+  private val worktreeWithSkipBranchRefusal: String =
+    "--worktree cannot be combined with --skip-branch: --skip-branch runs on " +
+      "the branch checked out now, and git will not check that branch out a " +
+      "second time in a new worktree"
+
+  private val worktreeWithKeepChangesRefusal: String =
+    "--worktree cannot be combined with --keep-changes: --keep-changes works " +
+      "on uncommitted files, which stay behind in the invoking checkout — a " +
+      "worktree is created from a commit and starts clean"
+
+  /** The single conversion from the raw flags an argv parser produces: a flow's
+    * own argv ([[OrcaArgs.parse]]) and `orca run`'s (the shell has its own
+    * parser for the same three flags) both come through here, so neither the
+    * wording of a refusal nor the set of refused pairs can drift. A refused
+    * pair is a message, never a value — which is what keeps it out of every
+    * type below this point.
+    */
+  def from(
+      worktree: Boolean,
+      skipBranch: Boolean,
+      keepChanges: Boolean
+  ): Either[String, RunTarget] =
+    val uncommitted =
+      if keepChanges then Uncommitted.Keep else Uncommitted.Stash
+    if !worktree then
+      Right(
+        if skipBranch then CurrentBranch(uncommitted)
+        else NewBranch(uncommitted)
+      )
+    else if skipBranch then Left(worktreeWithSkipBranchRefusal)
+    else if keepChanges then Left(worktreeWithKeepChangesRefusal)
+    else Right(Worktree)

--- a/runner/src/main/scala/orca/RunTarget.scala
+++ b/runner/src/main/scala/orca/RunTarget.scala
@@ -31,12 +31,13 @@ enum RunTarget:
   /** A separate checkout under `.orca/worktrees/` (`--worktree`). */
   case Worktree
 
-  /** Runs on the branch already checked out, instead of creating one. */
+  // Views for the two setup decisions that turn on a single axis (which branch
+  // to bind, what to do with a dirty tree). Derived, so no caller can set one
+  // without the case that implies it.
   def skipBranch: Boolean = this match
     case CurrentBranch(_)        => true
     case NewBranch(_) | Worktree => false
 
-  /** Leaves uncommitted files in the tree instead of stashing them. */
   def keepChanges: Boolean = this match
     case NewBranch(uncommitted)     => uncommitted == Uncommitted.Keep
     case CurrentBranch(uncommitted) => uncommitted == Uncommitted.Keep

--- a/runner/src/main/scala/orca/flow.scala
+++ b/runner/src/main/scala/orca/flow.scala
@@ -120,9 +120,10 @@ private enum FlowOutcome:
   * reused after, and everything below it — git, the progress log, the session
   * manifest — uses that directory instead. A refusal (no repository, no
   * commits, something orca did not create already at the path) ends the run
-  * before any of that starts. `--worktree` cannot be combined with `skipBranch`
-  * or `keepChanges`; the pair is refused here as well as in `OrcaArgs.parse`,
-  * since an `OrcaArgs` built by hand never passed through the parser.
+  * before any of that starts. `--worktree` combines with neither
+  * `--skip-branch` nor `--keep-changes`, and `RunTarget` — what `args` carries
+  * those three flags as — has no case for either pair, so the refusal happens
+  * once, converting argv (`OrcaArgs.parse`).
   *
   * Overrides default to `None` so the runtime can build the default lazily —
   * `TerminalInteraction` in particular takes the resolved `workDir`, which
@@ -173,17 +174,13 @@ def flow(
   // the session manifest below; everything downstream is handed `workDir`
   // explicitly, so it is the single value to change.
   def resolveRunDir(): Either[String, os.Path] =
-    OrcaArgs
-      .worktreeRefusal(args)
-      .toLeft(())
-      .flatMap: _ =>
-        if !args.worktree.value then Right(workDir)
-        else
-          // Resolution can throw as well as refuse — a symlinked or unwritable
-          // `.orca`, a git that won't start. One `Left` shape for every outcome
-          // keeps the reporting below the only way out.
-          try WorktreeRun.resolve(workDir, args.userPrompt)
-          catch case NonFatal(e) => Left(TextUtil.throwableMessage(e))
+    if args.target != RunTarget.Worktree then Right(workDir)
+    else
+      // Resolution can throw as well as refuse — a symlinked or unwritable
+      // `.orca`, a git that won't start. One `Left` shape for every outcome
+      // keeps the reporting below the only way out.
+      try WorktreeRun.resolve(workDir, args.userPrompt)
+      catch case NonFatal(e) => Left(TextUtil.throwableMessage(e))
 
   // The run proper. Everything under here uses `dir`, never `workDir`.
   def runIn(dir: os.Path): FlowOutcome =
@@ -263,7 +260,8 @@ def flow(
           FlowOutcome.Failed
         case Right(dir) =>
           val where =
-            if args.worktree.value then s"$dir (worktree)" else dir.toString
+            if args.target == RunTarget.Worktree then s"$dir (worktree)"
+            else dir.toString
           flowLog.info(
             "orca {} starting (workDir={})",
             OrcaBanner.version,
@@ -315,7 +313,7 @@ private[orca] def runFlow(
     wiring: FlowWiring = FlowWiring(),
     pricing: PriceList = Pricing.default
 )(body: FlowControl ?=> Unit): Unit =
-  val debug = OrcaDebug.enabled || args.verbose.value
+  val debug = OrcaDebug.enabled || args.verbose
   // Acquire both guards before `supervised:` (neither needs an `Ox` scope) so a
   // violation is caught before any git mutation. See [[FlowLock]] for the
   // two-layer rationale and release-ordering symmetry.

--- a/runner/src/main/scala/orca/flow.scala
+++ b/runner/src/main/scala/orca/flow.scala
@@ -173,9 +173,9 @@ def flow(
   // Where the run happens. This settles before the directory's first consumer,
   // the session manifest below; everything downstream is handed `workDir`
   // explicitly, so it is the single value to change.
-  def resolveRunDir(): Either[String, os.Path] =
-    if args.target != RunTarget.Worktree then Right(workDir)
-    else
+  def resolveRunDir(): Either[String, os.Path] = args.target match
+    case RunTarget.NewBranch(_) | RunTarget.CurrentBranch(_) => Right(workDir)
+    case RunTarget.Worktree                                  =>
       // Resolution can throw as well as refuse — a symlinked or unwritable
       // `.orca`, a git that won't start. One `Left` shape for every outcome
       // keeps the reporting below the only way out.
@@ -259,9 +259,10 @@ def flow(
           System.err.println(s"[orca] $message")
           FlowOutcome.Failed
         case Right(dir) =>
-          val where =
-            if args.target == RunTarget.Worktree then s"$dir (worktree)"
-            else dir.toString
+          val where = args.target match
+            case RunTarget.Worktree => s"$dir (worktree)"
+            case RunTarget.NewBranch(_) | RunTarget.CurrentBranch(_) =>
+              dir.toString
           flowLog.info(
             "orca {} starting (workDir={})",
             OrcaBanner.version,

--- a/runner/src/main/scala/orca/runner/FlowLifecycle.scala
+++ b/runner/src/main/scala/orca/runner/FlowLifecycle.scala
@@ -524,8 +524,8 @@ object FlowLifecycle:
       val dirtyCount = git.dirtyPaths().size
       val facts = DirtyTreeFacts(
         ownLogPresent = ownLog != ProgressStore.LoadResult.Absent,
-        skipBranch = args.skipBranch.value,
-        keepChanges = args.keepChanges.value,
+        skipBranch = args.target.skipBranch,
+        keepChanges = args.target.keepChanges,
         dirtyCount = dirtyCount
       )
       DirtyTreePolicy.decide(facts, tty, ask) match
@@ -548,7 +548,7 @@ object FlowLifecycle:
         WorkspaceWrite
     ): UntrackedFiles =
       if dirtyCount > 0 then
-        if args.keepChanges.value then
+        if args.target.keepChanges then
           emit(
             OrcaEvent.Step(
               "ignoring --keep-changes: this task already has a progress " +
@@ -614,8 +614,8 @@ object FlowLifecycle:
 
     /** Shared by [[bindBranch]]'s corrupt-log and absent-log arms: resolve +
       * create a fresh branch via [[freshRun]], then mint [[BranchMode]] from
-      * `args.skipBranch` (skip-branch mode never creates a branch, so it reads
-      * as `Reused`).
+      * `args.target` (skip-branch mode never creates a branch, so it reads as
+      * `Reused`).
       */
     private def freshBinding(
         startBranch: String,
@@ -644,7 +644,7 @@ object FlowLifecycle:
       BranchBinding(
         branch,
         startBranch,
-        if args.skipBranch.value then BranchMode.Reused
+        if args.target.skipBranch then BranchMode.Reused
         else BranchMode.Created,
         headAtBinding
       )
@@ -913,7 +913,7 @@ object FlowLifecycle:
     * "main" this time. [[createFreshBranch]] applies the same policy to a
     * git-level collision.
     *
-    * `args.skipBranch` skips all of this: the run binds to `startBranch`
+    * A `CurrentBranch` target skips all of this: the run binds to `startBranch`
     * verbatim via [[reuseCurrentBranch]] instead.
     */
   private def freshRun(
@@ -931,7 +931,7 @@ object FlowLifecycle:
       emit: OrcaEvent => Unit
   )(using InStage, WorkspaceWrite): FeatureBranch =
     val branch =
-      if args.skipBranch.value then
+      if args.target.skipBranch then
         reuseCurrentBranch(startBranch, protectedBranches)
       else
         val strategy =
@@ -970,7 +970,7 @@ object FlowLifecycle:
         branch = branch.value,
         promptHash = ProgressStore.hashPrompt(args.userPrompt),
         branchMode =
-          if args.skipBranch.value then BranchMode.Reused
+          if args.target.skipBranch then BranchMode.Reused
           else BranchMode.Created,
         userPrompt = Some(args.userPrompt),
         flowName = flowName,

--- a/runner/src/test/scala/orca/OrcaArgsTest.scala
+++ b/runner/src/test/scala/orca/OrcaArgsTest.scala
@@ -44,6 +44,14 @@ class OrcaArgsTest extends munit.FunSuite:
       Right(RunTarget.NewBranch(Uncommitted.Keep))
     )
 
+  test("--skip-branch with --keep-changes: current branch, files kept"):
+    assertEquals(
+      OrcaArgs
+        .parse(Seq("--skip-branch", "--keep-changes", "do the thing"))
+        .map(_.target),
+      Right(RunTarget.CurrentBranch(Uncommitted.Keep))
+    )
+
   test("--worktree targets a worktree"):
     val result = OrcaArgs
       .parse(Seq("--worktree", "do the thing"))

--- a/runner/src/test/scala/orca/OrcaArgsTest.scala
+++ b/runner/src/test/scala/orca/OrcaArgsTest.scala
@@ -1,11 +1,14 @@
 package orca
 
-import mainargs.Flag
-
 class OrcaArgsTest extends munit.FunSuite:
 
   test("parses an empty argv into defaults (empty prompt, verbose off)"):
-    assertEquals(OrcaArgs.parse(Nil), Right(OrcaArgs("", Flag())))
+    assertEquals(
+      OrcaArgs.parse(Nil),
+      Right(
+        OrcaArgs("", verbose = false, RunTarget.NewBranch(Uncommitted.Stash))
+      )
+    )
 
   test("a single positional argument becomes userPrompt"):
     val result = OrcaArgs
@@ -13,7 +16,7 @@ class OrcaArgsTest extends munit.FunSuite:
       .toOption
       .getOrElse(fail("expected successful parse"))
     assertEquals(result.userPrompt, "implement feature X")
-    assertEquals(result.verbose.value, false)
+    assertEquals(result.verbose, false)
 
   test("--verbose flag sets verbose = true"):
     val result = OrcaArgs
@@ -21,27 +24,33 @@ class OrcaArgsTest extends munit.FunSuite:
       .toOption
       .getOrElse(fail("expected successful parse"))
     assertEquals(result.userPrompt, "do the thing")
-    assertEquals(result.verbose.value, true)
+    assertEquals(result.verbose, true)
 
-  test("--skip-branch flag sets skipBranch = true; absent defaults to false"):
+  test("--skip-branch targets the current branch; absent, a new one"):
     val result = OrcaArgs
       .parse(Seq("--skip-branch", "do the thing"))
       .toOption
       .getOrElse(fail("expected successful parse"))
     assertEquals(result.userPrompt, "do the thing")
-    assertEquals(result.skipBranch.value, true)
+    assertEquals(result.target, RunTarget.CurrentBranch(Uncommitted.Stash))
     assertEquals(
-      OrcaArgs.parse(Seq("do the thing")).map(_.skipBranch.value),
-      Right(false)
+      OrcaArgs.parse(Seq("do the thing")).map(_.target),
+      Right(RunTarget.NewBranch(Uncommitted.Stash))
     )
 
-  test("--worktree flag sets worktree = true"):
+  test("--keep-changes keeps uncommitted files on the chosen branch"):
+    assertEquals(
+      OrcaArgs.parse(Seq("--keep-changes", "do the thing")).map(_.target),
+      Right(RunTarget.NewBranch(Uncommitted.Keep))
+    )
+
+  test("--worktree targets a worktree"):
     val result = OrcaArgs
       .parse(Seq("--worktree", "do the thing"))
       .toOption
       .getOrElse(fail("expected successful parse"))
     assertEquals(result.userPrompt, "do the thing")
-    assertEquals(result.worktree.value, true)
+    assertEquals(result.target, RunTarget.Worktree)
 
   test("--worktree with --skip-branch is refused, naming both flags"):
     assertRefused(Seq("--worktree", "--skip-branch", "x"), "--skip-branch")

--- a/runner/src/test/scala/orca/RunTargetTest.scala
+++ b/runner/src/test/scala/orca/RunTargetTest.scala
@@ -1,0 +1,21 @@
+package orca
+
+class RunTargetTest extends munit.FunSuite:
+
+  test("toArgv renders each destination as the flags OrcaArgs parses back"):
+    assertEquals(
+      List(
+        RunTarget.NewBranch(Uncommitted.Stash),
+        RunTarget.NewBranch(Uncommitted.Keep),
+        RunTarget.CurrentBranch(Uncommitted.Stash),
+        RunTarget.CurrentBranch(Uncommitted.Keep),
+        RunTarget.Worktree
+      ).map(_.toArgv),
+      List(
+        Nil,
+        Seq("--keep-changes"),
+        Seq("--skip-branch"),
+        Seq("--skip-branch", "--keep-changes"),
+        Seq("--worktree")
+      )
+    )

--- a/runner/src/test/scala/orca/runner/FlowLifecycleTest.scala
+++ b/runner/src/test/scala/orca/runner/FlowLifecycleTest.scala
@@ -6,7 +6,9 @@ import orca.{
   FlowContext,
   OrcaArgs,
   OrcaDir,
+  RunTarget,
   StackSettings,
+  Uncommitted,
   WorkspaceWrite,
   runFlow,
   stage,
@@ -49,7 +51,6 @@ import orca.tools.{
   UntrackedFiles,
   Worktrees
 }
-import mainargs.Flag
 import ox.supervised
 import ox.either.orThrow
 
@@ -129,7 +130,7 @@ class FlowLifecycleTest extends munit.FunSuite:
           animated = false
         )
         flow(
-          args = OrcaArgs(prompt, worktree = Flag(true)),
+          args = OrcaArgs(prompt, target = RunTarget.Worktree),
           stackSettings = Some(StackSettings.empty),
           claude = Some(_ => StubAgent.claude),
           workDir = workDir,
@@ -704,7 +705,10 @@ class FlowLifecycleTest extends munit.FunSuite:
     val _ = writeForeignLog(workDir, branch = "my-work")
     val thrown = intercept[orca.OrcaFlowException]:
       val _ = FlowLifecycle.setup(
-        args = OrcaArgs("a brand new task", skipBranch = Flag(true)),
+        args = OrcaArgs(
+          "a brand new task",
+          target = RunTarget.CurrentBranch(Uncommitted.Stash)
+        ),
         agent = StubAgent.claude,
         git = git,
         workDir = workDir,
@@ -881,7 +885,8 @@ class FlowLifecycleTest extends munit.FunSuite:
     val prompt = "skip-branch starting commit"
     val store = ProgressStore.default(workDir, prompt)
     val setup = FlowLifecycle.setup(
-      args = OrcaArgs(prompt, skipBranch = Flag(true)),
+      args =
+        OrcaArgs(prompt, target = RunTarget.CurrentBranch(Uncommitted.Stash)),
       agent = StubAgent.claude,
       git = git,
       workDir = workDir,
@@ -2216,7 +2221,8 @@ class FlowLifecycleTest extends munit.FunSuite:
         animated = false
       )
       flow(
-        args = OrcaArgs(prompt, skipBranch = Flag(true)),
+        args =
+          OrcaArgs(prompt, target = RunTarget.CurrentBranch(Uncommitted.Stash)),
         stackSettings = Some(StackSettings.empty),
         claude = Some(_ => StubAgent.claude),
         workDir = workDir,
@@ -2266,7 +2272,10 @@ class FlowLifecycleTest extends munit.FunSuite:
           animated = false
         )
         runFlow(
-          args = OrcaArgs(prompt, skipBranch = Flag(true)),
+          args = OrcaArgs(
+            prompt,
+            target = RunTarget.CurrentBranch(Uncommitted.Stash)
+          ),
           stackSettings = Some(StackSettings.empty),
           wiring = FlowWiring(claude = Some(_ => StubAgent.claude)),
           workDir = workDir,
@@ -2313,7 +2322,10 @@ class FlowLifecycleTest extends munit.FunSuite:
           animated = false
         )
         runFlow(
-          args = OrcaArgs(prompt, skipBranch = Flag(true)),
+          args = OrcaArgs(
+            prompt,
+            target = RunTarget.CurrentBranch(Uncommitted.Stash)
+          ),
           stackSettings = Some(StackSettings.empty),
           wiring = FlowWiring(claude = Some(_ => StubAgent.claude)),
           workDir = workDir,
@@ -2353,7 +2365,10 @@ class FlowLifecycleTest extends munit.FunSuite:
           animated = false
         )
         runFlow(
-          args = OrcaArgs(prompt, skipBranch = Flag(true)),
+          args = OrcaArgs(
+            prompt,
+            target = RunTarget.CurrentBranch(Uncommitted.Stash)
+          ),
           stackSettings = Some(StackSettings.empty),
           wiring = FlowWiring(claude = Some(_ => StubAgent.claude)),
           workDir = workDir,
@@ -2437,7 +2452,8 @@ class FlowLifecycleTest extends munit.FunSuite:
         animated = false
       )
       flow(
-        args = OrcaArgs(prompt, skipBranch = Flag(true)),
+        args =
+          OrcaArgs(prompt, target = RunTarget.CurrentBranch(Uncommitted.Stash)),
         stackSettings = Some(StackSettings.empty),
         claude = Some(_ => StubAgent.claude),
         workDir = workDir,
@@ -2502,7 +2518,8 @@ class FlowLifecycleTest extends munit.FunSuite:
         animated = false
       )
       flow(
-        args = OrcaArgs(prompt, skipBranch = Flag(true)),
+        args =
+          OrcaArgs(prompt, target = RunTarget.CurrentBranch(Uncommitted.Stash)),
         stackSettings = Some(StackSettings.empty),
         claude = Some(_ => StubAgent.claude),
         workDir = workDir,
@@ -2572,7 +2589,8 @@ class FlowLifecycleTest extends munit.FunSuite:
         animated = false
       )
       flow(
-        args = OrcaArgs(prompt, skipBranch = Flag(true)),
+        args =
+          OrcaArgs(prompt, target = RunTarget.CurrentBranch(Uncommitted.Stash)),
         stackSettings = Some(StackSettings.empty),
         claude = Some(_ => StubAgent.claude),
         workDir = workDir,
@@ -2608,7 +2626,8 @@ class FlowLifecycleTest extends munit.FunSuite:
         animated = false
       )
       flow(
-        args = OrcaArgs(prompt, skipBranch = Flag(true)),
+        args =
+          OrcaArgs(prompt, target = RunTarget.CurrentBranch(Uncommitted.Stash)),
         stackSettings = Some(StackSettings.empty),
         claude = Some(_ => StubAgent.claude),
         workDir = workDir,
@@ -2658,7 +2677,8 @@ class FlowLifecycleTest extends munit.FunSuite:
         animated = false
       )
       flow(
-        args = OrcaArgs(prompt, skipBranch = Flag(true)),
+        args =
+          OrcaArgs(prompt, target = RunTarget.CurrentBranch(Uncommitted.Stash)),
         stackSettings = Some(StackSettings.empty),
         claude = Some(_ => StubAgent.claude),
         workDir = workDir,
@@ -2701,7 +2721,7 @@ class FlowLifecycleTest extends munit.FunSuite:
         animated = false
       )
       flow(
-        args = OrcaArgs(prompt, keepChanges = Flag(true)),
+        args = OrcaArgs(prompt, target = RunTarget.NewBranch(Uncommitted.Keep)),
         stackSettings = Some(StackSettings.empty),
         claude = Some(_ => StubAgent.claude),
         workDir = workDir,
@@ -2781,7 +2801,7 @@ class FlowLifecycleTest extends munit.FunSuite:
         animated = false
       )
       flow(
-        args = OrcaArgs(prompt, keepChanges = Flag(true)),
+        args = OrcaArgs(prompt, target = RunTarget.NewBranch(Uncommitted.Keep)),
         stackSettings = Some(StackSettings.empty),
         claude = Some(_ => StubAgent.claude),
         workDir = workDir,
@@ -2923,7 +2943,8 @@ class FlowLifecycleTest extends munit.FunSuite:
           animated = false
         )
         runFlow(
-          args = OrcaArgs(prompt, keepChanges = Flag(true)),
+          args =
+            OrcaArgs(prompt, target = RunTarget.NewBranch(Uncommitted.Keep)),
           stackSettings = Some(StackSettings.empty),
           wiring = FlowWiring(claude = Some(_ => StubAgent.claude)),
           workDir = workDir,
@@ -2962,7 +2983,7 @@ class FlowLifecycleTest extends munit.FunSuite:
         animated = false
       )
       flow(
-        args = OrcaArgs(prompt, keepChanges = Flag(true)),
+        args = OrcaArgs(prompt, target = RunTarget.NewBranch(Uncommitted.Keep)),
         stackSettings = Some(StackSettings.empty),
         claude = Some(_ => StubAgent.claude),
         workDir = workDir,
@@ -3003,7 +3024,8 @@ class FlowLifecycleTest extends munit.FunSuite:
         animated = false
       )
       flow(
-        args = OrcaArgs(prompt, skipBranch = Flag(true)),
+        args =
+          OrcaArgs(prompt, target = RunTarget.CurrentBranch(Uncommitted.Stash)),
         stackSettings = Some(StackSettings.empty),
         claude = Some(_ => StubAgent.claude),
         workDir = workDir,
@@ -3503,7 +3525,7 @@ class FlowLifecycleTest extends munit.FunSuite:
         animated = false
       )
       flow(
-        args = OrcaArgs(prompt, keepChanges = Flag(true)),
+        args = OrcaArgs(prompt, target = RunTarget.NewBranch(Uncommitted.Keep)),
         stackSettings = Some(StackSettings.empty),
         claude = Some(_ => StubAgent.claude),
         workDir = workDir,

--- a/shell/src/main/scala/orca/shell/Main.scala
+++ b/shell/src/main/scala/orca/shell/Main.scala
@@ -405,12 +405,12 @@ object Main:
     * the resume happens on the current branch by design, and a resumed log's
     * `bindBranch` (`FlowLifecycle`) ignores `skipBranch` entirely, so the
     * default target passed here is exactly as correct as any other would be —
-    * `Worktree` included: the run is launched IN `run.dir`, the directory its
-    * log was found in, which is what makes this a resume. That target would
-    * instead re-derive a path from the task text, which is the same directory
-    * only when the log happened to be in an orca-made worktree of that exact
-    * prompt. `runAction` is injectable, [[AuthorAction]]-style, so a test can
-    * record the call instead of spawning a real subprocess.
+    * the worktree axis included: the run is launched IN `run.dir`, the
+    * directory its log was found in, which is what makes this a resume.
+    * `Worktree` would instead re-derive a path from the task text, which is the
+    * same directory only when the log happened to be in an orca-made worktree
+    * of that exact prompt. `runAction` is injectable, [[AuthorAction]]-style,
+    * so a test can record the call instead of spawning a real subprocess.
     */
   private[shell] def resumeInterruptedRun(
       ui: ShellUi,

--- a/shell/src/main/scala/orca/shell/Main.scala
+++ b/shell/src/main/scala/orca/shell/Main.scala
@@ -1,6 +1,7 @@
 package orca.shell
 
 import org.jline.terminal.Terminal
+import orca.{RunTarget, Uncommitted}
 import orca.settings.GlobalSettings
 import orca.shell.actions.{
   AuthorAction,
@@ -390,12 +391,7 @@ object Main:
       target <- promptRunTarget(ui)
     do
       val opts = RunAction.RunOptions(
-        flags = FlowFlags(
-          verbose = false,
-          skipBranch = target.skipBranch,
-          keepChanges = false,
-          worktree = target.worktree
-        ),
+        flags = FlowFlags(verbose = false, target = target),
         fallback = FallbackPolicy.Ask(ui)
       )
       runAction(flow, task, opts, workDir, terminal).discard
@@ -408,13 +404,13 @@ object Main:
     * ([[RunAction.run]]/[[orca.shell.run.FlowLauncher]]): no branch prompt —
     * the resume happens on the current branch by design, and a resumed log's
     * `bindBranch` (`FlowLifecycle`) ignores `skipBranch` entirely, so the
-    * all-false flags passed here are exactly as correct as any other value
-    * would be — `worktree` included: the run is launched IN `run.dir`, the
-    * directory its log was found in, which is what makes this a resume. The
-    * flag would instead re-derive a path from the task text, which is the same
-    * directory only when the log happened to be in an orca-made worktree of
-    * that exact prompt. `runAction` is injectable, [[AuthorAction]]-style, so a
-    * test can record the call instead of spawning a real subprocess.
+    * default target passed here is exactly as correct as any other would be —
+    * `Worktree` included: the run is launched IN `run.dir`, the directory its
+    * log was found in, which is what makes this a resume. That target would
+    * instead re-derive a path from the task text, which is the same directory
+    * only when the log happened to be in an orca-made worktree of that exact
+    * prompt. `runAction` is injectable, [[AuthorAction]]-style, so a test can
+    * record the call instead of spawning a real subprocess.
     */
   private[shell] def resumeInterruptedRun(
       ui: ShellUi,
@@ -438,9 +434,7 @@ object Main:
           RunAction.RunOptions(
             flags = FlowFlags(
               verbose = false,
-              skipBranch = false,
-              keepChanges = false,
-              worktree = false
+              target = RunTarget.NewBranch(Uncommitted.Stash)
             ),
             fallback = FallbackPolicy.Ask(ui)
           )
@@ -467,15 +461,15 @@ object Main:
     * `CurrentBranch` is skip-branch mode (ADR 0018 amendment): the
     * handoff-from-harness case, where the user already planned work on a branch
     * carrying plan files. `Worktree` is `--worktree`, which orca refuses
-    * together with `--skip-branch` (`OrcaArgs.worktreeRefusal`) — one choice
-    * cannot express that pair, where two independent confirms could.
-    * `private[shell]` so a scripted-UI test can drive it directly.
+    * together with `--skip-branch` — one choice cannot express that pair, where
+    * two independent confirms could. `private[shell]` so a scripted-UI test can
+    * drive it directly.
     */
   private[shell] def promptRunTarget(ui: ShellUi): Option[RunTarget] =
     ui.select(
       "Where should this run's work go?",
       MainMenu.runTargetChoices,
-      preselect = Some(RunTarget.NewBranch)
+      preselect = Some(RunTarget.NewBranch(Uncommitted.Stash))
     ) match
       case UiOutcome.Cancelled        => None
       case UiOutcome.Selected(target) => Some(target)

--- a/shell/src/main/scala/orca/shell/MainMenu.scala
+++ b/shell/src/main/scala/orca/shell/MainMenu.scala
@@ -1,5 +1,6 @@
 package orca.shell
 
+import orca.{RunTarget, Uncommitted}
 import orca.shell.resume.InterruptedRun
 import orca.shell.ui.Choice
 import orca.util.TextUtil
@@ -19,32 +20,6 @@ private[shell] enum MenuItem:
   */
 private[shell] enum ChangeMode:
   case Hand, Agent
-
-/** Where a run's work goes, asked via [[MainMenu.runTargetChoices]] once the
-  * flow and the task text are settled.
-  *
-  * One choice on one axis, rather than a branch confirm followed by a worktree
-  * confirm: the two answers are not independent — orca refuses `--worktree`
-  * together with `--skip-branch` — and asking them separately makes the illegal
-  * pair expressible, leaving prompt order to prevent it. A worktree run creates
-  * a branch of its own, so all three cases here are branch-creating or not in
-  * exactly one way.
-  */
-private[shell] enum RunTarget:
-  /** A branch orca creates in this checkout — the default. */
-  case NewBranch
-
-  /** The branch checked out now; the flow commits onto it (`--skip-branch`). */
-  case CurrentBranch
-
-  /** A separate checkout under `.orca/worktrees/` (`--worktree`). */
-  case Worktree
-
-  /** Runs on the branch already checked out, instead of a new one. */
-  def skipBranch: Boolean = this == RunTarget.CurrentBranch
-
-  /** Runs in a worktree rather than the invoking checkout. */
-  def worktree: Boolean = this == RunTarget.Worktree
 
 private[shell] object MainMenu:
 
@@ -116,15 +91,24 @@ private[shell] object MainMenu:
     Choice(ChangeMode.Hand, "By hand — open in your editor")
   )
 
-  /** [[RunTarget]]'s rows, in the order they are offered. `NewBranch` leads
-    * because it is the default, and the position is load-bearing rather than
-    * cosmetic: `ConsoleUiShell` cannot honor `preselect`, so the first row is
-    * what the cursor starts on and what Enter picks.
+  /** Where a run's work goes, offered as one choice on one axis rather than a
+    * branch confirm followed by a worktree confirm: the answers are not
+    * independent — orca refuses `--worktree` with `--skip-branch` — and asking
+    * separately would leave prompt order to prevent a pair [[RunTarget]] has no
+    * case for. The menu never keeps uncommitted files, so every row stashes.
+    *
+    * `NewBranch` leads because it is the default, and the position is
+    * load-bearing rather than cosmetic: `ConsoleUiShell` cannot honor
+    * `preselect`, so the first row is what the cursor starts on and what Enter
+    * picks.
     */
   val runTargetChoices: List[Choice[RunTarget]] = List(
-    Choice(RunTarget.NewBranch, "A new branch in this checkout"),
     Choice(
-      RunTarget.CurrentBranch,
+      RunTarget.NewBranch(Uncommitted.Stash),
+      "A new branch in this checkout"
+    ),
+    Choice(
+      RunTarget.CurrentBranch(Uncommitted.Stash),
       "The branch checked out now — the flow commits onto it"
     ),
     Choice(

--- a/shell/src/main/scala/orca/shell/actions/AuthorAction.scala
+++ b/shell/src/main/scala/orca/shell/actions/AuthorAction.scala
@@ -1,7 +1,7 @@
 package orca.shell.actions
 
 import org.jline.terminal.Terminal
-import orca.OrcaDir
+import orca.{OrcaDir, RunTarget, Uncommitted}
 import orca.shell.ShellVersion
 import orca.shell.create.{
   AuthoringSandbox,
@@ -139,9 +139,7 @@ private[shell] object AuthorAction:
       sandbox,
       FlowFlags(
         verbose = false,
-        skipBranch = false,
-        keepChanges = false,
-        worktree = false
+        target = RunTarget.NewBranch(Uncommitted.Stash)
       ),
       terminal
     )

--- a/shell/src/main/scala/orca/shell/cli/Cli.scala
+++ b/shell/src/main/scala/orca/shell/cli/Cli.scala
@@ -2,9 +2,10 @@ package orca.shell.cli
 
 import mainargs.{Flag, ParserForMethods, Renderer, Util, arg, main}
 import org.jline.terminal.Terminal
+import orca.RunTarget
 import orca.settings.GlobalSettings
 import orca.shell.WorktreeScan
-import orca.shell.run.{FlowFlags, LaunchResult}
+import orca.shell.run.LaunchResult
 import orca.shell.ui.ShellUi
 import orca.subprocess.TtyProbe
 
@@ -167,11 +168,11 @@ private[shell] object Cli:
     RunCli.run(
       flowRef = flow,
       task = task,
-      flags = FlowFlags(
-        verbose = verbose.value,
+      verbose = verbose.value,
+      target = RunTarget.from(
+        worktree = worktree.value,
         skipBranch = skipBranch.value,
-        keepChanges = keepChanges.value,
-        worktree = worktree.value
+        keepChanges = keepChanges.value
       ),
       honorPin = honorPin.value,
       workDir = os.pwd,

--- a/shell/src/main/scala/orca/shell/cli/RunCli.scala
+++ b/shell/src/main/scala/orca/shell/cli/RunCli.scala
@@ -1,6 +1,6 @@
 package orca.shell.cli
 
-import orca.OrcaArgs
+import orca.RunTarget
 import orca.shell.actions.{FlowResolution, RunAction}
 import orca.shell.run.{FallbackPolicy, FlowFlags, FlowLauncher}
 
@@ -13,36 +13,33 @@ import Cli.{actionFailure, complete, usageFailure, withTerminal}
   */
 private[cli] object RunCli:
 
-  /** A contradictory `--worktree` pair is refused first, before anything is
-    * resolved or spawned, saving a `scala-cli` start and its dependency
-    * resolution. The flow child refuses it too, on this same shared decision,
-    * and stays the authority — this only makes the answer immediate.
+  /** `target` arrives unvalidated — a `Left` is the refusal
+    * [[orca.RunTarget.from]] returned for a contradictory `--worktree` pair. It
+    * is refused first, before anything is resolved or spawned, saving a
+    * `scala-cli` start and its dependency resolution; the flow child refuses
+    * the same argv on the same shared decision and stays the authority, this
+    * only makes the answer immediate. Below the refusal only the validated
+    * target exists, so no launch path can be handed a pair orca refuses.
     */
   def run(
       flowRef: String,
       task: Option[String],
-      flags: FlowFlags,
+      verbose: Boolean,
+      target: Either[String, RunTarget],
       honorPin: Boolean,
       workDir: os.Path,
       tty: Boolean
   ): Int =
     complete:
       for
-        _ <- OrcaArgs
-          .worktreeRefusal(
-            worktree = flags.worktree,
-            skipBranch = flags.skipBranch,
-            keepChanges = flags.keepChanges
-          )
-          .toLeft(())
-          .left
-          .map(usageFailure)
+        runTarget <- target.left.map(usageFailure)
         resolved <- FlowResolution
           .resolve(flowRef, workDir)
           .left
           .map(actionFailure)
         taskText <- readTask(task, tty, readAllStdin).left.map(usageFailure)
       yield withTerminal: terminal =>
+        val flags = FlowFlags(verbose, runTarget)
         val result =
           if honorPin then
             FlowLauncher.runHonoringPin(

--- a/shell/src/main/scala/orca/shell/run/FlowLauncher.scala
+++ b/shell/src/main/scala/orca/shell/run/FlowLauncher.scala
@@ -1,6 +1,7 @@
 package orca.shell.run
 
 import org.jline.terminal.Terminal
+import orca.RunTarget
 import orca.shell.ShellVersion
 import orca.shell.flows.BuiltInFlows
 import orca.shell.ui.{ShellOutput, ShellUi, UiOutcome}
@@ -27,16 +28,12 @@ private[shell] enum FallbackPolicy:
   * adjacent same-typed positional Booleans that a call site could silently
   * transpose without a compile error.
   *
-  * `worktree` combines with neither `skipBranch` nor `keepChanges`; a builder
-  * that can produce either pair has to ask `OrcaArgs.worktreeRefusal` (as
-  * [[orca.shell.cli.RunCli]] does), or the flow child refuses it after a spawn.
+  * `target` is the run's destination as one [[orca.RunTarget]] rather than the
+  * three flags it renders to, so the combinations orca refuses (`--worktree`
+  * with `--skip-branch` or `--keep-changes`) cannot be handed to a launch path
+  * at all.
   */
-private[shell] case class FlowFlags(
-    verbose: Boolean,
-    skipBranch: Boolean,
-    keepChanges: Boolean,
-    worktree: Boolean
-)
+private[shell] case class FlowFlags(verbose: Boolean, target: RunTarget)
 
 /** Runs a selected flow as a `scala-cli run` child inheriting the shell's
   * terminal (ADR 0021 §2). By default the shell forces its own orca version via
@@ -84,16 +81,16 @@ private[shell] object FlowLauncher:
       .getOrElse(Seq.empty)
 
   /** `scala-cli run <flow> --quiet --verbose [--dep ...] --workspace <dir> --
-    * <task> [--verbose] [--skip-branch] [--keep-changes] [--worktree]`. The
-    * `--verbose` before `--` is scala-cli's own ([[loggingArgs]]); the one
-    * after is the flow's, parsed by its own `OrcaArgs` — which spells its flags
-    * `--verbose`/`--skip-branch`/`--keep-changes`/`--worktree`, so they land
-    * after `--` alongside the task text, not before it. `--workspace` relocates
-    * scala-cli's own `.scala-build`/`.bsp` build metadata to `workspaceDir`
-    * ([[resolveWorkspaceDir]]) instead of next to `flow` — load-bearing for a
-    * Project-tier flow, whose script lives inside the user's own repo
-    * (`<repo>/.orca/flows/<name>.sc`), same pollution class the `orca` shim's
-    * own `--workspace` fixes (ADR 0021 §1 amendment).
+    * <task> [--verbose] [<target flags>]`. The `--verbose` before `--` is
+    * scala-cli's own ([[loggingArgs]]); everything after `--` is the flow's
+    * own, parsed by its `OrcaArgs`, so it lands alongside the task text rather
+    * than before it — the destination flags come from
+    * [[orca.RunTarget.toArgv]], which is where their spelling lives.
+    * `--workspace` relocates scala-cli's own `.scala-build`/`.bsp` build
+    * metadata to `workspaceDir` ([[resolveWorkspaceDir]]) instead of next to
+    * `flow` — load-bearing for a Project-tier flow, whose script lives inside
+    * the user's own repo (`<repo>/.orca/flows/<name>.sc`), same pollution class
+    * the `orca` shim's own `--workspace` fixes (ADR 0021 §1 amendment).
     *
     * Requires `task` to be non-blank — `Main.promptTask` re-prompts on blank
     * input before this is ever called, so an empty task here means a caller
@@ -111,17 +108,12 @@ private[shell] object FlowLauncher:
       "task text must be non-blank — Main.promptTask re-prompts before calling"
     )
     val verboseArgs = if flags.verbose then Seq("--verbose") else Seq.empty
-    val skipBranchArgs =
-      if flags.skipBranch then Seq("--skip-branch") else Seq.empty
-    val keepChangesArgs =
-      if flags.keepChanges then Seq("--keep-changes") else Seq.empty
-    val worktreeArgs = if flags.worktree then Seq("--worktree") else Seq.empty
     Seq("scala-cli", "run", flow.toString) ++
       loggingArgs ++
       depArgs(orcaVersion) ++
       Seq("--workspace", workspaceDir.toString) ++
       Seq("--", task) ++
-      verboseArgs ++ skipBranchArgs ++ keepChangesArgs ++ worktreeArgs
+      verboseArgs ++ flags.target.toArgv
 
   /** The compile probe's argv — same `--workspace` treatment as [[argv]], and
     * for the same reason: without it, the probe (run whenever the forced

--- a/shell/src/test/scala/orca/shell/MainTest.scala
+++ b/shell/src/test/scala/orca/shell/MainTest.scala
@@ -1,7 +1,7 @@
 package orca.shell
 
 import org.jline.terminal.{Terminal, TerminalBuilder}
-import orca.StackSettings
+import orca.{RunTarget, StackSettings, Uncommitted}
 import orca.runner.manifest.{
   ManifestOutcome,
   ManifestSession,
@@ -567,33 +567,31 @@ class MainTest extends munit.FunSuite:
 
   // --- promptRunTarget (where the run's work goes, asked as one choice) ---
 
+  private val newBranch = RunTarget.NewBranch(Uncommitted.Stash)
+
   test("promptRunTarget: the three destinations are offered, new branch first"):
-    val ui = RecordingSelectUi(UiOutcome.Selected(RunTarget.NewBranch))
-    assertEquals(Main.promptRunTarget(ui), Some(RunTarget.NewBranch))
+    val ui = RecordingSelectUi(UiOutcome.Selected(newBranch))
+    assertEquals(Main.promptRunTarget(ui), Some(newBranch))
     assertEquals(
       ui.recordedChoices.head.map(_.value),
-      List(RunTarget.NewBranch, RunTarget.CurrentBranch, RunTarget.Worktree)
+      List(
+        newBranch,
+        RunTarget.CurrentBranch(Uncommitted.Stash),
+        RunTarget.Worktree
+      )
     )
 
   test(
     "promptRunTarget: a new branch leads the rows and is marked preselected"
   ):
-    val ui = RecordingSelectUi(UiOutcome.Selected(RunTarget.NewBranch))
-    assertEquals(Main.promptRunTarget(ui), Some(RunTarget.NewBranch))
-    assertEquals(ui.recordedPreselect, Some(Some(RunTarget.NewBranch)))
+    val ui = RecordingSelectUi(UiOutcome.Selected(newBranch))
+    assertEquals(Main.promptRunTarget(ui), Some(newBranch))
+    assertEquals(ui.recordedPreselect, Some(Some(newBranch)))
 
   test("promptRunTarget: cancelling aborts the run"):
     assertEquals(
       Main.promptRunTarget(RecordingSelectUi[RunTarget](UiOutcome.Cancelled)),
       None
-    )
-
-  test("RunTarget: each destination maps to one flag pair, never both"):
-    // The pair orca refuses (`--worktree` with `--skip-branch`) has no case
-    // that produces it — which is the point of asking once rather than twice.
-    assertEquals(
-      RunTarget.values.toList.map(t => (t.skipBranch, t.worktree)),
-      List((false, false), (true, false), (false, true))
     )
 
   // --- runFlow (the interactive launch path) ---
@@ -632,14 +630,7 @@ class MainTest extends munit.FunSuite:
       )
       assertEquals(
         recorded,
-        Some(
-          FlowFlags(
-            verbose = false,
-            skipBranch = false,
-            keepChanges = false,
-            worktree = true
-          )
-        )
+        Some(FlowFlags(verbose = false, target = RunTarget.Worktree))
       )
 
   // --- editFlow / createNewFlow / createForkFlow (ADR 0021 §6/§9 amendment:
@@ -1033,9 +1024,7 @@ class MainTest extends munit.FunSuite:
         Some(
           worktree -> FlowFlags(
             verbose = false,
-            skipBranch = false,
-            keepChanges = false,
-            worktree = false
+            target = RunTarget.NewBranch(Uncommitted.Stash)
           )
         )
       )

--- a/shell/src/test/scala/orca/shell/actions/AuthorActionTest.scala
+++ b/shell/src/test/scala/orca/shell/actions/AuthorActionTest.scala
@@ -1,6 +1,7 @@
 package orca.shell.actions
 
 import org.jline.terminal.{Terminal, TerminalBuilder}
+import orca.{RunTarget, Uncommitted}
 import orca.shell.ShellVersion
 import orca.shell.create.{CreateTarget, CreateTier}
 import orca.shell.flows.{BuiltInFlows, DiscoveredFlow, FlowOrigin}
@@ -136,9 +137,7 @@ class AuthorActionTest extends munit.FunSuite:
         call.flags,
         FlowFlags(
           verbose = false,
-          skipBranch = false,
-          keepChanges = false,
-          worktree = false
+          target = RunTarget.NewBranch(Uncommitted.Stash)
         )
       )
       assertEquals(call.fallback, FallbackPolicy.Ask(NoPromptUi))

--- a/shell/src/test/scala/orca/shell/actions/RunActionTest.scala
+++ b/shell/src/test/scala/orca/shell/actions/RunActionTest.scala
@@ -1,5 +1,6 @@
 package orca.shell.actions
 
+import orca.{RunTarget, Uncommitted}
 import orca.shell.flows.{DiscoveredFlow, FlowOrigin}
 import orca.shell.run.{FallbackPolicy, FlowFlags, LaunchResult}
 
@@ -19,9 +20,7 @@ class RunActionTest extends munit.FunSuite:
       val flags =
         FlowFlags(
           verbose = true,
-          skipBranch = false,
-          keepChanges = true,
-          worktree = false
+          target = RunTarget.NewBranch(Uncommitted.Keep)
         )
       val recording = RecordingLaunch()
 

--- a/shell/src/test/scala/orca/shell/run/FlowLauncherTest.scala
+++ b/shell/src/test/scala/orca/shell/run/FlowLauncherTest.scala
@@ -1,5 +1,7 @@
 package orca.shell.run
 
+import orca.{RunTarget, Uncommitted}
+
 class FlowLauncherTest extends munit.FunSuite:
 
   private val flow = os.root / "home" / "u" / "flow.sc"
@@ -7,14 +9,12 @@ class FlowLauncherTest extends munit.FunSuite:
 
   /** Only the fields under test, defaulted off. Deliberately test-local:
     * production `FlowFlags` stays without defaults so every real construction
-    * site keeps stating each flag.
+    * site keeps stating what it launches.
     */
   private def flags(
       verbose: Boolean = false,
-      skipBranch: Boolean = false,
-      keepChanges: Boolean = false,
-      worktree: Boolean = false
-  ): FlowFlags = FlowFlags(verbose, skipBranch, keepChanges, worktree)
+      target: RunTarget = RunTarget.NewBranch(Uncommitted.Stash)
+  ): FlowFlags = FlowFlags(verbose, target)
 
   test("argv forces --dep with a release version, before --workspace/--"):
     val result = FlowLauncher.argv(
@@ -104,7 +104,7 @@ class FlowLauncherTest extends munit.FunSuite:
       flow,
       Some("0.0.18"),
       "do the thing",
-      flags(skipBranch = true),
+      flags(target = RunTarget.CurrentBranch(Uncommitted.Stash)),
       workspaceDir
     )
     assertEquals(
@@ -134,7 +134,10 @@ class FlowLauncherTest extends munit.FunSuite:
       flow,
       None,
       "do the thing",
-      flags(verbose = true, skipBranch = true),
+      flags(
+        verbose = true,
+        target = RunTarget.CurrentBranch(Uncommitted.Stash)
+      ),
       workspaceDir
     )
     assertEquals(
@@ -161,7 +164,7 @@ class FlowLauncherTest extends munit.FunSuite:
       flow,
       Some("0.0.18"),
       "do the thing",
-      flags(keepChanges = true),
+      flags(target = RunTarget.NewBranch(Uncommitted.Keep)),
       workspaceDir
     )
     assertEquals(
@@ -187,13 +190,13 @@ class FlowLauncherTest extends munit.FunSuite:
     )
 
   test(
-    "argv adds --worktree (OrcaArgs's exact flag spelling) after -- when set"
+    "argv adds --worktree (OrcaArgs's exact flag spelling) after the flow's own --verbose"
   ):
     val result = FlowLauncher.argv(
       flow,
       None,
       "do the thing",
-      flags(worktree = true),
+      flags(verbose = true, target = RunTarget.Worktree),
       workspaceDir
     )
     assertEquals(
@@ -208,12 +211,13 @@ class FlowLauncherTest extends munit.FunSuite:
         workspaceDir.toString,
         "--",
         "do the thing",
+        "--verbose",
         "--worktree"
       )
     )
 
   test(
-    "argv adds every flow flag in a fixed order after --: verbose, skip-branch, keep-changes, worktree"
+    "argv adds every flag a single run can carry, in a fixed order after --"
   ):
     val result = FlowLauncher.argv(
       flow,
@@ -221,9 +225,7 @@ class FlowLauncherTest extends munit.FunSuite:
       "do the thing",
       flags(
         verbose = true,
-        skipBranch = true,
-        keepChanges = true,
-        worktree = true
+        target = RunTarget.CurrentBranch(Uncommitted.Keep)
       ),
       workspaceDir
     )
@@ -241,8 +243,7 @@ class FlowLauncherTest extends munit.FunSuite:
         "do the thing",
         "--verbose",
         "--skip-branch",
-        "--keep-changes",
-        "--worktree"
+        "--keep-changes"
       )
     )
 


### PR DESCRIPTION
`--worktree` cannot be combined with `--skip-branch` or with `--keep-changes`.
Both pairs were refused at runtime, but nothing stopped code from building one:
`OrcaArgs` carried three independent `Flag` fields, and the shell's `FlowFlags`
three independent `Boolean`s, built at four launch sites.

The three flags now become one value once argv is parsed:

```scala
enum RunTarget:
  case NewBranch(uncommitted: Uncommitted)      // Stash | Keep
  case CurrentBranch(uncommitted: Uncommitted)
  case Worktree
```

`Worktree` carries neither a branch mode nor an `Uncommitted`, so the five legal
combinations are the only ones that can be written.

## What is now impossible

- **The refusal inside `flow()` is gone.** It was there because an `OrcaArgs`
  built by hand had never been through the parser. Such an `OrcaArgs` can no
  longer hold a refused pair, so there is nothing left to check.
- **A launch path cannot be handed a refused pair.** `FlowFlags` holds a
  `RunTarget`, so the four sites that build one (menu run, resume, flow
  authoring, `orca run`) cannot spawn a flow child that would refuse its own
  argv.
- **One type, not two.** The shell had its own three-case `RunTarget` for the
  menu; it is folded into the shared one rather than left as a second enum
  meaning the same thing.
- **One home for the flag spelling.** `RunTarget.toArgv` renders the flags the
  shell appends after `--`, next to the `@arg` annotations that parse them back.

## What is still representable, and why

mainargs builds a case class straight from argv, so raw `Flag` fields have to
exist at the parse boundary. They moved to `RawArgs`, private to `package
orca`, whose only consumer is `OrcaArgs.parse`. `orca run` has the same
boundary — its own mainargs `@main` flags — and converts them the same way.
Both conversions go through `RunTarget.from`, the single place a refused pair is
worded and rejected. So argv can still say `--worktree --skip-branch`; nothing
past those two conversions can.

One derived pair of booleans is left: `DirtyTreeFacts(skipBranch, keepChanges)`,
the dirty-tree policy's input, now filled from `target.skipBranch` /
`target.keepChanges`. It has no `worktree` field, so it cannot express a refused
pair either.

`ParserForClass[OrcaArgs]` is no longer given, since `OrcaArgs` is no longer the
parser's type. Flow scripts keep writing `flow(OrcaArgs(args))`.

## No behaviour change

Same flags, same refusal wording and precedence (`--worktree --keep-changes`
still names only those two), same exit codes, same argv passed to the flow
child.

`sbt scalafmtAll` clean, `sbt test` green: 2238 tests, 0 failures.
