### PR TITLE
Say what a worktree run refuses, and test the refusals

### DIFF
--- a/runner/src/main/scala/orca/runner/WorktreeRun.scala
+++ b/runner/src/main/scala/orca/runner/WorktreeRun.scala
@@ -31,8 +31,17 @@ private[orca] object WorktreeRun:
     * yet. `invokingDir` is where orca was started, which may itself be a
     * worktree of the repository — the answer is the same either way.
     *
-    * `Left` is a message for the user: no repository or no commits to start
-    * from, something already occupying the path, or git's own refusal.
+    * `Left` is a sentence for the user, one of:
+    *   - no git repository around `invokingDir`, or one with no commit to start
+    *     from;
+    *   - a repository whose main checkout cannot be named — a
+    *     `--separate-git-dir` or submodule layout, or a git too old to answer
+    *     the query;
+    *   - something other than a worktree of this repository already at the
+    *     path;
+    *   - the run's own branch already carries commits that putting the worktree
+    *     back on it would strand;
+    *   - git's own refusal of the create or of the branch step.
     */
   def resolve(
       invokingDir: os.Path,

--- a/runner/src/test/scala/orca/runner/WorktreeRunTest.scala
+++ b/runner/src/test/scala/orca/runner/WorktreeRunTest.scala
@@ -88,10 +88,7 @@ class WorktreeRunTest extends munit.FunSuite:
     val path = resolved(repo, "task A")
     git(repo, "worktree", "remove", "--force", path.toString)
     os.makeDir.all(path)
-    val refusal = WorktreeRun
-      .resolve(repo, "task A")
-      .left
-      .getOrElse(fail("expected a refusal"))
+    val refusal = refusalOf(repo)
     assert(refusal.contains(path.toString), refusal)
 
   test("outside a git repository, orca's own wording is used"):
@@ -105,6 +102,25 @@ class WorktreeRunTest extends munit.FunSuite:
       WorktreeRun.resolve(GitRepo.empty(), "task A"),
       Left(GitPreconditions.needsRepoWithCommit)
     )
+
+  test("a main worktree that is not a checkout is named as the reason"):
+    val checkout = GitRepo.seededSeparateGitDir()
+    val worktree = checkout / os.up / "wt"
+    assertEquals(Worktrees.add(checkout, worktree), Right(()))
+    // Resolving from here finds no main checkout, and the user is told it is
+    // the repository's layout — not that they have no repository.
+    val refusal = refusalOf(worktree)
+    assert(refusal.contains("--separate-git-dir"), refusal)
+
+  test("a git that does not answer the query is named as the reason"):
+    // rev-parse prints one path per line, so a repository path holding a
+    // newline makes the answer unreadable — as does a git too old for
+    // `--path-format`, which is what the user is pointed at.
+    val repo = TempDirs.dir() / "two\nlines"
+    os.makeDir.all(repo)
+    git(repo, "init", "-b", "main")
+    val refusal = refusalOf(repo)
+    assert(refusal.contains("git 2.31 or newer"), refusal)
 
   test("reuse puts a detached worktree back on its branch"):
     val repo = GitRepo.seeded()
@@ -126,10 +142,7 @@ class WorktreeRunTest extends munit.FunSuite:
     // Detached BEHIND the branch, so putting the run back on it would strand
     // that commit — which is what orca refuses to do.
     git(path, "checkout", "--detach", "-q", "HEAD~1")
-    val refusal = WorktreeRun
-      .resolve(repo, "task A")
-      .left
-      .getOrElse(fail("expected a refusal"))
+    val refusal = refusalOf(repo)
     assert(refusal.contains(branch), refusal)
     // The remedy names the branch, which is what holds the commits. Removing
     // the worktree does not help: the next run recreates it detached and hits
@@ -150,6 +163,12 @@ class WorktreeRunTest extends munit.FunSuite:
     WorktreeRun
       .resolve(repo, userPrompt)
       .getOrElse(fail("expected a resolved worktree"))
+
+  private def refusalOf(cwd: os.Path): String =
+    WorktreeRun
+      .resolve(cwd, "task A")
+      .left
+      .getOrElse(fail("expected a refusal"))
 
   private def git(cwd: os.Path, args: String*): Unit =
     os.proc("git" +: args).call(cwd = cwd).discard

--- a/tools/src/main/scala/orca/tools/Worktrees.scala
+++ b/tools/src/main/scala/orca/tools/Worktrees.scala
@@ -46,9 +46,12 @@ private[orca] enum StartBranchFailure:
   * working directory is fixed before its body runs, so no flow can use these.
   * They run during startup, before any tool exists.
   *
-  * The two reads answer "not known" (`None` / empty) rather than failing, so a
-  * caller outside a git repository — or one scanning on every menu redraw — has
-  * nothing to handle. [[add]] is a write, so its failure is returned.
+  * The reads answer "not known" rather than failing — `None`, an empty list, a
+  * fail-closed `false` — so a caller outside a git repository, or one scanning
+  * on every menu redraw, has nothing to handle. [[mainCheckoutOrReason]] is the
+  * exception: it names why it could not answer, for the caller that has to put
+  * the refusal into words. The writes, [[add]] and [[startBranch]], return
+  * their failures.
   */
 private[orca] object Worktrees:
 

--- a/tools/src/test/scala/orca/testkit/GitRepo.scala
+++ b/tools/src/test/scala/orca/testkit/GitRepo.scala
@@ -22,7 +22,35 @@ object GitRepo:
   /** `empty()` plus a single `seed.txt` commit (`seed`). */
   def seeded(): os.Path =
     val dir = empty()
+    seed(dir)
+    dir
+
+  /** [[seeded]] with the git directory kept outside the checkout
+    * (`--separate-git-dir`); the checkout is returned. git names that git
+    * directory as the repository's main worktree, so a linked worktree of this
+    * repo has no main checkout to be found from.
+    */
+  def seededSeparateGitDir(): os.Path =
+    val root = TempDirs.dir(prefix = "orca-gitrepo-")
+    val checkout = root / "checkout"
+    os.makeDir.all(checkout)
+    val _ = os
+      .proc(
+        "git",
+        "init",
+        "-b",
+        "main",
+        s"--separate-git-dir=${root / "gitdir"}"
+      )
+      .call(cwd = checkout)
+    val _ = os
+      .proc("git", "config", "user.email", "test@example.com")
+      .call(cwd = checkout)
+    val _ = os.proc("git", "config", "user.name", "Test").call(cwd = checkout)
+    seed(checkout)
+    checkout
+
+  private def seed(dir: os.Path): Unit =
     os.write(dir / "seed.txt", "seed")
     val _ = os.proc("git", "add", "-A").call(cwd = dir)
     val _ = os.proc("git", "commit", "-m", "seed").call(cwd = dir)
-    dir

--- a/tools/src/test/scala/orca/tools/WorktreesTest.scala
+++ b/tools/src/test/scala/orca/tools/WorktreesTest.scala
@@ -40,17 +40,7 @@ class WorktreesTest extends munit.FunSuite:
     assertEquals(Worktrees.mainCheckout(path), Some(repo))
 
   test("mainCheckout answers the checkout when the git dir lives outside it"):
-    val root = TempDirs.dir()
-    val checkout = root / "checkout"
-    os.makeDir.all(checkout)
-    git(
-      checkout,
-      "init",
-      "-q",
-      "-b",
-      "main",
-      s"--separate-git-dir=${root / "gitdir"}"
-    ).discard
+    val checkout = GitRepo.seededSeparateGitDir()
     assertEquals(Worktrees.mainCheckout(checkout), Some(checkout))
 
   test("mainCheckout is empty outside a git repository"):
@@ -110,24 +100,23 @@ class WorktreesTest extends munit.FunSuite:
     assertEquals(Worktrees.headBranch(path), Some("wt-branch"))
     assertEquals(gitOut(path, "rev-parse", "--abbrev-ref", "HEAD"), "wt-branch")
 
+  test("a worktree that cannot be read reads as not on a branch"):
+    val repo = GitRepo.seeded()
+    val path = repo / "wt"
+    assertEquals(Worktrees.add(repo, path), Right(()))
+    assertEquals(Worktrees.startBranch(path, "wt-branch"), Right(()))
+    // What `git clean -xdff` leaves: git cannot be started in a directory that
+    // is not there, so the branch it was on a moment ago is not an answer any
+    // more. os-lib spawns from a thread of its own, so the failed exec also
+    // prints a stack trace to stderr — the probe catches it, and the test log
+    // shows it even while passing.
+    os.remove.all(path)
+    assertEquals(Worktrees.headBranch(path), None)
+    assert(!Worktrees.onABranch(path), "unknown must not read as on a branch")
+
   test("mainCheckout never answers the git dir, even from a linked worktree"):
-    val root = TempDirs.dir()
-    val checkout = root / "checkout"
-    os.makeDir.all(checkout)
-    git(
-      checkout,
-      "init",
-      "-q",
-      "-b",
-      "main",
-      s"--separate-git-dir=${root / "gitdir"}"
-    ).discard
-    git(checkout, "config", "user.email", "t@e.com").discard
-    git(checkout, "config", "user.name", "T").discard
-    os.write(checkout / "seed.txt", "seed")
-    git(checkout, "add", "-A").discard
-    git(checkout, "commit", "-q", "-m", "seed").discard
-    val worktree = root / "wt"
+    val checkout = GitRepo.seededSeparateGitDir()
+    val worktree = checkout / os.up / "wt"
     assertEquals(Worktrees.add(checkout, worktree), Right(()))
     // git names the git dir as the main worktree here, so there is no checkout
     // to answer with: refusing beats writing a worktree inside `.git`.


### PR DESCRIPTION
Closes the four doc and test gaps the review of #166 left open. Docs and
tests only — no behaviour change.

**`Worktrees`' object doc** talked about "the two reads", which the object
has outgrown. It now states the rule for all of the reads, and names
`mainCheckoutOrReason` as the one that gives a reason instead of a blank
"not known".

**`WorktreeRun.resolve`'s doc** listed three of the messages a caller can
get back. It lists all of them now, and says what each one means.

**Two of the three "no main checkout" messages had no test**: the one for
a repository whose main worktree is not a checkout (`--separate-git-dir`
or a submodule), and the one for a git that does not answer the query.
The second is reached with a repository path holding a newline, which
makes git's answer unreadable in the same way an old git does.

**`headBranch` and `onABranch` answer "not on a branch" when a worktree
cannot be read at all**, which nothing tested. The new test deletes the
worktree directory first, so git really cannot be run there; it fails if
that fail-closed answer is taken out. os-lib prints the failed exec's
stack trace from a thread of its own, so the test log shows it while
passing — noted in the test.

The `--separate-git-dir` repo two tests were building inline is now
`GitRepo.seededSeparateGitDir`.

`sbt scalafmtAll` and `sbt test` are green: 2239 tests, 0 failures.
